### PR TITLE
Fix recently introduced compiler warnings

### DIFF
--- a/core/include/seeding/detail/singlet.hpp
+++ b/core/include/seeding/detail/singlet.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "definitions/qualifiers.hpp"
 #include "edm/container.hpp"
 
@@ -15,9 +17,9 @@ namespace traccc {
 /// location of spacepoint in internal spacepoint container
 struct sp_location {
     /// index of the bin of the spacepoint grid
-    unsigned int bin_idx;
+    std::size_t bin_idx;
     /// index of the spacepoint in the bin
-    unsigned int sp_idx;
+    std::size_t sp_idx;
 };
 
 inline TRACCC_HOST_DEVICE bool operator==(const sp_location& lhs,

--- a/core/include/seeding/doublet_finding.hpp
+++ b/core/include/seeding/doublet_finding.hpp
@@ -67,10 +67,6 @@ struct doublet_finding
         // Run the algorithm
         const auto& spM =
             isp_container.items[spM_location.bin_idx][spM_location.sp_idx];
-        const auto& rM = spM.radius();
-        const auto& zM = spM.z();
-        const auto& varianceRM = spM.varianceR();
-        const auto& varianceZM = spM.varianceZ();
 
         auto& counts = bin_information.bottom_idx.counts;
         auto& bottom_bin_indices = bin_information.bottom_idx.vector_indices;

--- a/core/include/seeding/seed_filtering.hpp
+++ b/core/include/seeding/seed_filtering.hpp
@@ -22,8 +22,9 @@ struct seed_filtering
           std::pair<host_triplet_collection&, host_seed_container&> > {
     seed_filtering() {}
 
-    output_type operator()(const input_type& i) const override {
+    output_type operator()(const input_type&) const override {
         // not used
+        __builtin_unreachable();
     }
 
     /// Callable operator for the seed filtering

--- a/core/include/seeding/seed_selecting_helper.hpp
+++ b/core/include/seeding/seed_selecting_helper.hpp
@@ -23,7 +23,7 @@ struct seed_selecting_helper {
     /// @param triplet_weight is the weight of triplet to be updated
     static TRACCC_HOST_DEVICE void seed_weight(
         const seedfilter_config& filter_config,
-        const internal_spacepoint<spacepoint>& spM,
+        const internal_spacepoint<spacepoint>&,
         const internal_spacepoint<spacepoint>& spB,
         const internal_spacepoint<spacepoint>& spT, scalar& triplet_weight) {
         scalar weight = 0;
@@ -50,10 +50,9 @@ struct seed_selecting_helper {
     /// @return boolean value
     static TRACCC_HOST_DEVICE bool single_seed_cut(
         const seedfilter_config& filter_config,
-        const internal_spacepoint<spacepoint>& spM,
+        const internal_spacepoint<spacepoint>&,
         const internal_spacepoint<spacepoint>& spB,
-        const internal_spacepoint<spacepoint>& spT,
-        const scalar& triplet_weight) {
+        const internal_spacepoint<spacepoint>&, const scalar& triplet_weight) {
         return !(spB.radius() > filter_config.good_spB_min_radius &&
                  triplet_weight < filter_config.good_spB_min_weight);
     }
@@ -68,8 +67,8 @@ struct seed_selecting_helper {
     ///
     /// @return boolean value
     static TRACCC_HOST_DEVICE bool cut_per_middle_sp(
-        const seedfilter_config& filter_config, const spacepoint& spM,
-        const spacepoint& spB, const spacepoint& spT,
+        const seedfilter_config& filter_config, const spacepoint&,
+        const spacepoint& spB, const spacepoint&,
         const scalar& triplet_weight) {
         return (triplet_weight > filter_config.seed_min_weight ||
                 spB.radius() > filter_config.spB_min_radius);

--- a/device/cuda/include/cuda/seeding/seed_finding.hpp
+++ b/device/cuda/include/cuda/seeding/seed_finding.hpp
@@ -38,7 +38,6 @@ struct seed_finding {
         : m_seedfinder_config(config),
           m_sp_grid(sp_grid),
           m_stats_config(stats_cfg),
-          m_mr(mr),
 
           // initialize all vecmem containers:
           // the size of header and item vector = the number of spacepoint bins
@@ -69,7 +68,8 @@ struct seed_finding {
                                                      mr),
                host_triplet_container::item_vector(sp_grid->size(false), mr)}),
           seed_container({host_seed_container::header_vector(1, 0, mr),
-                          host_seed_container::item_vector(1, mr)}) {
+                          host_seed_container::item_vector(1, mr)}),
+          m_mr(mr) {
         first_alloc = true;
     }
 

--- a/examples/cuda/seeding_example_cuda.cpp
+++ b/examples/cuda/seeding_example_cuda.cpp
@@ -33,7 +33,7 @@
 // custom
 #include "tml_stats_config.hpp"
 
-int seq_run(const std::string& detector_file, const std::string& hits_dir,
+int seq_run(const std::string&, const std::string& hits_dir,
             unsigned int skip_events, unsigned int events, bool skip_cpu,
             bool skip_write) {
 
@@ -41,7 +41,6 @@ int seq_run(const std::string& detector_file, const std::string& hits_dir,
     uint64_t n_modules = 0;
     uint64_t n_spacepoints = 0;
     uint64_t n_internal_spacepoints = 0;
-    uint64_t n_doublets = 0;
     uint64_t n_seeds = 0;
     uint64_t n_seeds_cuda = 0;
 

--- a/examples/cuda/seq_example_cuda.cpp
+++ b/examples/cuda/seq_example_cuda.cpp
@@ -66,7 +66,6 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
     uint64_t n_measurements = 0;
     uint64_t n_spacepoints = 0;
     uint64_t n_internal_spacepoints = 0;
-    uint64_t n_doublets = 0;
     uint64_t n_seeds = 0;
     uint64_t n_seeds_cuda = 0;
 
@@ -80,10 +79,6 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
     float binning_cpu(0);
     float seeding_cpu(0);
 
-    float clusterization_cuda(0);
-    float measurement_creation_cuda(0);
-    float spacepoint_formation_cuda(0);
-    float binning_cuda(0);
     float seeding_cuda(0);
 
     // Memory resource used by the EDM.


### PR DESCRIPTION
I've noticed that we have had some compiler warnings creep into the build recently, and there are quite a few. It makes it a little hard to read the output of the compiler. This simple commit resolves all the warnings I could find using GCC 7.5.0.

Relates to #64.