### PR TITLE
Set c++17 cuda standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
     
 # Set GPU-related options
 if( TRACCC_BUILD_CUDA )
+  set( CMAKE_CUDA_STANDARD 17 CACHE STRING "The (CUDA) C++ standard to use" )
   add_subdirectory( device/cuda )
 endif()
 


### PR DESCRIPTION
This tiny PR forces to use c++17 for cuda .

I want to use some c++17 features (e.g. std::optional) for track parameter estimation which I am working on.
Due to the reason stated in [mattermost link](https://mattermost.web.cern.ch/acts/pl/jbdtcby6kbgexcxixngjrmm39h), the default vecmem c++ cuda standard is 14, but I think it's okay to use c++17 because we are not using DPC++ AFAIK.

Anyway we may need this because acts highly relies on c++17...