### PR TITLE
Decouple I/O from traccc's algorithm

### DIFF
--- a/examples/openmp/CMakeLists.txt
+++ b/examples/openmp/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_executable (par_example par_example.cpp)
 target_link_libraries (par_example LINK_PUBLIC traccc::core traccc::io vecmem::core OpenMP::OpenMP_CXX)
+
+add_subdirectory(io_decoupled)

--- a/examples/openmp/io_decoupled/CMakeLists.txt
+++ b/examples/openmp/io_decoupled/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(io_dec_par_example io_dec_par_example.cpp)
+target_link_libraries(io_dec_par_example LINK_PUBLIC traccc::core traccc::io vecmem::core OpenMP::OpenMP_CXX)

--- a/examples/openmp/io_decoupled/io_dec_par_example.cpp
+++ b/examples/openmp/io_decoupled/io_dec_par_example.cpp
@@ -1,0 +1,116 @@
+#include "algorithms/component_connection.hpp"
+#include "algorithms/measurement_creation.hpp"
+#include "algorithms/spacepoint_formation.hpp"
+#include "edm/measurement.hpp"
+#include "edm/spacepoint.hpp"
+#include "reader.hpp"
+#include "writer.hpp"
+#include "tmp_edm.hpp"
+
+#include <iostream>
+#include <chrono>
+
+traccc::demonstrator_result run(traccc::demonstrator_input input_data, vecmem::host_memory_resource resource) {
+
+    // Algorithms
+    traccc::component_connection cc;
+    traccc::measurement_creation mt;
+    traccc::spacepoint_formation sp;
+
+    auto startAlgorithms = std::chrono::system_clock::now();
+
+    // Output stats
+    int64_t n_modules = 0;
+    uint64_t n_cells = 0;
+    uint64_t n_clusters = 0;
+    uint64_t n_measurements = 0;
+    uint64_t n_space_points = 0;
+
+    traccc::demonstrator_result aggregated_results(input_data.size(), &resource);
+
+#pragma omp parallel for reduction(+:n_modules, n_cells, n_clusters, n_measurements, n_space_points)
+    for (size_t event = 0; event < input_data.size(); ++event) {
+        traccc::host_cell_container cells_per_event = input_data.operator[](event);
+
+        traccc::host_measurement_container measurements_per_event;
+        traccc::host_spacepoint_container spacepoints_per_event;
+        measurements_per_event.headers.reserve(cells_per_event.headers.size());
+        measurements_per_event.items.reserve(cells_per_event.headers.size());
+        spacepoints_per_event.headers.reserve(cells_per_event.headers.size());
+        spacepoints_per_event.items.reserve(cells_per_event.headers.size());
+
+#pragma omp parallel for
+        for (size_t i = 0; i < cells_per_event.items.size(); ++i) {
+            auto &module = cells_per_event.headers[i];
+            module.pixel = traccc::pixel_segmentation{-8.425, -36.025, 0.05, 0.05};
+
+            // The algorithmic code part: start
+            traccc::cluster_collection clusters_per_module =
+                    cc({cells_per_event.items[i], cells_per_event.headers[i]});
+            clusters_per_module.position_from_cell = module.pixel;
+
+            traccc::host_measurement_collection measurements_per_module =
+                    mt({clusters_per_module, module});
+            traccc::host_spacepoint_collection spacepoints_per_module =
+                    sp({module, measurements_per_module});
+            // The algorithmnic code part: end
+
+            n_cells += cells_per_event.items[i].size();
+            n_clusters += clusters_per_module.items.size();
+            n_measurements += measurements_per_module.size();
+            n_space_points += spacepoints_per_module.size();
+
+#pragma omp critical
+            {
+                measurements_per_event.items.push_back(
+                        std::move(measurements_per_module));
+                measurements_per_event.headers.push_back(module);
+
+                spacepoints_per_event.items.push_back(
+                        std::move(spacepoints_per_module));
+                spacepoints_per_event.headers.push_back(module.module);
+            }
+        }
+
+        aggregated_results[event] = traccc::result({measurements_per_event, spacepoints_per_event});
+
+    }
+
+    auto endAlgorithms = std::chrono::system_clock::now();
+    std::chrono::duration<double> diffAlgo = endAlgorithms - startAlgorithms;
+    std::cout << "Algorithms time: " << diffAlgo.count() << " sec." << std::endl;
+
+    std::cout << "==> Statistics ... " << std::endl;
+    std::cout << "- read    " << n_cells << " cells from " << n_modules << " modules" << std::endl;
+    std::cout << "- created " << n_clusters << " clusters. " << std::endl;
+    std::cout << "- created " << n_measurements << " measurements. " << std::endl;
+    std::cout << "- created " << n_space_points << " space points. " << std::endl;
+
+    return aggregated_results;
+
+}
+
+// The main routine
+int main(int argc, char *argv[]) {
+
+    if (argc < 4) {
+        std::cout << "Not enough arguments, minimum requirement: " << std::endl;
+        std::cout << "./io_dec_par_example <detector_file> <cell_directory> <events>" << std::endl;
+        return -1;
+    }
+
+    auto detector_file = std::string(argv[1]);
+    auto cell_directory = std::string(argv[2]);
+    auto events = static_cast<size_t> (std::atoi(argv[3]));
+
+    auto start = std::chrono::system_clock::now();
+    vecmem::host_memory_resource resource;
+    set_default_resource(&resource);
+
+    traccc::write(
+            run(traccc::read(events, detector_file, cell_directory, resource), resource));
+
+    auto end = std::chrono::system_clock::now();
+    std::chrono::duration<double> diff = end - start;
+    std::cout << "Total execution time: " << diff.count() << " sec." << std::endl;
+}

