### PR TITLE
Add macros for host and device qualifiers

### DIFF
--- a/core/include/definitions/qualifiers.hpp
+++ b/core/include/definitions/qualifiers.hpp
@@ -1,0 +1,27 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#if defined(__CUDACC__)
+#define TRACCC_DEVICE __device__
+#else
+#define TRACCC_DEVICE
+#endif
+
+#if defined(__CUDACC__)
+#define TRACCC_HOST __host__
+#else
+#define TRACCC_HOST
+#endif
+
+#if defined(__CUDACC__)
+#define TRACCC_HOST_DEVICE __host__ __device__
+#else
+#define TRACCC_HOST_DEVICE
+#endif


### PR DESCRIPTION
As with some of the other ACTS projects, we will want to have some macros to add host and device (or both) qualifiers to functions without having the non-CUDA compiler implode on itself.