### PR TITLE
Clean up unused variables in CSV module

### DIFF
--- a/io/include/csv/csv_io.hpp
+++ b/io/include/csv/csv_io.hpp
@@ -277,12 +277,10 @@ std::vector<cluster_collection> read_truth_clusters(
 host_spacepoint_container read_hits(
     fatras_hit_reader& hreader, vecmem::memory_resource& resource,
     unsigned int max_hits = std::numeric_limits<unsigned int>::max()) {
-    uint64_t reference_id = 0;
     host_spacepoint_container result = {
         host_spacepoint_container::header_vector(&resource),
         host_spacepoint_container::item_vector(&resource)};
 
-    bool first_line_read = false;
     unsigned int read_hits = 0;
     csv_fatras_hit iohit;
 


### PR DESCRIPTION
Nothing major, but these two unused variables were spamming my builds up with unused variable warnings, so I'd like to get rid of them.