### PR TITLE
fix bug in seed selecting

### DIFF
--- a/device/cuda/src/seeding/seed_selecting.cu
+++ b/device/cuda/src/seeding/seed_selecting.cu
@@ -66,8 +66,7 @@ void seed_selecting(const seedfilter_config& filter_config,
     unsigned int num_blocks = 0;
     for (size_t i = 0; i < internal_sp.nbins(); ++i) {
         num_blocks +=
-            triplet_counter_container.get_headers()[i].n_mid_bot / num_threads +
-            1;
+            doublet_counter_container.get_headers()[i].n_spM / num_threads + 1;
     }
 
     // shared memory assignment for the triplets of a compatible middle
@@ -107,7 +106,7 @@ __global__ void seed_selecting_kernel(
 
     // Get the bin and item index
     unsigned int bin_idx(0), item_idx(0);
-    cuda_helper::find_idx_on_container(triplet_counter_device, bin_idx,
+    cuda_helper::find_idx_on_container(doublet_counter_device, bin_idx,
                                        item_idx);
     // Header of internal spacepoint container : spacepoint bin information
     // Item of internal spacepoint container : internal spacepoint objects per

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -176,6 +176,10 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
             }
             float matching_rate = float(n_match) / seeds.get_headers()[0];
             std::cout << "event " << std::to_string(event) << std::endl;
+            std::cout << " number of seeds (cpu): " << seeds.get_headers()[0]
+                      << std::endl;
+            std::cout << " number of seeds (cuda): "
+                      << seeds_cuda.get_headers()[0] << std::endl;
             std::cout << " seed matching rate: " << matching_rate << std::endl;
 
             // track parameter estimation


### PR DESCRIPTION
Can't believe that I spent a whole day to fix this bug
There was a non-trivial discrepancy (1~3%) between cpu and cuda seeding, especially for ttbar 100 pileups, which I had no clue. 
I finally spotted the culprit XD 
Anyway I feel like to improve comments in cuda seeding codes at some point... hard to figure out what I have done
I attached print outputs below. 

<details>
  <summary>Click to expand!</summary>

### ttbar <100>, float

event 0
 seed matching rate: 1
 track parameters matching rate: 1
event 1
 seed matching rate: 1
 track parameters matching rate: 1
event 2
 seed matching rate: 1
 track parameters matching rate: 1
event 3
 seed matching rate: 1
 track parameters matching rate: 1
event 4
 seed matching rate: 1
 track parameters matching rate: 1
event 5
 seed matching rate: 1
 track parameters matching rate: 1
event 6
 seed matching rate: 1
 track parameters matching rate: 1
event 7
 seed matching rate: 1
 track parameters matching rate: 1
event 8
 seed matching rate: 1
 track parameters matching rate: 1
event 9
 seed matching rate: 1
 track parameters matching rate: 1
event 10
 seed matching rate: 1
 track parameters matching rate: 1
event 11
 seed matching rate: 1
 track parameters matching rate: 1
event 12
 seed matching rate: 1
 track parameters matching rate: 1
event 13
 seed matching rate: 1
 track parameters matching rate: 1
event 14
 seed matching rate: 1
 track parameters matching rate: 1
event 15
 seed matching rate: 1
 track parameters matching rate: 1
event 16
 seed matching rate: 1
 track parameters matching rate: 1
event 17
 seed matching rate: 1
 track parameters matching rate: 1
event 18
 seed matching rate: 1
 track parameters matching rate: 1
event 19
 seed matching rate: 1
 track parameters matching rate: 1
event 20
 seed matching rate: 1
 track parameters matching rate: 1
event 21
 seed matching rate: 0.999608
 track parameters matching rate: 0.999608
event 22
 seed matching rate: 0.999557
 track parameters matching rate: 0.999557
event 23
 seed matching rate: 1
 track parameters matching rate: 1
event 24
 seed matching rate: 0.999735
 track parameters matching rate: 0.999735
event 25
 seed matching rate: 1
 track parameters matching rate: 1
event 26
 seed matching rate: 1
 track parameters matching rate: 1
event 27
 seed matching rate: 1
 track parameters matching rate: 1
event 28
 seed matching rate: 1
 track parameters matching rate: 1
event 29
 seed matching rate: 1
 track parameters matching rate: 1
event 30
 seed matching rate: 1
 track parameters matching rate: 1
event 31
 seed matching rate: 1
 track parameters matching rate: 1
event 32
 seed matching rate: 1
 track parameters matching rate: 1
event 33
 seed matching rate: 1
 track parameters matching rate: 1
event 34
 seed matching rate: 1
 track parameters matching rate: 1
event 35
 seed matching rate: 1
 track parameters matching rate: 1
event 36
 seed matching rate: 1
 track parameters matching rate: 1
event 37
 seed matching rate: 1
 track parameters matching rate: 1
event 38
 seed matching rate: 1
 track parameters matching rate: 1
event 39
 seed matching rate: 1
 track parameters matching rate: 1
event 40
 seed matching rate: 1
 track parameters matching rate: 1
event 41
 seed matching rate: 1
 track parameters matching rate: 1
event 42
 seed matching rate: 1
 track parameters matching rate: 1
event 43
 seed matching rate: 1
 track parameters matching rate: 1
event 44
 seed matching rate: 1
 track parameters matching rate: 1
event 45
 seed matching rate: 1
 track parameters matching rate: 1
event 46
 seed matching rate: 1
 track parameters matching rate: 1
event 47
 seed matching rate: 1
 track parameters matching rate: 1
event 48
 seed matching rate: 1
 track parameters matching rate: 1
event 49
 seed matching rate: 1
 track parameters matching rate: 1
==> Statistics ... 
- read    2394854 spacepoints from 547755 modules
- created        8328911 cells           
- created        2394854 meaurements     
- created        2394854 spacepoints     
- created        0 internal spacepoints
- created (cpu)  137147 seeds
- created (cuda) 137144 seeds
==> Elpased time ... 
wall time           60.5018   
file reading (cpu)        17.805    
clusterization_time (cpu) 5.99457   
seeding_time (cpu)        7.58981   
seeding_time (cuda)       1.28417   
tr_par_esti_time (cpu)    0.118508  
tr_par_esti_time (cuda)   0.127873  

### ttbar <200>, float

event 0
 seed matching rate: 1
 track parameters matching rate: 1
event 1
 seed matching rate: 1
 track parameters matching rate: 1
event 2
 seed matching rate: 1
 track parameters matching rate: 1
event 3
 seed matching rate: 1
 track parameters matching rate: 1
event 4
 seed matching rate: 1
 track parameters matching rate: 1
event 5
 seed matching rate: 1
 track parameters matching rate: 1
event 6
 seed matching rate: 1
 track parameters matching rate: 1
event 7
 seed matching rate: 1
 track parameters matching rate: 1
event 8
 seed matching rate: 1
 track parameters matching rate: 1
event 9
 seed matching rate: 1
 track parameters matching rate: 1
event 10
 seed matching rate: 1
 track parameters matching rate: 1
event 11
 seed matching rate: 1
 track parameters matching rate: 1
event 12
 seed matching rate: 1
 track parameters matching rate: 1
event 13
 seed matching rate: 1
 track parameters matching rate: 1
event 14
 seed matching rate: 1
 track parameters matching rate: 1
event 15
 seed matching rate: 1
 track parameters matching rate: 1
event 16
 seed matching rate: 1
 track parameters matching rate: 1
event 17
 seed matching rate: 1
 track parameters matching rate: 1
event 18
 seed matching rate: 1
 track parameters matching rate: 1
event 19
 seed matching rate: 1
 track parameters matching rate: 1
event 20
 seed matching rate: 1
 track parameters matching rate: 1
event 21
 seed matching rate: 0.999868
 track parameters matching rate: 0.999868
event 22
 seed matching rate: 1
 track parameters matching rate: 1
event 23
 seed matching rate: 1
 track parameters matching rate: 1
event 24
 seed matching rate: 1
 track parameters matching rate: 1
event 25
 seed matching rate: 1
 track parameters matching rate: 1
event 26
 seed matching rate: 1
 track parameters matching rate: 1
event 27
 seed matching rate: 1
 track parameters matching rate: 1
event 28
 seed matching rate: 1
 track parameters matching rate: 1
event 29
 seed matching rate: 1
 track parameters matching rate: 1
event 30
 seed matching rate: 1
 track parameters matching rate: 1
event 31
 seed matching rate: 0.999902
 track parameters matching rate: 0.999902
event 32
 seed matching rate: 1
 track parameters matching rate: 1
event 33
 seed matching rate: 1
 track parameters matching rate: 1
event 34
 seed matching rate: 1
 track parameters matching rate: 1
event 35
 seed matching rate: 1
 track parameters matching rate: 1
event 36
 seed matching rate: 1
 track parameters matching rate: 1
event 37
 seed matching rate: 1
 track parameters matching rate: 1
event 38
 seed matching rate: 1
 track parameters matching rate: 1
event 39
 seed matching rate: 1
 track parameters matching rate: 1
event 40
 seed matching rate: 1
 track parameters matching rate: 1
event 41
 seed matching rate: 1
 track parameters matching rate: 1
event 42
 seed matching rate: 0.999901
 track parameters matching rate: 0.999901
event 43
 seed matching rate: 1
 track parameters matching rate: 1
event 44
 seed matching rate: 1
 track parameters matching rate: 1
event 45
 seed matching rate: 1
 track parameters matching rate: 1
event 46
 seed matching rate: 1
 track parameters matching rate: 1
event 47
 seed matching rate: 1
 track parameters matching rate: 1
event 48
 seed matching rate: 1
 track parameters matching rate: 1
event 49
 seed matching rate: 1
 track parameters matching rate: 1
==> Statistics ... 
- read    4642535 spacepoints from 671340 modules
- created        16176639 cells           
- created        4642535 meaurements     
- created        4642535 spacepoints     
- created        0 internal spacepoints
- created (cpu)  461662 seeds
- created (cuda) 461661 seeds
==> Elpased time ... 
wall time           131.341   
file reading (cpu)        33.4916   
clusterization_time (cpu) 7.66749   
seeding_time (cpu)        31.4609   
seeding_time (cuda)       2.28208   
tr_par_esti_time (cpu)    0.198447  
tr_par_esti_time (cuda)   0.161402 

</details> 

There is still some very trivial discrepancy, but I will investigate later...