### PR TITLE
GitHub SYCL/HIP Compatibility, main branch (2022.02.02.)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Consider .hip and .sycl files as C++.
+*.hip linguist-language=C++
+*.sycl linguist-language=C++


### PR DESCRIPTION
Taught GitHub how to render `.sycl` files with syntax highlighting. And while at it, I also added a rule for `.hip` files. Even if those may or may not happen in this repository.

This is just a copy-paste from the [vecmem](https://github.com/acts-project/vecmem) repository...