### PR TITLE
Use HTTPS for data submodule instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/msmk0/dfelibs.git
 [submodule "data"]
 	path = data
-	url = ssh://git@gitlab.cern.ch:7999/acts/traccc-data.git
+	url = https://gitlab.cern.ch/acts/traccc-data.git


### PR DESCRIPTION
Currently, the submodule for the traccc data, which comes from CERN Gitlab, is set to use SSH. However, this means that anyone who cannot log in to CERN Gitlab cannot fully check out this repository. By changing to the HTTPS protocol, we resolve this issue, since the data repository is public. This should make it easier for external developers to work on traccc, and it will make working with CI easier (see #50).