### PR TITLE
Make acts and traccc cpu seeding results same

### DIFF
--- a/core/include/seeding/seed_filtering.hpp
+++ b/core/include/seeding/seed_filtering.hpp
@@ -71,27 +71,23 @@ struct seed_filtering
 
         // sort seeds based on their weights
         std::sort(seeds_per_spM.begin(), seeds_per_spM.end(),
-                  [](seed& seed1, seed& seed2) {
+                  [&](seed& seed1, seed& seed2) {
                       if (seed1.weight != seed2.weight) {
                           return seed1.weight > seed2.weight;
                       } else {
-                          return std::abs(seed1.z_vertex) <
-                                 std::abs(seed2.z_vertex);
-                          /*
                           scalar seed1_sum = 0;
                           scalar seed2_sum = 0;
-                          seed1_sum += pow(seed1.spB.y(),2) +
-                          pow(seed1.spB.z(),2); seed1_sum +=
-                          pow(seed1.spM.y(),2) + pow(seed1.spM.z(),2); seed1_sum
-                          += pow(seed1.spT.y(),2) + pow(seed1.spT.z(),2);
+                          auto& spB1 = sp_container.at(seed1.spB_link);
+                          auto& spT1 = sp_container.at(seed1.spT_link);
+                          auto& spB2 = sp_container.at(seed2.spB_link);
+                          auto& spT2 = sp_container.at(seed2.spT_link);
 
-                          seed2_sum += pow(seed2.spB.y(),2) +
-                          pow(seed2.spB.z(),2); seed2_sum +=
-                          pow(seed2.spM.y(),2) + pow(seed2.spM.z(),2); seed2_sum
-                          += pow(seed2.spT.y(),2) + pow(seed2.spT.z(),2);
+                          seed1_sum += pow(spB1.y(), 2) + pow(spB1.z(), 2);
+                          seed1_sum += pow(spT1.y(), 2) + pow(spT1.z(), 2);
+                          seed2_sum += pow(spB2.y(), 2) + pow(spB2.z(), 2);
+                          seed2_sum += pow(spT2.y(), 2) + pow(spT2.z(), 2);
 
                           return seed1_sum > seed2_sum;
-                          */
                       }
                   });
 

--- a/core/include/seeding/track_params_estimation_helper.hpp
+++ b/core/include/seeding/track_params_estimation_helper.hpp
@@ -102,8 +102,6 @@ inline TRACCC_HOST_DEVICE bound_vector seed_to_bound_vector(
     params[e_bound_loc0] = meas_for_spB.local[0];
     params[e_bound_loc1] = meas_for_spB.local[1];
 
-    // printf("%f %f \n", meas_for_spB.local[0], meas_for_spB.local[1]);
-
     // The estimated q/pt in [GeV/c]^-1 (note that the pt is the
     // projection of momentum on the transverse plane of the new frame)
     scalar qOverPt =

--- a/examples/algorithms/cuda/include/cuda/track_finding/seeding_algorithm.hpp
+++ b/examples/algorithms/cuda/include/cuda/track_finding/seeding_algorithm.hpp
@@ -43,26 +43,34 @@ class seeding_algorithm
         m_grid_config.deltaRMax = m_config.deltaRMax;
         m_grid_config.cotThetaMax = m_config.cotThetaMax;
 
+        // multiplet estimator
+        m_estimator.m_cfg.safety_factor = 2.0;
+        m_estimator.m_cfg.safety_adder = 10;
+        // m_estimator.m_cfg.safety_factor = 10.0;
+        // m_estimator.m_cfg.safety_adder = 50000;
+        m_estimator.m_cfg.par_for_mb_doublets = {1, 28.77, 0.4221};
+        m_estimator.m_cfg.par_for_mt_doublets = {1, 19.73, 0.232};
+        m_estimator.m_cfg.par_for_triplets = {1, 0, 0.02149};
+        m_estimator.m_cfg.par_for_seeds = {0, 0.3431};
+
         sb = std::make_shared<traccc::cuda::spacepoint_binning>(
             traccc::cuda::spacepoint_binning(m_config, m_grid_config, mr));
         sf = std::make_shared<traccc::cuda::seed_finding>(
-            traccc::cuda::seed_finding(m_config, sb->nbins(), mr));
+            traccc::cuda::seed_finding(m_config, m_estimator, sb->nbins(), mr));
     }
 
     output_type operator()(
         host_spacepoint_container&& spacepoints) const override {
-
         output_type seeds({host_seed_container(1, &m_mr.get())});
         auto internal_sp_g2 = sb->operator()(std::move(spacepoints));
-        seeds =
-            sf->operator()(std::move(spacepoints), std::move(internal_sp_g2));
-
+        seeds = sf->operator()(std::move(internal_sp_g2));
         return seeds;
     }
 
     private:
     seedfinder_config m_config;
     spacepoint_grid_config m_grid_config;
