### PR TITLE
Remove loud include of Acts package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,6 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY
    "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH
    "Directory for the built static libraries" )
 
-# Add acts core
-find_package(Acts) 
- 
 # Include the traccc CMake code.
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
 include( traccc-compiler-options )


### PR DESCRIPTION
This `find_package` is doing essentially the same thing that [`cmake/traccc-acts.cmake`](https://github.com/acts-project/traccc/blob/77cc01fccc28940100ffe369c053ff38b8a93bff/cmake/traccc-acts.cmake) is doing, which means that we get some loud (and rather scary) error messages if we do not have Acts installed in the development. The previously mentioned CMake file should be more than sufficient to find Acts in virtually all cases, so we do not need to look for it in the main CMake file as well.