### PR TITLE
Require CMake 3.18 or higher for builds with CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ endif()
     
 # Set GPU-related options
 if( TRACCC_BUILD_CUDA )
+  # TODO: Tuck all of this away neatly in a CUDA configuration file.
+  cmake_minimum_required(VERSION 3.18)
   set( CMAKE_CUDA_STANDARD 17 CACHE STRING "The (CUDA) C++ standard to use" )
   add_subdirectory( device/cuda )
 endif()


### PR DESCRIPTION
As it turns out CMake versions 3.17 and lower are not able to build CUDA correctly with the C++17 standard. To ensure that builds work correctly, I am adding a check to ensure that the minimum version is 3.18, which doe support C++17.