### PR TITLE
Add a fixture base class for tests using data

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,25 @@
+enable_testing()
+
+macro(add_traccc_test TESTNAME FILES PLUGIN_LIBRARY)
+    add_executable(${TESTNAME} ${FILES})
+    target_link_libraries(${TESTNAME} gtest gmock gtest_main)
+    target_link_libraries(${TESTNAME} traccc::core)
+    target_link_libraries(${TESTNAME} traccc::tests::common)
+    target_link_libraries(${TESTNAME} ${PLUGIN_LIBRARY})
+    set_target_properties(${TESTNAME} PROPERTIES FOLDER tests)
+    add_test(unit_test_${TESTNAME} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TESTNAME})
+    set_tests_properties(unit_test_${TESTNAME} PROPERTIES
+    ENVIRONMENT TRACCC_TEST_DATA_DIR=${PROJECT_SOURCE_DIR}/data/)
+endmacro()
+
+add_library(traccc_tests_common INTERFACE)
+
+target_include_directories(
+    traccc_tests_common
+    INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+
+add_library(traccc::tests::common ALIAS traccc_tests_common)
+
 add_subdirectory(cpu)

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -1,15 +1,2 @@
-enable_testing()
-
-macro(add_traccc_test TESTNAME FILES PLUGIN_LIBRARY)
-    add_executable(${TESTNAME} ${FILES})
-    target_link_libraries(${TESTNAME} gtest gmock gtest_main)
-    target_link_libraries(${TESTNAME} traccc::core)
-    target_link_libraries(${TESTNAME} ${PLUGIN_LIBRARY})
-    set_target_properties(${TESTNAME} PROPERTIES FOLDER tests)
-    add_test(unit_test_${TESTNAME} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TESTNAME})
-    set_tests_properties(unit_test_${TESTNAME} PROPERTIES 
-    ENVIRONMENT TRACCC_TEST_DATA_DIR=${PROJECT_SOURCE_DIR}/data/)
-endmacro()
-
 add_subdirectory(io)
 add_subdirectory(algorithms)

--- a/tests/cpu/io/csv_io_tests.cpp
+++ b/tests/cpu/io/csv_io_tests.cpp
@@ -10,18 +10,13 @@
 #include <vecmem/memory/host_memory_resource.hpp>
 
 #include "csv/csv_io.hpp"
+#include "tests/data_test.hpp"
+
+class io : public traccc::tests::data_test {};
 
 // This defines the local frame test suite
-TEST(io, csv_read_single_module) {
-
-    auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
-    }
-    auto data_directory = std::string(env_d_d) + std::string("/");
-
-    std::string file = data_directory + std::string("single_module/cells.csv");
+TEST_F(io, csv_read_single_module) {
+    std::string file = get_datafile("single_module/cells.csv");
     traccc::cell_reader creader(
         file, {"module", "cannel0", "channel1", "activation", "time"});
 
@@ -42,14 +37,8 @@ TEST(io, csv_read_single_module) {
 }
 
 // This defines the local frame test suite
-TEST(io, csv_read_two_modules) {
-    auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
-    }
-    auto data_directory = std::string(env_d_d);
-    std::string file = data_directory + std::string("two_modules/cells.csv");
+TEST_F(io, csv_read_two_modules) {
+    std::string file = get_datafile("two_modules/cells.csv");
 
     traccc::cell_reader creader(
         file, {"module", "cannel0", "channel1", "activation", "time"});
@@ -82,16 +71,8 @@ TEST(io, csv_read_two_modules) {
 }
 
 // This reads in the tml pixel barrel first event
-TEST(io, csv_read_tml_transforms) {
-
-    auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
-    }
-    auto data_directory = std::string(env_d_d);
-    std::string file =
-        data_directory + std::string("tml_detector/trackml-detector.csv");
+TEST_F(io, csv_read_tml_transforms) {
+    std::string file = get_datafile("tml_detector/trackml-detector.csv");
 
     traccc::surface_reader sreader(
         file, {"geometry_id", "cx", "cy", "cz", "rot_xu", "rot_xv", "rot_xw",
@@ -102,16 +83,9 @@ TEST(io, csv_read_tml_transforms) {
 }
 
 // This reads in the tml pixel barrel first event
-TEST(io, csv_read_tml_pixelbarrel) {
-
-    auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
-    }
-    auto data_directory = std::string(env_d_d);
-    std::string file = data_directory +
-                       std::string("tml_pixel_barrel/event000000000-cells.csv");
+TEST_F(io, csv_read_tml_pixelbarrel) {
+    std::string file =
+        get_datafile("tml_pixel_barrel/event000000000-cells.csv");
 
     traccc::cell_reader creader(
         file, {"module", "cannel0", "channel1", "activation", "time"});

--- a/tests/include/tests/data_test.hpp
+++ b/tests/include/tests/data_test.hpp
@@ -1,0 +1,42 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::tests {
+/**
+ * @brief Test fixture base class for accessing the data directory.
+ *
+ * We have a lot of tests which need to access data from the data directory,
+ * which is set via the TRACCC_TEST_DATA_DIR environment variable. This raises
+ * a lot of boilerplate code though, so we can abstract some of this away by
+ * defining a fixture base class which automatically grabs the data directory.
+ *
+ * @warning If you need to write a fixture which subclasses this class and you
+ * need a custom SetUp function, make sure to mark it as `override` and make
+ * sure to call `data_test::SetUp()` at the start of it.
+ */
+class data_test : public ::testing::Test {
+    protected:
+    std::string data_directory;
+
+    virtual void SetUp() override {
+        char* env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
+
+        if (env_d_d == nullptr) {
+            throw std::ios_base::failure(
+                "Test data directory not found. Please set "
+                "TRACCC_TEST_DATA_DIR.");
+        }
+
+        data_directory = std::string(env_d_d) + std::string("/");
+    }
+
+    std::string get_datafile(std::string name) { return data_directory + name; }
+};
+}  // namespace traccc::tests


### PR DESCRIPTION
We have a lot of tests which need to access data from the data directory, which is set via the `TRACCC_TEST_DATA_DIR` environment variable. This raises a lot of boilerplate code though, so we can abstract some of this away by defining a fixture base class which automatically grabs the data directory.