### PR TITLE
Cell EDM Update, main branch (2021.04.12.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,40 @@
-cmake_minimum_required(VERSION 3.9)
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
+# Set up the project.
+cmake_minimum_required(VERSION 3.9)
 project(traccc VERSION 0.0 LANGUAGES CXX)
 
-enable_testing()
+# Standard CMake include(s).
+include( CTest )
+include( GNUInstallDirs )
 
-option(TRACCC_UNIT_TESTS "Enable unit tests" On)
-option(TRACCC_BENCHMARKS "Enable benchmark tests" On)
+# Explicitly set the output directory for the binaries. Such that if this
+# project is included by another project, the main project's configuration would
+# win out.
+set( CMAKE_RUNTIME_OUTPUT_DIRECTORY
+   "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}" CACHE PATH
+   "Directory for the built binaries" )
+set( CMAKE_LIBRARY_OUTPUT_DIRECTORY
+   "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH
+   "Directory for the built libraries" )
+set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY
+   "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH
+   "Directory for the built static libraries" )
 
-set(CMAKE_CXX_STANDARD 17)
+# Include the traccc CMake code.
+list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
+include( traccc-compiler-options )
 
-set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_PREFIX}/include)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_INSTALL_PREFIX}/lib)
-set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib)
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
-
-set(TF_BUILD_EXAMPLES OFF)
-set(TF_BUILD_TESTS OFF)
-set(INSTALL_GTEST OFF)
-set(BENCHMARK_ENABLE_INSTALL OFF)
-set(BENCHMARK_ENABLE_TESTING OFF)
-
+# Build the necessary externals.
 add_subdirectory(extern)
+include( traccc-vecmem )
 
+# Build the traccc code.
 add_subdirectory(core)
 add_subdirectory(io)
 add_subdirectory(examples)
 add_subdirectory(tests)
-

--- a/cmake/traccc-compiler-options.cmake
+++ b/cmake/traccc-compiler-options.cmake
@@ -1,0 +1,25 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Guard against multiple includes.
+include_guard( GLOBAL )
+
+# Include the helper function(s).
+include( traccc-functions )
+
+# Set up the used C++ standard(s).
+set( CMAKE_CXX_STANDARD 17 CACHE STRING "The (host) C++ standard to use" )
+
+# Turn on a number of warnings for the "known compilers".
+if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
+    ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" ) )
+
+   # Basic flags for all major build modes.
+   foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
+      traccc_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wall" )
+      traccc_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wextra" )
+   endforeach()
+endif()

--- a/cmake/traccc-functions.cmake
+++ b/cmake/traccc-functions.cmake
@@ -1,0 +1,30 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Guard against multiple includes.
+include_guard( GLOBAL )
+
+# Helper function for adding individual flags to "flag variables".
+#
+# Usage: traccc_add_flag( CMAKE_CXX_FLAGS "-Wall" )
+#
+function( traccc_add_flag name value )
+
+   # Escape special characters in the value:
+   set( matchedValue "${value}" )
+   foreach( c "*" "." "^" "$" "+" "?" )
+      string( REPLACE "${c}" "\\${c}" matchedValue "${matchedValue}" )
+   endforeach()
+
+   # Check if the variable already has this value in it:
+   if( "${${name}}" MATCHES "${matchedValue}" )
+      return()
+   endif()
+
+   # If not, then let's add it now:
+   set( ${name} "${${name}} ${value}" PARENT_SCOPE )
+
+endfunction( traccc_add_flag )

