### PR TITLE
Add a simple CI build workflow

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,6 +1,7 @@
 name: Builds
 
 on:
+  push:
   pull_request:
     branches:
       - main

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -8,15 +8,15 @@ on:
 
 jobs:
   builds:
-    name: ${{ matrix.platform.name }}
+    name: ${{ matrix.platform.name }}-${{ matrix.build }}
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2004:v11
     strategy:
       matrix:
         platform:
-          - name: cpu
+          - name: CPU
             container: ghcr.io/acts-project/ubuntu2004:v11
-          - name: cuda
+          - name: CUDA
             container: ghcr.io/acts-project/ubuntu1804_cuda:v11
         build:
           - Release

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,0 +1,30 @@
+name: Builds
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  builds:
+    name: ${{ matrix.platform.name }}
+    runs-on: ubuntu-latest
+    container: ghcr.io/acts-project/ubuntu2004:v11
+    strategy:
+      matrix:
+        platform:
+          - name: cpu
+            container: ghcr.io/acts-project/ubuntu2004:v11
+          - name: cuda
+            container: ghcr.io/acts-project/ubuntu1804_cuda:v11
+        build:
+          - Release
+          - Debug
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Configure
+        run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.build }} -B build -S .
+      - name: Build
+        run: cmake --build build --


### PR DESCRIPTION
We've had an issue recently where a commit slipped through the CI system and broke the entire `traccc` build. This is not necessarily unexpected, because our current CI system doesn't actually do any checks whether the code still builds. This commit aims to resolve that situation by adding a workflow that tries to build the code, and fails if there is a compiler error. This workflow will build the code in `Release` and `Debug` builds, and it will use a standard CPU image as well as an image with the CUDA compiler.