### PR TITLE
CMake Cleanup/Updates, main branch (2021.08.10.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,14 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
 include( traccc-compiler-options )
 
-# Build the necessary externals.
-add_subdirectory(extern)
-include(traccc-dependencies)
-
 # Build the traccc code.
 add_subdirectory(core)
 add_subdirectory(io)
 add_subdirectory(examples)
-add_subdirectory(tests)
+if(BUILD_TESTING)
+   add_subdirectory(tests)
+endif()
+
+# Build the necessary externals.
+add_subdirectory(extern)
+include(traccc-dependencies)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,7 @@
 add_subdirectory(cpu)
 
-find_package(OpenMP)
-if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+find_package(OpenMP COMPONENTS CXX)
+if (OpenMP_CXX_FOUND)
     add_subdirectory(openmp)
     message(STATUS "OpenMP found! Include /examples/openmp subdirectory")
 endif()

--- a/examples/cpu/CMakeLists.txt
+++ b/examples/cpu/CMakeLists.txt
@@ -1,14 +1,15 @@
 add_executable (seq_single_module seq_single_module.cpp)
 target_link_libraries (seq_single_module LINK_PUBLIC traccc::core vecmem::core)
-add_test(example_seq_single_module ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/seq_single_module)
+add_test(NAME example_seq_single_module
+         COMMAND seq_single_module)
 
 add_executable (seq_example seq_example.cpp)
 target_link_libraries (seq_example LINK_PUBLIC traccc::core traccc::io vecmem::core)
-add_test(example_seq ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/seq_example
-		     tml_detector/trackml-detector.csv tml_pixels/ 10)
+add_test(NAME example_seq
+         COMMAND seq_example tml_detector/trackml-detector.csv tml_pixels/ 10)
 set_tests_properties(example_seq PROPERTIES ENVIRONMENT TRACCC_TEST_DATA_DIR=${PROJECT_SOURCE_DIR}/data/)
 
 add_executable (ccl_example ccl_example.cpp)
 target_link_libraries (ccl_example LINK_PUBLIC traccc::core traccc::io)
-add_test(example_ccl ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ccl_example 
-		     ${PROJECT_SOURCE_DIR}/data/tml_pixels/event000000000-cells.csv)
+add_test(NAME example_ccl
+         COMMAND ccl_example ${PROJECT_SOURCE_DIR}/data/tml_pixels/event000000000-cells.csv)

--- a/examples/openmp/CMakeLists.txt
+++ b/examples/openmp/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable (par_example par_example.cpp)
 target_link_libraries (par_example LINK_PUBLIC traccc::core traccc::io vecmem::core OpenMP::OpenMP_CXX)
-add_test(example_par ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/par_example
-		     tml_detector/trackml-detector.csv tml_pixels/ 10)
+add_test(NAME example_par
+         COMMAND par_example tml_detector/trackml-detector.csv tml_pixels/ 10)
 set_tests_properties(example_par PROPERTIES ENVIRONMENT TRACCC_TEST_DATA_DIR=${PROJECT_SOURCE_DIR}/data/)
 
 add_subdirectory(io_decoupled)

--- a/examples/openmp/io_decoupled/CMakeLists.txt
+++ b/examples/openmp/io_decoupled/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(io_dec_par_example io_dec_par_example.cpp)
 target_link_libraries(io_dec_par_example LINK_PUBLIC traccc::core traccc::io vecmem::core OpenMP::OpenMP_CXX)
 
-add_test(example_io_dec_par ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/io_dec_par_example
-		     tml_detector/trackml-detector.csv tml_pixels/ 10)
+add_test(NAME example_io_dec_par
+         COMMAND io_dec_par_example tml_detector/trackml-detector.csv tml_pixels/ 10)
 set_tests_properties(example_io_dec_par PROPERTIES ENVIRONMENT TRACCC_TEST_DATA_DIR=${PROJECT_SOURCE_DIR}/data/)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,3 @@
-enable_testing()
 
 macro(add_traccc_test TESTNAME FILES PLUGIN_LIBRARY)
     add_executable(${TESTNAME} ${FILES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ macro(add_traccc_test TESTNAME FILES PLUGIN_LIBRARY)
     target_link_libraries(${TESTNAME} traccc::tests::common)
     target_link_libraries(${TESTNAME} ${PLUGIN_LIBRARY})
     set_target_properties(${TESTNAME} PROPERTIES FOLDER tests)
-    add_test(unit_test_${TESTNAME} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TESTNAME})
+    add_test(NAME unit_test_${TESTNAME} COMMAND ${TESTNAME})
     set_tests_properties(unit_test_${TESTNAME} PROPERTIES
     ENVIRONMENT TRACCC_TEST_DATA_DIR=${PROJECT_SOURCE_DIR}/data/)
 endmacro()


### PR DESCRIPTION
The main trigger for this PR was #71, but once I started going, I changed a couple of things. :stuck_out_tongue:

So the original point was to replace the simple `add_test(<test name> <command>)` calls with `add_test(NAME <test name> COMMAND <command>)` ones. This is necessary because unfortunately CMake does not expand target names with the first formalism into full path names to the built executables. But it does do so with the second formalism. (This is not documented anywhere, and I consider it a bug. I just never took the time to report it to the developers... :frowning:)

While updating the OpenMP tests, I noticed that global variables were being updated for no reason whatsoever. Since the code was already correctly using the `OpenMP::OpenMP_CXX` imported target. Which, by itself, is enough to set up the build of the OpenMP code correctly. So I simply removed those lines. (Note by the way that `${OpenMP_EXE_LINKER_FLAGS}` is **not** an existing variable. It was never set to anything... :stuck_out_tongue:)

Finally, as long as I was tweaking the tests anyway, I tried to make the project respect the `BUILD_TESTING` flag a bit more. This is a flag automatically set up by [CTest](https://cmake.org/cmake/help/latest/module/CTest.html). And projects are advised to use it in the setup of their own tests. (With `BUILD_TESTING=FALSE` the `add_test(...)` function does not do anything. So it's a good idea to not even build the test executables in such a case.) The examples are still being built with `BUILD_TESTING=FALSE` as well, they are just not set up as tests for CTest in that case.
  - I had to re-order the setup of the externals and traccc's own code for this to work. Since in `traccc-vecmem.cmake` we set `BUILD_TESTING=FALSE` explicitly to avoid VecMem building its tests. Which would interfere with how traccc builds GoogleTest. So it seemed easiest to just put that forceful setting of `BUILD_TESTING` at the end of the configuration, to have everything else get `BUILD_TESTING` from the cache variable set up by CTest, as it should.

Pinging @paulgessinger, @georgi-mania.

P.S. I also put a couple of newlines at the end of the files that were missing it. :stuck_out_tongue: