### PR TITLE
Mark header functions inline to avoid linker error

### DIFF
--- a/core/include/clusterization/detail/sparse_ccl.hpp
+++ b/core/include/clusterization/detail/sparse_ccl.hpp
@@ -23,7 +23,8 @@ namespace detail {
 /// @param L an equivalance table
 ///
 /// @return the root of @param e
-unsigned int find_root(const std::vector<unsigned int>& L, unsigned int e) {
+inline unsigned int find_root(const std::vector<unsigned int>& L,
+                              unsigned int e) {
     unsigned int r = e;
     while (L[r] != r) {
         r = L[r];
@@ -36,8 +37,8 @@ unsigned int find_root(const std::vector<unsigned int>& L, unsigned int e) {
 /// @param L an equivalance table
 ///
 /// @return the rleast common ancestor of the entries
-unsigned int make_union(std::vector<unsigned int>& L, unsigned int e1,
-                        unsigned int e2) {
+inline unsigned int make_union(std::vector<unsigned int>& L, unsigned int e1,
+                               unsigned int e2) {
     int e;
     if (e1 < e2) {
         e = e1;
@@ -55,7 +56,7 @@ unsigned int make_union(std::vector<unsigned int>& L, unsigned int e1,
 /// @param b the second cell
 ///
 /// @return boolan to indicate 8-cell connectivity
-bool is_adjacent(cell a, cell b) {
+inline bool is_adjacent(cell a, cell b) {
     return (a.channel0 - b.channel0) * (a.channel0 - b.channel0) <= 1 and
            (a.channel1 - b.channel1) * (a.channel1 - b.channel1) <= 1;
 }
@@ -68,14 +69,14 @@ bool is_adjacent(cell a, cell b) {
 /// @param b the second cell
 ///
 /// @return boolan to indicate !8-cell connectivity
-bool is_far_enough(cell a, cell b) {
+inline bool is_far_enough(cell a, cell b) {
     return (a.channel1 - b.channel1) > 1;
 }
 
 /// Sparce CCL algorithm
 ///
 template <template <typename> class vector_type>
-std::tuple<unsigned int, std::vector<unsigned int>> sparse_ccl(
+inline std::tuple<unsigned int, std::vector<unsigned int>> sparse_ccl(
     const cell_collection<vector_type>& cells) {
 
     // Internal list linking

--- a/io/include/io/csv.hpp
+++ b/io/include/io/csv.hpp
@@ -172,7 +172,8 @@ using surface_reader = dfe::NamedTupleCsvReader<csv_surface>;
 /// Read the geometry information per module and fill into a map
 ///
 /// @param sreader The surface reader type
-std::map<geometry_id, transform3> read_surfaces(surface_reader& sreader) {
+inline std::map<geometry_id, transform3> read_surfaces(
+    surface_reader& sreader) {
 
     std::map<geometry_id, transform3> transform_map;
     csv_surface iosurface;
@@ -316,7 +317,7 @@ inline std::vector<cluster_collection> read_truth_clusters(
 ///
 /// @param hreader The measurement reader type
 /// @param resource The memory resource to use for the return value
-host_measurement_container read_measurements(
+inline host_measurement_container read_measurements(
     measurement_reader& mreader, vecmem::memory_resource& resource,
     const std::map<geometry_id, transform3>& tfmap = {},
     unsigned int max_measurements = std::numeric_limits<unsigned int>::max()) {

--- a/io/include/io/reader.hpp
+++ b/io/include/io/reader.hpp
@@ -14,7 +14,7 @@
 
 namespace traccc {
 
-traccc::geometry read_geometry(const std::string &detector_file) {
+inline traccc::geometry read_geometry(const std::string &detector_file) {
     // Read the surface transforms
     std::string io_detector_file = data_directory() + detector_file;
     traccc::surface_reader sreader(

--- a/io/include/io/utils.hpp
+++ b/io/include/io/utils.hpp
@@ -5,7 +5,7 @@
 
 namespace traccc {
 
-const std::string &data_directory() {
+inline const std::string &data_directory() {
     static const std::string data_dir = [] {
         auto env_d_d = std::getenv("TRACCC_TEST_DATA_DIR");
         if (env_d_d == nullptr) {
@@ -20,7 +20,7 @@ const std::string &data_directory() {
     return data_dir;
 }
 
-std::string get_event_filename(size_t event, const std::string &suffix) {
+inline std::string get_event_filename(size_t event, const std::string &suffix) {
     std::stringstream stream;
     stream << "event";
     stream << std::setfill('0') << std::setw(9) << event;


### PR DESCRIPTION
Currently we have a lot of non-inline header functions which are causing me grief at link-time, because they are being compiled twice. This commit resolves that issue - for now - by marking those functions as inline.