### PR TITLE
Bug fix - initializing local memory in doublet finding

### DIFF
--- a/device/sycl/src/seeding/doublet_finding.sycl
+++ b/device/sycl/src/seeding/doublet_finding.sycl
@@ -79,8 +79,10 @@ class DupletFind {
         auto mid_top_doublets_per_bin =
             mid_top_doublet_device.get_items().at(bin_idx);
 
-        auto num_mid_bot_doublets_per_thread = m_localMemBot.get_pointer();
-        auto num_mid_top_doublets_per_thread = m_localMemTop.get_pointer();
+        auto num_mid_bot_doublets_per_thread = m_localMemBot;
+        auto num_mid_top_doublets_per_thread = m_localMemTop;
+        num_mid_bot_doublets_per_thread[workItemIdx] = 0;
+        num_mid_top_doublets_per_thread[workItemIdx] = 0; 
         // Convenient alias for the number of doublets per thread
         auto& n_mid_bot_per_spM = num_mid_bot_doublets_per_thread[workItemIdx];
         auto& n_mid_top_per_spM = num_mid_top_doublets_per_thread[workItemIdx];

--- a/device/sycl/src/seeding/doublet_finding.sycl
+++ b/device/sycl/src/seeding/doublet_finding.sycl
@@ -82,7 +82,7 @@ class DupletFind {
         auto num_mid_bot_doublets_per_thread = m_localMemBot;
         auto num_mid_top_doublets_per_thread = m_localMemTop;
         num_mid_bot_doublets_per_thread[workItemIdx] = 0;
-        num_mid_top_doublets_per_thread[workItemIdx] = 0; 
+        num_mid_top_doublets_per_thread[workItemIdx] = 0;
         // Convenient alias for the number of doublets per thread
         auto& n_mid_bot_per_spM = num_mid_bot_doublets_per_thread[workItemIdx];
         auto& n_mid_top_per_spM = num_mid_top_doublets_per_thread[workItemIdx];


### PR DESCRIPTION
This bug was spotted after trying to run the SYCL seeding algorithm in a loop:
```
Running ./seeding_example tml_detector/trackml-detector.csv tml_hits/  9 0
Running on device: NVIDIA GeForce RTX 3050 Ti Laptop GPU
event 0
 seed matching rate: 0.996104
 track parameters matching rate: 0.999026

PI CUDA ERROR:
	Value:           700
	Name:            CUDA_ERROR_ILLEGAL_ADDRESS
	Description:     an illegal memory access was encountered
	Function:        wait
	Source Location: /home/konradd/software/llvm/sycl/plugins/cuda/pi_cuda.cpp:449

terminate called after throwing an instance of 'cl::sycl::runtime_error'
  what():  Native API failed. Native API returns: -999 (Unknown OpenCL error code) -999 (Unknown OpenCL error code)
Aborted (core dumped)
```
The error here comes from `triplet_counting` kernel which is trying to be invoked with an arbitrarily high number of threads per block. That's because, on the second try, the `doublet_finding` gives out a strangely big number of doublets found. And it seems like this was caused by not initializing the arrays in local memory before accessing them. 

By fixing that, everything seems to work fine on the CUDA backend...for now :smiling_face_with_tear: 

pinging @krasznaa 