--- a/examples/openmp/io_decoupled/io_dec_par_example.cpp
+++ b/examples/openmp/io_decoupled/io_dec_par_example.cpp
@@ -108,7 +108,8 @@ int main(int argc, char *argv[]) {
     set_default_resource(&resource);
 
     traccc::write(
-            run(traccc::read(events, detector_file, cell_directory, resource), resource));
+        run(traccc::read(events, detector_file, cell_directory, resource),
+            resource));
 
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> diff = end - start;

--- a/examples/openmp/io_decoupled/io_dec_par_example.cpp
+++ b/examples/openmp/io_decoupled/io_dec_par_example.cpp
@@ -1,16 +1,17 @@
+#include <chrono>
+#include <iostream>
+
 #include "algorithms/component_connection.hpp"
 #include "algorithms/measurement_creation.hpp"
 #include "algorithms/spacepoint_formation.hpp"
 #include "edm/measurement.hpp"
 #include "edm/spacepoint.hpp"
 #include "reader.hpp"
-#include "writer.hpp"
 #include "tmp_edm.hpp"
+#include "writer.hpp"
 
-#include <iostream>
-#include <chrono>
-
-traccc::demonstrator_result run(traccc::demonstrator_input input_data, vecmem::host_memory_resource resource) {
+traccc::demonstrator_result run(traccc::demonstrator_input input_data,
+                                vecmem::host_memory_resource resource) {
 
     // Algorithms
     traccc::component_connection cc;
@@ -26,11 +27,13 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data, vecmem::h
     uint64_t n_measurements = 0;
     uint64_t n_space_points = 0;
 
-    traccc::demonstrator_result aggregated_results(input_data.size(), &resource);
+    traccc::demonstrator_result aggregated_results(input_data.size(),
+                                                   &resource);
 
 #pragma omp parallel for reduction(+:n_modules, n_cells, n_clusters, n_measurements, n_space_points)
     for (size_t event = 0; event < input_data.size(); ++event) {
-        traccc::host_cell_container cells_per_event = input_data.operator[](event);
+        traccc::host_cell_container cells_per_event =
+            input_data.operator[](event);
 
         traccc::host_measurement_container measurements_per_event;
         traccc::host_spacepoint_container spacepoints_per_event;
@@ -42,17 +45,18 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data, vecmem::h
 #pragma omp parallel for
         for (size_t i = 0; i < cells_per_event.items.size(); ++i) {
             auto &module = cells_per_event.headers[i];
-            module.pixel = traccc::pixel_segmentation{-8.425, -36.025, 0.05, 0.05};
+            module.pixel =
+                traccc::pixel_segmentation{-8.425, -36.025, 0.05, 0.05};
 
             // The algorithmic code part: start
             traccc::cluster_collection clusters_per_module =
-                    cc({cells_per_event.items[i], cells_per_event.headers[i]});
+                cc({cells_per_event.items[i], cells_per_event.headers[i]});
             clusters_per_module.position_from_cell = module.pixel;
 
             traccc::host_measurement_collection measurements_per_module =
-                    mt({clusters_per_module, module});
+                mt({clusters_per_module, module});
             traccc::host_spacepoint_collection spacepoints_per_module =
-                    sp({module, measurements_per_module});
+                sp({module, measurements_per_module});
             // The algorithmnic code part: end
 
             n_cells += cells_per_event.items[i].size();
@@ -63,31 +67,34 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data, vecmem::h
 #pragma omp critical
             {
                 measurements_per_event.items.push_back(
-                        std::move(measurements_per_module));
+                    std::move(measurements_per_module));
                 measurements_per_event.headers.push_back(module);
 
                 spacepoints_per_event.items.push_back(
-                        std::move(spacepoints_per_module));
+                    std::move(spacepoints_per_module));
                 spacepoints_per_event.headers.push_back(module.module);
             }
         }
 
-        aggregated_results[event] = traccc::result({measurements_per_event, spacepoints_per_event});
-
+        aggregated_results[event] =
+            traccc::result({measurements_per_event, spacepoints_per_event});
     }
 
     auto endAlgorithms = std::chrono::system_clock::now();
     std::chrono::duration<double> diffAlgo = endAlgorithms - startAlgorithms;
