### PR TITLE
Improve the numerical stability of measurement variance calculation

### DIFF
--- a/core/include/clusterization/measurement_creation.hpp
+++ b/core/include/clusterization/measurement_creation.hpp
@@ -61,6 +61,15 @@ struct measurement_creation
         for (const auto &cluster : clusters.items) {
             scalar totalWeight = 0.;
 
+            // To calculate the mean and variance with high numerical stability
+            // we use a weighted variant of Welford's algorithm. This is a
+            // single-pass online algorithm that works well for large numbers
+            // of samples, as well as samples with very high values.
+            //
+            // To learn more about this algorithm please refer to:
+            // [1] https://doi.org/10.1080/00401706.1962.10490022
+            // [2] The Art of Computer Programming, Donald E. Knuth, second
+            //     edition, chapter 4.2.2.
             point2 mean = {0., 0.}, var = {0., 0.};
 
             // Should not happen


### PR DESCRIPTION
In the current measurement creation algorithm, the variance of measurement positions is calculated using a naive single-pass algorithm. This algorithm is extremely numerically unstable because it is prone to catastrophic cancellation. Especially when using floats (for GPU processing), this algorithm will not provide the necessary accuracy and will likely lead to nonsensical variance values being calculated.

In this commit, I update the measurement creation algorithm to use a weighted variation of Welford's algorithm, which is a numerically stable single-pass algorithm which can work for large numbers of activations as well as high coordinate ranges. This should improve the accuracy of the variance calculation significantly.