### PR TITLE
Fix missing vector-scalar division usage

### DIFF
--- a/core/include/clusterization/measurement_creation.hpp
+++ b/core/include/clusterization/measurement_creation.hpp
@@ -98,7 +98,8 @@ struct measurement_creation
                 // normalize the cell position
                 m.local = mean;
                 // normalize the variance
-                m.variance = var / totalWeight;
+                m.variance[0] = var[0] / totalWeight;
+                m.variance[1] = var[1] / totalWeight;
                 // plus pitch^2 / 12
                 m.variance = m.variance + point2{pitch[0] * pitch[0] / 12,
                                                  pitch[1] * pitch[1] / 12};


### PR DESCRIPTION
This, I think, snuck in when we switched to the new `algebra-plugins`. There is some use of vector-scalar division which is not defined with the current version of the algebra, which leads to a compiler error. I've removed this division and changed it to two scalar-scalar divisions for now.