### PR TITLE
VecMem Update, main branch (2021.09.08.)

### DIFF
--- a/cmake/traccc-vecmem.cmake
+++ b/cmake/traccc-vecmem.cmake
@@ -24,7 +24,7 @@ message( STATUS "Building VecMem as part of the traccc project" )
 # Declare where to get VecMem from.
 FetchContent_Declare( VecMem
    GIT_REPOSITORY "https://github.com/acts-project/vecmem.git"
-   GIT_TAG "v0.2.0" )
+   GIT_TAG "v0.3.0" )
 
 # Prevent VecMem from building its tests. As it would interfere with how traccc
 # builds/uses GoogleTest.


### PR DESCRIPTION
Upgraded to the latest [VecMem](https://github.com/acts-project/vecmem) release. (https://github.com/acts-project/vecmem/releases/tag/v0.3.0)

This brings in some improvements over the currently used tag, but it doesn't require any changes in this project's code. As discussed in #78, it will only very slightly help that PR. So the two could be merged in any order in principle.