### PR TITLE
Configure policybot to not interpret comments as approval

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -13,3 +13,7 @@ approval_rules:
     allow_contributor: true # Update button 'contributions' should be ignored
     invalidate_on_push: true
     ignore_update_merges: true
+
+  methods:
+    comments: []
+    github_review: true


### PR DESCRIPTION
@krasznaa I think this should remove the behavior we saw in #24.