-    std::cout << "Algorithms time: " << diffAlgo.count() << " sec." << std::endl;
+    std::cout << "Algorithms time: " << diffAlgo.count() << " sec."
+              << std::endl;
 
     std::cout << "==> Statistics ... " << std::endl;
-    std::cout << "- read    " << n_cells << " cells from " << n_modules << " modules" << std::endl;
+    std::cout << "- read    " << n_cells << " cells from " << n_modules
+              << " modules" << std::endl;
     std::cout << "- created " << n_clusters << " clusters. " << std::endl;
-    std::cout << "- created " << n_measurements << " measurements. " << std::endl;
-    std::cout << "- created " << n_space_points << " space points. " << std::endl;
+    std::cout << "- created " << n_measurements << " measurements. "
+              << std::endl;
+    std::cout << "- created " << n_space_points << " space points. "
+              << std::endl;
 
     return aggregated_results;
-
 }
 
 // The main routine
@@ -95,13 +102,15 @@ int main(int argc, char *argv[]) {
 
     if (argc < 4) {
         std::cout << "Not enough arguments, minimum requirement: " << std::endl;
-        std::cout << "./io_dec_par_example <detector_file> <cell_directory> <events>" << std::endl;
+        std::cout
+            << "./io_dec_par_example <detector_file> <cell_directory> <events>"
+            << std::endl;
         return -1;
     }
 
     auto detector_file = std::string(argv[1]);
     auto cell_directory = std::string(argv[2]);
-    auto events = static_cast<size_t> (std::atoi(argv[3]));
+    auto events = static_cast<size_t>(std::atoi(argv[3]));
 
     auto start = std::chrono::system_clock::now();
     vecmem::host_memory_resource resource;
@@ -113,5 +122,6 @@ int main(int argc, char *argv[]) {
 
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> diff = end - start;
-    std::cout << "Total execution time: " << diff.count() << " sec." << std::endl;
+    std::cout << "Total execution time: " << diff.count() << " sec."
+              << std::endl;
 }

--- a/io/include/reader.hpp
+++ b/io/include/reader.hpp
@@ -71,7 +71,6 @@ namespace traccc {
             }
 
         }
-
         return input_data;
     }
 

