### PR TITLE
Add SYCL CI, main branch (2022.02.02.)

### DIFF
--- a/.github/ci_setup.sh
+++ b/.github/ci_setup.sh
@@ -1,0 +1,30 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+#
+# This script is meant to configure the build/runtime environment of the
+# Docker contaners that are used in the project's CI configuration.
+#
+# Usage: source .github/ci_setup.sh <platform name>
+#
+
+# The platform name.
+PLATFORM_NAME=$1
+
+# Set up the correct environment for the SYCL tests.
+if [ "${PLATFORM_NAME}" = "SYCL" ]; then
+   source /opt/intel/oneapi/setvars.sh
+   export CXX=`which clang++`
+   export SYCLCXX=`which dpcpp`
+   export SYCL_DEVICE_FILTER=host
+   # This is a hack to make Acts's "--coverage" flag work correctly with
+   # oneAPI 2021.2.0. It may be removed once we update to a version of oneAPI
+   # in the CI that does not have this issue.
+   export LDFLAGS="-L${CMPLR_ROOT}/linux/compiler/lib/intel64_lin -lirc"
+fi
+
+# Make sure that GNU Make and CTest would use all available cores.
+export MAKEFLAGS="-j`nproc`"
+export CTEST_PARALLEL_LEVEL=`nproc`

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,3 +1,9 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
 name: Builds
 
 on:
@@ -5,9 +11,6 @@ on:
   pull_request:
     branches:
       - main
-
-env:
-  CTEST_OUTPUT_ON_FAILURE: 1
 
 jobs:
   builds:
@@ -21,9 +24,15 @@ jobs:
             container: ghcr.io/acts-project/ubuntu2004:v11
           - name: CUDA
             container: ghcr.io/acts-project/ubuntu2004_cuda:v16.1
+          - name: SYCL
+            container: ghcr.io/acts-project/ubuntu2004_oneapi:v16.1
         build:
           - Release
           - Debug
+    # Use BASH as the shell from the images.
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Dependencies
         run: apt-get install -y git-lfs
@@ -32,17 +41,15 @@ jobs:
           submodules: true
           lfs: true
       - name: Configure
-        run: >
-          if ${{ matrix.platform.name == 'CPU'}}; then
-            cmake -B build -S . \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build }}
-          elif ${{ matrix.platform.name == 'CUDA'}}; then
-            cmake -B build -S . \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
-              -DCMAKE_CUDA_COMPILER=$(which nvcc) \
-              -DTRACCC_BUILD_CUDA=ON
-          fi
+        run: |
+          source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
+          cmake -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DTRACCC_BUILD_${{ matrix.platform.name }}=TRUE -S ${GITHUB_WORKSPACE} -B build
       - name: Build
-        run: cmake --build build -- -j$(nproc)
-      - name: Run tests & examples
-        run: CTEST_PARALLEL_LEVEL=$(nproc) cmake --build build -- test
+        run: |
+          source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
+          cmake --build build
+      - name: Test
+        run: |
+          cd build
+          source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
+          ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ if( TRACCC_SETUP_GOOGLETEST )
 endif()
 
 # option for algebra plugins (ARRAY EIGEN SMATRIX VC VECMEM)
-set(TRACCC_ALGEBRA_PLUGINS EIGEN CACHE STRING "Algebra plugin to use in the build")
+set(TRACCC_ALGEBRA_PLUGINS ARRAY CACHE STRING "Algebra plugin to use in the build")
 message(STATUS "Building with plugin type: " ${TRACCC_ALGEBRA_PLUGINS})
 add_definitions(-DALGEBRA_PLUGINS_INCLUDE_${TRACCC_ALGEBRA_PLUGINS})
 

