### PR TITLE
BUG : enable SYCL when TRACCC_BUILD_SYCL is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,11 @@ if( TRACCC_BUILD_CUDA )
   add_subdirectory( device/cuda )
 endif()
 
+# enable SYCL language
+if ( TRACCC_BUILD_SYCL )
+  enable_language(SYCL)
+endif()
+
 # Build the traccc code.
 add_subdirectory(core)
 add_subdirectory(io)


### PR DESCRIPTION
VecMem refuses to build when  `enable_language(SYCL)` is set.

I tested with two versions of DPC++ on my laptop :
- Intel(R) oneAPI DPC++/C++ Compiler 2021.4.0 (2021.4.0.20210924)
- Intel(R) oneAPI DPC++ Compiler 2021.1 (2020.10.0.1113)

What I did : 
- clone the repo, checkout on this branch (or just add `enable_language(SYCL)` in the root `CMakeLists.txt`)
- initialize the submodules : `git submodule update --init`
- and run the following command: 

```bash
mkdir build && \
cmake \
-D CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:/usr/local" \
-D CMAKE_CXX_COMPILER=dpcpp \
-D CMAKE_SYCL_COMPILER=/home/sylvain/intel/oneapi/compiler/2021.4.0/linux/bin/dpcpp \
-D CMAKE_SYCL_COMPILER_ENV_VAR=/home/sylvain/intel/oneapi/setvars.sh \
TRACCC_BUILD_SYCL=On -S . -B build && \
cd build  && \
make && \
ctest
```

Here is the full error message : 
```log
Scanning dependencies of target vecmem_core
[ 78%] Building CXX object _deps/vecmem-build/core/CMakeFiles/vecmem_core.dir/src/memory/allocator.cpp.o
[ 78%] Building CXX object _deps/vecmem-build/core/CMakeFiles/vecmem_core.dir/src/memory/deallocator.cpp.o
[ 79%] Building CXX object _deps/vecmem-build/core/CMakeFiles/vecmem_core.dir/src/memory/host_memory_resource.cpp.o
[ 80%] Building CXX object _deps/vecmem-build/core/CMakeFiles/vecmem_core.dir/src/memory/binary_page_memory_resource.cpp.o
[ 80%] Building CXX object _deps/vecmem-build/core/CMakeFiles/vecmem_core.dir/src/memory/contiguous_memory_resource.cpp.o
[ 81%] Building CXX object _deps/vecmem-build/core/CMakeFiles/vecmem_core.dir/src/utils/copy.cpp.o
[ 82%] Linking CXX shared library ../../../lib/libvecmem_core.so
[ 82%] Built target vecmem_core
Scanning dependencies of target ccl_example
[ 83%] Building CXX object examples/run/cpu/CMakeFiles/ccl_example.dir/ccl_example.cpp.o
In file included from /home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/examples/run/cpu/ccl_example.cpp:14:
In file included from /home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/core/include/clusterization/component_connection.hpp:10:
In file included from /home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/core/include/clusterization/detail/sparse_ccl.hpp:10:
In file included from /home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/core/include/edm/cell.hpp:12:
In file included from /home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/core/include/edm/container.hpp:15:
In file included from /home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/containers/device_vector.hpp:12:
In file included from /home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/atomic.hpp:109:
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:43:5: error: no member named 'global_ptr' in namespace 'sycl'
    __VECMEM_SYCL_ATOMIC_CALL1(store, m_ptr, data);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:48: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                     ~~~~~~~~~~^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:43:5: error: unexpected type name 'value_type': expected expression
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:59: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                                          ^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:59:12: error: no member named 'global_ptr' in namespace 'sycl'
    return __VECMEM_SYCL_ATOMIC_CALL0(load, m_ptr);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:19:48: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL0'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)))
                                     ~~~~~~~~~~^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:59:12: error: unexpected type name 'value_type': expected expression
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:19:59: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL0'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)))
                                                          ^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:71:12: error: no member named 'global_ptr' in namespace 'sycl'
    return __VECMEM_SYCL_ATOMIC_CALL1(exchange, m_ptr, data);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:48: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                     ~~~~~~~~~~^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:71:12: error: unexpected type name 'value_type': expected expression
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:59: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                                          ^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:86:12: error: no member named 'global_ptr' in namespace 'sycl'
    return __VECMEM_SYCL_ATOMIC_CALL2(compare_exchange_strong, m_ptr, expected,
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:26:48: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL2'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                     ~~~~~~~~~~^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:86:12: error: unexpected type name 'value_type': expected expression
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:26:59: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL2'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                                          ^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:106:12: error: no member named 'global_ptr' in namespace 'sycl'
    return __VECMEM_SYCL_ATOMIC_CALL1(fetch_add, m_ptr, data);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:48: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                     ~~~~~~~~~~^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:106:12: error: unexpected type name 'value_type': expected expression
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:59: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                                          ^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:121:12: error: no member named 'global_ptr' in namespace 'sycl'
    return __VECMEM_SYCL_ATOMIC_CALL1(fetch_sub, m_ptr, data);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:48: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                     ~~~~~~~~~~^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:121:12: error: unexpected type name 'value_type': expected expression
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:59: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                                          ^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:136:12: error: no member named 'global_ptr' in namespace 'sycl'
    return __VECMEM_SYCL_ATOMIC_CALL1(fetch_and, m_ptr, data);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:48: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                     ~~~~~~~~~~^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:136:12: error: unexpected type name 'value_type': expected expression
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:59: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                                          ^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:150:12: error: no member named 'global_ptr' in namespace 'sycl'
    return __VECMEM_SYCL_ATOMIC_CALL1(fetch_or, m_ptr, data);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:48: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                     ~~~~~~~~~~^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:150:12: error: unexpected type name 'value_type': expected expression
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:59: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                                          ^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:165:12: error: no member named 'global_ptr' in namespace 'sycl'
    return __VECMEM_SYCL_ATOMIC_CALL1(fetch_xor, m_ptr, data);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:48: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                     ~~~~~~~~~~^
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:165:12: error: unexpected type name 'value_type': expected expression
/home/data_sync/academique/These/Traccc/test_compil_11-05/traccc_base_enable_sycl/build/_deps/vecmem-src/core/include/vecmem/memory/impl/atomic.ipp:22:59: note: expanded from macro '__VECMEM_SYCL_ATOMIC_CALL1'
        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
                                                          ^
18 errors generated.
make[2]: *** [examples/run/cpu/CMakeFiles/ccl_example.dir/build.make:63: examples/run/cpu/CMakeFiles/ccl_example.dir/ccl_example.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2127: examples/run/cpu/CMakeFiles/ccl_example.dir/all] Error 2
make: *** [Makefile:163: all] Error 2
```