### PR TITLE
BUG : target_link_libraries for a .sycl not working

### DIFF
--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -9,3 +9,8 @@ enable_language( SYCL )
 
 # Example executable(s).
 add_executable( traccc_sycl_language_example "sycl_language_example.sycl" )
+
+# BUG, 2022-01-19, commit 4bdd0db7f4068d978878e6fb92a6d96b0968bf87
+# Does not compile when linking any internal library to a .sycl
+target_link_libraries (traccc_sycl_language_example LINK_PUBLIC
+  traccc::algorithms)


### PR DESCRIPTION
Hi,

#106 solved my SYCL compilation issue, I can now compile the `traccc_sycl_language_example` program from the `.sycl` code and run it. But once I try to link any internal library, I got a compilation error.

Maybe I'm missing something again, but to reproduce this error I only need to change the `examples/run/sycl/CMakeLists.txt` and add after the `add_executable( traccc_sycl_language_example "sycl_language_example.sycl" )` line something like `target_link_libraries( traccc_sycl_language_example LINK_PUBLIC traccc::algorithms )` or any other library really, to have the same error. Not the same list of included files, but exactly the same `fatal error: 'stdlib.h' file not found`.

Here is the output I got every time :

```log
[ 94%] Linking CXX executable ../../../bin/seq_single_module
[ 94%] Built target seq_single_module
Scanning dependencies of target traccc_sycl_language_example
[ 94%] Building SYCL object examples/run/sycl/CMakeFiles/traccc_sycl_language_example.dir/sycl_language_example.sycl.o
In file included from /home/data_sync/academique/These/Traccc/traccc_sycl_link_bug_with_link_updated/examples/run/sycl/sycl_language_example.sycl:9:
In file included from /home/sylvain/intel/oneapi/compiler/2021.4.0/linux/bin/../include/sycl/CL/sycl.hpp:11:
In file included from /home/sylvain/intel/oneapi/compiler/2021.4.0/linux/bin/../include/sycl/CL/sycl/accessor.hpp:12:
In file included from /home/sylvain/intel/oneapi/compiler/2021.4.0/linux/bin/../include/sycl/CL/sycl/atomic.hpp:11:
In file included from /home/sylvain/intel/oneapi/compiler/2021.4.0/linux/bin/../include/sycl/CL/__spirv/spirv_ops.hpp:13:
In file included from /home/sylvain/intel/oneapi/compiler/2021.4.0/linux/bin/../include/sycl/CL/sycl/detail/stl_type_traits.hpp:12:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/iterator:66:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/streambuf_iterator.h:35:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/streambuf:41:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/ios_base.h:41:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/locale_classes.h:40:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/string:55:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/basic_string.h:6545:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/ext/string_conversions.h:41:
/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/cstdlib:75:15: fatal error: 'stdlib.h' file not found
#include_next <stdlib.h>
              ^~~~~~~~~~
1 error generated.
make[2]: *** [examples/run/sycl/CMakeFiles/traccc_sycl_language_example.dir/build.make:63: examples/run/sycl/CMakeFiles/traccc_sycl_language_example.dir/sycl_language_example.sycl.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:15211: examples/run/sycl/CMakeFiles/traccc_sycl_language_example.dir/all] Error 2
make: *** [Makefile:163: all] Error 2
```

So just changing the `examples/run/sycl/CMakeLists.txt` file from:
```
add_executable( traccc_sycl_language_example "sycl_language_example.sycl" )
```

To (for example, `traccc::algorithms` can be any other library):
```
add_executable( traccc_sycl_language_example "sycl_language_example.sycl" )
target_link_libraries ( traccc_sycl_language_example LINK_PUBLIC traccc::algorithms )
```

And a little ping to @stephenswat and @krasznaa , thank you! And happy new year :fox_face: 