+    multiplet_estimator m_estimator;
     std::reference_wrapper<vecmem::memory_resource> m_mr;
     std::shared_ptr<traccc::cuda::spacepoint_binning> sb;
     std::shared_ptr<traccc::cuda::seed_finding> sf;

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -34,6 +34,7 @@
 #include "Acts/Seeding/SeedFilter.hpp"
 #include "Acts/Seeding/Seedfinder.hpp"
 #include "Acts/Seeding/SpacePointGrid.hpp"
+#include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
@@ -60,13 +61,16 @@ inline bool operator==(const traccc::spacepoint& traccc_sp,
 inline bool operator==(const Acts::BoundVector& acts_vec,
                        const traccc::bound_vector& traccc_vec) {
     if (std::abs(acts_vec[Acts::eBoundLoc0] -
-                 traccc_vec[traccc::e_bound_loc0]) < traccc::float_epsilon &&
+                 traccc_vec[traccc::e_bound_loc0]) <
+            traccc::float_epsilon * 10 &&
         std::abs(acts_vec[Acts::eBoundLoc1] -
-                 traccc_vec[traccc::e_bound_loc1]) < traccc::float_epsilon &&
+                 traccc_vec[traccc::e_bound_loc1]) <
+            traccc::float_epsilon * 10 &&
         std::abs(acts_vec[Acts::eBoundTheta] -
-                 traccc_vec[traccc::e_bound_theta]) < traccc::float_epsilon &&
+                 traccc_vec[traccc::e_bound_theta]) <
+            traccc::float_epsilon * 10 &&
         std::abs(acts_vec[Acts::eBoundPhi] - traccc_vec[traccc::e_bound_phi]) <
-            traccc::float_epsilon) {
+            traccc::float_epsilon * 10) {
         return true;
     }
     return false;
