### PR TITLE
Introduce a pre-commit hook for clang-format

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,21 @@
+# traccc git hooks
+
+This directory stores some useful hooks for traccc developers. To install one of
+these hooks, run the following command (from the repository root):
+
+    ln -s $(pwd)/.githooks/pre-commit .git/hooks
+
+If you are using a modern version of coreutils and you need relative paths, for
+example if your mount points may change, use:
+
+    ln -rs .githooks/pre-commit .git/hooks
+
+To install all hooks in this repository, you can also run:
+
+    git config --local core.hooksPath .githooks
+
+## Requirements
+
+These hooks require clang-format to be installed, and findable. Either
+`clang-format` needs to be a binary findable by bash, or the
+`CLANG_FORMAT_BINARY` environment variable must be set to a clang-format binary.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# TRACCC library, part of the ACTS project (R&D line)
+# (c) 2021 CERN for the benefit of the ACTS project
+# Mozilla Public License Version 2.0
+
+# This pre-commit hook checks the formatting of the code according to the
+# .clang-format file present in the repository. To use this hook, you will need
+# clang-format installed, and one of the following must be true:
+#  1. clang-format is binary that can be located by the shell.
+#  2. The CLANG_FORMAT_BINARY environment variable is set.
+
+# Throughout this script, we cannot afford to have any of our commands fail, so
+# we exit immediately if any errors do happen.
+set -e
+
+# Use the portable mktemp command to create a temporary into which we will write
+# some of our temporary files.
+TMP_DIR=$(mktemp -d)
+
+# Declare a function that removes the just-created temporary directory.
+function finish {
+    rm -rf "${TMP_DIR}"
+}
+
+# Ensure that the temporary directory is cleared out if the script exits for any
+# reason, either through exiting naturally, or if there are any errors.
+trap finish EXIT
+
+# Establish which clang-format binary we want to use.
+BINARY=${CLANG_FORMAT_BINARY:-clang-format}
+
+# Determine which files have changed in the index.
+COPY_FILES=$(git diff --name-only --cached)
+
+# If the index is empty, then we have nothing to do. We will pass control back
+# to git itself, so it can handle this strange state from here.
+if [[ -z ${COPY_FILES} ]]; then
+    exit 0
+fi
+
+# Create a copy of the repository, using only the files that are changed in the
+# index, in our temporary directory.
+git checkout-index --prefix=${TMP_DIR}/old/ ${COPY_FILES}
+
+# Make sure our new directory exists. Git will not create the directory if the
+# index is empty, so we will need to check for this.
+if ! [[ -d "${TMP_DIR}/old/" ]]; then
+    echo "ERROR: Temporary directory was not created. Empty index?"
+    exit 1
+fi
+
+# Make a copy of our new index directory, so we can later compare them.
+cp -r ${TMP_DIR}/old/ ${TMP_DIR}/new/
+
+# Copy the clang-format configuration from the git repository.
+cp $(git rev-parse --show-toplevel)/.clang-format ${TMP_DIR}
+
+# Find the list of files we would like to check.
+CHECK_FILES=$(find ${TMP_DIR}/new/ \( -iname '*.cpp' -or -iname '*.hpp' -or -iname '*.ipp' -or -iname '*.cu' -or -iname '*.cuh' -or -iname '*.hip' -or -iname '*.sycl' \))
+
+# If there is not a single file we might want to format, we can just exit. If we
+# don't, clang-format will whinge at us and we don't want that, now do we?
+if [[ -z ${CHECK_FILES} ]]; then
+    exit 0
+fi
+
+# Run clang-format on one of the copies of our index, editing the files
+# in-place. Because we have two copies of the index but we are only formatting
+# one, we can later compare them to see the differences!
+$BINARY -i -style=file ${CHECK_FILES}
+
+# Establish the difference between the two copies of our index. If there are any
+# formatting mistakes, these two directories will differ. If they are the same,
+# this will print nothing and return 0. In that case, the script exits naturally
+# with a zero error code. If there is a difference, then this will print the
+# diff and return a non-zero code. Because we have set the -e flag earlier, this
+# will also exit the hook, preventing a commit.
+diff -u --color -r ${TMP_DIR}/old/ ${TMP_DIR}/new/


### PR DESCRIPTION
As it stands, there are a few ways to ensure your code conforms to `clang-format`. You could run the tool manually, you could run the bash script in the `.github` directory, you could use a CICD simulator like `act`, or you could just push and see what Github actions things of the code. In my opinion, none of these are really ideal, and I think one of the most powerful tools for enforcing formatting standards like this is the pre-commit hook.

This merge request adds a pre-commit hook that will check the user's index for bad formatting, and it will refuse the commit if anything is wrong.

The hook is designed to look only at the index, which has a few advantages. Firstly, it won't reject commits for existing bad formatting in other files. Secondly, it allows users to partially stage files without having to worry about messing up the formatting.

Note that this hook is not automatically installed, any developer that wants to use them has to enable them manually (good, otherwise RCE exploits would be very easy). Instructions on how to do that are included in the `.githooks/README.md` file.