### PR TITLE
Reject warnings in CI builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -35,15 +35,16 @@ jobs:
         run: >
           if ${{ matrix.platform.name == 'CPU'}}; then
             cmake -B build -S . \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build }} 
+              -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
+              -DCMAKE_CXX_FLAGS="-Werror"
           elif ${{ matrix.platform.name == 'CUDA'}}; then
             cmake -B build -S . \
               -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
               -DCMAKE_CUDA_COMPILER=$(which nvcc) \
-              -DTRACCC_BUILD_CUDA=ON 
+              -DTRACCC_BUILD_CUDA=ON \
+              -DCMAKE_CXX_FLAGS="-Werror"
           fi
       - name: Build
         run: cmake --build build -- -j$(nproc)
       - name: Run tests & examples
         run: CTEST_PARALLEL_LEVEL=$(nproc) cmake --build build -- test
-


### PR DESCRIPTION
As we have discussed in #64, we want to reject warnings in CI builds in order to prevent potential code smells from creeping into our code base. This commit enables the -Werror flag on all CI builds, and adds some CMake logic to ensure that the dependencies can still be built correctly.

I noticed that my compiler was throwing a few warnings when building the Acts core, and those warnings became errors too. Obviously that's not ideal, so I added some CMake hacks to disable the warning in the local scope for both ways we build dependencies. I'd love another pair of eyes on this to make sure I am not doing something stupid there.

Resolves #64.