--- a/device/sycl/include/traccc/sycl/seeding/detail/sycl_helper.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/detail/sycl_helper.hpp
@@ -27,6 +27,7 @@ using local_accessor = ::sycl::accessor<T, 1, ::sycl::access::mode::read_write,
 // Some useful helper funcitons
 struct sycl_helper {
 
+    /*
     /// Function that performs reduction on the local memory using subgroup
     /// operations
     ///
@@ -62,6 +63,7 @@ struct sycl_helper {
             }
         }
     }
+    */
 
     /// Get index of header vector of event data container for a given block ID.
     ///

--- a/device/sycl/src/seeding/doublet_finding.sycl
+++ b/device/sycl/src/seeding/doublet_finding.sycl
@@ -199,10 +199,11 @@ class DupletFind {
             }
         }
         // Calculate the number doublets per "block" with reducing sum technique
-        ::sycl::group_barrier(workGroup);
+        // ::sycl::group_barrier(workGroup);
+        item.barrier();
         // Warp shuffle reduction algorithm
-        sycl_helper::reduceInShared(num_mid_bot_doublets_per_thread, item);
-        sycl_helper::reduceInShared(num_mid_top_doublets_per_thread, item);
+        // sycl_helper::reduceInShared(num_mid_bot_doublets_per_thread, item);
+        // sycl_helper::reduceInShared(num_mid_top_doublets_per_thread, item);
 
         // Another reduction variant (doesn't always work)
         //  num_mid_bot_doublets_per_thread[0] =
