### PR TITLE
Add `link_type` in container for indexing and its application to seeding

### DIFF
--- a/core/include/edm/container.hpp
+++ b/core/include/edm/container.hpp
@@ -67,7 +67,7 @@ class container_element {
 template <typename header_t, typename item_t,
           template <typename> class vector_t,
           template <typename> class jagged_vector_t,
-          template <typename...> class pair_type = std::pair>
+          template <typename...> class pair_type = thrust::pair>
 class container {
     public:
     /// @name Type definitions

--- a/core/include/edm/container.hpp
+++ b/core/include/edm/container.hpp
@@ -67,7 +67,7 @@ class container_element {
 template <typename header_t, typename item_t,
           template <typename> class vector_t,
           template <typename> class jagged_vector_t,
-          template <typename...> class pair_type = thrust::pair>
+          template <typename...> class pair_type = std::pair>
 class container {
     public:
     /// @name Type definitions

--- a/core/include/edm/internal_spacepoint.hpp
+++ b/core/include/edm/internal_spacepoint.hpp
@@ -85,6 +85,18 @@ struct internal_spacepoint {
     }
 
     TRACCC_HOST_DEVICE
+    internal_spacepoint& operator=(internal_spacepoint sp) {
+        m_link = sp.m_link;
+        m_x = sp.m_x;
+        m_y = sp.m_y;
+        m_z = sp.m_z;
+        m_r = sp.m_r;
+        m_varianceR = sp.m_varianceR;
+        m_varianceZ = sp.m_varianceZ;
+        return *this;
+    }
+
+    TRACCC_HOST_DEVICE
     static inline internal_spacepoint<spacepoint_t> invalid_value() {
 
         link_type l = {detray::invalid_value<decltype(l.first)>(),

--- a/core/include/edm/internal_spacepoint.hpp
+++ b/core/include/edm/internal_spacepoint.hpp
@@ -86,7 +86,8 @@ struct internal_spacepoint {
 
     TRACCC_HOST_DEVICE
     internal_spacepoint& operator=(internal_spacepoint sp) {
-        m_link = sp.m_link;
+        m_link.first = sp.m_link.first;
+        m_link.second = sp.m_link.second;
         m_x = sp.m_x;
         m_y = sp.m_y;
         m_z = sp.m_z;

--- a/core/include/edm/internal_spacepoint.hpp
+++ b/core/include/edm/internal_spacepoint.hpp
@@ -85,6 +85,22 @@ struct internal_spacepoint {
     }
 
     TRACCC_HOST_DEVICE
+    internal_spacepoint& operator=(
+        const internal_spacepoint<spacepoint_t>& sp) {
+
+        m_link.first = sp.m_link.first;
+        m_link.second = sp.m_link.second;
+        m_x = sp.m_x;
+        m_y = sp.m_y;
+        m_z = sp.m_z;
+        m_r = sp.m_r;
+        m_varianceR = sp.m_varianceR;
+        m_varianceZ = sp.m_varianceZ;
+
+        return *this;
+    }
+
+    TRACCC_HOST_DEVICE
     static inline internal_spacepoint<spacepoint_t> invalid_value() {
 
         link_type l = {detray::invalid_value<decltype(l.first)>(),

--- a/core/include/edm/internal_spacepoint.hpp
+++ b/core/include/edm/internal_spacepoint.hpp
@@ -85,19 +85,6 @@ struct internal_spacepoint {
     }
 
     TRACCC_HOST_DEVICE
-    internal_spacepoint& operator=(internal_spacepoint sp) {
-        m_link.first = sp.m_link.first;
-        m_link.second = sp.m_link.second;
-        m_x = sp.m_x;
-        m_y = sp.m_y;
-        m_z = sp.m_z;
-        m_r = sp.m_r;
-        m_varianceR = sp.m_varianceR;
-        m_varianceZ = sp.m_varianceZ;
-        return *this;
-    }
-
-    TRACCC_HOST_DEVICE
     static inline internal_spacepoint<spacepoint_t> invalid_value() {
 
         link_type l = {detray::invalid_value<decltype(l.first)>(),

--- a/core/include/edm/internal_spacepoint.hpp
+++ b/core/include/edm/internal_spacepoint.hpp
@@ -27,21 +27,30 @@
 namespace traccc {
 
 /// Item: A internal spacepoint definition
-template <typename spacepoint>
+template <typename spacepoint_t>
 struct internal_spacepoint {
+
+    // FIXME: geometry_id is hard-coded here
+    using spacepoint_container_type = host_container<geometry_id, spacepoint_t>;
+    using link_type = typename spacepoint_container_type::link_type;
+
+    link_type m_link;
+
     scalar m_x;
     scalar m_y;
     scalar m_z;
     scalar m_r;
     scalar m_varianceR;
     scalar m_varianceZ;
-    spacepoint m_sp;
 
     internal_spacepoint() = default;
 
-    TRACCC_HOST_DEVICE
-    internal_spacepoint(const spacepoint& sp, const vector2& offsetXY)
-        : m_sp(sp) {
+    template <typename spacepoint_container_t>
+    TRACCC_HOST_DEVICE internal_spacepoint(
+        const spacepoint_container_t& sp_container, const link_type& sp_link,
+        const vector2& offsetXY)
+        : m_link(std::move(sp_link)) {
+        const spacepoint_t& sp = sp_container.at(sp_link);
         m_x = sp.global[0] - offsetXY[0];
         m_y = sp.global[1] - offsetXY[1];
         m_z = sp.global[2];
@@ -53,8 +62,20 @@ struct internal_spacepoint {
     }
 
     TRACCC_HOST_DEVICE
-    internal_spacepoint(const internal_spacepoint<spacepoint>& sp)
-        : m_sp(sp.sp()) {
+    internal_spacepoint(const link_type& sp_link) : m_link(std::move(sp_link)) {
+
+        m_x = 0;
+        m_y = 0;
+        m_z = 0;
+        m_r = 0;
+        m_varianceR = 0;
+        m_varianceZ = 0;
+    }
+
+    TRACCC_HOST_DEVICE
+    internal_spacepoint(const internal_spacepoint<spacepoint_t>& sp)
+        : m_link(std::move(sp.m_link)) {
+
         m_x = sp.m_x;
         m_y = sp.m_y;
         m_z = sp.m_z;
@@ -64,37 +85,15 @@ struct internal_spacepoint {
     }
 
     TRACCC_HOST_DEVICE
-    internal_spacepoint& operator=(internal_spacepoint&& sp) {
-        m_sp = std::move(sp.sp());
-        m_x = std::move(sp.m_x);
-        m_y = std::move(sp.m_y);
-        m_z = std::move(sp.m_z);
-        m_r = std::move(sp.m_r);
-        m_varianceR = std::move(sp.m_varianceR);
-        m_varianceZ = std::move(sp.m_varianceZ);
-        return *this;
+    static inline internal_spacepoint<spacepoint_t> invalid_value() {
+
+        link_type l = {detray::invalid_value<decltype(l.first)>(),
+                       detray::invalid_value<decltype(l.second)>()};
+
+        return internal_spacepoint<spacepoint_t>({std::move(l)});
     }
 
-    TRACCC_HOST_DEVICE
-    internal_spacepoint& operator=(const internal_spacepoint<spacepoint>& sp) {
-        m_sp = sp.sp();
-        m_x = sp.m_x;
-        m_y = sp.m_y;
-        m_z = sp.m_z;
-        m_r = sp.m_r;
-        m_varianceR = sp.m_varianceR;
-        m_varianceZ = sp.m_varianceZ;
-        return *this;
-    }
-
-    TRACCC_HOST_DEVICE
-    static inline internal_spacepoint<spacepoint> invalid_value() {
-        spacepoint sp = spacepoint::invalid_value();
-        return internal_spacepoint<spacepoint>({sp, {0., 0.}});
-    }
-
-    TRACCC_HOST_DEVICE
-    const scalar& x() const { return m_x; }
+    TRACCC_HOST_DEVICE const scalar& x() const { return m_x; }
 
     TRACCC_HOST_DEVICE
     const scalar& y() const { return m_y; }
@@ -113,9 +112,6 @@ struct internal_spacepoint {
 
     TRACCC_HOST_DEVICE
     const scalar& varianceZ() const { return m_varianceZ; }
-
-    TRACCC_HOST_DEVICE
-    const spacepoint& sp() const { return m_sp; }
 };
 
 template <typename spacepoint_t>

--- a/core/include/edm/seed.hpp
+++ b/core/include/edm/seed.hpp
@@ -29,9 +29,14 @@ struct seed {
     TRACCC_HOST_DEVICE
     seed& operator=(const seed& aSeed) {
 
-        spB_link = aSeed.spB_link;
-        spM_link = aSeed.spM_link;
-        spT_link = aSeed.spT_link;
+        spB_link.first = aSeed.spB_link.first;
+        spB_link.second = aSeed.spB_link.second;
+
+        spM_link.first = aSeed.spM_link.first;
+        spM_link.second = aSeed.spM_link.second;
+
+        spT_link.first = aSeed.spT_link.first;
+        spT_link.second = aSeed.spT_link.second;
 
         weight = aSeed.weight;
         z_vertex = aSeed.z_vertex;

--- a/core/include/edm/seed.hpp
+++ b/core/include/edm/seed.hpp
@@ -16,17 +16,23 @@ namespace traccc {
 
 /// Item: seed consisting of three spacepoints, z origin and weight
 struct seed {
-    spacepoint spB;
-    spacepoint spM;
-    spacepoint spT;
+
+    using link_type = typename host_spacepoint_container::link_type;
+
+    link_type spB_link;
+    link_type spM_link;
+    link_type spT_link;
+
     scalar weight;
     scalar z_vertex;
 
     TRACCC_HOST_DEVICE
     seed& operator=(const seed& aSeed) {
-        spB = aSeed.spB;
-        spM = aSeed.spM;
-        spT = aSeed.spT;
+
+        spB_link = aSeed.spB_link;
+        spM_link = aSeed.spM_link;
+        spT_link = aSeed.spT_link;
+
         weight = aSeed.weight;
         z_vertex = aSeed.z_vertex;
         return *this;
@@ -34,7 +40,8 @@ struct seed {
 };
 
 inline bool operator==(const seed& lhs, const seed& rhs) {
-    return (lhs.spB == rhs.spB && lhs.spM == rhs.spM && lhs.spT == rhs.spT);
+    return (lhs.spB_link == rhs.spB_link && lhs.spM_link == rhs.spM_link &&
+            lhs.spT_link == rhs.spT_link);
 }
 
 /// Container of internal_spacepoint for an event

--- a/core/include/seeding/seed_filtering.hpp
+++ b/core/include/seeding/seed_filtering.hpp
@@ -17,11 +17,13 @@ namespace traccc {
 
 /// Seed filtering to filter out the bad triplets
 struct seed_filtering
-    : public algorithm<std::pair<host_triplet_collection&,
-                                 host_seed_container&>(const sp_grid&)> {
+    : public algorithm<
+          std::pair<host_triplet_collection&, host_seed_container&>(
+              const host_spacepoint_container&, const sp_grid&)> {
     seed_filtering() {}
 
-    output_type operator()(const sp_grid&) const override {
+    output_type operator()(const host_spacepoint_container&,
+                           const sp_grid&) const override {
         // not used
         __builtin_unreachable();
     }
@@ -35,7 +37,8 @@ struct seed_filtering
     ///
     /// @return seeds are the vector of seeds where the new compatible seeds are
     /// added
-    void operator()(const sp_grid& g2, output_type& o) const {
+    void operator()(const host_spacepoint_container& sp_container,
+                    const sp_grid& g2, output_type& o) const {
         auto& triplets = o.first;
         auto& seeds = o.second;
 
@@ -62,7 +65,7 @@ struct seed_filtering
                 continue;
             }
 
-            seeds_per_spM.push_back({spB.m_sp, spM.m_sp, spT.m_sp,
+            seeds_per_spM.push_back({spB.m_link, spM.m_link, spT.m_link,
                                      triplet.weight, triplet.z_vertex});
         }
 
@@ -101,8 +104,7 @@ struct seed_filtering
             // don't cut first element
             for (size_t i = 1; i < itLength; i++) {
                 if (seed_selecting_helper::cut_per_middle_sp(
-                        m_filter_config, seeds_per_spM[i].spM,
-                        seeds_per_spM[i].spB, seeds_per_spM[i].spT,
+                        m_filter_config, sp_container, seeds_per_spM[i],
                         seeds_per_spM[i].weight)) {
                     new_seeds.push_back(std::move(seeds_per_spM[i]));
                 }

--- a/core/include/seeding/seed_finding.hpp
+++ b/core/include/seeding/seed_finding.hpp
@@ -21,7 +21,8 @@
 namespace traccc {
 
 /// Seed finding
-struct seed_finding : public algorithm<host_seed_container(const sp_grid&)> {
+struct seed_finding : public algorithm<host_seed_container(
+                          const host_spacepoint_container&, const sp_grid&)> {
 
     /// Constructor for the seed finding
     ///
@@ -33,12 +34,12 @@ struct seed_finding : public algorithm<host_seed_container(const sp_grid&)> {
     /// Callable operator for the seed finding
     ///
     /// @return seed_collection is the vector of seeds per event
-    output_type operator()(const sp_grid& g2) const override {
-        output_type seeds;
+    output_type operator()(const host_spacepoint_container& sp_container,
+                           const sp_grid& g2) const override {
 
         // Run the algorithm
-        seeds = {host_seed_container::header_vector(1, 0),
-                 host_seed_container::item_vector(1)};
+        output_type seeds = {host_seed_container::header_vector(1, 0),
+                             host_seed_container::item_vector(1)};
 
         const bool bottom = true;
         const bool top = false;
@@ -80,7 +81,7 @@ struct seed_finding : public algorithm<host_seed_container(const sp_grid&)> {
                 // seed filtering
                 std::pair<host_triplet_collection&, host_seed_container&>
                     filter_output(triplets_per_spM, seeds);
-                m_seed_filtering(g2, filter_output);
+                m_seed_filtering(sp_container, g2, filter_output);
             }
         }
 

--- a/core/include/seeding/seed_selecting_helper.hpp
+++ b/core/include/seeding/seed_selecting_helper.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <edm/internal_spacepoint.hpp>
+#include <edm/seed.hpp>
 #include <seeding/detail/seeding_config.hpp>
 
 namespace traccc {
@@ -60,16 +61,19 @@ struct seed_selecting_helper {
     /// Cut triplets with criteria
     ///
     /// @param filter_config is seed filtering configuration parameters
-    /// @param spM is middle spacepoint
-    /// @param spB is bottom spacepoint
-    /// @param spT is top spacepoint
+    /// @param sp_container is spacepoint container
+    /// @param seed is seed
     /// @param triplet_weight is the weight of triplet
     ///
     /// @return boolean value
+    template <typename spacepoint_container_t>
     static TRACCC_HOST_DEVICE bool cut_per_middle_sp(
-        const seedfilter_config& filter_config, const spacepoint&,
-        const spacepoint& spB, const spacepoint&,
+        const seedfilter_config& filter_config,
+        const spacepoint_container_t& sp_container, const seed& seed,
         const scalar& triplet_weight) {
+
+        const auto& spB = sp_container.at(seed.spB_link);
+
         return (triplet_weight > filter_config.seed_min_weight ||
                 spB.radius() > filter_config.spB_min_radius);
     }

--- a/core/include/seeding/spacepoint_binning.hpp
+++ b/core/include/seeding/spacepoint_binning.hpp
@@ -48,10 +48,10 @@ struct spacepoint_binning
         // space points with delta r < rbin size can be out of order
         for (auto& rbin : rbins) {
             for (auto& sp_loc : rbin) {
-                const spacepoint& sp =
-                    sp_container.get_items()[sp_loc.bin_idx][sp_loc.sp_idx];
-                auto isp =
-                    internal_spacepoint<spacepoint>(sp, m_config.beamPos);
+
+                auto isp = internal_spacepoint<spacepoint>(
+                    sp_container, {sp_loc.bin_idx, sp_loc.sp_idx},
+                    m_config.beamPos);
 
                 point2 sp_position = {isp.phi(), isp.z()};
                 g2.populate(sp_position, std::move(isp));

--- a/core/include/seeding/track_params_estimation.hpp
+++ b/core/include/seeding/track_params_estimation.hpp
@@ -17,7 +17,7 @@ namespace traccc {
 
 struct track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
-          const host_seed_container&)> {
+          const host_spacepoint_container&, const host_seed_container&)> {
     public:
     /// Constructor for track_params_estimation
     ///
@@ -29,11 +29,13 @@ struct track_params_estimation
     /// @param input_type is the seed container
     ///
     /// @return vector of bound track parameters
-    output_type operator()(const host_seed_container& i) const override {
+    output_type operator()(
+        const host_spacepoint_container& sp_container,
+        const host_seed_container& seed_container) const override {
         output_type result(&m_mr.get());
 
         // input for seed vector
-        const auto& seeds = i.get_items()[0];
+        const auto& seeds = seed_container.get_items()[0];
 
         // convenient assumption on bfield and mass
         // TODO: Make use of bfield extenstion in the future
@@ -42,7 +44,7 @@ struct track_params_estimation
         for (auto seed : seeds) {
             bound_track_parameters track_params;
             track_params.vector() =
-                seed_to_bound_vector(seed, bfield, PION_MASS_MEV);
+                seed_to_bound_vector(sp_container, seed, bfield, PION_MASS_MEV);
 
             result.push_back(track_params);
         }

--- a/core/include/seeding/track_params_estimation_helper.hpp
+++ b/core/include/seeding/track_params_estimation_helper.hpp
@@ -33,14 +33,16 @@ inline TRACCC_HOST_DEVICE vector2 uv_transform(const scalar& x,
 /// @param seed is the input seed
 /// @param bfield is the magnetic field
 /// @param mass is the mass of particle
+template <typename spacepoint_container_t>
 inline TRACCC_HOST_DEVICE bound_vector seed_to_bound_vector(
-    const seed& seed, const vector3& bfield, const scalar mass) {
+    const spacepoint_container_t& sp_container, const seed& seed,
+    const vector3& bfield, const scalar mass) {
 
     bound_vector params;
 
-    const auto& spB = seed.spB;
-    const auto& spM = seed.spM;
-    const auto& spT = seed.spT;
+    const auto& spB = sp_container.at(seed.spB_link);
+    const auto& spM = sp_container.at(seed.spM_link);
+    const auto& spT = sp_container.at(seed.spT_link);
 
     darray<vector3, 3> sp_global_positions;
     sp_global_positions[0] = spB.global;
@@ -85,7 +87,8 @@ inline TRACCC_HOST_DEVICE bound_vector seed_to_bound_vector(
 
     // The momentum direction in the new frame (the center of the circle
     // has the coordinate (-1.*A/(2*B), 1./(2*B)))
-    vector3 transDirection({1., A, scalar(std::hypot(1., A)) * invTanTheta});
+    vector3 transDirection =
+        vector3({1., A, scalar(std::hypot(1., A)) * invTanTheta});
     // Transform it back to the original frame
     vector3 direction =
         transform3::rotate(trans._data, vector::normalize(transDirection));

--- a/device/cuda/include/cuda/seeding/seed_finding.hpp
+++ b/device/cuda/include/cuda/seeding/seed_finding.hpp
@@ -28,7 +28,8 @@ namespace traccc {
 namespace cuda {
 
 /// Seed finding for cuda
-struct seed_finding : public algorithm<host_seed_container(sp_grid&&)> {
+struct seed_finding : public algorithm<host_seed_container(
+                          host_spacepoint_container&&, sp_grid&&)> {
 
     /// Constructor for the cuda seed finding
     ///
@@ -51,7 +52,8 @@ struct seed_finding : public algorithm<host_seed_container(sp_grid&&)> {
     /// Callable operator for the seed finding
     ///
     /// @return seed_collection is the vector of seeds per event
-    output_type operator()(sp_grid&& g2) const override {
+    output_type operator()(host_spacepoint_container&& spacepoints,
+                           sp_grid&& g2) const override {
         std::lock_guard<std::mutex> lock(*mutex);
 
         size_t n_internal_sp = 0;
@@ -120,7 +122,7 @@ struct seed_finding : public algorithm<host_seed_container(sp_grid&&)> {
 
         // seed selecting
         traccc::cuda::seed_selecting(
-            m_seedfilter_config, g2, doublet_counter_container,
+            m_seedfilter_config, spacepoints, g2, doublet_counter_container,
             triplet_counter_container, triplet_container, seed_container,
             m_mr.get());
         return seed_container;

--- a/device/cuda/include/cuda/seeding/seed_selecting.hpp
+++ b/device/cuda/include/cuda/seeding/seed_selecting.hpp
@@ -32,6 +32,7 @@ namespace cuda {
 /// @param seed_container vecmem container for seeds
 /// @param resource vecmem memory resource
 void seed_selecting(const seedfilter_config& filter_config,
+                    host_spacepoint_container& spacepoints,
                     sp_grid& internal_sp,
                     host_doublet_counter_container& doublet_counter_container,
                     host_triplet_counter_container& triplet_counter_container,

--- a/device/cuda/include/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/cuda/seeding/track_params_estimation.hpp
@@ -16,7 +16,7 @@ namespace cuda {
 /// track parameter estimation for cuda
 struct track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
-          host_seed_container&&)> {
+          host_spacepoint_container&&, host_seed_container&&)> {
     public:
     /// Constructor for track_params_estimation
     ///
@@ -28,7 +28,8 @@ struct track_params_estimation
     /// @param input_type is the seed container
     ///
     /// @return vector of bound track parameters
-    output_type operator()(host_seed_container&& seeds) const override;
+    output_type operator()(host_spacepoint_container&& spacepoints,
+                           host_seed_container&& seeds) const override;
 
     private:
     std::reference_wrapper<vecmem::memory_resource> m_mr;

--- a/device/cuda/src/seeding/counting_grid_capacities.cu
+++ b/device/cuda/src/seeding/counting_grid_capacities.cu
@@ -82,7 +82,9 @@ __global__ void counting_grid_capacities_kernel(
 
     /// Ignore is radius index is invalid value
     if (r_index != detray::invalid_value<size_t>()) {
-        auto isp = internal_spacepoint<spacepoint>(sp, config.beamPos);
+
+        auto isp = internal_spacepoint<spacepoint>(
+            spacepoints_device, {header_idx, sp_idx}, config.beamPos);
 
         /// Get bin index in grid
         size_t bin_index =

--- a/device/cuda/src/seeding/populating_grid.cu
+++ b/device/cuda/src/seeding/populating_grid.cu
@@ -89,7 +89,9 @@ __global__ void populating_grid_kernel(
 
     /// Ignore is radius index is invalid value
     if (r_index != detray::invalid_value<size_t>()) {
-        auto isp = internal_spacepoint<spacepoint>(sp, config.beamPos);
+
+        auto isp = internal_spacepoint<spacepoint>(
+            spacepoints_device, {header_idx, sp_idx}, config.beamPos);
 
         /// Get bin index in grid
         size_t bin_index =

--- a/device/cuda/src/seeding/seed_selecting.cu
+++ b/device/cuda/src/seeding/seed_selecting.cu
@@ -49,12 +49,14 @@ __device__ static bool triplet_weight_compare(const triplet& lhs,
 /// @param triplet_container vecmem container for triplets
 /// @param seed_container vecmem container for seeds
 __global__ void seed_selecting_kernel(
-    const seedfilter_config filter_config, sp_grid_view internal_sp_view,
+    const seedfilter_config filter_config,
+    spacepoint_container_view spacepoints_view, sp_grid_view internal_sp_view,
     doublet_counter_container_view doublet_counter_view,
     triplet_counter_container_view triplet_counter_view,
     triplet_container_view triplet_view, seed_container_view seed_view);
 
 void seed_selecting(const seedfilter_config& filter_config,
+                    host_spacepoint_container& spacepoints,
                     sp_grid& internal_sp,
                     host_doublet_counter_container& doublet_counter_container,
                     host_triplet_counter_container& triplet_counter_container,
@@ -62,6 +64,7 @@ void seed_selecting(const seedfilter_config& filter_config,
                     host_seed_container& seed_container,
                     vecmem::memory_resource& resource) {
 
+    auto spacepoints_view = get_data(spacepoints, &resource);
     auto doublet_counter_container_view =
         get_data(doublet_counter_container, &resource);
     auto triplet_counter_container_view =
@@ -95,21 +98,24 @@ void seed_selecting(const seedfilter_config& filter_config,
 
     // run the kernel
     seed_selecting_kernel<<<num_blocks, num_threads, sh_mem>>>(
-        filter_config, internal_sp_view, doublet_counter_container_view,
-        triplet_counter_container_view, triplet_container_view,
-        seed_container_view);
+        filter_config, spacepoints_view, internal_sp_view,
+        doublet_counter_container_view, triplet_counter_container_view,
+        triplet_container_view, seed_container_view);
     // cuda error check
     CUDA_ERROR_CHECK(cudaGetLastError());
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 }
 
 __global__ void seed_selecting_kernel(
-    const seedfilter_config filter_config, sp_grid_view internal_sp_view,
+    const seedfilter_config filter_config,
+    spacepoint_container_view spacepoints_view, sp_grid_view internal_sp_view,
     doublet_counter_container_view doublet_counter_view,
     triplet_counter_container_view triplet_counter_view,
     triplet_container_view triplet_view, seed_container_view seed_view) {
 
     // Get device container for input parameters
+    device_spacepoint_container spacepoints_device(
+        {spacepoints_view.headers, spacepoints_view.items});
     sp_grid_device internal_sp_device(internal_sp_view);
 
     device_doublet_counter_container doublet_counter_device(
@@ -264,9 +270,12 @@ __global__ void seed_selecting_kernel(
             break;
         }
 
+        seed aSeed({spB.m_link, spM.m_link, spT.m_link, aTriplet.weight,
+                    aTriplet.z_vertex});
+
         // check if it is a good triplet
         if (seed_selecting_helper::cut_per_middle_sp(
-                filter_config, spM.sp(), spB.sp(), spT.sp(), aTriplet.weight) ||
+                filter_config, spacepoints_device, aSeed, aTriplet.weight) ||
             n_seeds_per_spM == 0) {
             auto pos = atomicAdd(&num_seeds, 1);
 
@@ -276,8 +285,7 @@ __global__ void seed_selecting_kernel(
             }
             n_seeds_per_spM++;
 
-            seeds[pos] = seed({spB.m_sp, spM.m_sp, spT.m_sp, aTriplet.weight,
-                               aTriplet.z_vertex});
+            seeds[pos] = aSeed;
         }
     }
 }

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -18,15 +18,17 @@ namespace cuda {
 /// @param params_view vector of bound track parameters at the bottom
 /// spacepoints
 __global__ void track_params_estimating_kernel(
-    seed_container_view seeds_view,
+    spacepoint_container_view spacepoints_view, seed_container_view seeds_view,
     vecmem::data::vector_view<bound_track_parameters> params_view);
 
 track_params_estimation::output_type track_params_estimation::operator()(
+    host_spacepoint_container&& spacepoints,
     host_seed_container&& seeds) const {
 
     auto n_seeds = seeds.get_headers()[0];
     output_type params(n_seeds, &m_mr.get());
 
+    auto spacepoints_view = get_data(spacepoints, &m_mr.get());
     auto seeds_view = get_data(seeds, &m_mr.get());
     auto params_view = vecmem::get_data(params);
 
@@ -40,8 +42,8 @@ track_params_estimation::output_type track_params_estimation::operator()(
         (seeds.get_headers()[0] + num_threads - 1) / num_threads;
 
     // run the kernel
-    track_params_estimating_kernel<<<num_blocks, num_threads>>>(seeds_view,
-                                                                params_view);
+    track_params_estimating_kernel<<<num_blocks, num_threads>>>(
+        spacepoints_view, seeds_view, params_view);
 
     // cuda error check
     CUDA_ERROR_CHECK(cudaGetLastError());
@@ -51,10 +53,12 @@ track_params_estimation::output_type track_params_estimation::operator()(
 }
 
 __global__ void track_params_estimating_kernel(
-    seed_container_view seeds_view,
+    spacepoint_container_view spacepoints_view, seed_container_view seeds_view,
     vecmem::data::vector_view<bound_track_parameters> params_view) {
 
     // Get device container for input parameters
+    device_spacepoint_container spacepoints_device(
+        {spacepoints_view.headers, spacepoints_view.items});
     device_seed_container seeds_device({seeds_view.headers, seeds_view.items});
     device_bound_track_parameters_collection params_device({params_view});
 
@@ -75,7 +79,8 @@ __global__ void track_params_estimating_kernel(
     auto& param = params_device[gid].vector();
 
     // Get bound track parameter
-    param = seed_to_bound_vector(seed, bfield, PION_MASS_MEV);
+    param =
+        seed_to_bound_vector(spacepoints_device, seed, bfield, PION_MASS_MEV);
 }
 
 }  // namespace cuda

--- a/examples/algorithms/cpu/include/track_finding/seeding_algorithm.hpp
+++ b/examples/algorithms/cpu/include/track_finding/seeding_algorithm.hpp
@@ -47,16 +47,13 @@ class seeding_algorithm
             traccc::seed_finding(m_config));
     }
 
-    output_type operator()(const host_spacepoint_container& i) const override {
-        output_type o;
-        this->operator()(i, o);
-        return o;
-    }
+    output_type operator()(
+        const host_spacepoint_container& spacepoints) const override {
 
-    void operator()(const host_spacepoint_container& spacepoints_per_event,
-                    output_type& seeds) const {
-        auto internal_sp_g2 = sb->operator()(spacepoints_per_event);
-        seeds = sf->operator()(internal_sp_g2);
+        auto internal_sp_g2 = sb->operator()(spacepoints);
+        output_type seeds = sf->operator()(spacepoints, internal_sp_g2);
+
+        return seeds;
     }
 
     seedfinder_config get_seedfinder_config() { return m_config; }

--- a/examples/algorithms/cuda/include/cuda/track_finding/seeding_algorithm.hpp
+++ b/examples/algorithms/cuda/include/cuda/track_finding/seeding_algorithm.hpp
@@ -61,9 +61,12 @@ class seeding_algorithm
 
     output_type operator()(
         host_spacepoint_container&& spacepoints) const override {
+
         output_type seeds({host_seed_container(1, &m_mr.get())});
         auto internal_sp_g2 = sb->operator()(std::move(spacepoints));
-        seeds = sf->operator()(std::move(internal_sp_g2));
+        seeds =
+            sf->operator()(std::move(spacepoints), std::move(internal_sp_g2));
+
         return seeds;
     }
 

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -65,7 +65,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
           Track params estimation
           ----------------------------*/
 
-        auto tp_output = tp(seeds);
+        auto tp_output = tp(spacepoints_per_event, seeds);
         auto& params = tp_output;
 
         /*----------------------------
@@ -84,7 +84,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
 
         traccc::write_measurements(event, measurements_per_event);
         traccc::write_spacepoints(event, spacepoints_per_event);
-        traccc::write_seeds(event, seeds);
+        traccc::write_seeds(event, spacepoints_per_event, seeds);
         traccc::write_estimated_track_parameters(event, params);
     }
 

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -115,7 +115,8 @@ int seq_run(const std::string& detector_file, const std::string& hits_dir,
         /*time*/ auto start_tp_estimating_cuda =
             std::chrono::system_clock::now();
 
-        auto params_cuda = tp_cuda(std::move(seeds_cuda));
+        auto params_cuda =
+            tp_cuda(std::move(spacepoints_per_event), std::move(seeds_cuda));
 
         /*time*/ auto end_tp_estimating_cuda = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_cuda =
@@ -129,7 +130,7 @@ int seq_run(const std::string& detector_file, const std::string& hits_dir,
 
         traccc::track_params_estimation::output_type params;
         if (!skip_cpu) {
-            params = tp(seeds);
+            params = tp(std::move(spacepoints_per_event), seeds);
         }
 
         /*time*/ auto end_tp_estimating_cpu = std::chrono::system_clock::now();
@@ -184,7 +185,7 @@ int seq_run(const std::string& detector_file, const std::string& hits_dir,
 
         if (!skip_cpu) {
             traccc::write_spacepoints(event, spacepoints_per_event);
-            traccc::write_seeds(event, seeds);
+            traccc::write_seeds(event, spacepoints_per_event, seeds);
             traccc::write_estimated_track_parameters(event, params);
 
             /*

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -135,7 +135,8 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
         /*time*/ auto start_tp_estimating_cuda =
             std::chrono::system_clock::now();
 
-        auto params_cuda = tp_cuda(std::move(seeds_cuda));
+        auto params_cuda =
+            tp_cuda(std::move(spacepoints_per_event), std::move(seeds_cuda));
 
         /*time*/ auto end_tp_estimating_cuda = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_cuda =
@@ -149,7 +150,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
 
         traccc::track_params_estimation::output_type params;
         if (!skip_cpu) {
-            params = tp(seeds);
+            params = tp(spacepoints_per_event, seeds);
         }
 
         /*time*/ auto end_tp_estimating_cpu = std::chrono::system_clock::now();
@@ -208,7 +209,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
         if (!skip_cpu) {
             traccc::write_measurements(event, measurements_per_event);
             traccc::write_spacepoints(event, spacepoints_per_event);
-            traccc::write_seeds(event, seeds);
+            traccc::write_seeds(event, spacepoints_per_event, seeds);
             traccc::write_estimated_track_parameters(event, params);
         }
     }

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -150,7 +150,7 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
 
         traccc::track_params_estimation::output_type params;
         if (run_cpu) {
-            params = tp(seeds);
+            params = tp(spacepoints_per_event, seeds);
         }
 
         /*time*/ auto end_tp_estimating_cpu = std::chrono::system_clock::now();

--- a/io/include/io/writer.hpp
+++ b/io/include/io/writer.hpp
@@ -43,15 +43,16 @@ inline void write_spacepoints(
 }
 
 inline void write_seeds(size_t event,
+                        const traccc::host_spacepoint_container &sp_container,
                         const traccc::host_seed_container &seeds) {
     traccc::seed_writer sd_writer{
         traccc::get_event_filename(event, "-seeds.csv")};
     for (auto &seed : seeds.get_items()[0]) {
         auto weight = seed.weight;
         auto z_vertex = seed.z_vertex;
-        auto spB = seed.spB;
-        auto spM = seed.spM;
-        auto spT = seed.spT;
+        const auto &spB = sp_container.at(seed.spB_link);
+        const auto &spM = sp_container.at(seed.spM_link);
+        const auto &spT = sp_container.at(seed.spT_link);
 
         sd_writer.append({weight, z_vertex, spB.x(), spB.y(), spB.z(), 0, 0,
                           spM.x(), spM.y(), spM.z(), 0, 0, spT.x(), spT.y(),


### PR DESCRIPTION
### 1. The motivation of the PR
- The `internal_spacepoint` object takes the copy of `spacepoint` as a member variable, which is a bit waste of memory and takes more time in global memory writing during spacepoint_binning

### 2. Major changes
- `container` class defines the `link_type` which is the pair of size types of header and item vector
-  `internal_spacepoint` takes the index of `spacepoint` in `spacepoint_container` with `link_type`


##### Before

https://github.com/acts-project/traccc/blob/b4b8562f219b520b9d854f09d42baaa7c56ce6fa/core/include/edm/internal_spacepoint.hpp#L30-L39

##### After 

```c++
template <typename spacepoint_t>
struct internal_spacepoint {

    using spacepoint_container_type = host_container<geometry_id, spacepoint_t>;
    using link_type = typename spacepoint_container_type::link_type;

    link_type m_link;

    scalar m_x;
    scalar m_y;
    scalar m_z;
    scalar m_r;
    scalar m_varianceR;
    scalar m_varianceZ;
```

### 3. Issue 
`std::pair` seems not working in device code with the following error:
```
/home/beomki/projects/traccc/traccc/core/include/edm/internal_spacepoint.hpp(108): error: calling a __host__ function("std::pair<unsigned long, unsigned long> ::operator =(const ::std::pair<unsigned long, unsigned long> &)") from a __device__ function("traccc::internal_spacepoint< ::traccc::spacepoint> ::operator =") is not allowed

/home/beomki/projects/traccc/traccc/core/include/edm/internal_spacepoint.hpp(108): error: identifier "std::pair<unsigned long, unsigned long> ::operator =" is undefined in device code
```
So, for the moment, I am utilizing `thrust::pair` as default argument for `pair_type`.