### PR TITLE
Fix clang compilation error in algorithms

### DIFF
--- a/core/include/utils/algorithm.hpp
+++ b/core/include/utils/algorithm.hpp
@@ -46,8 +46,9 @@ class algorithm<R(A...)> {
 };
 
 template <typename A, typename B, typename C, typename... R>
-auto compose(std::function<std::remove_reference_t<B>(A)> f,
-             std::function<C(B)> g, R... rs) {
+auto compose(
+    std::function<std::remove_const_t<std::remove_reference_t<B>>(A)> f,
+    std::function<C(B)> g, R... rs) {
     if constexpr (sizeof...(R) > 0) {
         auto h = compose(g, rs...);
         return [f, h](A&& i) { return h(f(std::forward<A>(i))); };


### PR DESCRIPTION
As @konradkusiak97 found out today, there is a bug in the algorithm code that makes it so that gcc can compile it, but clang cannot. The issue in question is that, apparently, gcc considers the two types `const T(void)` and `T(void)` to be compatible at template resolution time, while clang does not. This was causing some issues. In order to resolve the issue, we can use `std::remove_const` to strip the constness away from the type.