### PR TITLE
Implement improved algorithm semantics

### DIFF
--- a/core/include/clusterization/component_connection.hpp
+++ b/core/include/clusterization/component_connection.hpp
@@ -25,12 +25,10 @@ namespace traccc {
 /// implementation internally.
 ///
 class component_connection
-    : public algorithm<
-          std::pair<const host_cell_collection&, const cell_module&>,
-          cluster_collection>,
-      public algorithm<
-          std::pair<const device_cell_collection&, const cell_module&>,
-          cluster_collection> {
+    : public algorithm<cluster_collection(const host_cell_collection&,
+                                          const cell_module&)>,
+      public algorithm<cluster_collection(const device_cell_collection&,
+                                          const cell_module&)> {
 
     public:
     /// @name Operators to use in host code
@@ -46,30 +44,9 @@ class component_connection
     /// c++20 piping interface:
     /// @return a cluster collection
     ///
-    cluster_collection operator()(
-        const std::pair<const host_cell_collection&, const cell_module&>& i)
-        const override {
-        const host_cell_collection& cells = i.first;
-        const cell_module& module = i.second;
+    cluster_collection operator()(const host_cell_collection& cells,
+                                  const cell_module& module) const override {
         return this->operator()<vecmem::vector>(cells, module);
-    }
-
-    /// Callable operator for the connected component, based on one single
-    /// module
-    ///
-    /// @param cells are the input cells into the connected component, they are
-    ///              per module and unordered
-    /// @param module The description of the module that the cells belong to
-    /// @param clusters[in,out] are the output clusters
-    ///
-    /// void interface
-    ///
-    void operator()(
-        const std::pair<const host_cell_collection&, const cell_module&>& i,
-        cluster_collection& clusters) const override {
-        const host_cell_collection& cells = i.first;
-        const cell_module& module = i.second;
-        this->operator()<vecmem::vector>(cells, module, clusters);
     }
 
     /// @}
@@ -89,30 +66,9 @@ class component_connection
     /// c++20 piping interface:
     /// @return a cluster collection
     ///
-    cluster_collection operator()(
-        const std::pair<const device_cell_collection&, const cell_module&>& i)
-        const override {
-        const device_cell_collection& cells = i.first;
-        const cell_module& module = i.second;
+    cluster_collection operator()(const device_cell_collection& cells,
+                                  const cell_module& module) const override {
         return this->operator()<vecmem::device_vector>(cells, module);
-    }
-
-    /// Callable operator for the connected component, based on one single
-    /// module
-    ///
-    /// @param cells are the input cells into the connected component, they are
-    ///              per module and unordered
-    /// @param module The description of the module that the cells belong to
-    /// @param clusters[in,out] are the output clusters
-    ///
-    /// void interface
-    ///
-    void operator()(
-        const std::pair<const device_cell_collection&, const cell_module&>& i,
-        cluster_collection& clusters) const override {
-        const device_cell_collection& cells = i.first;
-        const cell_module& module = i.second;
-        this->operator()<vecmem::device_vector>(cells, module, clusters);
     }
 
     private:

--- a/core/include/clusterization/measurement_creation.hpp
+++ b/core/include/clusterization/measurement_creation.hpp
@@ -17,9 +17,8 @@ namespace traccc {
 
 /// Connected component labeling.
 struct measurement_creation
-    : public algorithm<
-          std::pair<const cluster_collection &, const cell_module &>,
-          host_measurement_collection> {
+    : public algorithm<host_measurement_collection(const cluster_collection &,
+                                                   const cell_module &)> {
 
     /// Callable operator for the connected component, based on one single
     /// module
@@ -32,9 +31,10 @@ struct measurement_creation
     ///
     /// @return a measurement collection - usually same size or sometime
     /// slightly smaller than the input
-    host_measurement_collection operator()(const input_type &i) const override {
+    host_measurement_collection operator()(
+        const cluster_collection &c, const cell_module &m) const override {
         output_type measurements;
-        this->operator()(i, measurements);
+        this->operator()(c, m, measurements);
         return measurements;
     }
 
@@ -49,10 +49,9 @@ struct measurement_creation
     ///
     /// @return a measurement collection - usually same size or sometime
     /// slightly smaller than the input
-    void operator()(const input_type &i,
-                    output_type &measurements) const override {
-        const cluster_collection &clusters = i.first;
-        const cell_module &module = i.second;
+    void operator()(const cluster_collection &clusters,
+                    const cell_module &module,
+                    output_type &measurements) const {
 
         // Run the algorithm
         auto pitch = module.pixel.get_pitch();

--- a/core/include/clusterization/spacepoint_formation.hpp
+++ b/core/include/clusterization/spacepoint_formation.hpp
@@ -15,9 +15,8 @@ namespace traccc {
 
 /// Connected component labeling.
 struct spacepoint_formation
-    : public algorithm<
-          std::pair<const cell_module&, const host_measurement_collection&>,
-          host_spacepoint_collection> {
+    : public algorithm<host_spacepoint_collection(
+          const cell_module&, const host_measurement_collection&)> {
 
     /// Callable operator for the space point formation, based on one single
     /// module
@@ -30,10 +29,11 @@ struct spacepoint_formation
     ///
     /// @return a measurement collection - size of input/output container is
     /// identical
-    output_type operator()(const input_type& i) const override {
-
+    output_type operator()(
+        const cell_module& c,
+        const host_measurement_collection& m) const override {
         output_type spacepoints;
-        this->operator()(i, spacepoints);
+        this->operator()(c, m, spacepoints);
         return spacepoints;
     }
 
@@ -48,9 +48,9 @@ struct spacepoint_formation
     ///
     /// @return a measurement collection - size of input/output container is
     /// identical
-    void operator()(const input_type& i, output_type& spacepoints) const {
-        const cell_module& module = i.first;
-        const host_measurement_collection& measurements = i.second;
+    void operator()(const cell_module& module,
+                    const host_measurement_collection& measurements,
+                    output_type& spacepoints) const {
         // Run the algorithm
         spacepoints.reserve(measurements.size());
         for (const auto& m : measurements) {

--- a/core/include/seeding/doublet_finding.hpp
+++ b/core/include/seeding/doublet_finding.hpp
@@ -19,9 +19,9 @@ namespace traccc {
 /// Doublet finding to search the combinations of two compatible spacepoints
 struct doublet_finding
     : public algorithm<
-          std::tuple<const host_internal_spacepoint_container&,
-                     const bin_information&, const sp_location&, const bool>,
-          std::pair<host_doublet_collection, host_lin_circle_collection> > {
+          std::pair<host_doublet_collection, host_lin_circle_collection>(
+              const host_internal_spacepoint_container&, const bin_information&,
+              const sp_location&, const bool&)> {
 
     /// Constructor for the doublet finding
     ///
@@ -37,9 +37,11 @@ struct doublet_finding
     /// @param bottom is whether it is for bottom or top spacepoints
     ///
     /// @return a pair of vectors of doublets and transformed coordinates
-    output_type operator()(const input_type& i) const override {
+    output_type operator()(const host_internal_spacepoint_container& s,
+                           const bin_information& b, const sp_location& l,
+                           const bool& q) const override {
         output_type result;
-        this->operator()(i, result);
+        this->operator()(s, b, l, q, result);
         return result;
     }
 
@@ -52,13 +54,10 @@ struct doublet_finding
     /// void interface
     ///
     /// @return a pair of vectors of doublets and transformed coordinates
-    void operator()(const input_type& i, output_type& o) const {
-
-        // input
-        const auto& isp_container = std::get<0>(i);
-        const auto& bin_information = std::get<1>(i);
-        const auto& spM_location = std::get<2>(i);
-        const auto& bottom = std::get<3>(i);
+    void operator()(const host_internal_spacepoint_container& isp_container,
+                    const bin_information& bin_information,
+                    const sp_location& spM_location, const bool& bottom,
+                    output_type& o) const {
 
         // output
         auto& doublets = o.first;

--- a/core/include/seeding/seed_filtering.hpp
+++ b/core/include/seeding/seed_filtering.hpp
@@ -18,11 +18,12 @@ namespace traccc {
 /// Seed filtering to filter out the bad triplets
 struct seed_filtering
     : public algorithm<
-          const host_internal_spacepoint_container&,
-          std::pair<host_triplet_collection&, host_seed_container&> > {
+          std::pair<host_triplet_collection&, host_seed_container&>(
+              const host_internal_spacepoint_container&)> {
     seed_filtering() {}
 
-    output_type operator()(const input_type&) const override {
+    output_type operator()(
+        const host_internal_spacepoint_container&) const override {
         // not used
         __builtin_unreachable();
     }
@@ -36,8 +37,8 @@ struct seed_filtering
     ///
     /// @return seeds are the vector of seeds where the new compatible seeds are
     /// added
-    void operator()(const input_type& i, output_type& o) const {
-        const auto& isp_container = i;
+    void operator()(const host_internal_spacepoint_container& isp_container,
+                    output_type& o) const {
         auto& triplets = o.first;
         auto& seeds = o.second;
 

--- a/core/include/seeding/seed_finding.hpp
+++ b/core/include/seeding/seed_finding.hpp
@@ -21,9 +21,8 @@
 namespace traccc {
 
 /// Seed finding
-struct seed_finding
-    : public algorithm<const host_internal_spacepoint_container&,
-                       host_seed_container> {
+struct seed_finding : public algorithm<host_seed_container(
+                          const host_internal_spacepoint_container&)> {
     /// Constructor for the seed finding
     ///
     /// @param config is seed finder configuration parameters
@@ -34,7 +33,8 @@ struct seed_finding
     /// Callable operator for the seed finding
     ///
     /// @return seed_collection is the vector of seeds per event
-    output_type operator()(const input_type& i) const override {
+    output_type operator()(
+        const host_internal_spacepoint_container& i) const override {
         output_type result;
         this->operator()(i, result);
         return result;
@@ -45,9 +45,8 @@ struct seed_finding
     /// void interface
     ///
     /// @return seed_collection is the vector of seeds per event
-    void operator()(const input_type& i, output_type& o) const {
-        // input
-        const auto& isp_container = i;
+    void operator()(const host_internal_spacepoint_container& isp_container,
+                    output_type& o) const {
         // output
         auto& seeds = o;
 
@@ -74,15 +73,15 @@ struct seed_finding
                 sp_location spM_location({i, j});
 
                 // middule-bottom doublet search
-                auto mid_bot = m_doublet_finding(
-                    {isp_container, bin_information, spM_location, bottom});
+                auto mid_bot = m_doublet_finding(isp_container, bin_information,
+                                                 spM_location, bottom);
 
                 if (mid_bot.first.empty())
                     continue;
 
                 // middule-top doublet search
-                auto mid_top = m_doublet_finding(
-                    {isp_container, bin_information, spM_location, top});
+                auto mid_top = m_doublet_finding(isp_container, bin_information,
+                                                 spM_location, top);
 
                 if (mid_top.first.empty())
                     continue;
@@ -96,8 +95,8 @@ struct seed_finding
                     auto& lb = mid_bot.second[k];
 
                     host_triplet_collection triplets =
-                        m_triplet_finding({isp_container, doublet_mb, lb,
-                                           mid_top.first, mid_top.second});
+                        m_triplet_finding(isp_container, doublet_mb, lb,
+                                          mid_top.first, mid_top.second);
 
                     triplets_per_spM.insert(std::end(triplets_per_spM),
                                             triplets.begin(), triplets.end());

--- a/core/include/seeding/triplet_finding.hpp
+++ b/core/include/seeding/triplet_finding.hpp
@@ -19,11 +19,10 @@ namespace traccc {
 /// Triplet finding to search the compatible combintations of two doublets which
 /// share same middle spacepoint
 struct triplet_finding
-    : public algorithm<
-          std::tuple<const host_internal_spacepoint_container&, const doublet&,
-                     const lin_circle&, const host_doublet_collection&,
-                     const host_lin_circle_collection&>,
-          host_triplet_collection> {
+    : public algorithm<host_triplet_collection(
+          const host_internal_spacepoint_container&, const doublet&,
+          const lin_circle&, const host_doublet_collection&,
+          const host_lin_circle_collection&)> {
     /// Constructor for the triplet finding
     ///
     /// @param seedfinder_config is the configuration parameters
@@ -40,9 +39,12 @@ struct triplet_finding
     /// doublets_mid_top
     ///
     /// @return a vector of triplets
-    output_type operator()(const input_type& i) const override {
+    output_type operator()(
+        const host_internal_spacepoint_container& isp, const doublet& d,
+        const lin_circle& lc, const host_doublet_collection& doublet,
+        const host_lin_circle_collection& lincol) const override {
         output_type result;
-        this->operator()(i, result);
+        this->operator()(isp, d, lc, doublet, lincol, result);
         return result;
     }
 
@@ -58,14 +60,11 @@ struct triplet_finding
     /// void interface
     ///
     /// @return a vector of triplets
-    void operator()(const input_type& i, output_type& o) const {
-
-        // input
-        const auto& isp_container = std::get<0>(i);
-        const auto& mid_bot = std::get<1>(i);
-        const auto& lb = std::get<2>(i);
-        const auto& doublets_mid_top = std::get<3>(i);
-        const auto& lin_circles_mid_top = std::get<4>(i);
+    void operator()(const host_internal_spacepoint_container& isp_container,
+                    const doublet& mid_bot, const lin_circle& lb,
+                    const host_doublet_collection& doublets_mid_top,
+                    const host_lin_circle_collection& lin_circles_mid_top,
+                    output_type& o) const {
 
         // output
         auto& triplets = o;

--- a/examples/algorithms/cpu/include/clusterization/clusterization_algorithm.hpp
+++ b/examples/algorithms/cpu/include/clusterization/clusterization_algorithm.hpp
@@ -27,17 +27,18 @@ namespace traccc {
 
 class clusterization_algorithm
     : public algorithm<
-          const host_cell_container&,
-          std::pair<host_measurement_container, host_spacepoint_container> > {
+          std::pair<host_measurement_container, host_spacepoint_container>(
+              const host_cell_container&)> {
     public:
-    output_type operator()(const input_type& cells_per_event) const override {
+    output_type operator()(
+        const host_cell_container& cells_per_event) const override {
         output_type o;
         this->operator()(cells_per_event, o);
         return o;
     }
 
-    void operator()(const input_type& cells_per_event,
-                    output_type& o) const override {
+    void operator()(const host_cell_container& cells_per_event,
+                    output_type& o) const {
         // output containers
         auto& measurements_per_event = o.first;
         auto& spacepoints_per_event = o.second;
@@ -51,13 +52,14 @@ class clusterization_algorithm
 
             // The algorithmic code part: start
             traccc::cluster_collection clusters_per_module =
-                cc({cells_per_event.at(i).items, cells_per_event.at(i).header});
+                cc(std::move(cells_per_event.at(i).items),
+                   cells_per_event.at(i).header);
             clusters_per_module.position_from_cell = module.pixel;
 
             traccc::host_measurement_collection measurements_per_module =
-                mt({clusters_per_module, module});
+                mt(std::move(clusters_per_module), module);
             traccc::host_spacepoint_collection spacepoints_per_module =
-                sp({module, measurements_per_module});
+                sp(module, std::move(measurements_per_module));
             // The algorithmnic code part: end
 
             measurements_per_event.push_back(

--- a/examples/algorithms/cpu/include/clusterization/clusterization_algorithm.hpp
+++ b/examples/algorithms/cpu/include/clusterization/clusterization_algorithm.hpp
@@ -52,14 +52,13 @@ class clusterization_algorithm
 
             // The algorithmic code part: start
             traccc::cluster_collection clusters_per_module =
-                cc(std::move(cells_per_event.at(i).items),
-                   cells_per_event.at(i).header);
+                cc(cells_per_event.at(i).items, cells_per_event.at(i).header);
             clusters_per_module.position_from_cell = module.pixel;
 
             traccc::host_measurement_collection measurements_per_module =
-                mt(std::move(clusters_per_module), module);
+                mt(clusters_per_module, module);
             traccc::host_spacepoint_collection spacepoints_per_module =
-                sp(module, std::move(measurements_per_module));
+                sp(module, measurements_per_module);
             // The algorithmnic code part: end
 
             measurements_per_event.push_back(

--- a/examples/algorithms/cpu/include/track_finding/seeding_algorithm.hpp
+++ b/examples/algorithms/cpu/include/track_finding/seeding_algorithm.hpp
@@ -17,8 +17,8 @@ namespace traccc {
 
 class seeding_algorithm
     : public algorithm<
-          const host_spacepoint_container&,
-          std::pair<host_internal_spacepoint_container, host_seed_container> > {
+          std::pair<host_internal_spacepoint_container, host_seed_container>(
+              const host_spacepoint_container&)> {
     public:
     seeding_algorithm(vecmem::memory_resource* mr = nullptr) : m_mr(mr) {
 
@@ -49,14 +49,14 @@ class seeding_algorithm
             traccc::seed_finding(m_config));
     }
 
-    output_type operator()(const input_type& i) const override {
+    output_type operator()(const host_spacepoint_container& i) const override {
         output_type o;
         this->operator()(i, o);
         return o;
     }
 
-    void operator()(const input_type& spacepoints_per_event,
-                    output_type& o) const override {
+    void operator()(const host_spacepoint_container& spacepoints_per_event,
+                    output_type& o) const {
         // output containers
         auto& internal_sp_per_event = o.first;
         auto& seeds = o.second;

--- a/examples/run/cpu/ccl_example.cpp
+++ b/examples/run/cpu/ccl_example.cpp
@@ -77,7 +77,7 @@ void run_on_event(traccc::component_connection& cc,
                   traccc::host_cell_container& data) {
     for (std::size_t i = 0; i < data.size(); ++i) {
         traccc::cluster_collection clusters_per_module =
-            cc(std::move(data.at(i).items), data.at(i).header);
+            cc(data.at(i).items, data.at(i).header);
     }
 }
 

--- a/examples/run/cpu/ccl_example.cpp
+++ b/examples/run/cpu/ccl_example.cpp
@@ -74,10 +74,10 @@ void print_statistics(const traccc::host_cell_container& data) {
 }
 
 void run_on_event(traccc::component_connection& cc,
-                  const traccc::host_cell_container& data) {
+                  traccc::host_cell_container& data) {
     for (std::size_t i = 0; i < data.size(); ++i) {
         traccc::cluster_collection clusters_per_module =
-            cc({data.at(i).items, data.at(i).header});
+            cc(std::move(data.at(i).items), data.at(i).header);
     }
 }
 

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -55,9 +55,9 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
         n_modules += cells_per_event.size();
         n_cells += cells_per_event.total_size();
 
-        auto ca_result = ca(std::move(cells_per_event));
-        auto measurements_per_event = std::move(ca_result.first);
-        auto spacepoints_per_event = std::move(ca_result.second);
+        auto ca_result = ca(cells_per_event);
+        auto measurements_per_event = ca_result.first;
+        auto spacepoints_per_event = ca_result.second;
 
         n_measurements += measurements_per_event.total_size();
         n_spacepoints += spacepoints_per_event.total_size();
@@ -66,7 +66,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
              Seed finding
           -------------------*/
 
-        auto sa_result = sa(std::move(spacepoints_per_event));
+        auto sa_result = sa(spacepoints_per_event);
         auto& internal_sp_per_event = sa_result.first;
         auto& seeds = sa_result.second;
 

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -52,12 +52,13 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
             Clusterization
           -------------------*/
 
-        auto ca_result = ca(cells_per_event);
-        auto& measurements_per_event = ca_result.first;
-        auto& spacepoints_per_event = ca_result.second;
-
         n_modules += cells_per_event.size();
         n_cells += cells_per_event.total_size();
+
+        auto ca_result = ca(std::move(cells_per_event));
+        auto measurements_per_event = std::move(ca_result.first);
+        auto spacepoints_per_event = std::move(ca_result.second);
+
         n_measurements += measurements_per_event.total_size();
         n_spacepoints += spacepoints_per_event.total_size();
 
@@ -65,7 +66,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
              Seed finding
           -------------------*/
 
-        auto sa_result = sa(spacepoints_per_event);
+        auto sa_result = sa(std::move(spacepoints_per_event));
         auto& internal_sp_per_event = sa_result.first;
         auto& seeds = sa_result.second;
 

--- a/examples/run/cpu/seq_single_module.cpp
+++ b/examples/run/cpu/seq_single_module.cpp
@@ -50,9 +50,9 @@ int main() {
     traccc::spacepoint_formation sp;
 
     // Algorithmic code: start
-    clusters = cc(std::move(cells), module);
-    measurements = mt(std::move(clusters), module);
-    spacepoints = sp(module, std::move(measurements));
+    clusters = cc(cells, module);
+    measurements = mt(clusters, module);
+    spacepoints = sp(module, measurements);
 
     return 0;
 }

--- a/examples/run/cpu/seq_single_module.cpp
+++ b/examples/run/cpu/seq_single_module.cpp
@@ -50,9 +50,9 @@ int main() {
     traccc::spacepoint_formation sp;
 
     // Algorithmic code: start
-    clusters = cc({cells, module});
-    measurements = mt({clusters, module});
-    spacepoints = sp({module, measurements});
+    clusters = cc(std::move(cells), module);
+    measurements = mt(std::move(clusters), module);
+    spacepoints = sp(module, std::move(measurements));
 
     return 0;
 }

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -120,7 +120,8 @@ int seq_run(const std::string& detector_file, const std::string& hits_dir,
         traccc::host_seed_container seeds;
         traccc::host_internal_spacepoint_container internal_sp_per_event;
         if (!skip_cpu) {
-            auto sa_result = sa(spacepoints_per_event);
+            auto sa_result =
+                sa(traccc::host_spacepoint_container(spacepoints_per_event));
             internal_sp_per_event = sa_result.first;
             seeds = sa_result.second;
             n_internal_spacepoints += internal_sp_per_event.total_size();

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -120,8 +120,7 @@ int seq_run(const std::string& detector_file, const std::string& hits_dir,
         traccc::host_seed_container seeds;
         traccc::host_internal_spacepoint_container internal_sp_per_event;
         if (!skip_cpu) {
-            auto sa_result =
-                sa(traccc::host_spacepoint_container(spacepoints_per_event));
+            auto sa_result = sa(spacepoints_per_event);
             internal_sp_per_event = sa_result.first;
             seeds = sa_result.second;
             n_internal_spacepoints += internal_sp_per_event.total_size();

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -89,10 +89,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
         /*time*/ auto start_clusterization_cpu =
             std::chrono::system_clock::now();
 
-        n_modules += cells_per_event.size();
-        n_cells += cells_per_event.total_size();
-
-        auto ca_result = ca(std::move(cells_per_event));
+        auto ca_result = ca(cells_per_event);
         auto& measurements_per_event = ca_result.first;
         auto& spacepoints_per_event = ca_result.second;
 
@@ -101,6 +98,8 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
             end_clusterization_cpu - start_clusterization_cpu;
         /*time*/ clusterization_cpu += time_clusterization_cpu.count();
 
+        n_modules += cells_per_event.size();
+        n_cells += cells_per_event.total_size();
         n_measurements += measurements_per_event.total_size();
         n_spacepoints += spacepoints_per_event.total_size();
 
@@ -128,8 +127,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
         traccc::host_seed_container seeds;
         traccc::host_internal_spacepoint_container internal_sp_per_event;
         if (!skip_cpu) {
-            auto sa_result =
-                sa(traccc::host_spacepoint_container(spacepoints_per_event));
+            auto sa_result = sa(spacepoints_per_event);
             internal_sp_per_event = sa_result.first;
             seeds = sa_result.second;
             n_internal_spacepoints += internal_sp_per_event.total_size();

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -88,7 +88,11 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
 
         /*time*/ auto start_clusterization_cpu =
             std::chrono::system_clock::now();
-        auto ca_result = ca(cells_per_event);
+
+        n_modules += cells_per_event.size();
+        n_cells += cells_per_event.total_size();
+
+        auto ca_result = ca(std::move(cells_per_event));
         auto& measurements_per_event = ca_result.first;
         auto& spacepoints_per_event = ca_result.second;
 
@@ -97,8 +101,6 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
             end_clusterization_cpu - start_clusterization_cpu;
         /*time*/ clusterization_cpu += time_clusterization_cpu.count();
 
-        n_modules += cells_per_event.size();
-        n_cells += cells_per_event.total_size();
         n_measurements += measurements_per_event.total_size();
         n_spacepoints += spacepoints_per_event.total_size();
 
@@ -126,7 +128,8 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
         traccc::host_seed_container seeds;
         traccc::host_internal_spacepoint_container internal_sp_per_event;
         if (!skip_cpu) {
-            auto sa_result = sa(spacepoints_per_event);
+            auto sa_result =
+                sa(traccc::host_spacepoint_container(spacepoints_per_event));
             internal_sp_per_event = sa_result.first;
             seeds = sa_result.second;
             n_internal_spacepoints += internal_sp_per_event.total_size();

--- a/examples/run/openmp/io_decoupled/io_dec_par_example.cpp
+++ b/examples/run/openmp/io_decoupled/io_dec_par_example.cpp
@@ -48,14 +48,14 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data,
 
             // The algorithmic code part: start
             traccc::cluster_collection clusters_per_module =
-                cc(std::move(cells_per_event.get_items()[i]),
+                cc(cells_per_event.get_items()[i],
                    cells_per_event.get_headers()[i]);
             clusters_per_module.position_from_cell = module.pixel;
 
             traccc::host_measurement_collection measurements_per_module =
-                mt(std::move(clusters_per_module), module);
+                mt(clusters_per_module, module);
             traccc::host_spacepoint_collection spacepoints_per_module =
-                sp(module, std::move(measurements_per_module));
+                sp(module, measurements_per_module);
             // The algorithmnic code part: end
 
             n_cells += cells_per_event.get_items()[i].size();

--- a/examples/run/openmp/io_decoupled/io_dec_par_example.cpp
+++ b/examples/run/openmp/io_decoupled/io_dec_par_example.cpp
@@ -48,14 +48,14 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data,
 
             // The algorithmic code part: start
             traccc::cluster_collection clusters_per_module =
-                cc({cells_per_event.get_items()[i],
-                    cells_per_event.get_headers()[i]});
+                cc(std::move(cells_per_event.get_items()[i]),
+                   cells_per_event.get_headers()[i]);
             clusters_per_module.position_from_cell = module.pixel;
 
             traccc::host_measurement_collection measurements_per_module =
-                mt({clusters_per_module, module});
+                mt(std::move(clusters_per_module), module);
             traccc::host_spacepoint_collection spacepoints_per_module =
-                sp({module, measurements_per_module});
+                sp(module, std::move(measurements_per_module));
             // The algorithmnic code part: end
 
             n_cells += cells_per_event.get_items()[i].size();

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -73,13 +73,14 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
 
             // The algorithmic code part: start
             traccc::cluster_collection clusters_per_module =
-                cc({cells_per_event.at(i).items, cells_per_event.at(i).header});
+                cc(std::move(cells_per_event.at(i).items),
+                   cells_per_event.at(i).header);
             clusters_per_module.position_from_cell = module.pixel;
 
             traccc::host_measurement_collection measurements_per_module =
-                mt({clusters_per_module, module});
+                mt(std::move(clusters_per_module), module);
             traccc::host_spacepoint_collection spacepoints_per_module =
-                sp({module, measurements_per_module});
+                sp(module, std::move(measurements_per_module));
             // The algorithmnic code part: end
 
             n_cells += cells_per_event.at(i).items.size();

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -73,14 +73,13 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
 
             // The algorithmic code part: start
             traccc::cluster_collection clusters_per_module =
-                cc(std::move(cells_per_event.at(i).items),
-                   cells_per_event.at(i).header);
+                cc(cells_per_event.at(i).items, cells_per_event.at(i).header);
             clusters_per_module.position_from_cell = module.pixel;
 
             traccc::host_measurement_collection measurements_per_module =
-                mt(std::move(clusters_per_module), module);
+                mt(clusters_per_module, module);
             traccc::host_spacepoint_collection spacepoints_per_module =
-                sp(module, std::move(measurements_per_module));
+                sp(module, measurements_per_module);
             // The algorithmnic code part: end
 
             n_cells += cells_per_event.at(i).items.size();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,4 +21,5 @@ target_include_directories(
 
 add_library(traccc::tests::common ALIAS traccc_tests_common)
 
+add_subdirectory(core)
 add_subdirectory(cpu)

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_traccc_test(algorithm algorithm_tests.cpp "")

--- a/tests/core/algorithm_tests.cpp
+++ b/tests/core/algorithm_tests.cpp
@@ -1,0 +1,219 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "utils/algorithm.hpp"
+
+class double_int : public traccc::algorithm<int(const int &)> {
+    public:
+    virtual int operator()(const int &i) const override { return 2 * i; }
+};
+
+class double_int_affine : public traccc::algorithm<int(int &&)> {
+    public:
+    virtual int operator()(int &&i) const override { return 2 * i; }
+};
+
+class double_string_affine
+    : public traccc::algorithm<std::string(std::string &&)> {
+    public:
+    virtual std::string operator()(std::string &&i) const override {
+        return i + i;
+    }
+};
+
+class double_string_regular
+    : public traccc::algorithm<std::string(const std::string &)> {
+    public:
+    virtual std::string operator()(const std::string &i) const override {
+        return i + i;
+    }
+};
+
+class add : public traccc::algorithm<int(const int &, const int &)> {
+    public:
+    virtual int operator()(const int &i, const int &j) const override {
+        return i + j;
+    }
+};
+
+TEST(algorithm, basic) {
+    double_int i;
+
+    ASSERT_EQ(i(1), 2);
+    ASSERT_EQ(i(-1), -2);
+    ASSERT_EQ(i(5), 10);
+}
+
+TEST(algorithm, basic_affine) {
+    double_int_affine i;
+
+    ASSERT_EQ(i(1), 2);
+    ASSERT_EQ(i(-1), -2);
+    ASSERT_EQ(i(5), 10);
+}
+
+TEST(algorithm, string_affine) {
+    double_string_affine i;
+
+    std::string s = "test";
+
+    ASSERT_EQ(i("hello"), "hellohello");
+    ASSERT_EQ(i("bye"), "byebye");
+    ASSERT_EQ(i(std::move(s)), "testtest");
+}
+
+TEST(algorithm, string_regular) {
+    double_string_regular i;
+
+    std::string s = "test";
+
+    ASSERT_EQ(i("hello"), "hellohello");
+    ASSERT_EQ(i("bye"), "byebye");
+    ASSERT_EQ(i(s), "testtest");
+}
+
+TEST(algorithm, compose_double_int_affine_1) {
+    double_int_affine i;
+
+    std::function<int(int &&)> f = traccc::compose(
+        std::function<int(int &&)>(i), std::function<int(int &&)>(i));
+
+    ASSERT_EQ(f(1), 4);
+    ASSERT_EQ(f(-1), -4);
+    ASSERT_EQ(f(5), 20);
+}
+
+TEST(algorithm, compose_double_int_affine_2) {
+    double_int_affine i;
+    double_int_affine j;
+
+    std::function<int(int &&)> f = traccc::compose(
+        std::function<int(int &&)>(i), std::function<int(int &&)>(j));
+
+    ASSERT_EQ(f(1), 4);
+    ASSERT_EQ(f(-1), -4);
+    ASSERT_EQ(f(5), 20);
+}
+
+TEST(algorithm, compose_double_int_regular_1) {
+    double_int i;
+
+    std::function<int(const int &)> f = traccc::compose(
+        std::function<int(const int &)>(i), std::function<int(const int &)>(i));
+
+    ASSERT_EQ(f(1), 4);
+    ASSERT_EQ(f(-1), -4);
+    ASSERT_EQ(f(5), 20);
+}
+
+TEST(algorithm, compose_double_int_regular_2) {
+    double_int i;
+    double_int j;
+
+    std::function<int(const int &)> f = traccc::compose(
+        std::function<int(const int &)>(i), std::function<int(const int &)>(j));
+
+    ASSERT_EQ(f(1), 4);
+    ASSERT_EQ(f(-1), -4);
+    ASSERT_EQ(f(5), 20);
+}
+
+TEST(algorithm, compose_string_lvalue_1) {
+    double_string_regular i;
+
+    std::string s = "test";
+
+    std::function<std::string(const std::string &)> f =
+        traccc::compose(std::function<std::string(const std::string &)>(i),
+                        std::function<std::string(const std::string &)>(i));
+
+    ASSERT_EQ(f("hello"), "hellohellohellohello");
+    ASSERT_EQ(f("bye"), "byebyebyebye");
+    ASSERT_EQ(f(s), "testtesttesttest");
+}
+
+TEST(algorithm, compose_string_rvalue_1) {
+    double_string_affine i;
+
+    std::string s = "test";
+
+    std::function<std::string(std::string &&)> f =
+        traccc::compose(std::function<std::string(std::string &&)>(i),
+                        std::function<std::string(std::string &&)>(i));
+
+    ASSERT_EQ(f("hello"), "hellohellohellohello");
+    ASSERT_EQ(f("bye"), "byebyebyebye");
+    ASSERT_EQ(f(std::move(s)), "testtesttesttest");
+}
+
+TEST(algorithm, compose_double_int_many_times) {
+    double_int i;
+
+    std::function<int(const int &)> f = traccc::compose(
+        std::function<int(const int &)>(i), std::function<int(const int &)>(i),
+        std::function<int(const int &)>(i), std::function<int(const int &)>(i),
+        std::function<int(const int &)>(i), std::function<int(const int &)>(i),
+        std::function<int(const int &)>(i), std::function<int(const int &)>(i));
+
+    ASSERT_EQ(f(1), 256);
+    ASSERT_EQ(f(-1), -256);
+    ASSERT_EQ(f(5), 1280);
+}
+
+TEST(algorithm, side_effect) {
+    double_int i;
+    int j = 0;
+
+    std::function<int(const int &)> f = traccc::compose(
+        std::function<int(const int &)>(i), std::function<int(const int &)>(i),
+        traccc::side_effect(std::function<int(const int &)>(i),
+                            std::function<void(const int &)>(
+                                [&j](const int &q) { j = q + 5; })));
+
+    ASSERT_EQ(f(1), 8);
+    ASSERT_EQ(j, 9);
+}
+
+TEST(algorithm, partial_application_bind) {
+    add i;
+    std::function<int(const int &)> f = std::bind(i, std::placeholders::_1, 5);
+
+    ASSERT_EQ(f(1), 6);
+    ASSERT_EQ(f(-1), 4);
+    ASSERT_EQ(f(5), 10);
+}
+
+TEST(algorithm, partial_application_lambda) {
+    add i;
+    std::function<int(const int &)> f = [i](const int &j) { return i(j, 5); };
+
+    ASSERT_EQ(f(1), 6);
+    ASSERT_EQ(f(-1), 4);
+    ASSERT_EQ(f(5), 10);
+}
+
+TEST(algorithm, partial_application_compose) {
+    add i;
+    std::function<int(const int &)> j = std::bind(i, std::placeholders::_1, 5);
+
+    std::function<int(const int &)> f = traccc::compose(j, j, j);
+
+    ASSERT_EQ(f(1), 16);
+    ASSERT_EQ(f(-1), 14);
+    ASSERT_EQ(f(5), 20);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/cpu/algorithms/component_connection_tests.cpp
+++ b/tests/cpu/algorithms/component_connection_tests.cpp
@@ -35,7 +35,7 @@ TEST(algorithms, component_connection) {
     module.module = 0;
 
     traccc::component_connection ccl;
-    auto clusters = ccl({cells, module});
+    auto clusters = ccl(std::move(cells), module);
 
     ASSERT_EQ(clusters.items.size(), 4u);
 }

--- a/tests/cpu/algorithms/component_connection_tests.cpp
+++ b/tests/cpu/algorithms/component_connection_tests.cpp
@@ -35,7 +35,7 @@ TEST(algorithms, component_connection) {
     module.module = 0;
 
     traccc::component_connection ccl;
-    auto clusters = ccl(std::move(cells), module);
+    auto clusters = ccl(cells, module);
 
     ASSERT_EQ(clusters.items.size(), 4u);
 }


### PR DESCRIPTION
Our current algorithm semantics, defined in #36, are not meeting our requirements. Firstly, they have an unnecessary output parameter method. Secondly, they do not allow us to specify the movement of affine data, of which we have a lot.

This commit changes the existing algorithm semantics in several ways. Firstly, multiple arguments are now more elegantly represented using a template parameter pack instead of a tuple. Secondly, the template is now in a more readable function type syntax. Thirdly, the output parameter version has been removed. Fourthly and lastly, the new algorithm semantics allow us to properly distinguish between different types of data.

Algorithms are now allowed to have affine data types as their arguments (rvalue references in templating), as well as immutable regular types (represented by const lvalue references). These two types should allow us to represent all the types of data we need.

I've also included some handy composition methods which should make it easier to compose smaller algorithms to build larger ones, and it should also make testing our algorithms easier in the long run.

This commit closes #77.

There are also some new tests to make sure these semantics work properly.