### PR TITLE
Use vecmem::static_array for fixed-sized arrays

### DIFF
--- a/core/include/definitions/primitives.hpp
+++ b/core/include/definitions/primitives.hpp
@@ -10,6 +10,7 @@
 #include <stdint.h>
 
 #include <array>
+#include <vecmem/containers/static_array.hpp>
 
 namespace traccc {
 
@@ -19,7 +20,7 @@ using event_id = uint64_t;
 using channel_id = unsigned int;
 
 template <typename T, std::size_t N>
-using array = std::array<T, N>;
+using array = vecmem::static_array<T, N>;
 
 using vector2 = array<scalar, 2>;
 using point2 = array<scalar, 2>;


### PR DESCRIPTION
Currently, we are still using a GPU-unfriendly std::array type in our algebra primitives, but this makes it very hard to use the code on the device size, as `std::array` is often not supported there. Thankfully, the `vecmem::static_array` type can support device code, and this commit changes all algebraic types to use it.