@@ -218,17 +219,17 @@ class DupletFind {
 
             // For loop reduction
 
-            //    uint32_t resultBottom = 0;
-            //        for (uint32_t i=0; i<groupDim; ++i){
-            //         resultBottom += num_mid_bot_doublets_per_thread[i];
-            //        }
-            //    num_mid_bot_doublets_per_thread[0] = resultBottom;
+            uint32_t resultBottom = 0;
+            for (uint32_t i = 0; i < groupDim; ++i) {
+                resultBottom += num_mid_bot_doublets_per_thread[i];
+            }
+            num_mid_bot_doublets_per_thread[0] = resultBottom;
 
-            //    uint32_t resultTop = 0;
-            //        for (uint32_t i=0; i<groupDim; ++i){
-            //         resultTop += num_mid_top_doublets_per_thread[i];
-            //        }
-            //     num_mid_top_doublets_per_thread[0] = resultTop;
+            uint32_t resultTop = 0;
+            for (uint32_t i = 0; i < groupDim; ++i) {
+                resultTop += num_mid_top_doublets_per_thread[i];
+            }
+            num_mid_top_doublets_per_thread[0] = resultTop;
 
             vecmem::atomic<uint32_t> objB(&num_mid_bot_doublets_per_bin);
             objB.fetch_add(num_mid_bot_doublets_per_thread[0]);

--- a/device/sycl/src/seeding/triplet_counting.sycl
+++ b/device/sycl/src/seeding/triplet_counting.sycl
@@ -135,7 +135,8 @@ class TripletCount {
         }
 
         if (mt_end_idx >= mid_top_doublets_per_bin.size()) {
-            mt_end_idx = fmin(mid_top_doublets_per_bin.size(), mt_end_idx);
+            mt_end_idx =
+                ::sycl::min(mid_top_doublets_per_bin.size(), mt_end_idx);
         }
 
         if (mt_start_idx >= mid_top_doublets_per_bin.size()) {

--- a/device/sycl/src/seeding/triplet_finding.sycl
+++ b/device/sycl/src/seeding/triplet_finding.sycl
@@ -164,7 +164,8 @@ class TripletFind {
         }
 
         if (mt_end_idx >= mid_top_doublets_per_bin.size()) {
-            mt_end_idx = fmin(mid_top_doublets_per_bin.size(), mt_end_idx);
+            mt_end_idx =
+                ::sycl::min(mid_top_doublets_per_bin.size(), mt_end_idx);
         }
 
         if (mt_start_idx >= mid_top_doublets_per_bin.size()) {
@@ -217,9 +218,10 @@ class TripletFind {
         }
         // Calculate the number of triplets per "block" with reducing sum
         // technique
-        ::sycl::group_barrier(workGroup);
+        // ::sycl::group_barrier(workGroup);
+        item.barrier();
         // Warp shuffle reduction algorithm
-        sycl_helper::reduceInShared(num_triplets_per_thread, item);
+        // sycl_helper::reduceInShared(num_triplets_per_thread, item);
 
         // Sycl group reduction algorithm - doesn't always work correctly
         // num_triplets_per_thread[0] = ::sycl::reduce_over_group(workGroup,
@@ -229,11 +231,11 @@ class TripletFind {
         // of triplets per block
         if (workItemIdx == 0) {
             // For loop reduction
-            //    uint32_t resultTriplets = 0;
-            //        for (uint32_t i=0; i<groupDim; ++i){
-            //         resultTriplets += num_triplets_per_thread[i];
-            //        }
-            //    num_triplets_per_thread[0] = resultTriplets;
+            uint32_t resultTriplets = 0;
+            for (uint32_t i = 0; i < groupDim; ++i) {
+                resultTriplets += num_triplets_per_thread[i];
+            }
+            num_triplets_per_thread[0] = resultTriplets;
             vecmem::atomic<uint32_t> obj(&num_triplets_per_bin);
             obj.fetch_add(num_triplets_per_thread[0]);
         }

--- a/device/sycl/src/seeding/weight_updating.sycl
+++ b/device/sycl/src/seeding/weight_updating.sycl
@@ -67,7 +67,8 @@ class WeightUpdate {
         auto triplets_per_bin = triplet_device.get_items().at(bin_idx);
 
         auto compat_seedR = m_localMem.get_pointer();
-        ::sycl::group_barrier(workGroup);
+        // ::sycl::group_barrier(workGroup);
+        item.barrier();
 
         // index of triplet in the item vector
         auto& triplet = triplets_per_bin[tr_idx];
@@ -96,7 +97,7 @@ class WeightUpdate {
         }
 
         if (end_idx >= triplets_per_bin.size()) {
-            end_idx = fmin(triplets_per_bin.size(), end_idx);
+            end_idx = ::sycl::min(triplets_per_bin.size(), end_idx);
         }
 
         // prevent overflow

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.8.0.tar.gz;URL_MD5;5394f2366e7a494852438cd1e7ef09a2"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.10.0.tar.gz;URL_MD5;712888e704d2e4c915ac1f25f28da467"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
This turned out to be quite a bit more painful than I first realised. But finally, building @konradkusiak97's SYCL code is more or less working as part of the CI.

I had to do the following things:
  - Update to the latest version of [vecmem](https://github.com/acts-project/vecmem), to include https://github.com/acts-project/vecmem/pull/163, which also properly fixes the issue discussed in #112;
  - Switch to `TRACCC_ALGEBRA_PLUGINS=ARRAY` by default;
    * The SYCL code only works with this setting, so to simplify the CI, this seemed reasonable for the host and CUDA code as well as a default;
    * I also noticed along the way that not every plugin works even with the host code at the moment. So a larger cleanup will be needed later on.
  - I had to force the oneAPI compiler to link everything against `libirc.so`;
    * This is to work around an issue with Acts using `--coverage` in Debug builds. An issue that is present with oneAPI 2021.4.0 as well. (I also tried to use 2022.1.0, but that one ran into other issues. So at that point I just gave up for now.)
  - I had to modify parts of the SYCL code to make it compatible with oneAPI 2021.2.0;
    * Switching the `::sycl::group_barrier(workGroup);` calls to `item.barrier();` will undoubtedly make things less efficient, but probably not by much;
    * The partial summing written by Konrad does not work in oneAPI 2021.2.0. So for now I switched to the simpler / slower code. We will need to re-think that part of the code anyway...

We **should** update to the latest version of oneAPI in a future PR. But for now this seemed to be the fastest way to get the CI working.