### PR TITLE
Various improvements to the new module map type

### DIFF
--- a/core/include/geometry/module_map.hpp
+++ b/core/include/geometry/module_map.hpp
@@ -82,7 +82,7 @@ class module_map {
      * @warning This method does no bounds checking, and will result in
      * undefined behaviour if the key does not exist in the map.
      */
-    V& operator[](const K& i) { return *at_helper(i, 0); }
+    const V& operator[](const K& i) const { return *at_helper(i, 0); }
 
     /**
      * @brief Find a given key in the map, with bounds checking.
@@ -91,8 +91,8 @@ class module_map {
      *
      * @return The value associated with the given key.
      */
-    V& at(const K& i) {
-        V* r = at_helper(i, 0);
+    const V& at(const K& i) const {
+        const V* r = at_helper(i, 0);
 
         if (r == nullptr) {
             throw std::out_of_range("Index not found in module map!");
@@ -108,7 +108,7 @@ class module_map {
      *
      * @return The total number of modules in this module map.
      */
-    std::size_t size(void) {
+    std::size_t size(void) const {
         std::size_t c = 0;
 
         for (const module_map_node& n : m_nodes) {
@@ -322,7 +322,7 @@ class module_map {
      * @param[in] i The value to look for.
      * @param[in] n The index of the subtree's root node.
      */
-    V* at_helper(const K& i, std::size_t n) {
+    const V* at_helper(const K& i, std::size_t n) const {
         /*
          * For memory safety, if we are out of bounds we will exit.
          */
@@ -333,7 +333,7 @@ class module_map {
         /*
          * Retrieve the current root node.
          */
-        module_map_node& node = m_nodes[n];
+        const module_map_node& node = m_nodes[n];
 
         /*
          * If the size is zero, it is essentially an invalid node (i.e. the

--- a/core/include/geometry/module_map.hpp
+++ b/core/include/geometry/module_map.hpp
@@ -10,7 +10,7 @@
 
 #include <iostream>
 
-#include "definitions/primitives.hpp"
+#include "definitions/algebra.hpp"
 
 namespace traccc {
 /**

--- a/core/include/geometry/module_map.hpp
+++ b/core/include/geometry/module_map.hpp
@@ -118,6 +118,10 @@ class module_map {
         return c;
     }
 
+    bool contains(const K& i) const { return at_helper(i, 0) != nullptr; }
+
+    bool empty(void) const { return m_nodes.empty(); }
+
     private:
     /**
      * @brief The internal representation of nodes in our binary search tree.

--- a/tests/cpu/geometry/module_map_tests.cpp
+++ b/tests/cpu/geometry/module_map_tests.cpp
@@ -63,6 +63,48 @@ TEST(geometry, module_map_operator_eq) {
 }
 
 /*
+ * Sanity check for the empty method.
+ */
+TEST(geometry, module_map_empty) {
+    std::map<std::size_t, std::string> inp{{0, "zero"},    {1, "one"},
+                                           {2, "two"},     {5, "five"},
+                                           {11, "eleven"}, {21, "twenty-one"}};
+
+    /*
+     * Convert the old-style map to a module map.
+     */
+    traccc::module_map<std::size_t, std::string> map(inp);
+
+    ASSERT_FALSE(map.empty());
+}
+
+/*
+ * Check whether the contains method works.
+ */
+TEST(geometry, module_map_contains) {
+    std::map<std::size_t, std::string> inp{{0, "zero"},    {1, "one"},
+                                           {2, "two"},     {5, "five"},
+                                           {11, "eleven"}, {21, "twenty-one"}};
+
+    /*
+     * Convert the old-style map to a module map.
+     */
+    traccc::module_map<std::size_t, std::string> map(inp);
+
+    ASSERT_TRUE(map.contains(0));
+    ASSERT_TRUE(map.contains(1));
+    ASSERT_TRUE(map.contains(2));
+    ASSERT_TRUE(map.contains(5));
+    ASSERT_TRUE(map.contains(11));
+    ASSERT_TRUE(map.contains(21));
+    ASSERT_FALSE(map.contains(3));
+    ASSERT_FALSE(map.contains(4));
+    ASSERT_FALSE(map.contains(6));
+    ASSERT_FALSE(map.contains(15));
+    ASSERT_FALSE(map.contains(510482));
+}
+
+/*
  * Check if the map fails correctly.
  */
 TEST(geometry, module_map_failure) {


### PR DESCRIPTION
As requested by @paulgessinger, this pull requests makes the following changes to the `traccc::module_map` type:

1. All accessor methods (and other methods) are now `const`.
1. Additional methods have been added to the class:
a. The `contains` method determines whether a key can be found in the map.
b. The `empty` method determines whether the map is empty, which it should never be.
1. Additional tests have been added for the new class methods.
1. A header inclusion error was fixed. 