### PR TITLE
Add path separators to TRACCC_TEST_DATA_DIR

### DIFF
--- a/examples/cpu/seq_example.cpp
+++ b/examples/cpu/seq_example.cpp
@@ -24,7 +24,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir, unsi
     {
         throw std::ios_base::failure("Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
     }
-    auto data_directory = std::string(env_d_d);
+    auto data_directory = std::string(env_d_d) + std::string("/");
 
     // Read the surface transforms
     std::string io_detector_file = data_directory + detector_file;

--- a/tests/io/csv_io_tests.cpp
+++ b/tests/io/csv_io_tests.cpp
@@ -18,7 +18,7 @@ TEST(io, csv_read_single_module)
     {
         throw std::ios_base::failure("Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
     }
-    auto data_directory = std::string(env_d_d);
+    auto data_directory = std::string(env_d_d) + std::string("/");
 
     std::string file = data_directory+std::string("single_module/cells.csv");
     traccc::cell_reader creader(file, {"module", "cannel0","channel1","activation","time"} );


### PR DESCRIPTION
Currently, the examples will fail to run if `TRACCC_TEST_DATA_DIR` does not end with a path separator (/). This is an unnecessary ergonomic papercut.