### PR TITLE
Add Acts as a dependency through FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ include( traccc-compiler-options )
 
 # Build the necessary externals.
 add_subdirectory(extern)
-include( traccc-vecmem )
+include(traccc-dependencies)
 
 # Build the traccc code.
 add_subdirectory(core)

--- a/cmake/traccc-acts.cmake
+++ b/cmake/traccc-acts.cmake
@@ -1,0 +1,31 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Guard against multiple includes.
+include_guard(GLOBAL)
+
+# Try to find ACTS installed on the system.
+find_package(Acts QUIET)
+
+# If it was found, then we're finished.
+if(Acts_FOUND)
+   # Call find_package again, just to nicely print where it is picked up from.
+   find_package(Acts)
+   return()
+endif()
+
+# Tell the user what's happening.
+message(STATUS "Building ACTS as part of the traccc project")
+
+# Declare where to get ACTS from.
+FetchContent_Declare(
+   Acts
+   GIT_REPOSITORY "https://github.com/acts-project/acts.git"
+   GIT_TAG "v9.2.0"
+)
+
+# Make the ACTS source available to the rest of the build system.
+FetchContent_MakeAvailable(Acts)

--- a/cmake/traccc-acts.cmake
+++ b/cmake/traccc-acts.cmake
@@ -7,7 +7,7 @@
 # Guard against multiple includes.
 include_guard(GLOBAL)
 
-# Try to find ACTS installed on the system.
+# Try to find Acts installed on the system.
 find_package(Acts QUIET)
 
 # If it was found, then we're finished.
@@ -18,14 +18,15 @@ if(Acts_FOUND)
 endif()
 
 # Tell the user what's happening.
-message(STATUS "Building ACTS as part of the traccc project")
+message(STATUS "Building Acts as a dependency of traccc")
 
-# Declare where to get ACTS from.
+# Declare where to get Acts from.
 FetchContent_Declare(
    Acts
    GIT_REPOSITORY "https://github.com/acts-project/acts.git"
    GIT_TAG "v9.2.0"
 )
 
-# Make the ACTS source available to the rest of the build system.
-FetchContent_MakeAvailable(Acts)
+# Make the Acts source available to the rest of the build system.
+FetchContent_Populate(Acts)
+add_subdirectory("${acts_SOURCE_DIR}" "${acts_BINARY_DIR}" EXCLUDE_FROM_ALL)

--- a/cmake/traccc-dependencies.cmake
+++ b/cmake/traccc-dependencies.cmake
@@ -1,0 +1,15 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+include_guard(GLOBAL)
+
+# CMake include(s).
+cmake_minimum_required(VERSION 3.11)
+include(FetchContent)
+
+# Include the CMake scripts for vecmem and the ACTS core.
+include(traccc-vecmem)
+include(traccc-acts)

--- a/cmake/traccc-vecmem.cmake
+++ b/cmake/traccc-vecmem.cmake
@@ -18,10 +18,6 @@ if( vecmem_FOUND )
    return()
 endif()
 
-# CMake include(s).
-cmake_minimum_required( VERSION 3.11 )
-include( FetchContent )
-
 # Tell the user what's happening.
 message( STATUS "Building VecMem as part of the traccc project" )
 


### PR DESCRIPTION
As we have seen in #35, we need to somehow include ACTS as a dependency for traccc so we can compile it easily, including on the CI. To make this possible, this pull request adds some CMake code to fetch and build the ACTS core in the same way that we build the vecmem code right now. That is to say, we see if it is installed on the system. If it is, we're done. If it isn't, CMake fetches the code from source for us, and adds it into the tree for building. This should give us a flexible solution to the dependency problem, at least for now.

Thanks Attila for laying most of the groundwork for this in your vecmem CMake file. :smiley: 