### PR TITLE
fix io cmakelist

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -14,7 +14,7 @@ install(TARGETS traccc_io
 target_link_libraries(traccc_io INTERFACE traccc::core dfelibs)
 
 install(
-  DIRECTORY csv
+  DIRECTORY include/csv
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-  add_library(traccc::io ALIAS traccc_io)
+add_library(traccc::io ALIAS traccc_io)


### PR DESCRIPTION
After `make install`, the following error occurs.

```
CMake Error at io/cmake_install.cmake:54 (file):
  file INSTALL cannot find "/home/beomki/projects/traccc/traccc/io/csv": No
  such file or directory.
```

So I changed the directory of csv installation.