### PR TITLE
Allow the use of a system detray installation

### DIFF
--- a/cmake/traccc-detray.cmake
+++ b/cmake/traccc-detray.cmake
@@ -7,6 +7,16 @@
 # Guard against multiple includes.
 include_guard( GLOBAL )
 
+# Try to find detray installed on the system.
+find_package(detray QUIET)
+
+# If it was found, then we're finished.
+if(detray_FOUND)
+  # Call find_package again, just to nicely print where it is picked up from.
+  find_package(detray)
+  return()
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building detray as part of the traccc project" )
 


### PR DESCRIPTION
Currently, our Acts and vecmem dependencies allow the user to supply their own, system-wide installation of those packages. traccc will try to find them, and use them if it succeeds. It only uses the submodules included if the system installation is not found.

This behaviour doesn't exist for detray, which makes the build system a little inconsistent. In this commit, I introduce the same checks that we have for Acts and vecmem, to make sure that we can use system installations of detray if desired.