### PR TITLE
Centralize per-event filename, data directory, clean up string usage

### DIFF
--- a/examples/cpu/seq_example.cpp
+++ b/examples/cpu/seq_example.cpp
@@ -29,13 +29,6 @@
 int seq_run(const std::string& detector_file, const std::string& cells_dir,
             unsigned int events) {
 
-    const char* env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
-    }
-    std::string data_directory = env_d_d + std::string("/");
-
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(detector_file);
 

--- a/examples/cpu/seq_example.cpp
+++ b/examples/cpu/seq_example.cpp
@@ -28,12 +28,13 @@
 
 int seq_run(const std::string& detector_file, const std::string& cells_dir,
             unsigned int events) {
-    auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
+
+    const char* env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
     if (env_d_d == nullptr) {
         throw std::ios_base::failure(
             "Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
     }
-    auto data_directory = std::string(env_d_d) + std::string("/");
+    std::string data_directory = env_d_d + std::string("/");
 
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(detector_file);
@@ -57,14 +58,9 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
     for (unsigned int event = 0; event < events; ++event) {
 
         // Read the cells from the relevant event file
-        std::string event_string = "000000000";
-        std::string event_number = std::to_string(event);
-        event_string.replace(event_string.size() - event_number.size(),
-                             event_number.size(), event_number);
-
-        std::string io_cells_file = data_directory + cells_dir +
-                                    std::string("/event") + event_string +
-                                    std::string("-cells.csv");
+        std::string io_cells_file =
+            traccc::data_directory() + cells_dir + "/" +
+            traccc::get_event_filename(event, "-cells.csv");
         traccc::cell_reader creader(
             io_cells_file, {"geometry_id", "hit_id", "cannel0", "channel1",
                             "activation", "time"});
@@ -168,8 +164,8 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
              Writer
           ------------*/
 
-        traccc::measurement_writer mwriter{std::string("event") + event_number +
-                                           "-measurements.csv"};
+        traccc::measurement_writer mwriter{
+            traccc::get_event_filename(event, "-measurements.csv")};
         for (size_t i = 0; i < measurements_per_event.items.size(); ++i) {
             auto measurements_per_module = measurements_per_event.items[i];
             auto module = measurements_per_event.headers[i];
@@ -179,8 +175,8 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
             }
         }
 
-        traccc::spacepoint_writer spwriter{std::string("event") + event_number +
-                                           "-spacepoints.csv"};
+        traccc::spacepoint_writer spwriter{
+            traccc::get_event_filename(event, "-spacepoints.csv")};
         for (size_t i = 0; i < spacepoints_per_event.items.size(); ++i) {
             auto spacepoints_per_module = spacepoints_per_event.items[i];
             auto module = spacepoints_per_event.headers[i];
@@ -192,7 +188,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
         }
 
         traccc::internal_spacepoint_writer internal_spwriter{
-            std::string("event") + event_number + "-internal_spacepoints.csv"};
+            traccc::get_event_filename(event, "-internal_spacepoints.csv")};
         for (size_t i = 0; i < internal_sp_per_event.items.size(); ++i) {
             auto internal_sp_per_bin = internal_sp_per_event.items[i];
             auto bin = internal_sp_per_event.headers[i].global_index;

--- a/examples/cpu/seq_example.cpp
+++ b/examples/cpu/seq_example.cpp
@@ -16,6 +16,7 @@
 #include "geometry/pixel_segmentation.hpp"
 #include "io/csv.hpp"
 #include "io/reader.hpp"
+#include "io/utils.hpp"
 
 // clusterization
 #include "clusterization/component_connection.hpp"

--- a/examples/openmp/par_example.cpp
+++ b/examples/openmp/par_example.cpp
@@ -23,12 +23,12 @@
 
 int par_run(const std::string &detector_file, const std::string &cells_dir,
             unsigned int events) {
-    auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
+    const char *env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
     if (env_d_d == nullptr) {
         throw std::ios_base::failure(
             "Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
     }
-    auto data_directory = std::string(env_d_d) + std::string("/");
+    auto data_directory = env_d_d + std::string("/");
 
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(detector_file);
@@ -53,14 +53,10 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
     for (unsigned int event = 0; event < events; ++event) {
 
         // Read the cells from the relevant event file
-        std::string event_string = "000000000";
-        std::string event_number = std::to_string(event);
-        event_string.replace(event_string.size() - event_number.size(),
-                             event_number.size(), event_number);
 
-        std::string io_cells_file = data_directory + cells_dir +
-                                    std::string("/event") + event_string +
-                                    std::string("-cells.csv");
+        std::string io_cells_file =
+            traccc::data_directory() + cells_dir + "/" +
+            traccc::get_event_filename(event, "-cells.csv");
         traccc::cell_reader creader(
             io_cells_file, {"geometry_id", "hit_id", "cannel0", "channel1",
                             "activation", "time"});
@@ -110,8 +106,8 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
             }
         }
 
-        traccc::measurement_writer mwriter{std::string("event") + event_number +
-                                           "-measurements.csv"};
+        traccc::measurement_writer mwriter{
+            traccc::get_event_filename(event, "-measurements.csv")};
         for (size_t i = 0; i < measurements_per_event.items.size(); ++i) {
             auto measurements_per_module = measurements_per_event.items[i];
             auto module = measurements_per_event.headers[i];
@@ -121,8 +117,8 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
             }
         }
 
-        traccc::spacepoint_writer spwriter{std::string("event") + event_number +
-                                           "-spacepoints.csv"};
+        traccc::spacepoint_writer spwriter{
+            traccc::get_event_filename(event, "-spacepoints.csv")};
         for (size_t i = 0; i < spacepoints_per_event.items.size(); ++i) {
             auto spacepoints_per_module = spacepoints_per_event.items[i];
             auto module = spacepoints_per_event.headers[i];

--- a/examples/openmp/par_example.cpp
+++ b/examples/openmp/par_example.cpp
@@ -19,6 +19,7 @@
 #include "geometry/pixel_segmentation.hpp"
 #include "io/csv.hpp"
 #include "io/reader.hpp"
+#include "io/utils.hpp"
 #include "omp.h"
 
 int par_run(const std::string &detector_file, const std::string &cells_dir,

--- a/examples/openmp/par_example.cpp
+++ b/examples/openmp/par_example.cpp
@@ -23,12 +23,6 @@
 
 int par_run(const std::string &detector_file, const std::string &cells_dir,
             unsigned int events) {
-    const char *env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
-    }
-    auto data_directory = env_d_d + std::string("/");
 
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(detector_file);

--- a/io/include/io/reader.hpp
+++ b/io/include/io/reader.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <functional>
-#include <iomanip>
 #include <vecmem/memory/host_memory_resource.hpp>
 
 #include "edm/cell.hpp"
@@ -11,33 +10,11 @@
 #include "geometry/geometry.hpp"
 #include "io/csv.hpp"
 #include "io/demonstrator_edm.hpp"
+#include "io/utils.hpp"
 
 namespace traccc {
 
-const std::string &data_directory() {
-    static const std::string data_dir = [] {
-        auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
-        if (env_d_d == nullptr) {
-            throw std::ios_base::failure(
-                "Test data directory not found. Please set "
-                "TRACCC_TEST_DATA_DIR.");
-        }
-        std::string data_dir = std::string(env_d_d);
-        return data_dir.append("/");
-    }();
-
-    return data_dir;
-}
-
-std::string get_event_filename(size_t event, const std::string &suffix) {
-    std::stringstream stream;
-    stream << "event";
-    stream << std::setfill('0') << std::setw(9) << event;
-    stream << suffix;
-    return stream.str();
-}
-
-inline traccc::geometry read_geometry(const std::string &detector_file) {
+traccc::geometry read_geometry(const std::string &detector_file) {
     // Read the surface transforms
     std::string io_detector_file = data_directory() + detector_file;
     traccc::surface_reader sreader(

--- a/io/include/io/reader.hpp
+++ b/io/include/io/reader.hpp
@@ -14,14 +14,19 @@
 
 namespace traccc {
 
-inline const std::string data_directory() {
-    auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
-    }
-    std::string data_dir = std::string(env_d_d);
-    return data_dir.append("/");
+const std::string &data_directory() {
+    static const std::string data_dir = [] {
+        auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
+        if (env_d_d == nullptr) {
+            throw std::ios_base::failure(
+                "Test data directory not found. Please set "
+                "TRACCC_TEST_DATA_DIR.");
+        }
+        std::string data_dir = std::string(env_d_d);
+        return data_dir.append("/");
+    }();
+
+    return data_dir;
 }
 
 std::string get_event_filename(size_t event, const std::string &suffix) {

--- a/io/include/io/reader.hpp
+++ b/io/include/io/reader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <iomanip>
 #include <vecmem/memory/host_memory_resource.hpp>
 
 #include "edm/cell.hpp"
@@ -23,12 +24,12 @@ inline const std::string data_directory() {
     return data_dir.append("/");
 }
 
-inline std::string get_event_filename(size_t event) {
-    std::string event_string{"000000000"};
-    std::string event_number = std::to_string(event);
-    event_string.replace(event_string.size() - event_number.size(),
-                         event_number.size(), event_number);
-    return event_string;
+std::string get_event_filename(size_t event, const std::string &suffix) {
+    std::stringstream stream;
+    stream << "event";
+    stream << std::setfill('0') << std::setw(9) << event;
+    stream << suffix;
+    return stream.str();
 }
 
 inline traccc::geometry read_geometry(const std::string &detector_file) {
@@ -46,8 +47,7 @@ inline traccc::host_cell_container read_cells_from_event(
     vecmem::host_memory_resource &resource) {
     // Read the cells from the relevant event file
     std::string io_cells_file =
-        data_directory() + cells_dir + std::string("/event") +
-        get_event_filename(event) + std::string("-cells.csv");
+        data_directory() + cells_dir + get_event_filename(event, "-cells.csv");
     traccc::cell_reader creader(
         io_cells_file,
         {"geometry_id", "hit_id", "cannel0", "channel1", "activation", "time"});

--- a/io/include/io/utils.hpp
+++ b/io/include/io/utils.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <iomanip>
+#include <sstream>
+
+namespace traccc {
+
+const std::string &data_directory() {
+    static const std::string data_dir = [] {
+        auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
+        if (env_d_d == nullptr) {
+            throw std::ios_base::failure(
+                "Test data directory not found. Please set "
+                "TRACCC_TEST_DATA_DIR.");
+        }
+        std::string data_dir = std::string(env_d_d);
+        return data_dir.append("/");
+    }();
+
+    return data_dir;
+}
+
+std::string get_event_filename(size_t event, const std::string &suffix) {
+    std::stringstream stream;
+    stream << "event";
+    stream << std::setfill('0') << std::setw(9) << event;
+    stream << suffix;
+    return stream.str();
+}
+
+}  // namespace traccc

--- a/io/include/io/writer.hpp
+++ b/io/include/io/writer.hpp
@@ -6,6 +6,7 @@
 #include "edm/spacepoint.hpp"
 #include "io/csv.hpp"
 #include "io/demonstrator_edm.hpp"
+#include "io/utils.hpp"
 
 namespace traccc {
 

--- a/io/include/io/writer.hpp
+++ b/io/include/io/writer.hpp
@@ -13,7 +13,7 @@ inline void write_measurements(
     size_t event,
     const traccc::host_measurement_container &measurements_per_event) {
     traccc::measurement_writer mwriter{
-        std::string("event") + std::to_string(event) + "-measurements.csv"};
+        get_event_filename(event, "-measurements.csv")};
     for (size_t i = 0; i < measurements_per_event.items.size(); ++i) {
         auto measurements_per_module = measurements_per_event.items[i];
         auto module = measurements_per_event.headers[i];
@@ -28,7 +28,7 @@ inline void write_spacepoints(
     size_t event,
     const traccc::host_spacepoint_container &spacepoints_per_event) {
     traccc::spacepoint_writer spwriter{
-        std::string("event") + std::to_string(event) + "-spacepoints.csv"};
+        get_event_filename(event, "-spacepoints.csv")};
     for (size_t i = 0; i < spacepoints_per_event.items.size(); ++i) {
         auto spacepoints_per_module = spacepoints_per_event.items[i];
         auto module = spacepoints_per_event.headers[i];

--- a/tests/cpu/geometry/module_map_tests.cpp
+++ b/tests/cpu/geometry/module_map_tests.cpp
@@ -11,6 +11,7 @@
 #include "definitions/primitives.hpp"
 #include "geometry/module_map.hpp"
 #include "io/csv.hpp"
+#include "io/reader.hpp"
 
 /*
  * Simple test of this map using integers and strings.
@@ -127,20 +128,9 @@ TEST(geometry, module_map_failure) {
  * existing map which is based on std::map.
  */
 TEST(geometry, module_map_read_trackml) {
-    /*
-     * First, some boilerplate code where we get the data directory.
-     */
-    auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
 
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set TRACCC_TEST_DATA_DIR.");
-    }
-
-    auto data_directory = std::string(env_d_d) + std::string("/");
-
-    std::string file =
-        data_directory + std::string("tml_detector/trackml-detector.csv");
+    std::string file = traccc::data_directory() +
+                       std::string("tml_detector/trackml-detector.csv");
 
     /*
      * Next, we read the surfaces from the TrackML data file, and we get back a

--- a/tests/include/tests/data_test.hpp
+++ b/tests/include/tests/data_test.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "io/reader.hpp"
+
 namespace traccc::tests {
 /**
  * @brief Test fixture base class for accessing the data directory.
@@ -25,17 +27,7 @@ class data_test : public ::testing::Test {
     protected:
     std::string data_directory;
 
-    virtual void SetUp() override {
-        char* env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
-
-        if (env_d_d == nullptr) {
-            throw std::ios_base::failure(
-                "Test data directory not found. Please set "
-                "TRACCC_TEST_DATA_DIR.");
-        }
-
-        data_directory = std::string(env_d_d) + std::string("/");
-    }
+    virtual void SetUp() override { data_directory = traccc::data_directory(); }
 
     std::string get_datafile(std::string name) { return data_directory + name; }
 };


### PR DESCRIPTION
Changes to use `std::stringstream` to do the padding.