### PR TITLE
VecMem Version Update, main branch (2021.07.08.)

### DIFF
--- a/cmake/traccc-vecmem.cmake
+++ b/cmake/traccc-vecmem.cmake
@@ -28,7 +28,7 @@ message( STATUS "Building VecMem as part of the traccc project" )
 # Declare where to get VecMem from.
 FetchContent_Declare( VecMem
    GIT_REPOSITORY "https://github.com/acts-project/vecmem.git"
-   GIT_TAG "2e06a5167e0927e6e6ed6a4f1abd5b5f552f059f" )
+   GIT_TAG "v0.2.0" )
 
 # Prevent VecMem from building its tests. As it would interfere with how traccc
 # builds/uses GoogleTest.


### PR DESCRIPTION
Updated the project to build [VecMem v0.2.0](https://github.com/acts-project/vecmem/releases/tag/v0.2.0) by default.

As I discussed with @stephenswat today, we desperately need to introduce some CI checks for the repository. As the current main branch doesn't build out of the box for instance. (Because the VecMem version built by it by default is too old.)