### PR TITLE
SYCL Example, main branch (2021.11.08.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 # Flags controlling which parts of traccc to build.
 option( TRACCC_BUILD_CUDA "Build the CUDA sources included in traccc"
    ${TRACCC_BUILD_CUDA_DEFAULT} )
+option( TRACCC_BUILD_SYCL "Build the SYCL sources included in traccc" FALSE )
 option( TRACCC_BUILD_TESTING "Build the (unit) tests of traccc" TRUE )
 
 # Clean up.
@@ -52,9 +53,11 @@ option( TRACCC_USE_SYSTEM_VECMEM
    FALSE )
 if( TRACCC_SETUP_VECMEM )
    if( TRACCC_USE_SYSTEM_VECMEM )
-      find_package( vecmem REQUIRED )
+      find_package( vecmem 0.7.0 REQUIRED COMPONENTS LANGUAGE )
    else()
       add_subdirectory( extern/vecmem )
+      # Make the "VecMem language code" available for the whole project.
+      include( "${VECMEM_LANGUAGE_DIR}/vecmem-check-language.cmake" )
    endif()
 endif()
 

--- a/examples/run/CMakeLists.txt
+++ b/examples/run/CMakeLists.txt
@@ -4,6 +4,10 @@ if (TRACCC_BUILD_CUDA)
   add_subdirectory(cuda)
 endif()
 
+if (TRACCC_BUILD_SYCL)
+  add_subdirectory(sycl)
+endif()
+
 find_package(OpenMP COMPONENTS CXX)
 if (OpenMP_CXX_FOUND)
     add_subdirectory(openmp)

--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -1,0 +1,11 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# We need the SYCL language in this directory.
+enable_language( SYCL )
+
+# Example executable(s).
+add_executable( traccc_sycl_language_example "sycl_language_example.sycl" )

--- a/examples/run/sycl/sycl_language_example.sycl
+++ b/examples/run/sycl/sycl_language_example.sycl
@@ -1,0 +1,54 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+// System include(s).
+#include <iostream>
+
+int main() {
+
+    // Loop over all available SYCL platforms.
+    for (const cl::sycl::platform& platform :
+         cl::sycl::platform::get_platforms()) {
+
+        // Print some information about the platform.
+        std::cout << "============ Platform ============" << std::endl;
+        std::cout << " Name   : "
+                  << platform.get_info<cl::sycl::info::platform::name>()
+                  << std::endl;
+        std::cout << " Vendor : "
+                  << platform.get_info<cl::sycl::info::platform::vendor>()
+                  << std::endl;
+        std::cout << " Version: "
+                  << platform.get_info<cl::sycl::info::platform::version>()
+                  << std::endl;
+
+        // Loop over all devices available from this platform.
+        for (const cl::sycl::device& device : platform.get_devices()) {
+
+            // Print some information about the device.
+            std::cout << "------------- Device -------------" << std::endl;
+            std::cout << " Name   : "
+                      << device.get_info<cl::sycl::info::device::name>()
+                      << std::endl;
+            std::cout << " Vendor : "
+                      << device.get_info<cl::sycl::info::device::vendor>()
+                      << std::endl;
+            std::cout << " Version: "
+                      << device.get_info<cl::sycl::info::device::version>()
+                      << std::endl;
+            std::cout << "----------------------------------" << std::endl;
+        }
+
+        std::cout << "==================================" << std::endl;
+    }
+
+    // Retrun gracefully.
+    return 0;
+}

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.6.0.tar.gz;URL_MD5;d741067ff148d2df3c4e6d4587d65fdc"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.7.0.tar.gz;URL_MD5;24e9bbb0b6b82406e01770d39b6a6ec0"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Added a [SYCL](https://www.khronos.org/sycl/) example application to the project. With the goal of helping the development of @konradkusiak97 and @SylvainJoube,

The ability to use VecMem's "language code" depends on https://github.com/acts-project/vecmem/pull/144. Until that is in, this will stay a draft.