@@ -215,6 +219,7 @@ TEST(algorithms, compare_with_acts_seeding) {
     auto groupIt = spGroup.begin();
     auto endOfGroups = spGroup.end();
 
+    // Run the ACTS seeding
     std::vector<Acts::Seed<SpacePoint>> seedVector;
     for (; !(groupIt == endOfGroups); ++groupIt) {
         auto seed_group = a.createSeedsForGroup(
@@ -223,16 +228,13 @@ TEST(algorithms, compare_with_acts_seeding) {
                           seed_group.end());
     }
 
+    // Count the number of matching seeds
+    // and push_back seed into sorted_seedVector
     std::vector<Acts::Seed<SpacePoint>> sorted_seedVector;
-
-    // seed equality check
-    unsigned int n_traccc_seeds = seeds.get_headers()[0];
-    unsigned int n_acts_seeds = seedVector.size();
     int n_seed_match = 0;
-    for (unsigned int i = 0; i < n_traccc_seeds; i++) {
+    for (auto& seed : seeds.get_items()[0]) {
         auto it = std::find_if(
             seedVector.begin(), seedVector.end(), [&](auto acts_seed) {
-                auto& seed = seeds.get_items()[0][i];
                 auto traccc_spB = spacepoints_per_event.at(seed.spB_link);
                 auto traccc_spM = spacepoints_per_event.at(seed.spM_link);
                 auto traccc_spT = spacepoints_per_event.at(seed.spT_link);
@@ -258,6 +260,8 @@ TEST(algorithms, compare_with_acts_seeding) {
     seedVector = sorted_seedVector;
 
     float seed_match_ratio = float(n_seed_match) / seeds.total_size();
+
+    // Ensure that the difference between ACTS and traccc is small enough
     EXPECT_TRUE((seed_match_ratio > 0.95) && (seed_match_ratio <= 1.));
 
     /*--------------------------------
@@ -295,26 +299,64 @@ TEST(algorithms, compare_with_acts_seeding) {
         const auto& tsl = tf3.translation();
         const auto& rot = tf3.rotation();
 
-        Acts::Vector3 center;
-        center(0, 0) = tsl[0];
-        center(1, 0) = tsl[1];
-        center(2, 0) = tsl[2];
-
         Acts::Vector3 normal;
         normal(0, 0) = traccc::transform3::element_getter()(rot, 0, 2);
         normal(1, 0) = traccc::transform3::element_getter()(rot, 1, 2);
         normal(2, 0) = traccc::transform3::element_getter()(rot, 2, 2);
-        auto bottomSurface =
-            Acts::Surface::makeShared<Acts::PlaneSurface>(center, normal);
+
+        std::shared_ptr<Acts::Surface> bottomSurface;
+        bool is_disc = false;
+        // barrel layer
+        if (abs(normal.dot(Acts::Vector3::UnitZ())) < traccc::float_epsilon) {
+            // for plane of barrel layers, translation and normal vector is used
+            // to form acts transform3
+
+            Acts::Vector3 center;
+            center(0, 0) = tsl[0];
+            center(1, 0) = tsl[1];
+            center(2, 0) = tsl[2];
+
+            bottomSurface =
+                Acts::Surface::makeShared<Acts::PlaneSurface>(center, normal);
+        }
+        // endcap layer
+        else {
+            is_disc = true;
+            // for disc of endcap layers, the traccc transform components are
+            // copied into acts transform3
+            Acts::Transform3 acts_tf3;
+            for (unsigned int i = 0; i < 4; i++) {
+                for (unsigned int j = 0; j < 4; j++) {
+                    acts_tf3(i, j) = traccc::transform3::element_getter()(
+                        tf3.matrix(), i, j);
+                }
+            }
+
+            // last three arugments are given randomly
+            bottomSurface = Acts::Surface::makeShared<Acts::DiscSurface>(
+                acts_tf3, 0., 10., 0.);
+        }
 
         // Test the full track parameters estimator
         auto fullParamsOpt = estimateTrackParamsFromSeed(
             geoCtx, spacePointPtrs.begin(), spacePointPtrs.end(),
             *bottomSurface, Acts::Vector3(0, 0, 2), 0.1);
 
-        EXPECT_TRUE(fullParamsOpt != std::nullopt);
+        auto acts_vec = *fullParamsOpt;
 
-        acts_params.push_back(*fullParamsOpt);
+        // Acts globalToLocal function on DiscSurface gives (u,v) in radial
+        // coordinate. Therefore acts parameters are converted into cartesian
+        // coordinate for comparison with traccc parameters
+        if (is_disc) {
+            auto x = acts_vec[Acts::eBoundLoc0] *
+                     std::cos(acts_vec[Acts::eBoundLoc1]);
+            auto y = acts_vec[Acts::eBoundLoc0] *
+                     std::sin(acts_vec[Acts::eBoundLoc1]);
+            acts_vec[Acts::eBoundLoc0] = x;
+            acts_vec[Acts::eBoundLoc1] = y;
+        }
+
+        acts_params.push_back(acts_vec);
     }
 
     // params equality check
@@ -333,8 +375,9 @@ TEST(algorithms, compare_with_acts_seeding) {
     EXPECT_TRUE((params_match_ratio > 0.95) && (params_match_ratio <= 1.));
 
     std::cout << "-------- Seeding Result ---------" << std::endl;
-    std::cout << "number of ACTS seeds: " << n_acts_seeds << std::endl;
-    std::cout << "number of traccc seeds: " << n_traccc_seeds << std::endl;
+    std::cout << "number of ACTS seeds: " << seedVector.size() << std::endl;
+    std::cout << "number of traccc seeds: " << seeds.get_headers()[0]
+              << std::endl;
     std::cout << "seed matching ratio: " << seed_match_ratio << std::endl;
     std::cout << "-------- Track Parameters Estimation Result ---------"
               << std::endl;

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -329,48 +329,6 @@ TEST(algorithms, compare_with_acts_seeding) {
         }
     }
 
-    for (unsigned int i = 0; i < traccc_params.size(); i++) {
-        if (!(acts_params[i] == traccc_params[i].vector())) {
-            auto& seed = seeds.get_items()[0][i];
-            auto traccc_spB = spacepoints_per_event.at(seed.spB_link);
-
-            traccc::geometry_id geo_id = 0;
-            for (std::size_t i_h = 0; i_h < spacepoints_per_event.size();
-                 i_h++) {
-                auto& items = spacepoints_per_event.get_items()[i_h];
-                if (std::find(items.begin(), items.end(), traccc_spB) !=
-                    items.end()) {
-                    geo_id = spacepoints_per_event.get_headers()[i_h];
-                    break;
-                }
-            }
-
-            const auto& tf3 = surface_transforms[geo_id];
-
-            auto new_param = tf3.point_to_local(traccc_spB.global);
-
-            std::cout << "original -------------------------------"
-                      << std::endl;
-            std::cout << tf3._data(0, 0) << "  " << tf3._data(0, 1) << "  "
-                      << tf3._data(0, 2) << "  " << tf3._data(0, 3)
-                      << std::endl;
-            std::cout << tf3._data(1, 0) << "  " << tf3._data(1, 1) << "  "
-                      << tf3._data(1, 2) << "  " << tf3._data(1, 3)
-                      << std::endl;
-            std::cout << tf3._data(2, 0) << "  " << tf3._data(2, 1) << "  "
-                      << tf3._data(2, 2) << "  " << tf3._data(2, 3)
-                      << std::endl;
-            std::cout << tf3._data(3, 0) << "  " << tf3._data(3, 1) << "  "
-                      << tf3._data(3, 2) << "  " << tf3._data(3, 3)
-                      << std::endl;
-
-            std::cout << traccc_params[i].vector()[0] << "  "
-                      << traccc_params[i].vector()[1] << "  "
-                      << acts_params[i][0] << "  " << acts_params[i][1] << "  "
-                      << new_param[0] << "  " << new_param[1] << std::endl;
-        }
-    }
-
     float params_match_ratio = float(n_params_match) / traccc_params.size();
     EXPECT_TRUE((params_match_ratio > 0.95) && (params_match_ratio <= 1.));
 

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -223,8 +223,11 @@ TEST(algorithms, compare_with_acts_seeding) {
     }
 
     // seed equality check
+    unsigned int n_traccc_seeds = seeds.get_headers()[0];
+    unsigned int n_acts_seeds = 0;
     int n_seed_match = 0;
     for (auto& outputVec : seedVector) {
+        n_acts_seeds += outputVec.size();
         for (auto& seed : outputVec) {
             if (std::find_if(
                     seeds.get_items()[0].begin(), seeds.get_items()[0].end(),
@@ -333,6 +336,8 @@ TEST(algorithms, compare_with_acts_seeding) {
     EXPECT_TRUE((params_match_ratio > 0.95) && (params_match_ratio <= 1.));
 
     std::cout << "-------- Result ---------" << std::endl;
+    std::cout << "number of ACTS seeds: " << n_acts_seeds << std::endl;
+    std::cout << "number of traccc seeds: " << n_traccc_seeds << std::endl;
     std::cout << "seed matching ratio: " << seed_match_ratio << std::endl;
     std::cout << "params matching ratio: " << params_match_ratio << std::endl;
 }

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -144,7 +144,6 @@ TEST(algorithms, compare_with_acts_seeding) {
 
     // Setup the config
     auto traccc_config = sa.get_seedfinder_config();
-    // auto traccc_grid_config = sa.get_spacepoint_grid_config();
 
     Acts::SeedfinderConfig<SpacePoint> config;
 
@@ -316,6 +315,8 @@ TEST(algorithms, compare_with_acts_seeding) {
                 geoCtx, spacePointPtrs.begin(), spacePointPtrs.end(),
                 *bottomSurface, Acts::Vector3(0, 0, 2), 0.1);
 
+            EXPECT_TRUE(fullParamsOpt != std::nullopt);
+
             acts_params.push_back(*fullParamsOpt);
         }
     }
@@ -335,9 +336,14 @@ TEST(algorithms, compare_with_acts_seeding) {
     float params_match_ratio = float(n_params_match) / traccc_params.size();
     EXPECT_TRUE((params_match_ratio > 0.95) && (params_match_ratio <= 1.));
 
-    std::cout << "-------- Result ---------" << std::endl;
+    std::cout << "-------- Seeding Result ---------" << std::endl;
     std::cout << "number of ACTS seeds: " << n_acts_seeds << std::endl;
     std::cout << "number of traccc seeds: " << n_traccc_seeds << std::endl;
     std::cout << "seed matching ratio: " << seed_match_ratio << std::endl;
+    std::cout << "-------- Track Parameters Estimation Result ---------"
+              << std::endl;
+    std::cout << "number of ACTS params: " << acts_params.size() << std::endl;
+    std::cout << "number of traccc params: " << traccc_params.size()
+              << std::endl;
     std::cout << "params matching ratio: " << params_match_ratio << std::endl;
 }


### PR DESCRIPTION
This PR is made on top of #110 and #108
There has been a discrepancy in acts and traccc cpu seeding due to different sorting algorithm. This PR fixes it.

Meanwhile there is still a small discrepancy in track parameter estimation for seeds whose bottom spacepoint is at the endcap layers. I am trying to debug it now. 

--------------------------------------------------------------------------------------------------------------

**UPDATE:**
Now the track paramter estimation results from acts and traccc are also identical. The discrepancy was because `Acts::DiscSurface::globalToLocal` gives parameters in radial coordinate while `algebra_plugins::point_to_local` does in cartesian coordinate regardless of plane type. I manually converted Acts track parameters into cartesian coordinate for comparison.

```
[==========] Running 632 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 2 tests from algorithms
[ RUN      ] algorithms.compare_with_acts_seeding
-------- Seeding Result ---------
number of ACTS seeds: 5134
number of traccc seeds: 5134
seed matching ratio: 1
-------- Track Parameters Estimation Result ---------
number of ACTS params: 5134
number of traccc params: 5134
params matching ratio: 1
```