--- a/io/include/reader.hpp
+++ b/io/include/reader.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "edm/cell.hpp"
+#include "edm/cluster.hpp"
+#include "edm/measurement.hpp"
+#include "edm/spacepoint.hpp"
+#include "tmp_edm.hpp"
+#include "csv/csv_io.hpp"
+#include <vecmem/memory/host_memory_resource.hpp>
+
+#include <functional>
+
+using namespace std::placeholders;
+
+namespace traccc {
+
+    const std::string data_directory() {
+        auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
+        if (env_d_d == nullptr) {
+            throw std::ios_base::failure("Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
+        }
+        std::string data_dir = std::string(env_d_d);
+        return data_dir.append("/");
+    }
+
+    std::string get_event_filename(size_t event) {
+        std::string event_string{"000000000"};
+        std::string event_number = std::to_string(event);
+        event_string.replace(event_string.size() - event_number.size(), event_number.size(), event_number);
+        return event_string;
+    }
+
+    traccc::geometry read_geometry(const std::string &detector_file) {
+        // Read the surface transforms
+        std::string io_detector_file = data_directory() + detector_file;
+        traccc::surface_reader sreader(io_detector_file,
+                                       {"geometry_id", "cx", "cy", "cz", "rot_xu", "rot_xv", "rot_xw", "rot_zu",
+                                        "rot_zv", "rot_zw"});
+        return traccc::read_surfaces(sreader);
+    }
+
+    traccc::host_cell_container read_cells_from_event(size_t event, const std::string &cells_dir,
+                                                      traccc::geometry surface_transforms, vecmem::host_memory_resource& resource) {
+        // Read the cells from the relevant event file
+        std::string io_cells_file =
+                data_directory() + cells_dir + std::string("/event") + get_event_filename(event) +
+                std::string("-cells.csv");
+        traccc::cell_reader creader(io_cells_file,
+                                    {"geometry_id", "hit_id", "cannel0", "channel1", "activation", "time"});
+        return traccc::read_cells(creader, resource, surface_transforms);
+    }
+
+    traccc::demonstrator_input
+    read(size_t events, const std::string &detector_file, const std::string &cell_directory, vecmem::host_memory_resource& resource) {
+        auto geometry = read_geometry(detector_file);
+        auto readFn = std::bind(read_cells_from_event, _1, cell_directory, geometry, resource);
+
+        traccc::demonstrator_input input_data(events, &resource);
+
+#if defined(_OPENMP)
+#pragma omp parallel for
+#endif
+        for (size_t event = 0; event < events; ++event) {
+            traccc::host_cell_container cells_per_event = readFn(event);
+
+#if defined(_OPENMP)
+#pragma omp critical
+#endif
+            {
+                input_data[event] = cells_per_event;
+            }
+
+        }
+
+        return input_data;
+    }
+
+} // end namespace

--- a/io/include/reader.hpp
+++ b/io/include/reader.hpp
@@ -1,77 +1,81 @@
 #pragma once
 
+#include <functional>
+#include <vecmem/memory/host_memory_resource.hpp>
+
+#include "csv/csv_io.hpp"
 #include "edm/cell.hpp"
 #include "edm/cluster.hpp"
 #include "edm/measurement.hpp"
 #include "edm/spacepoint.hpp"
 #include "tmp_edm.hpp"
-#include "csv/csv_io.hpp"
-#include <vecmem/memory/host_memory_resource.hpp>
-
-#include <functional>
 
 using namespace std::placeholders;
 
 namespace traccc {
 
-    const std::string data_directory() {
-        auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
-        if (env_d_d == nullptr) {
-            throw std::ios_base::failure("Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
-        }
-        std::string data_dir = std::string(env_d_d);
-        return data_dir.append("/");
+const std::string data_directory() {
+    auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
+    if (env_d_d == nullptr) {
+        throw std::ios_base::failure(
+            "Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
     }
+    std::string data_dir = std::string(env_d_d);
+    return data_dir.append("/");
+}
 
-    std::string get_event_filename(size_t event) {
-        std::string event_string{"000000000"};
-        std::string event_number = std::to_string(event);
-        event_string.replace(event_string.size() - event_number.size(), event_number.size(), event_number);
-        return event_string;
-    }
+std::string get_event_filename(size_t event) {
+    std::string event_string{"000000000"};
+    std::string event_number = std::to_string(event);
+    event_string.replace(event_string.size() - event_number.size(),
+                         event_number.size(), event_number);
+    return event_string;
+}
 
-    traccc::geometry read_geometry(const std::string &detector_file) {
-        // Read the surface transforms
-        std::string io_detector_file = data_directory() + detector_file;
-        traccc::surface_reader sreader(io_detector_file,
-                                       {"geometry_id", "cx", "cy", "cz", "rot_xu", "rot_xv", "rot_xw", "rot_zu",
-                                        "rot_zv", "rot_zw"});
-        return traccc::read_surfaces(sreader);
-    }
+traccc::geometry read_geometry(const std::string &detector_file) {
+    // Read the surface transforms
+    std::string io_detector_file = data_directory() + detector_file;
+    traccc::surface_reader sreader(
+        io_detector_file, {"geometry_id", "cx", "cy", "cz", "rot_xu", "rot_xv",
+                           "rot_xw", "rot_zu", "rot_zv", "rot_zw"});
+    return traccc::read_surfaces(sreader);
+}
 
-    traccc::host_cell_container read_cells_from_event(size_t event, const std::string &cells_dir,
-                                                      traccc::geometry surface_transforms, vecmem::host_memory_resource& resource) {
-        // Read the cells from the relevant event file
-        std::string io_cells_file =
-                data_directory() + cells_dir + std::string("/event") + get_event_filename(event) +
-                std::string("-cells.csv");
-        traccc::cell_reader creader(io_cells_file,
-                                    {"geometry_id", "hit_id", "cannel0", "channel1", "activation", "time"});
-        return traccc::read_cells(creader, resource, surface_transforms);
-    }
+traccc::host_cell_container read_cells_from_event(
+    size_t event, const std::string &cells_dir,
+    traccc::geometry surface_transforms,
+    vecmem::host_memory_resource &resource) {
+    // Read the cells from the relevant event file
+    std::string io_cells_file =
+        data_directory() + cells_dir + std::string("/event") +
+        get_event_filename(event) + std::string("-cells.csv");
+    traccc::cell_reader creader(
+        io_cells_file,
+        {"geometry_id", "hit_id", "cannel0", "channel1", "activation", "time"});
+    return traccc::read_cells(creader, resource, surface_transforms);
+}
 
-    traccc::demonstrator_input
-    read(size_t events, const std::string &detector_file, const std::string &cell_directory, vecmem::host_memory_resource& resource) {
-        auto geometry = read_geometry(detector_file);
-        auto readFn = std::bind(read_cells_from_event, _1, cell_directory, geometry, resource);
+traccc::demonstrator_input read(size_t events, const std::string &detector_file,
+                                const std::string &cell_directory,
+                                vecmem::host_memory_resource &resource) {
+    auto geometry = read_geometry(detector_file);
+    auto readFn = std::bind(read_cells_from_event, _1, cell_directory, geometry,
+                            resource);
 
-        traccc::demonstrator_input input_data(events, &resource);
+    traccc::demonstrator_input input_data(events, &resource);
 
 #if defined(_OPENMP)
 #pragma omp parallel for
 #endif
-        for (size_t event = 0; event < events; ++event) {
-            traccc::host_cell_container cells_per_event = readFn(event);
+    for (size_t event = 0; event < events; ++event) {
+        traccc::host_cell_container cells_per_event = readFn(event);
 
 #if defined(_OPENMP)
 #pragma omp critical
 #endif
-            {
-                input_data[event] = cells_per_event;
-            }
-
-        }
-        return input_data;
+        { input_data[event] = cells_per_event; }
     }
+    return input_data;
+}
 
-} // end namespace
+}  // namespace traccc

--- a/io/include/tmp_edm.hpp
+++ b/io/include/tmp_edm.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
+#include <map>
+
 #include "edm/cell.hpp"
 #include "edm/measurement.hpp"
 #include "edm/spacepoint.hpp"
 
-#include <map>
-
 namespace traccc {
-    struct result {
-        traccc::host_measurement_container measurements;
-        traccc::host_spacepoint_container spacepoints;
-    };
+struct result {
+    traccc::host_measurement_container measurements;
+    traccc::host_spacepoint_container spacepoints;
+};
 
-    using geometry = std::map<traccc::geometry_id, traccc::transform3>;
-    using demonstrator_input = vecmem::vector<traccc::host_cell_container>;
-    using demonstrator_result = vecmem::vector<traccc::result>;
-}
+using geometry = std::map<traccc::geometry_id, traccc::transform3>;
+using demonstrator_input = vecmem::vector<traccc::host_cell_container>;
+using demonstrator_result = vecmem::vector<traccc::result>;
+}  // namespace traccc

--- a/io/include/tmp_edm.hpp
+++ b/io/include/tmp_edm.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "edm/cell.hpp"
+#include "edm/measurement.hpp"
+#include "edm/spacepoint.hpp"
+
+#include <map>
+
+namespace traccc {
+
+    struct result {
+        traccc::host_measurement_container measurements;
+        traccc::host_spacepoint_container spacepoints;
+    };
+
+    using geometry = std::map<traccc::geometry_id, traccc::transform3>;
+    using demonstrator_input = vecmem::vector<traccc::host_cell_container>;
+    using demonstrator_result = vecmem::vector<traccc::result>;
+}

--- a/io/include/tmp_edm.hpp
+++ b/io/include/tmp_edm.hpp
@@ -7,7 +7,6 @@
 #include <map>
 
 namespace traccc {
-
     struct result {
         traccc::host_measurement_container measurements;
         traccc::host_spacepoint_container spacepoints;

--- a/io/include/writer.hpp
+++ b/io/include/writer.hpp
@@ -45,4 +45,4 @@ namespace traccc {
         }
     }
 
-} // end namespace
+    }  // namespace traccc

--- a/io/include/writer.hpp
+++ b/io/include/writer.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "edm/cell.hpp"
+#include "edm/cluster.hpp"
+#include "edm/measurement.hpp"
+#include "edm/spacepoint.hpp"
+#include "csv/csv_io.hpp"
+#include "tmp_edm.hpp"
+
+namespace traccc {
+
+    void write_measurements(size_t event, const traccc::host_measurement_container &measurements_per_event) {
+        traccc::measurement_writer mwriter{std::string("event") + std::to_string(event) + "-measurements.csv"};
+        for (size_t i = 0; i < measurements_per_event.items.size(); ++i) {
+            auto measurements_per_module = measurements_per_event.items[i];
+            auto module = measurements_per_event.headers[i];
+            for (const auto &measurement : measurements_per_module) {
+                const auto &local = measurement.local;
+                mwriter.append({module.module, local[0], local[1], 0., 0.});
+            }
+        }
+    }
+
+    void write_spacepoints(size_t event, const traccc::host_spacepoint_container &spacepoints_per_event) {
+        traccc::spacepoint_writer spwriter{std::string("event") + std::to_string(event) + "-spacepoints.csv"};
+        for (size_t i = 0; i < spacepoints_per_event.items.size(); ++i) {
+            auto spacepoints_per_module = spacepoints_per_event.items[i];
+            auto module = spacepoints_per_event.headers[i];
+            for (const auto &spacepoint : spacepoints_per_module) {
+                const auto &pos = spacepoint.global;
+                spwriter.append({module, pos[0], pos[1], pos[2], 0., 0., 0.});
+            }
+        }
+    }
+
+    void write(traccc::demonstrator_result aggregated_results) {
+
+#if defined(_OPENMP)
+#pragma omp parallel for
+#endif
+        for (size_t event = 0; event < aggregated_results.size(); ++event) {
+            auto &eventResult = aggregated_results.at(event);
+            write_measurements(event, eventResult.measurements);
+            write_spacepoints(event, eventResult.spacepoints);
+        }
+    }
+
+} // end namespace

--- a/io/include/writer.hpp
+++ b/io/include/writer.hpp
@@ -1,48 +1,54 @@
 #pragma once
 
+#include "csv/csv_io.hpp"
 #include "edm/cell.hpp"
 #include "edm/cluster.hpp"
 #include "edm/measurement.hpp"
 #include "edm/spacepoint.hpp"
-#include "csv/csv_io.hpp"
 #include "tmp_edm.hpp"
 
 namespace traccc {
 
-    void write_measurements(size_t event, const traccc::host_measurement_container &measurements_per_event) {
-        traccc::measurement_writer mwriter{std::string("event") + std::to_string(event) + "-measurements.csv"};
-        for (size_t i = 0; i < measurements_per_event.items.size(); ++i) {
-            auto measurements_per_module = measurements_per_event.items[i];
-            auto module = measurements_per_event.headers[i];
-            for (const auto &measurement : measurements_per_module) {
-                const auto &local = measurement.local;
-                mwriter.append({module.module, local[0], local[1], 0., 0.});
-            }
+void write_measurements(
+    size_t event,
+    const traccc::host_measurement_container &measurements_per_event) {
+    traccc::measurement_writer mwriter{
+        std::string("event") + std::to_string(event) + "-measurements.csv"};
+    for (size_t i = 0; i < measurements_per_event.items.size(); ++i) {
+        auto measurements_per_module = measurements_per_event.items[i];
+        auto module = measurements_per_event.headers[i];
+        for (const auto &measurement : measurements_per_module) {
+            const auto &local = measurement.local;
+            mwriter.append({module.module, local[0], local[1], 0., 0.});
         }
     }
+}
 
-    void write_spacepoints(size_t event, const traccc::host_spacepoint_container &spacepoints_per_event) {
-        traccc::spacepoint_writer spwriter{std::string("event") + std::to_string(event) + "-spacepoints.csv"};
-        for (size_t i = 0; i < spacepoints_per_event.items.size(); ++i) {
-            auto spacepoints_per_module = spacepoints_per_event.items[i];
-            auto module = spacepoints_per_event.headers[i];
-            for (const auto &spacepoint : spacepoints_per_module) {
-                const auto &pos = spacepoint.global;
-                spwriter.append({module, pos[0], pos[1], pos[2], 0., 0., 0.});
-            }
+void write_spacepoints(
+    size_t event,
+    const traccc::host_spacepoint_container &spacepoints_per_event) {
+    traccc::spacepoint_writer spwriter{
+        std::string("event") + std::to_string(event) + "-spacepoints.csv"};
+    for (size_t i = 0; i < spacepoints_per_event.items.size(); ++i) {
+        auto spacepoints_per_module = spacepoints_per_event.items[i];
+        auto module = spacepoints_per_event.headers[i];
+        for (const auto &spacepoint : spacepoints_per_module) {
+            const auto &pos = spacepoint.global;
+            spwriter.append({module, pos[0], pos[1], pos[2], 0., 0., 0.});
         }
     }
+}
 
-    void write(traccc::demonstrator_result aggregated_results) {
+void write(traccc::demonstrator_result aggregated_results) {
 
 #if defined(_OPENMP)
 #pragma omp parallel for
 #endif
-        for (size_t event = 0; event < aggregated_results.size(); ++event) {
-            auto &eventResult = aggregated_results.at(event);
-            write_measurements(event, eventResult.measurements);
-            write_spacepoints(event, eventResult.spacepoints);
-        }
+    for (size_t event = 0; event < aggregated_results.size(); ++event) {
+        auto &eventResult = aggregated_results.at(event);
+        write_measurements(event, eventResult.measurements);
+        write_spacepoints(event, eventResult.spacepoints);
     }
+}
 
-    }  // namespace traccc
+}  // namespace traccc


### PR DESCRIPTION
Add new example (io_dec_par_example) which works as function composition: `write o run o read`. In detail:

1. read the input CSV files and store the data in memory (`demonstrator_input`)
2. run the traccc::algorithms and stores the results in memory (`demonstrator_output`)
3. writes output CSV based on in-memory temporary results

**Note 1:** The code uses OpenMP parallel loops if OMP support is enabled. The `reader` and `writer` header files should compile without OpenMP support too.
**Note 2:** The `vecmem::resource` is passed by reference to all the functions that require it in order to ensure a state-less model (as agreed in ACTS Parallelization meeting on 04.06.2021) 
**Note 3:** Performance results for this implementation were shown in ACTS Parallelization meeting on 23.07.2021.