### PR TITLE
Fix external dependency tag for detray

### DIFF
--- a/cmake/traccc-detray.cmake
+++ b/cmake/traccc-detray.cmake
@@ -13,7 +13,7 @@ message( STATUS "Building detray as part of the traccc project" )
 # Declare where to get VecMem from.
 FetchContent_Declare( Detray
   GIT_REPOSITORY "https://github.com/acts-project/detray.git"
-  GIT_TAG        origin/main)
+  GIT_TAG        "08db24ab9b924f3072c63a8673dec1eb2372ffde")
 
 # Prevent Detray from building its tests and benchmarks
 # builds/uses GoogleTest.


### PR DESCRIPTION
As it stands, the detray dependency points towards the main branch of the detray repository. This is dangerous, because it means an update to detray can potentially break the compilation of traccc, and this is exactly what happens. The HEAD of traccc does not currently build. As a temporary fix (until we can start putting out numbered releases of detray) I am proposing we fix the version of detray to a given commit.