### PR TITLE
Rework the vector and matrix types used for algebra

### DIFF
--- a/core/include/definitions/algebra.hpp
+++ b/core/include/definitions/algebra.hpp
@@ -445,7 +445,7 @@ namespace traccc
          * 
          * @param v the input vector
          **/
-        inline std::array<scalar, 3> normalize(const std::array<scalar, 2> &v)
+        inline std::array<scalar, 2> normalize(const std::array<scalar, 2> &v)
         {
             scalar oon = 1. / std::sqrt(dot(v, v));
             return {v[0] * oon, v[1] * oon};
@@ -476,4 +476,3 @@ namespace traccc
     } // namespace vector
 
 } // end of namespace
-

--- a/core/include/definitions/algebra.hpp
+++ b/core/include/definitions/algebra.hpp
@@ -17,42 +17,42 @@
 namespace traccc
 {
 
-    inline std::array<scalar, 2> operator*(const std::array<scalar, 2> &a, scalar s)
+    inline vector2 operator*(const vector2 &a, scalar s)
     {
         return {a[0] * s, a[1] * s};
     }
 
-    inline std::array<scalar, 2> operator*(scalar s, const std::array<scalar, 2> &a)
+    inline vector2 operator*(scalar s, const vector2 &a)
     {
         return {s * a[0], s * a[1]};
     }
 
-    inline std::array<scalar, 2> operator-(const std::array<scalar, 2> &a, const std::array<scalar, 2> &b)
+    inline vector2 operator-(const vector2 &a, const vector2 &b)
     {
         return {a[0] - b[0], a[1] - b[1]};
     }
 
-    inline std::array<scalar, 2> operator+(const std::array<scalar, 2> &a, const std::array<scalar, 2> &b)
+    inline vector2 operator+(const vector2 &a, const vector2 &b)
     {
         return {a[0] + b[0], a[1] + b[1]};
     }
 
-    inline std::array<scalar, 3> operator*(const std::array<scalar, 3> &a, scalar s)
+    inline vector3 operator*(const vector3 &a, scalar s)
     {
         return {a[0] * s, a[1] * s, a[2] * s};
     }
 
-    inline std::array<scalar, 3> operator*(scalar s, const std::array<scalar, 3> &a)
+    inline vector3 operator*(scalar s, const vector3 &a)
     {
         return {s * a[0], s * a[1], s * a[2]};
     }
 
-    inline std::array<scalar, 3> operator-(const std::array<scalar, 3> &a, const std::array<scalar, 3> &b)
+    inline vector3 operator-(const vector3 &a, const vector3 &b)
     {
         return {a[0] - b[0], a[1] - b[1], a[2] - b[2]};
     }
 
-    inline std::array<scalar, 3> operator+(const std::array<scalar, 3> &a, const std::array<scalar, 3> &b)
+    inline vector3 operator+(const vector3 &a, const vector3 &b)
     {
         return {a[0] + b[0], a[1] + b[1], a[2] + b[2]};
     }
@@ -70,7 +70,7 @@ namespace traccc
          * 
          * @return a vector (expression) representing the cross product
          **/
-        inline std::array<scalar, 3> cross(const std::array<scalar, 3> &a, const std::array<scalar, 3> &b)
+        inline vector3 cross(const vector3 &a, const vector3 &b)
         {
             return {a[1] * b[2] - b[1] * a[2], a[2] * b[0] - b[2] * a[0], a[0] * b[1] - b[0] * a[1]};
         }
@@ -113,7 +113,7 @@ namespace traccc
          * 
          * @param v the input vector 
          **/
-        inline auto norm(const std::array<scalar, 2> &v)
+        inline auto norm(const vector2 &v)
         {
             return perp(v);
         }
@@ -122,7 +122,7 @@ namespace traccc
          * 
          * @param v the input vector 
          **/
-        inline auto norm(const std::array<scalar, 3> &v)
+        inline auto norm(const vector3 &v)
         {
             return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
         }
@@ -144,7 +144,7 @@ namespace traccc
         template <unsigned int kROWS, typename matrix_type>
         auto vector(const matrix_type &m, unsigned int row, unsigned int col) noexcept
         {
-            std::array<scalar, kROWS> subvector;
+            array<scalar, kROWS> subvector;
             for (unsigned int irow = row; irow < row + kROWS; ++irow)
             {
                 subvector[irow - row] = m[col][irow];
@@ -159,7 +159,7 @@ namespace traccc
         template <unsigned int kROWS, unsigned int kCOLS, typename matrix_type>
         auto block(const matrix_type &m, unsigned int row, unsigned int col) noexcept
         {
-            std::array<std::array<scalar, kROWS>, kCOLS> submatrix;
+            array<array<scalar, kROWS>, kCOLS> submatrix;
             for (unsigned int icol = col; icol < col + kCOLS; ++icol)
             {
                 for (unsigned int irow = row; irow < row + kROWS; ++irow)
@@ -177,7 +177,7 @@ namespace traccc
         struct transform3
         {
 
-            using matrix44 = std::array<std::array<scalar, 4>, 4>;
+            using matrix44 = array<array<scalar, 4>, 4>;
 
             matrix44 _data;
             matrix44 _data_inv;
@@ -253,7 +253,7 @@ namespace traccc
              * 
              * @param ma is the full 4x4 matrix 16 array
              **/
-            transform3(const std::array<scalar, 16> &ma)
+            transform3(const array<scalar, 16> &ma)
             {
                 _data[0][0] = ma[0];
                 _data[0][1] = ma[4];
@@ -436,7 +436,7 @@ namespace traccc
          * 
          * @return the scalar dot product value 
          **/
-        inline scalar dot(const std::array<scalar, 2> &a, const std::array<scalar, 2> &b)
+        inline scalar dot(const vector2 &a, const vector2 &b)
         {
             return a[0] * b[0] + a[1] * b[1];
         }
@@ -445,7 +445,7 @@ namespace traccc
          * 
          * @param v the input vector
          **/
-        inline std::array<scalar, 2> normalize(const std::array<scalar, 2> &v)
+        inline vector2 normalize(const vector2 &v)
         {
             scalar oon = 1. / std::sqrt(dot(v, v));
             return {v[0] * oon, v[1] * oon};
@@ -458,7 +458,7 @@ namespace traccc
          * 
          * @return the scalar dot product value 
          **/
-        inline scalar dot(const std::array<scalar, 3> &a, const std::array<scalar, 3> &b)
+        inline scalar dot(const vector3 &a, const vector3 &b)
         {
             return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
         }
@@ -467,7 +467,7 @@ namespace traccc
          * 
          * @param v the input vector
          **/
-        inline std::array<scalar, 3> normalize(const std::array<scalar, 3> &v)
+        inline vector3 normalize(const vector3 &v)
         {
             scalar oon = 1. / std::sqrt(dot(v, v));
             return {v[0] * oon, v[1] * oon, v[2] * oon};

--- a/core/include/definitions/primitives.hpp
+++ b/core/include/definitions/primitives.hpp
@@ -16,12 +16,14 @@ namespace traccc {
     using geometry_id = uint64_t;
     using event_id = uint64_t;
     using channel_id = unsigned int;
-    
-    using vector2 = std::array<scalar, 2>;
-    using point2 = std::array<scalar, 2>;
-    using variance2 = std::array<scalar, 2>;
-    using point3 = std::array<scalar, 3>;
-    using vector3 = std::array<scalar, 3>;
-    using variance3 = std::array<scalar, 3>;
 
+    template<typename T, std::size_t N>
+    using array = std::array<T, N>;
+
+    using vector2 = array<scalar, 2>;
+    using point2 = array<scalar, 2>;
+    using variance2 = array<scalar, 2>;
+    using point3 = array<scalar, 3>;
+    using vector3 = array<scalar, 3>;
+    using variance3 = array<scalar, 3>;
 }


### PR DESCRIPTION
This is a continuation of #34. This merge request does the following things:

1. It fixes a bug where the two-dimensional normalize function returned a three-dimensional vector.
2. It changes all uses of `std::array` to use typedefs, so we can switch the types easily later.

The plan is to implement a static array type in vecmem, which will serve as a device-friendly replacement for `std::array`.