### PR TITLE
Swap from std::array to a GPU friendly array type

### DIFF
--- a/core/include/definitions/algebra.hpp
+++ b/core/include/definitions/algebra.hpp
@@ -445,7 +445,7 @@ namespace traccc
          * 
          * @param v the input vector
          **/
-        std::array<scalar, 3> normalize(const std::array<scalar, 2> &v)
+        std::array<scalar, 2> normalize(const std::array<scalar, 2> &v)
         {
             scalar oon = 1. / std::sqrt(dot(v, v));
             return {v[0] * oon, v[1] * oon};

--- a/core/include/definitions/algebra.hpp
+++ b/core/include/definitions/algebra.hpp
@@ -17,42 +17,42 @@
 namespace traccc
 {
 
-    std::array<scalar, 2> operator*(const std::array<scalar, 2> &a, scalar s)
+    vector2 operator*(const vector2 &a, scalar s)
     {
         return {a[0] * s, a[1] * s};
     }
 
-    std::array<scalar, 2> operator*(scalar s, const std::array<scalar, 2> &a)
+    vector2 operator*(scalar s, const vector2 &a)
     {
         return {s * a[0], s * a[1]};
     }
 
-    std::array<scalar, 2> operator-(const std::array<scalar, 2> &a, const std::array<scalar, 2> &b)
+    vector2 operator-(const vector2 &a, const vector2 &b)
     {
         return {a[0] - b[0], a[1] - b[1]};
     }
 
-    std::array<scalar, 2> operator+(const std::array<scalar, 2> &a, const std::array<scalar, 2> &b)
+    vector2 operator+(const vector2 &a, const vector2 &b)
     {
         return {a[0] + b[0], a[1] + b[1]};
     }
 
-    std::array<scalar, 3> operator*(const std::array<scalar, 3> &a, scalar s)
+    vector3 operator*(const vector3 &a, scalar s)
     {
         return {a[0] * s, a[1] * s, a[2] * s};
     }
 
-    std::array<scalar, 3> operator*(scalar s, const std::array<scalar, 3> &a)
+    vector3 operator*(scalar s, const vector3 &a)
     {
         return {s * a[0], s * a[1], s * a[2]};
     }
 
-    std::array<scalar, 3> operator-(const std::array<scalar, 3> &a, const std::array<scalar, 3> &b)
+    vector3 operator-(const vector3 &a, const vector3 &b)
     {
         return {a[0] - b[0], a[1] - b[1], a[2] - b[2]};
     }
 
-    std::array<scalar, 3> operator+(const std::array<scalar, 3> &a, const std::array<scalar, 3> &b)
+    vector3 operator+(const vector3 &a, const vector3 &b)
     {
         return {a[0] + b[0], a[1] + b[1], a[2] + b[2]};
     }
@@ -70,7 +70,7 @@ namespace traccc
          * 
          * @return a vector (expression) representing the cross product
          **/
-        std::array<scalar, 3> cross(const std::array<scalar, 3> &a, const std::array<scalar, 3> &b)
+        vector3 cross(const vector3 &a, const vector3 &b)
         {
             return {a[1] * b[2] - b[1] * a[2], a[2] * b[0] - b[2] * a[0], a[0] * b[1] - b[0] * a[1]};
         }
@@ -113,7 +113,7 @@ namespace traccc
          * 
          * @param v the input vector 
          **/
-        auto norm(const std::array<scalar, 2> &v)
+        auto norm(const vector2 &v)
         {
             return perp(v);
         }
@@ -122,7 +122,7 @@ namespace traccc
          * 
          * @param v the input vector 
          **/
-        auto norm(const std::array<scalar, 3> &v)
+        auto norm(const vector3 &v)
         {
             return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
         }
@@ -436,7 +436,7 @@ namespace traccc
          * 
          * @return the scalar dot product value 
          **/
-        scalar dot(const std::array<scalar, 2> &a, const std::array<scalar, 2> &b)
+        scalar dot(const vector2 &a, const vector2 &b)
         {
             return a[0] * b[0] + a[1] * b[1];
         }
@@ -445,7 +445,7 @@ namespace traccc
          * 
          * @param v the input vector
          **/
-        std::array<scalar, 2> normalize(const std::array<scalar, 2> &v)
+        vector2 normalize(const vector2 &v)
         {
             scalar oon = 1. / std::sqrt(dot(v, v));
             return {v[0] * oon, v[1] * oon};
@@ -458,7 +458,7 @@ namespace traccc
          * 
          * @return the scalar dot product value 
          **/
-        scalar dot(const std::array<scalar, 3> &a, const std::array<scalar, 3> &b)
+        scalar dot(const vector3 &a, const vector3 &b)
         {
             return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
         }
@@ -467,7 +467,7 @@ namespace traccc
          * 
          * @param v the input vector
          **/
-        std::array<scalar, 3> normalize(const std::array<scalar, 3> &v)
+        vector3 normalize(const vector3 &v)
         {
             scalar oon = 1. / std::sqrt(dot(v, v));
             return {v[0] * oon, v[1] * oon, v[2] * oon};

--- a/core/include/definitions/algebra.hpp
+++ b/core/include/definitions/algebra.hpp
@@ -144,7 +144,7 @@ namespace traccc
         template <unsigned int kROWS, typename matrix_type>
         auto vector(const matrix_type &m, unsigned int row, unsigned int col) noexcept
         {
-            std::array<scalar, kROWS> subvector;
+            array<scalar, kROWS> subvector;
             for (unsigned int irow = row; irow < row + kROWS; ++irow)
             {
                 subvector[irow - row] = m[col][irow];
@@ -159,7 +159,7 @@ namespace traccc
         template <unsigned int kROWS, unsigned int kCOLS, typename matrix_type>
         auto block(const matrix_type &m, unsigned int row, unsigned int col) noexcept
         {
-            std::array<std::array<scalar, kROWS>, kCOLS> submatrix;
+            array<array<scalar, kROWS>, kCOLS> submatrix;
             for (unsigned int icol = col; icol < col + kCOLS; ++icol)
             {
                 for (unsigned int irow = row; irow < row + kROWS; ++irow)
@@ -177,7 +177,7 @@ namespace traccc
         struct transform3
         {
 
-            using matrix44 = std::array<std::array<scalar, 4>, 4>;
+            using matrix44 = array<array<scalar, 4>, 4>;
 
             matrix44 _data;
             matrix44 _data_inv;
@@ -253,7 +253,7 @@ namespace traccc
              * 
              * @param ma is the full 4x4 matrix 16 array
              **/
-            transform3(const std::array<scalar, 16> &ma)
+            transform3(const array<scalar, 16> &ma)
             {
                 _data[0][0] = ma[0];
                 _data[0][1] = ma[4];

--- a/core/include/definitions/array.hpp
+++ b/core/include/definitions/array.hpp
@@ -1,0 +1,167 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace traccc {
+    template<typename T, std::size_t N>
+    class array {
+    public:
+        using size_type = std::size_t;
+
+        array(
+            void
+        ) {
+        }
+
+        template<
+            typename ... Tp,
+            typename = std::enable_if_t<sizeof ...(Tp) == N>,
+            typename = std::enable_if_t<(std::is_convertible_v<Tp, T> && ...)>
+        >
+        array(
+            Tp && ... a
+        )
+            : array(std::index_sequence_for<Tp ...>(), std::forward<Tp>(a) ...)
+        {}
+
+        constexpr
+        T &
+        at(
+            size_type i
+        ) {
+            if (i >= N) {
+                throw std::out_of_range();
+            }
+
+            return operator[](i);
+        }
+
+        constexpr
+        const T &
+        at(
+            size_type i
+        ) const {
+            if (i >= N) {
+                throw std::out_of_range();
+            }
+
+            return operator[](i);
+        }
+
+        constexpr
+        T &
+        operator[](
+            size_type i
+        ) {
+            return v[i];
+        }
+
+        constexpr
+        const T &
+        operator[](
+            size_type i
+        ) const {
+            return v[i];
+        }
+
+        constexpr
+        T &
+        front(
+            void
+        ) {
+            return v[0];
+        }
+
+        constexpr
+        const T &
+        front(
+            void
+        ) const {
+            return v[0];
+        }
+
+        constexpr
+        T &
+        back(
+            void
+        ) {
+            return v[N - 1];
+        }
+
+        constexpr
+        const T &
+        back(
+            void
+        ) const {
+            return v[N - 1];
+        }
+
+        constexpr
+        T *
+        data(
+            void
+        ) {
+            return v;
+        }
+
+        constexpr
+        const T *
+        data(
+            void
+        ) const {
+            return v;
+        }
+
+    private:
+        template<
+            size_type ... Is,
+            typename ... Tp
+        >
+        array(
+            std::index_sequence<Is ...>,
+            Tp && ... a
+        ) {
+            (static_cast<void>(v[Is] = a), ...);
+        }
+
+        T v[N];
+    };
+
+    template<typename T, std::size_t N>
+    bool
+    operator==(
+        const array<T, N> & lhs,
+        const array<T, N> & rhs
+    ) {
+        for (typename array<T, N>::size_type i = 0; i < N; ++i) {
+            if (lhs[i] != rhs[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    template<typename T, std::size_t N>
+    bool
+    operator!=(
+        const array<T, N> & lhs,
+        const array<T, N> & rhs
+    ) {
+        for (typename array<T, N>::size_type i = 0; i < N; ++i) {
+            if (lhs[i] == rhs[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/core/include/definitions/primitives.hpp
+++ b/core/include/definitions/primitives.hpp
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <array>
+#include "array.hpp"
+
 #include <stdint.h>
 
 namespace traccc {
@@ -17,11 +18,11 @@ namespace traccc {
     using event_id = uint64_t;
     using channel_id = unsigned int;
     
-    using vector2 = std::array<scalar, 2>;
-    using point2 = std::array<scalar, 2>;
-    using variance2 = std::array<scalar, 2>;
-    using point3 = std::array<scalar, 3>;
-    using vector3 = std::array<scalar, 3>;
-    using variance3 = std::array<scalar, 3>;
+    using vector2 = array<scalar, 2>;
+    using point2 = array<scalar, 2>;
+    using variance2 = array<scalar, 2>;
+    using point3 = array<scalar, 3>;
+    using vector3 = array<scalar, 3>;
+    using variance3 = array<scalar, 3>;
 
 }


### PR DESCRIPTION
We use `std::array` in a lot of places in the EDM, and obviously this type is not GPU-friendly; it cannot be used in CUDA kernels, for example. To solve this problem, I have implemented a new, basic, GPU-friendly array type to replace it. This merge request does a few things:

1. It fixes a bug where the two-dimensional norm was silently returning a three-dimensional vector.
2. It changes most uses of `std::array` to the typedefs, like `traccc::vector3`.
3. It introduces a new `traccc::array` type which is a little simpler than `std::vector`, a little stricter, but can be used on the GPU.
4. It changes the typedefs like `traccc::vector3` to use the new `traccc::array` type.