--- a/cmake/traccc-vecmem.cmake
+++ b/cmake/traccc-vecmem.cmake
@@ -1,0 +1,40 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Guard against multiple includes.
+include_guard( GLOBAL )
+
+# Look for VecMem, quietly first time around. Since if it is not found (which is
+# likely), it prints multiple lines of warnings.
+find_package( vecmem QUIET )
+
+# If it was found, then we're finished.
+if( vecmem_FOUND )
+   # Call find_package again, just to nicely print where it is picked up from.
+   find_package( vecmem )
+   return()
+endif()
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.11 )
+include( FetchContent )
+
+# Tell the user what's happening.
+message( STATUS "Building VecMem as part of the traccc project" )
+
+# Declare where to get VecMem from.
+FetchContent_Declare( VecMem
+   GIT_REPOSITORY "https://github.com/acts-project/vecmem.git"
+   GIT_TAG "2e06a5167e0927e6e6ed6a4f1abd5b5f552f059f" )
+
+# Prevent VecMem from building its tests. As it would interfere with how traccc
+# builds/uses GoogleTest.
+set( BUILD_TESTING FALSE )
+
+# Get it into the current directory.
+FetchContent_Populate( VecMem )
+add_subdirectory( "${vecmem_SOURCE_DIR}" "${vecmem_BINARY_DIR}"
+   EXCLUDE_FROM_ALL )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -5,6 +5,8 @@ target_include_directories(traccc_core
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
+target_link_libraries(traccc_core
+  INTERFACE vecmem::core)
 
 install(TARGETS traccc_core
         PUBLIC_HEADER

--- a/core/include/algorithms/component_connection.hpp
+++ b/core/include/algorithms/component_connection.hpp
@@ -1,7 +1,7 @@
 /** TRACCC library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2021 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 
@@ -13,48 +13,122 @@
 
 namespace traccc {
 
-    /// Connected component labelling.
-    struct component_connection {
+    /// Connected component labelling
+    ///
+    /// Note that the separation between the public and private interface is
+    /// only there in the class because the compilers can't automatically figure
+    /// out the "vector type" of the templated implementation, without adding a
+    /// lot of "internal knowledge" about the vector types into this piece of
+    /// code. So instead the public operators are specifically implemented for
+    /// the host- and device versions of the EDM, making use of a single
+    /// implementation internally.
+    ///
+    class component_connection {
 
-        /// Callable operator for the connected component, based on one single module 
+    public:
+        /// @name Operators to use in host code
+        /// @{
+
+        /// Callable operator for the connected component, based on one single module
         ///
         /// @param cells are the input cells into the connected component, they are
         ///              per module and unordered
-        /// @param opt the call options
+        /// @param module The description of the module that the cells belong to
         ///
         /// c++20 piping interface:
-        /// @return a cluster collection  
-        cluster_collection operator()(const cell_collection& cells) const {            
+        /// @return a cluster collection
+        ///
+        cluster_collection operator()(const host_cell_collection& cells,
+                                      const cell_module& module) const {
+
+            return this->operator()< vecmem::vector >( cells, module );
+        }
+
+        /// Callable operator for the connected component, based on one single module
+        ///
+        /// @param cells are the input cells into the connected component, they are
+        ///              per module and unordered
+        /// @param module The description of the module that the cells belong to
+        /// @param clusters[in,out] are the output clusters
+        ///
+        /// void interface
+        ///
+        void operator()(const host_cell_collection& cells,
+                        const cell_module& module,
+                        cluster_collection& clusters) const {
+
+            this->operator()< vecmem::vector >( cells, module, clusters );
+        }
+
+        /// @}
+
+        /// @name Operators to use in device code
+        /// @{
+
+        /// Callable operator for the connected component, based on one single module
+        ///
+        /// This version of the function is meant to be used in device code.
+        ///
+        /// @param cells are the input cells into the connected component, they are
+        ///              per module and unordered
+        /// @param module The description of the module that the cells belong to
+        ///
+        /// c++20 piping interface:
+        /// @return a cluster collection
+        ///
+        cluster_collection operator()(const device_cell_collection& cells,
+                                      const cell_module& module) const {
+
+            return this->operator()< vecmem::device_vector >( cells, module );
+        }
+
+        /// Callable operator for the connected component, based on one single module
+        ///
+        /// @param cells are the input cells into the connected component, they are
+        ///              per module and unordered
+        /// @param module The description of the module that the cells belong to
+        /// @param clusters[in,out] are the output clusters
+        ///
+        /// void interface
+        ///
+        void operator()(const device_cell_collection& cells,
+                        const cell_module& module,
+                        cluster_collection& clusters) const {
+
+            this->operator()< vecmem::device_vector >( cells, module, clusters );
+        }
+
+    private:
+        /// Implementation for the public cell collection creation operators
+        template< template< typename > class vector_type >
+        cluster_collection operator()(const cell_collection< vector_type >& cells,
+                                      const cell_module& module) const {
             cluster_collection clusters;
-            clusters.placement = cells.placement;
-            this->operator()(cells, clusters);
+            clusters.placement = module.placement;
+            this->operator()< vector_type >(cells, module, clusters);
             return clusters;
         }
 
-        /// Callable operator for the connected component, based on one single module 
-        ///
-        /// @param cells are the input cells into the connected component, they are
-        ///              per module and unordered
-        /// @param clusters[in,out] are the output clusters 
-        /// @param opt the call options
-        ///
-        /// void interface
-        void operator()(const cell_collection& cells, cluster_collection& clusters) const {         
+        /// Implementation for the public cell collection creation operators
+        template< template< typename > class vector_type >
+        void operator()(const cell_collection< vector_type >& cells,
+                        const cell_module& module,
+                        cluster_collection& clusters) const {
             // Assign the module id
-            clusters.module = cells.module;
-            // Run the algorithm  
-            auto connected_cells = detail::sparse_ccl(cells.items);
+            clusters.module = module.module;
+            // Run the algorithm
+            auto connected_cells = detail::sparse_ccl<vector_type>(cells);
             std::vector<cluster> cluster_items(std::get<0>(connected_cells),cluster{});
             unsigned int icell = 0;
             for (auto cell_label : std::get<1>(connected_cells)){
                 auto cindex = static_cast<unsigned int>(cell_label-1);
                 if (cindex < cluster_items.size()){
-                    cluster_items[cindex].cells.push_back(cells.items[icell++]);
+                    cluster_items[cindex].cells.push_back(cells[icell++]);
                 }
             }
             clusters.items = cluster_items;
         }
 
-    };
+    }; // class component_connection
 
-}
+} // namespace traccc

--- a/core/include/algorithms/detail/sparse_ccl.hpp
+++ b/core/include/algorithms/detail/sparse_ccl.hpp
@@ -1,7 +1,7 @@
 /** TRACCC library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2021 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 
@@ -21,20 +21,20 @@ namespace traccc {
         ///
         /// @param L an equivalance table
         ///
-        /// @return the root of @param e 
+        /// @return the root of @param e
         unsigned int find_root(const std::vector<unsigned int>& L, unsigned int e) {
             unsigned int r = e;
             while (L[r] != r) {
                 r = L[r];
             }
             return r;
-        } 
+        }
 
         /// Create a union of two entries @param e1 and @param e2
         ///
         /// @param L an equivalance table
         ///
-        /// @return the rleast common ancestor of the entries 
+        /// @return the rleast common ancestor of the entries
         unsigned int make_union(std::vector<unsigned int>& L, unsigned int e1, unsigned int e2){
             int e;
             if (e1 < e2){
@@ -54,11 +54,11 @@ namespace traccc {
         ///
         /// @return boolan to indicate 8-cell connectivity
         bool is_adjacent(cell a, cell b) {
-            return (a.channel0 - b.channel0)*(a.channel0 - b.channel0) <= 1 
-                and (a.channel1 - b.channel1)*(a.channel1 - b.channel1) <= 1; 
+            return (a.channel0 - b.channel0)*(a.channel0 - b.channel0) <= 1
+                and (a.channel1 - b.channel1)*(a.channel1 - b.channel1) <= 1;
         }
 
-        /// Helper method to find define distance, 
+        /// Helper method to find define distance,
         /// does not need abs, as channels are sorted in
         /// column major
         ///
@@ -67,13 +67,14 @@ namespace traccc {
         ///
         /// @return boolan to indicate !8-cell connectivity
         bool is_far_enough(cell a, cell b){
-            return (a.channel1 - b.channel1) > 1; 
+            return (a.channel1 - b.channel1) > 1;
         }
 
         /// Sparce CCL algorithm
         ///
+        template< template< typename > class vector_type >
         std::tuple<unsigned int, std::vector<unsigned int>>
-        sparse_ccl(const std::vector<cell>& cells){
+        sparse_ccl(const cell_collection< vector_type >& cells){
 
             // Internal list linking
             std::vector<unsigned int> L(cells.size(),0);
@@ -100,7 +101,7 @@ namespace traccc {
                 unsigned int l = 0;
                 if (L[i] == i){
                     ++labels;
-                    l = labels; 
+                    l = labels;
                 } else {
                     l = L[L[i]];
                 }

--- a/core/include/edm/cell.hpp
+++ b/core/include/edm/cell.hpp
@@ -1,22 +1,36 @@
 /** TRACCC library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2021 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
+// traccc include(s).
 #include "definitions/algebra.hpp"
 #include "definitions/primitives.hpp"
-#include <vector>
+
+// VecMem include(s).
+#include <vecmem/containers/jagged_vector.hpp>
+#include <vecmem/containers/jagged_device_vector.hpp>
+#include <vecmem/containers/vector.hpp>
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/containers/data/jagged_vector_buffer.hpp>
+#include <vecmem/containers/data/vector_buffer.hpp>
+
+// System include(s).
 #include <limits>
 
 namespace traccc {
 
+    /// @name Types to use in algorithmic code
+    /// @{
+
+    /// Channel identifier type
     using channel_id = unsigned int;
 
-    /// A cell definition: 
+    /// A cell definition:
     ///
     /// maximum two channel identifiers
     /// and one activiation value, such as a time stamp
@@ -27,23 +41,128 @@ namespace traccc {
         scalar time = 0.;
     };
 
-    /// A cell collection: 
+    /// Container of cells belonging to one detector module
+    template< template< typename > class vector_t >
+    using cell_collection = vector_t< cell >;
+
+    /// Convenience declaration for the cell collection type to use in host code
+    using host_cell_collection = cell_collection< vecmem::vector >;
+    /// Convenience declaration for the cell collection type to use in device code
+    using device_cell_collection = cell_collection< vecmem::device_vector >;
+
+    /// Header information for all of the cells in a specific detector module
     ///
-    /// it remembers the moduleentifier and also 
-    /// keeps track of the cell ranges for chosing optimal
-    /// algorithm.
-    struct cell_collection { 
+    /// It is handled separately from the list of all of the cells belonging to
+    /// the detector module, to be able to lay out the data in memory in a way
+    /// that is more friendly towards accelerators.
+    ///
+    struct cell_module {
 
         event_id event = 0;
         geometry_id module = 0;
         transform3 placement = transform3{};
 
-        std::vector<cell> items;
-        std::array<channel_id,2> range0 = {std::numeric_limits<channel_id>::max(), 0};
-        std::array<channel_id,2> range1 = {std::numeric_limits<channel_id>::max(), 0};         
-    };
+        channel_id range0[ 2 ] = { std::numeric_limits< channel_id >::max(), 0 };
+        channel_id range1[ 2 ] = { std::numeric_limits< channel_id >::max(), 0 };
 
-    using cell_container = std::vector<cell_collection>;
+    }; // struct cell_module
 
-}
+    /// Container describing all of the cells in a given event
+    ///
+    /// This is the "main" cell container of the code, holding all relevant
+    /// information about all of the cells in a given event.
+    ///
+    /// It can be instantiated with different vector types, to be able to use
+    /// the same container type in both host and device code.
+    ///
+    template< template< typename > class vector_t,
+              template< typename > class jagged_vector_t >
+    class cell_container {
 
+    public:
+        /// @name Type definitions
+        /// @{
+
+        /// Vector type used by the cell container
+        template< typename T >
+        using vector_type = vector_t< T >;
+        /// Jagged vector type used by the cell container
+        template< typename T >
+        using jagged_vector_type = jagged_vector_t< T >;
+
+        /// The cell module vector type
+        using cell_module_vector = vector_type< cell_module >;
+        /// The cell vector type
+        using cell_vector = jagged_vector_type< cell >;
+
+        /// @}
+
+        /// Headers for all of the modules (holding cells) in the event
+        cell_module_vector modules;
+        /// All of the cells in the event
+        cell_vector cells;
+
+    }; // class cell_container
+
+    /// Convenience declaration for the cell container type to use in host code
+    using host_cell_container =
+        cell_container< vecmem::vector, vecmem::jagged_vector >;
+    /// Convenience declaration for the cell container type to use in device code
+    using device_cell_container =
+        cell_container< vecmem::device_vector, vecmem::jagged_device_vector >;
+
+    /// @}
+
+    /// @name Types used to send data back and forth between host and device code
+    /// @{
+
+    /// Structure holding (some of the) data about the cells in host code
+    struct cell_container_data {
+        vecmem::data::vector_view< cell_module > modules;
+        vecmem::data::jagged_vector_data< cell > cells;
+    }; // struct cell_container_data
+
+    /// Structure holding (all of the) data about the cells in host code
+    struct cell_container_buffer {
+        vecmem::data::vector_buffer< cell_module > modules;
+        vecmem::data::jagged_vector_buffer< cell > cells;
+    }; // struct cell_container_data
+
+    /// Structure used to send the data about the cells to device code
+    ///
+    /// This is the type that can be passed to device code as-is. But since in
+    /// host code one needs to manage the data describing a
+    /// @c traccc::cell_container either using @c traccc::cell_container_data or
+    /// @c traccc::cell_container_buffer, it needs to have constructors from
+    /// both of those types.
+    ///
+    /// In fact it needs to be created from one of those types, as such an
+    /// object can only function if an instance of one of those types exists
+    /// alongside it as well.
+    ///
+    struct cell_container_view {
+
+        /// Constructor from a @c cell_container_data object
+        cell_container_view( const cell_container_data& data )
+        : modules( data.modules ), cells( data.cells ) {}
+
+        /// Constructor from a @c cell_container_buffer object
+        cell_container_view( const cell_container_buffer& buffer )
+        : modules( buffer.modules ), cells( buffer.cells ) {}
+
+        /// View of the data describing the headers of the cell holding modules
+        vecmem::data::vector_view< cell_module > modules;
+        /// View of the data describing all of the cells
+        vecmem::data::jagged_vector_view< cell > cells;
+
+    }; // struct cell_container_view
+
+    /// Helper function for making a "simple" object out of the cell container
+    cell_container_data get_data( host_cell_container& cc ) {
+        return { { vecmem::get_data( cc.modules ) },
+                 { vecmem::get_data( cc.cells ) } };
+    }
+
+    /// @}
+
+} // namespace traccc

--- a/examples/cpu/CMakeLists.txt
+++ b/examples/cpu/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable (seq_single_module seq_single_module.cpp)
-target_link_libraries (seq_single_module LINK_PUBLIC traccc::core)
+target_link_libraries (seq_single_module LINK_PUBLIC traccc::core vecmem::core)
 
 add_executable (seq_example seq_example.cpp)
-target_link_libraries (seq_example LINK_PUBLIC traccc::core traccc::io)
+target_link_libraries (seq_example LINK_PUBLIC traccc::core traccc::io vecmem::core)

--- a/examples/cpu/seq_example.cpp
+++ b/examples/cpu/seq_example.cpp
@@ -1,7 +1,7 @@
 /** TRACCC library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2021 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 
@@ -14,6 +14,8 @@
 #include "algorithms/measurement_creation.hpp"
 #include "algorithms/spacepoint_formation.hpp"
 #include "csv/csv_io.hpp"
+
+#include <vecmem/memory/host_memory_resource.hpp>
 
 #include <iostream>
 
@@ -43,6 +45,9 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir, unsi
     uint64_t n_measurements = 0;
     uint64_t n_space_points = 0;
 
+    // Memory resource used by the EDM.
+    vecmem::host_memory_resource resource;
+
     // Loop over events
     for (unsigned int event = 0; event < events; ++event){
 
@@ -53,25 +58,25 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir, unsi
 
         std::string io_cells_file = data_directory+cells_dir+std::string("/event")+event_string+std::string("-cells.csv");
         traccc::cell_reader creader(io_cells_file, {"geometry_id", "hit_id", "cannel0", "channel1", "activation", "time"});
-        traccc::cell_container cells_per_event = traccc::read_cells(creader, surface_transforms);
-        m_modules += cells_per_event.size();
+        traccc::host_cell_container cells_per_event = traccc::read_cells(creader, resource, surface_transforms);
+        m_modules += cells_per_event.modules.size();
 
         // Output containers
         traccc::measurement_container measurements_per_event;
         traccc::spacepoint_container spacepoints_per_event;
-        measurements_per_event.reserve(cells_per_event.size());
-        spacepoints_per_event.reserve(cells_per_event.size());
+        measurements_per_event.reserve(cells_per_event.modules.size());
+        spacepoints_per_event.reserve(cells_per_event.modules.size());
 
-        for (auto &cells_per_module : cells_per_event)
+        for (std::size_t i = 0; i < cells_per_event.cells.size(); ++i )
         {
             // The algorithmic code part: start
-            traccc::cluster_collection clusters_per_module =  cc(cells_per_module);
+            traccc::cluster_collection clusters_per_module = cc(cells_per_event.cells[i], cells_per_event.modules[i]);
             clusters_per_module.position_from_cell = traccc::pixel_segmentation{-8.425, -36.025, 0.05, 0.05};
             traccc::measurement_collection measurements_per_module = mt(clusters_per_module);
             traccc::spacepoint_collection spacepoints_per_module = sp(measurements_per_module);
             // The algorithmnic code part: end
-            
-            n_cells += cells_per_module.items.size();
+
+            n_cells += cells_per_event.cells[i].size();
             n_clusters += clusters_per_module.items.size();
             n_measurements += measurements_per_module.items.size();
             n_space_points += spacepoints_per_module.items.size();
@@ -79,7 +84,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir, unsi
             measurements_per_event.push_back(std::move(measurements_per_module));
             spacepoints_per_event.push_back(std::move(spacepoints_per_module));
         }
-    
+
         traccc::measurement_writer mwriter{std::string("event")+event_number+"-measurements.csv"};
         for (const auto& measurements_per_module : measurements_per_event){
             auto module = measurements_per_module.module;

--- a/examples/cpu/seq_single_module.cpp
+++ b/examples/cpu/seq_single_module.cpp
@@ -1,7 +1,7 @@
 /** TRACCC library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2021 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 
@@ -14,41 +14,46 @@
 #include "algorithms/measurement_creation.hpp"
 #include "algorithms/spacepoint_formation.hpp"
 
+#include <vecmem/memory/host_memory_resource.hpp>
+
 int main(){
-  
+
+  // Memory resource used in the test.
+  vecmem::host_memory_resource resource;
+
   /// Following [DOI: 10.1109/DASIP48288.2019.9049184]
-  std::vector<traccc::cell> cell_items = 
-        { {1, 0, 1., 0. }, 
-          {8, 4, 2., 0.}, 
-          {10, 4, 3., 0.}, 
-          {9, 5, 4., 0.}, 
-          {10, 5, 5., 0}, 
-          {12, 12, 6, 0}, 
-          {3, 13, 7, 0}, 
-          {11, 13, 8, 0}, 
-          {4, 14, 9, 0 } };
+  traccc::host_cell_collection cells =
+        { { {1, 0, 1., 0. },
+            {8, 4, 2., 0.},
+            {10, 4, 3., 0.},
+            {9, 5, 4., 0.},
+            {10, 5, 5., 0},
+            {12, 12, 6, 0},
+            {3, 13, 7, 0},
+            {11, 13, 8, 0},
+            {4, 14, 9, 0 } },
+          &resource };
 
 
-  traccc::cell_collection cells;
-  cells.items = cell_items;
-  cells.module = 0;
+  traccc::cell_module module;
+  module.module = 0;
 
   traccc::cluster_collection clusters;
   clusters.position_from_cell = traccc::pixel_segmentation{0.,0.,1.,1.};
 
   traccc::measurement_collection measurements;
   measurements.placement = traccc::transform3{};
-  
+
   traccc::spacepoint_collection spacepoints;
 
   traccc::component_connection cc;
   traccc::measurement_creation mt;
-  traccc::spacepoint_formation sp; 
+  traccc::spacepoint_formation sp;
 
   // Algorithmic code: start
-  clusters = cc(cells);
-  measurements= mt(clusters); 
-  spacepoints = sp(measurements); 
-                                      
+  clusters = cc(cells, module);
+  measurements= mt(clusters);
+  spacepoints = sp(measurements);
+
   return 0;
 }

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,2 +1,16 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Turn off the installation of GoogleTest.
+option(INSTALL_GTEST "Flag controlling the installation of GTest" OFF)
+
+# Needed once the benachmark external will be added to the build.
+#set(BENCHMARK_ENABLE_INSTALL OFF)
+#set(BENCHMARK_ENABLE_TESTING OFF)
+
+# Add the external submodules.
 add_subdirectory(dfelibs)
 add_subdirectory(googletest)

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -11,7 +11,7 @@ install(TARGETS traccc_io
           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/io
 )
 
-target_link_libraries(traccc_io INTERFACE traccc::core dfelibs)
+target_link_libraries(traccc_io INTERFACE traccc::core dfelibs vecmem::core)
 
 install(
   DIRECTORY include/csv

--- a/io/include/csv/csv_io.hpp
+++ b/io/include/csv/csv_io.hpp
@@ -1,7 +1,7 @@
 /** TRACCC library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2021 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 
@@ -15,6 +15,9 @@
 #include <dfe/dfe_namedtuple.hpp>
 #include <dfe/dfe_io_dsv.hpp>
 
+#include <vecmem/memory/memory_resource.hpp>
+
+#include <cassert>
 #include <fstream>
 #include <climits>
 #include <map>
@@ -22,7 +25,7 @@
 namespace traccc {
 
   struct csv_cell {
-    
+
     uint64_t geometry_id = 0;
     uint64_t hit_id = 0;
     channel_id channel0 = 0;
@@ -51,7 +54,7 @@ namespace traccc {
   };
 
   using measurement_writer = dfe::NamedTupleCsvWriter<csv_measurement>;
-  
+
   struct csv_spacepoint {
 
     uint64_t geometry_id = 0;
@@ -66,7 +69,7 @@ namespace traccc {
   using spacepoint_writer = dfe::NamedTupleCsvWriter<csv_spacepoint>;
 
   struct csv_surface {
-    
+
     uint64_t geometry_id = 0;
     scalar cx, cy, cz;
     scalar rot_xu,rot_xv,rot_xw;
@@ -90,7 +93,7 @@ namespace traccc {
     while (sreader.read(iosurface)){
 
       geometry_id module = iosurface.geometry_id;
-      
+
       vector3 t{iosurface.cx, iosurface.cy, iosurface.cz};
       vector3 x{iosurface.rot_xu, iosurface.rot_yu, iosurface.rot_zu};
       vector3 z{iosurface.rot_xw, iosurface.rot_yw, iosurface.rot_zw};
@@ -103,21 +106,26 @@ namespace traccc {
   }
 
   /// Read the collection of cells per module and fill into a collection
-  /// 
+  ///
   /// @param creader The cellreader type
+  /// @param resource The memory resource to use for the return value
   /// @param tfmap the (optional) transform map
   /// @param max_cells the (optional) maximum number of cells to be read in
-  std::vector<cell_collection> read_cells(cell_reader& creader, 
-            const std::map<geometry_id, transform3>& tfmap ={}, 
-                unsigned int max_cells = std::numeric_limits<unsigned int>::max()){
+  host_cell_container read_cells(cell_reader& creader,
+            vecmem::memory_resource& resource,
+            const std::map<geometry_id, transform3>& tfmap ={},
+            unsigned int max_cells = std::numeric_limits<unsigned int>::max()){
 
     uint64_t reference_id = 0;
-    std::vector<cell_collection> cell_container;
+    host_cell_container result = {
+      host_cell_container::cell_module_vector( &resource ),
+      host_cell_container::cell_vector( &resource ) };
 
     bool first_line_read = false;
     unsigned int read_cells = 0;
     csv_cell iocell;
-    cell_collection cells;
+    host_cell_collection cells( &resource );
+    cell_module module;
     while (creader.read(iocell)){
 
       if (first_line_read and iocell.geometry_id != reference_id){
@@ -125,46 +133,50 @@ namespace traccc {
         if (not tfmap.empty()){
           auto tfentry = tfmap.find(iocell.geometry_id);
           if (tfentry != tfmap.end()){
-             cells.placement = tfentry->second;
+             module.placement = tfentry->second;
           }
         }
         // Sort in column major order
-        std::sort(cells.items.begin(), cells.items.end(), [](const auto& a, const auto& b){ return a.channel1 < b.channel1; } );
-        cell_container.push_back(cells);
+        std::sort(cells.begin(), cells.end(), [](const auto& a, const auto& b){ return a.channel1 < b.channel1; } );
+        result.modules.push_back(module);
+        result.cells.push_back(cells);
         // Clear for next round
-        cells = cell_collection();
+        cells = host_cell_collection( &resource );
+        module = cell_module();
       }
       first_line_read = true;
       reference_id = static_cast<uint64_t>(iocell.geometry_id);
 
-      cells.module = reference_id;
-      cells.range0[0] = std::min(cells.range0[0],iocell.channel0);
-      cells.range0[1] = std::max(cells.range0[1],iocell.channel0);
-      cells.range1[0] = std::min(cells.range1[0],iocell.channel1);
-      cells.range1[1] = std::max(cells.range1[1],iocell.channel1);
+      module.module = reference_id;
+      module.range0[0] = std::min(module.range0[0],iocell.channel0);
+      module.range0[1] = std::max(module.range0[1],iocell.channel0);
+      module.range1[0] = std::min(module.range1[0],iocell.channel1);
+      module.range1[1] = std::max(module.range1[1],iocell.channel1);
 
-      cells.items.push_back(cell{iocell.channel0, iocell.channel1, iocell.value, iocell.timestamp});
+      cells.push_back(cell{iocell.channel0, iocell.channel1, iocell.value, iocell.timestamp});
       if (++read_cells >= max_cells){
         break;
       }
-    }    
+    }
 
     // Clean up after loop
     // Sort in column major order
-    std::sort(cells.items.begin(), cells.items.end(), [](const auto& a, const auto& b){ return a.channel1 < b.channel1; } );
-    cell_container.push_back(cells);
+    std::sort(cells.begin(), cells.end(), [](const auto& a, const auto& b){ return a.channel1 < b.channel1; } );
+    result.modules.push_back(module);
+    result.cells.push_back(cells);
+    assert( result.cells.size() == result.modules.size() );
 
-    return cell_container;
+    return result;
   }
 
   /// Read the collection of cells per module and fill into a collection
   /// of truth clusters.
-  /// 
+  ///
   /// @param creader The cellreader type
   /// @param tfmap the (optional) transform map
   /// @param max_clusters the (optional) maximum number of cells to be read in
-  std::vector<cluster_collection> read_truth_clusters(cell_reader& creader, 
-            const std::map<geometry_id, transform3>& tfmap ={}, 
+  std::vector<cluster_collection> read_truth_clusters(cell_reader& creader,
+            const std::map<geometry_id, transform3>& tfmap ={},
                 unsigned int max_cells = std::numeric_limits<unsigned int>::max()){
 
     // Reference for switching the container
@@ -199,7 +211,7 @@ namespace traccc {
       if (first_line_read and truth_id != iocell.hit_id){
           truth_clusters.items.push_back({truth_cells});
           truth_cells.clear();
-      } 
+      }
       truth_cells.push_back(cell{iocell.channel0, iocell.channel1, iocell.value, iocell.timestamp});
 
       first_line_read = true;
@@ -209,7 +221,7 @@ namespace traccc {
       if (++read_cells >= max_cells){
         break;
       }
-    }    
+    }
 
     return cluster_container;
   }

--- a/tests/algorithms/CMakeLists.txt
+++ b/tests/algorithms/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_traccc_test(component_connection component_connection_tests.cpp "")
+add_traccc_test(component_connection component_connection_tests.cpp vecmem::core)

--- a/tests/algorithms/component_connection_tests.cpp
+++ b/tests/algorithms/component_connection_tests.cpp
@@ -1,7 +1,7 @@
 /** TRACCC library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2021 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 
@@ -9,30 +9,35 @@
 #include "edm/cluster.hpp"
 #include "algorithms/component_connection.hpp"
 
+#include <vecmem/memory/host_memory_resource.hpp>
+
 #include <gtest/gtest.h>
 
 // This defines the local frame test suite
 TEST(algorithms, component_connection){
 
-    /// Following [DOI: 10.1109/DASIP48288.2019.9049184]
-    std::vector<traccc::cell> cell_items = 
-        { {1, 0, 1., 0. }, 
-          {8, 4, 2., 0.}, 
-          {10, 4, 3., 0.}, 
-          {9, 5, 4., 0.}, 
-          {10, 5, 5., 0}, 
-          {12, 12, 6, 0}, 
-          {3, 13, 7, 0}, 
-          {11, 13, 8, 0}, 
-          {4, 14, 9, 0 } };
+    // Memory resource used in the test.
+    vecmem::host_memory_resource resource;
 
-    traccc::cell_collection cells;
-    cells.items = cell_items;
-    cells.module = 0;
+    /// Following [DOI: 10.1109/DASIP48288.2019.9049184]
+    traccc::host_cell_collection cells =
+      { { {1, 0, 1., 0. },
+          {8, 4, 2., 0.},
+          {10, 4, 3., 0.},
+          {9, 5, 4., 0.},
+          {10, 5, 5., 0},
+          {12, 12, 6, 0},
+          {3, 13, 7, 0},
+          {11, 13, 8, 0},
+          {4, 14, 9, 0 } },
+        &resource };
+
+    traccc::cell_module module;
+    module.module = 0;
 
     traccc::component_connection ccl;
-    auto clusters = ccl(cells);
-   
+    auto clusters = ccl(cells, module);
+
     ASSERT_EQ(clusters.items.size(), 4u);
 
 }

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_traccc_test(csv_io_tests csv_io_tests.cpp traccc::io)
+add_traccc_test(csv_io_tests csv_io_tests.cpp "traccc::io;vecmem::core" )


### PR DESCRIPTION
So... This is how I imagine that we should try to organise the EDM in traccc using [vecmem](https://github.com/acts-project/vecmem).

The design of the updated `traccc::cell_collection` and `traccc::cell_container` structs is the same as what I outlined a while ago in https://github.com/krasznaa/traccc/commit/6a75c4915d49c97fe69763e2c1475ebfd1f93c03, and what @stephenswat did in #19. It makes `traccc::cell_container` into a struct that holds a "simple vector" of "header information" for each detector module in the event, and a "jagged vector" that holds all of the cells belonging to all of those detector modules.

It's just that, unlike the previous 2 examples, this time around I did all of this using the VecMem types in a (hopefully) clever templated way. Abstracting the vector types out of the container types. Plus I added a bunch of code for handling the data from the updated `traccc::cell_container` in a GPU friendly way. But none of that is exercised in the code at this point yet.

Then I went and updated all of the algorithmic code to use the updated EDM correctly. Most of this meant relatively simple changes. Making sure that the CSV reading code would make use of `vecmem::memory_resource` and that "cell" and "module" information would be handled in separate objects.

The only really tricky part (in my mind at least) is what I did with `traccc::component_connection`. I was desperately trying to re-write that code in a templated way in which the compiler could correctly instantiate the type's operators based on what specialisation of `traccc::cell_collection` they receive. But as I explained in a detailed e-mail on the `atlas-sw-core` mailing list over the weekend (sorry for those not in ATLAS :frowning:), this doesn't work quite as well as I was hoping it would. I can give a longer explanation in the discussion if needed.

Instead I created a separate public and private interface for `traccc::component_connection`. The public interface provides functions specifically for the "host" and "device" EDM types, while the templated implementation was made private. This way the user can make use of the class with simple calls, while internally the algorithm is still only implemented once. This is not as elegant as I was hoping it to be, but I thought for now it should suffice.

Note that basically all functions will eventually need to be re-written never to return EDM objects, but just to operate on existing ones. So that the algorithms would not have to decide themselves how the memory management of the objects would be set up. (Avoiding the change in this PR for instance, where `traccc::read_cells(...)` needs to receive a `vecmem::memory_resource` parameter.) But I didn't want to do that already in this PR.

For a proper implementation of the clusterization on GPUs, the cluster EDM will need to be re-written in a similar fashion as well. We should discuss in the PR whether that should be added to this PR, or be done separately once/if this PR goes in.

Pinging @stephenswat, @paulgessinger, @asalzburger, @beomki-yeo and @SylvainJoube.