### PR TITLE
Add Seeding Performance Writer

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -25,7 +25,7 @@ jobs:
           - name: CUDA
             container: ghcr.io/acts-project/ubuntu2004_cuda:v16.1
           - name: SYCL
-            container: ghcr.io/acts-project/ubuntu2004_oneapi:v19
+            container: ghcr.io/acts-project/ubuntu2004_oneapi:v20
         build:
           - Release
           - Debug

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -25,7 +25,7 @@ jobs:
           - name: CUDA
             container: ghcr.io/acts-project/ubuntu2004_cuda:v16.1
           - name: SYCL
-            container: ghcr.io/acts-project/ubuntu2004_oneapi:v16.1
+            container: ghcr.io/acts-project/ubuntu2004_oneapi:v19
         build:
           - Release
           - Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,8 @@ add_subdirectory( plugins )
 if ( TRACCC_BUILD_EXAMPLES )
    # Find Boost.
    find_package( Boost REQUIRED COMPONENTS program_options)
+   # Find ROOT.
+   find_package( ROOT COMPONENTS RIO Tree Hist )
    add_subdirectory( examples )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ The `data` directory is a submodule hosted as `git lfs` on `https://gitlab.cern.
 
 ### Prerequisites
 
-- [Boost](https://www.boost.org/)
+- [Boost](https://www.boost.org/): program_options
+- [ROOT](https://root.cern/): RIO, Hist, Tree
 
 ## Getting started
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -8,7 +8,6 @@
 traccc_add_library( traccc_core core TYPE INTERFACE
   # Common definitions.
   "include/traccc/definitions/track_parametrization.hpp"
-  "include/traccc/definitions/unit_vectors.hpp"
   "include/traccc/definitions/primitives.hpp"
   "include/traccc/definitions/common.hpp"
   "include/traccc/definitions/qualifiers.hpp"
@@ -27,6 +26,7 @@ traccc_add_library( traccc_core core TYPE INTERFACE
   "include/traccc/geometry/pixel_segmentation.hpp"
   # Utilities.
   "include/traccc/utils/algorithm.hpp"
+  "include/traccc/utils/unit_vectors.hpp"
   # Clusterization algorithmic code.
   "include/traccc/clusterization/detail/sparse_ccl.hpp"
   "include/traccc/clusterization/component_connection.hpp"

--- a/core/include/traccc/edm/seed.hpp
+++ b/core/include/traccc/edm/seed.hpp
@@ -45,6 +45,16 @@ struct seed {
         z_vertex = aSeed.z_vertex;
         return *this;
     }
+
+    TRACCC_HOST_DEVICE
+    std::vector<measurement> get_measurements(
+        const host_spacepoint_container& spacepoints) const {
+        std::vector<measurement> result;
+        result.push_back(spacepoints.at(spB_link).meas);
+        result.push_back(spacepoints.at(spM_link).meas);
+        result.push_back(spacepoints.at(spT_link).meas);
+        return result;
+    }
 };
 
 inline bool operator==(const seed& lhs, const seed& rhs) {

--- a/core/include/traccc/edm/track_parameters.hpp
+++ b/core/include/traccc/edm/track_parameters.hpp
@@ -11,7 +11,7 @@
 #include "traccc/definitions/common.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/definitions/track_parametrization.hpp"
-#include "traccc/definitions/unit_vectors.hpp"
+#include "traccc/utils/unit_vectors.hpp"
 
 namespace traccc {
 

--- a/core/include/traccc/seeding/detail/seeding_config.hpp
+++ b/core/include/traccc/seeding/detail/seeding_config.hpp
@@ -20,7 +20,7 @@ struct seedfinder_config {
     // m_config.zMax = 2800.;
     scalar zMin = -1186;
     scalar zMax = 1186;
-    scalar rMax = 250;
+    scalar rMax = 200;
     // WARNING: if rMin is smaller than impactMax, the bin size will be 2*pi,
     // which will make seeding very slow!
     scalar rMin = 33;
@@ -41,9 +41,9 @@ struct seedfinder_config {
     // equivalent to 2.7 eta (pseudorapidity)
     scalar cotThetaMax = 7.40627;
     // minimum distance in mm in r between two measurements within one seed
-    scalar deltaRMin = 5;
+    scalar deltaRMin = 1;
     // maximum distance in mm in r between two measurements within one seed
-    scalar deltaRMax = 200;
+    scalar deltaRMax = 60;
 
     // FIXME: this is not used yet
     //        scalar upperPtResolutionPerSeed = 20* Acts::GeV;
@@ -70,7 +70,7 @@ struct seedfinder_config {
     scalar bFieldInZ = 0.00199724;
     // location of beam in x,y plane.
     // used as offset for Space Points
-    vector2 beamPos{-.5, -.5};
+    vector2 beamPos{-.0, -.0};
 
     // average radiation lengths of material on the length of a seed. used for
     // scattering.

--- a/core/include/traccc/seeding/seed_filtering.hpp
+++ b/core/include/traccc/seeding/seed_filtering.hpp
@@ -124,6 +124,8 @@ struct seed_filtering
         }
     }
 
+    seedfilter_config get_seedfilter_config() { return m_filter_config; }
+
     private:
     seedfilter_config m_filter_config;
 };

--- a/core/include/traccc/utils/unit_vectors.hpp
+++ b/core/include/traccc/utils/unit_vectors.hpp
@@ -23,4 +23,16 @@ TRACCC_HOST_DEVICE inline vector3 make_direction_unit_from_phi_theta(
     };
 }
 
+TRACCC_HOST_DEVICE inline scalar phi(const vector3& v) {
+    return std::atan2(v[1], v[0]);
+}
+
+TRACCC_HOST_DEVICE inline scalar eta(const vector3& v) {
+    return std::atanh(v[2] / getter::norm(v));
+}
+
+TRACCC_HOST_DEVICE inline scalar theta(const vector3& v) {
+    return std::atan2(std::sqrt(v[0] * v[0] + v[1] * v[1]), v[2]);
+}
+
 }  // namespace traccc

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(algorithms)
+add_subdirectory(performance)
 add_subdirectory(run)

--- a/examples/performance/CMakeLists.txt
+++ b/examples/performance/CMakeLists.txt
@@ -1,0 +1,18 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Set up the "build" of the traccc::performance library.
+traccc_add_library( traccc_performance performance TYPE INTERFACE
+  #event
+  "include/traccc/event/event_map.hpp" 
+  #efficiency
+  "include/traccc/efficiency/seeding_performance_writer.hpp" 
+  "include/traccc/efficiency/duplication_plot_tool.hpp" 
+  "include/traccc/efficiency/eff_plot_tool.hpp" 
+  "include/traccc/efficiency/helpers.hpp"
+  "include/traccc/efficiency/track_classification.hpp" )
+target_link_libraries( traccc_performance
+  INTERFACE traccc::core ROOT::RIO ROOT::Hist ROOT::Tree )

--- a/examples/performance/include/traccc/efficiency/duplication_plot_tool.hpp
+++ b/examples/performance/include/traccc/efficiency/duplication_plot_tool.hpp
@@ -1,0 +1,136 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/edm/particle.hpp"
+#include "traccc/efficiency/helpers.hpp"
+#include "traccc/utils/unit_vectors.hpp"
+
+namespace traccc {
+
+// Tools to make duplication rate and duplication number plots to show tracking
+// duplication.
+//
+// The duplication is investigated for those truth-matched reco tracks. If there
+// are a few reco tracks matched to the same truth particle, the reco track with
+// the highest matching probability is tagges as 'real' and the others are
+// 'duplicated'.
+class duplication_plot_tool {
+    public:
+    /// @brief The nested configuration struct
+    struct config {
+        std::map<std::string, plot_helpers::binning> var_binning = {
+            {"Eta", plot_helpers::binning("#eta", 40, -4, 4)},
+            {"Phi", plot_helpers::binning("#phi", 100, -3.15, 3.15)},
+            {"Pt", plot_helpers::binning("pT [GeV/c]", 40, 0, 100)},
+            {"Num", plot_helpers::binning("N", 30, -0.5, 29.5)}};
+    };
+
+    /// @brief Nested Cache struct
+    struct duplication_plot_cache {
+        TProfile* n_duplicated_vs_pT;   ///< Number of duplicated tracks vs pT
+        TProfile* n_duplicated_vs_eta;  ///< Number of duplicated tracks vs eta
+        TProfile* n_duplicated_vs_phi;  ///< Number of duplicated tracks vs phi
+        TEfficiency*
+            duplication_rate_vs_pT;  ///< Tracking duplication rate vs pT
+        TEfficiency*
+            duplication_rate_vs_eta;  ///< Tracking duplication rate vs eta
+        TEfficiency*
+            duplication_rate_vs_phi;  ///< Tracking duplication rate vs phi
+    };
+
+    /// Constructor
+    ///
+    /// @param cfg Configuration struct
+    duplication_plot_tool(const config& cfg) : m_cfg(cfg) {}
+
+    /// @brief book the duplication plots
+    ///
+    /// @param duplicationPlotCache the cache for duplication plots
+    void book(std::string name, duplication_plot_cache& cache) const {
+        plot_helpers::binning b_pt = m_cfg.var_binning.at("Pt");
+        plot_helpers::binning b_eta = m_cfg.var_binning.at("Eta");
+        plot_helpers::binning b_phi = m_cfg.var_binning.at("Phi");
+        plot_helpers::binning b_num = m_cfg.var_binning.at("Num");
+
+        // duplication rate vs pT
+        cache.duplication_rate_vs_pT = plot_helpers::book_eff(
+            TString(name) + "_duplicationRate_vs_pT",
+            "Duplication rate;pT [GeV/c];Duplication rate", b_pt);
+        // duplication rate vs eta
+        cache.duplication_rate_vs_eta = plot_helpers::book_eff(
+            TString(name) + "_duplicationRate_vs_eta",
+            "Duplication rate;#eta;Duplication rate", b_eta);
+        // duplication rate vs phi
+        cache.duplication_rate_vs_phi = plot_helpers::book_eff(
+            TString(name) + "_duplicationRate_vs_phi",
+            "Duplication rate;#phi;Duplication rate", b_phi);
+
+        // duplication number vs pT
+        cache.n_duplicated_vs_pT = plot_helpers::book_prof(
+            TString(name) + "_nDuplicated_vs_pT",
+            "Number of duplicated track candidates", b_pt, b_num);
+        // duplication number vs eta
+        cache.n_duplicated_vs_eta = plot_helpers::book_prof(
+            TString(name) + "_nDuplicated_vs_eta",
+            "Number of duplicated track candidates", b_eta, b_num);
+        // duplication number vs phi
+        cache.n_duplicated_vs_phi = plot_helpers::book_prof(
+            TString(name) + "_nDuplicated_vs_phi",
+            "Number of duplicated track candidates", b_phi, b_num);
+    }
+
+    /// @brief fill number of duplicated tracks for a truth particle seed
+    ///
+    /// @param duplicationPlotCache cache object for duplication plots
+    /// @param truthParticle the truth Particle
+    /// @param nDuplicatedTracks the number of duplicated tracks
+    void fill(duplication_plot_cache& cache, const particle& truth_particle,
+              size_t n_duplicated_tracks) const {
+        const auto t_phi = phi(truth_particle.mom);
+        const auto t_eta = eta(truth_particle.mom);
+        const auto t_pT =
+            getter::perp(vector2{truth_particle.mom[0], truth_particle.mom[1]});
+
+        plot_helpers::fill_prof(cache.n_duplicated_vs_pT, t_pT,
+                                n_duplicated_tracks);
+        plot_helpers::fill_prof(cache.n_duplicated_vs_eta, t_eta,
+                                n_duplicated_tracks);
+        plot_helpers::fill_prof(cache.n_duplicated_vs_phi, t_phi,
+                                n_duplicated_tracks);
+    }
+
+    /// @brief write the duplication plots to file
+    ///
+    /// @param duplicationPlotCache cache object for duplication plots
+    void write(const duplication_plot_cache& cache) const {
+        cache.duplication_rate_vs_pT->Write();
+        cache.duplication_rate_vs_eta->Write();
+        cache.duplication_rate_vs_phi->Write();
+        cache.n_duplicated_vs_pT->Write();
+        cache.n_duplicated_vs_eta->Write();
+        cache.n_duplicated_vs_phi->Write();
+    }
+
+    /// @brief delete the duplication plots
+    ///
+    /// @param duplicationPlotCache cache object for duplication plots
+    void clear(duplication_plot_cache& cache) const {
+        delete cache.duplication_rate_vs_pT;
+        delete cache.duplication_rate_vs_eta;
+        delete cache.duplication_rate_vs_phi;
+        delete cache.n_duplicated_vs_pT;
+        delete cache.n_duplicated_vs_eta;
+        delete cache.n_duplicated_vs_phi;
+    }
+
+    private:
+    config m_cfg;  ///< The Config class
+};
+
+}  // namespace traccc

--- a/examples/performance/include/traccc/efficiency/eff_plot_tool.hpp
+++ b/examples/performance/include/traccc/efficiency/eff_plot_tool.hpp
@@ -1,0 +1,105 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/edm/particle.hpp"
+#include "traccc/efficiency/helpers.hpp"
+#include "traccc/utils/unit_vectors.hpp"
+
+namespace traccc {
+
+// Tools to make efficiency plots to show tracking efficiency.
+// For the moment, the efficiency is taken as the fraction of successfully
+// smoothed track over all tracks
+class eff_plot_tool {
+    public:
+    /// @brief The nested configuration struct
+    struct config {
+        std::map<std::string, plot_helpers::binning> var_binning = {
+            {"Eta", plot_helpers::binning("#eta", 40, -4, 4)},
+            {"Phi", plot_helpers::binning("#phi", 100, -3.15, 3.15)},
+            {"Pt", plot_helpers::binning("pT [GeV/c]", 40, 0, 100)}};
+    };
+
+    /// @brief Nested Cache struct
+    struct eff_plot_cache {
+        TEfficiency* track_eff_vs_pT{nullptr};   ///< Tracking efficiency vs pT
+        TEfficiency* track_eff_vs_eta{nullptr};  ///< Tracking efficiency vs eta
+        TEfficiency* track_eff_vs_phi{nullptr};  ///< Tracking efficiency vs phi
+    };
+
+    /// Constructor
+    ///
+    /// @param cfg Configuration struct
+    /// @param lvl Message level declaration
+    eff_plot_tool(const config& cfg) : m_cfg(cfg) {}
+
+    /// @brief book the efficiency plots
+    ///
+    /// @param effPlotCache the cache for efficiency plots
+    void book(std::string name, eff_plot_cache& cache) const {
+
+        plot_helpers::binning b_phi = m_cfg.var_binning.at("Phi");
+        plot_helpers::binning b_eta = m_cfg.var_binning.at("Eta");
+        plot_helpers::binning b_pt = m_cfg.var_binning.at("Pt");
+
+        // efficiency vs pT
+        cache.track_eff_vs_pT = plot_helpers::book_eff(
+            TString(name) + "_trackeff_vs_pT",
+            "Tracking efficiency;Truth pT [GeV/c];Efficiency", b_pt);
+        // efficiency vs eta
+        cache.track_eff_vs_eta = plot_helpers::book_eff(
+            TString(name) + "_trackeff_vs_eta",
+            "Tracking efficiency;Truth #eta;Efficiency", b_eta);
+        // efficiency vs phi
+        cache.track_eff_vs_phi = plot_helpers::book_eff(
+            TString(name) + "_trackeff_vs_phi",
+            "Tracking efficiency;Truth #phi;Efficiency", b_phi);
+    }
+
+    /// @brief fill efficiency plots
+    ///
+    /// @param effPlotCache cache object for efficiency plots
+    /// @param truthParticle the truth Particle
+    /// @param status the reconstruction status
+    void fill(eff_plot_cache& cache, const particle& truth_particle,
+              bool status) const {
+
+        const auto t_phi = phi(truth_particle.mom);
+        const auto t_eta = eta(truth_particle.mom);
+        const auto t_pT =
+            getter::perp(vector2{truth_particle.mom[0], truth_particle.mom[1]});
+
+        plot_helpers::fill_eff(cache.track_eff_vs_pT, t_pT, status);
+        plot_helpers::fill_eff(cache.track_eff_vs_eta, t_eta, status);
+        plot_helpers::fill_eff(cache.track_eff_vs_phi, t_phi, status);
+    }
+
+    /// @brief write the efficiency plots to file
+    ///
+    /// @param effPlotCache cache object for efficiency plots
+    void write(const eff_plot_cache& cache) const {
+        cache.track_eff_vs_pT->Write();
+        cache.track_eff_vs_eta->Write();
+        cache.track_eff_vs_phi->Write();
+    }
+
+    /// @brief delete the efficiency plots
+    ///
+    /// @param effPlotCache cache object for efficiency plots
+    void clear(eff_plot_cache& cache) const {
+        delete cache.track_eff_vs_pT;
+        delete cache.track_eff_vs_eta;
+        delete cache.track_eff_vs_phi;
+    }
+
+    private:
+    config m_cfg;  ///< The Config class
+};
+
+}  // namespace traccc

--- a/examples/performance/include/traccc/efficiency/helpers.hpp
+++ b/examples/performance/include/traccc/efficiency/helpers.hpp
@@ -1,0 +1,125 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <string>
+
+#include "TEfficiency.h"
+#include "TFitResult.h"
+#include "TFitResultPtr.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TProfile.h"
+#include "TROOT.h"
+
+namespace traccc {
+
+namespace plot_helpers {
+/// @brief Nested binning struct for booking plots
+struct binning {
+    binning(){};
+
+    binning(std::string b_title, int bins, float b_min, float b_max)
+        : title(b_title), n_bins(bins), min(b_min), max(b_max){};
+
+    std::string title;  ///< title to be displayed
+    int n_bins;         ///< number of bins
+    float min;          ///< minimum value
+    float max;          ///< maximum value
+};
+
+/// @brief book a 1D histogram
+/// @param histName the name of histogram
+/// @param histTitle the title of histogram
+/// @param varBinning the binning info of variable
+/// @return histogram pointer
+TH1F* book_histo(const char* hist_name, const char* hist_title,
+                 const binning& var_binning) {
+    TH1F* hist = new TH1F(hist_name, hist_title, var_binning.n_bins,
+                          var_binning.min, var_binning.max);
+    hist->GetXaxis()->SetTitle(var_binning.title.c_str());
+    hist->GetYaxis()->SetTitle("Entries");
+    hist->Sumw2();
+    return hist;
+}
+
+/// @brief fill a 1D histogram
+/// @param hist histogram to fill
+/// @param value value to fill
+/// @param weight weight to fill
+void fill_histo(TH1F* hist, float value, float weight = 1.0) {
+    assert(hist != nullptr);
+    hist->Fill(value, weight);
+}
+
+/// @brief extract details, i.e. mean and width of a 1D histogram and fill
+/// them into histograms
+/// @param inputHist histogram to investigate
+/// @param j  which bin number of meanHist and widthHist to fill
+/// @param meanHist histogram to fill the mean value of inputHist
+/// @param widthHist  histogram to fill the width value of inputHist
+///
+/// @todo  write specialized helper class to extract details of hists
+void ana_histo(TH1D* input_hist, int j, TH1F* mean_hist, TH1F* width_hist) {
+    // evaluate mean and width via the Gauss fit
+    assert(input_hist != nullptr);
+    if (input_hist->GetEntries() > 0) {
+        TFitResultPtr r = input_hist->Fit("gaus", "QS0");
+        if (r.Get() and ((r->Status() % 1000) == 0)) {
+            // fill the mean and width into 'j'th bin of the meanHist and
+            // widthHist, respectively
+            mean_hist->SetBinContent(j, r->Parameter(1));
+            mean_hist->SetBinError(j, r->ParError(1));
+            width_hist->SetBinContent(j, r->Parameter(2));
+            width_hist->SetBinError(j, r->ParError(2));
+        }
+    }
+}
+
+/// @brief book a 1D efficiency plot
+/// @param effName the name of plot
+/// @param effTitle the title of plot
+/// @param varBinning the binning info of variable
+/// @return TEfficiency pointer
+TEfficiency* book_eff(const char* eff_name, const char* eff_title,
+                      const binning& var_binning) {
+    TEfficiency* efficiency =
+        new TEfficiency(eff_name, eff_title, var_binning.n_bins,
+                        var_binning.min, var_binning.max);
+    return efficiency;
+}
+
+/// @brief fill a 1D efficiency plot
+/// @param efficiency plot to fill
+/// @param value value to fill
+/// @param status bool to denote passed or not
+void fill_eff(TEfficiency* efficiency, float value, bool status) {
+    assert(efficiency != nullptr);
+    efficiency->Fill(status, value);
+}
+
+TProfile* book_prof(const char* prof_name, const char* prof_title,
+                    const binning& var_x_binning,
+                    const binning& var_y_binning) {
+    TProfile* prof = new TProfile(prof_name, prof_title, var_x_binning.n_bins,
+                                  var_x_binning.min, var_x_binning.max,
+                                  var_y_binning.min, var_y_binning.max);
+    prof->GetXaxis()->SetTitle(var_x_binning.title.c_str());
+    prof->GetYaxis()->SetTitle(var_y_binning.title.c_str());
+    return prof;
+}
+
+void fill_prof(TProfile* profile, float x_value, float y_value,
+               float weight = 1.0) {
+    assert(profile != nullptr);
+    profile->Fill(x_value, y_value, weight);
+}
+
+}  // namespace plot_helpers
+
+}  // namespace traccc

--- a/examples/performance/include/traccc/efficiency/seeding_performance_writer.hpp
+++ b/examples/performance/include/traccc/efficiency/seeding_performance_writer.hpp
@@ -1,0 +1,177 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/edm/seed.hpp"
+#include "traccc/efficiency/duplication_plot_tool.hpp"
+#include "traccc/efficiency/eff_plot_tool.hpp"
+#include "traccc/efficiency/track_classification.hpp"
+#include "traccc/event/event_map.hpp"
+#include "traccc/io/mapper.hpp"
+
+// ROOT
+#include <TFile.h>
+#include <TTree.h>
+
+namespace traccc {
+
+class seeding_performance_writer {
+
+    public:
+    struct config {
+
+        /// Output filename.
+        std::string file_path = "performance_track_seeding.root";
+        /// Output file mode
+        std::string file_mode = "RECREATE";
+
+        /// Plot tool configurations.
+        eff_plot_tool::config eff_plot_tool_config;
+        duplication_plot_tool::config duplication_plot_tool_config;
+
+        /// Cut values
+        scalar pT_cut = 1.;
+    };
+
+    /// Construct from configuration and log level.
+    /// @param config The configuration
+    /// @param level
+    seeding_performance_writer(config cfg)
+        : m_cfg(std::move(cfg)),
+          m_eff_plot_tool(m_cfg.eff_plot_tool_config),
+          m_duplication_plot_tool(m_cfg.duplication_plot_tool_config) {
+
+        auto path = m_cfg.file_path;
+
+        m_output_file = TFile::Open(path.c_str(), m_cfg.file_mode.c_str());
+
+        if (not m_output_file) {
+            throw std::invalid_argument("Could not open '" + path + "'");
+        }
+    };
+
+    ~seeding_performance_writer() {
+
+        for (auto& [name, cache] : m_eff_plot_caches) {
+            m_eff_plot_tool.clear(cache);
+        }
+
+        for (auto& [name, cache] : m_duplication_plot_caches) {
+            m_duplication_plot_tool.clear(cache);
+        }
+
+        if (m_output_file) {
+            m_output_file->Close();
+        }
+    }
+
+    void add_cache(std::string name) {
+        m_eff_plot_tool.book(name, m_eff_plot_caches[name]);
+        m_duplication_plot_tool.book(name, m_duplication_plot_caches[name]);
+    }
+
+    void write(std::string name, const host_seed_collection& seeds,
+               const host_spacepoint_container& spacepoints,
+               event_map& evt_map) {
+
+        auto& p_map = evt_map.ptc_map;
+        auto& m_p_map = evt_map.meas_ptc_map;
+
+        std::map<particle_id, std::size_t> match_counter;
+
+        std::size_t n_matched_seeds = 0;
+
+        for (const auto& sd : seeds) {
+            auto measurements = sd.get_measurements(spacepoints);
+
+            std::vector<particle_hit_count> particle_hit_counts =
+                identify_contributing_particles(measurements, m_p_map);
+
+            if (particle_hit_counts.size() == 1) {
+                auto pid = particle_hit_counts.at(0).ptc.particle_id;
+
+                match_counter[pid]++;
+                n_matched_seeds++;
+            }
+        }
+
+        std::size_t n_particles = 0;
+        std::size_t n_matched_particles = 0;
+        std::size_t n_duplicated_particles = 0;
+
+        for (auto const& [pid, ptc] : p_map) {
+            bool is_matched = false;
+            auto it = match_counter.find(pid);
+
+            std::size_t n_matched_seeds_for_particle = 0;
+
+            // Count only charged particles which satisfiy pT_cut
+            if (ptc.charge == 0 || getter::perp(ptc.mom) < m_cfg.pT_cut) {
+                continue;
+            }
+
+            n_particles++;
+
+            if (it != match_counter.end()) {
+                is_matched = true;
+                n_matched_particles++;
+                n_matched_seeds_for_particle = it->second;
+
+                if (n_matched_seeds_for_particle > 1) {
+                    n_duplicated_particles++;
+                }
+            }
+
+            m_eff_plot_tool.fill(m_eff_plot_caches[name], ptc, is_matched);
+            m_duplication_plot_tool.fill(m_duplication_plot_caches[name], ptc,
+                                         n_matched_seeds_for_particle - 1);
+        }
+
+        m_n_total_seeds += seeds.size();
+        m_n_total_matched_seeds += n_matched_seeds;
+        m_n_total_particles += n_particles;
+        m_n_total_matched_particles += n_matched_particles;
+        m_n_total_duplicated_particles = n_duplicated_particles;
+    }
+
+    void finalize() {
+        m_output_file->cd();
+
+        for (auto const& [name, cache] : m_eff_plot_caches) {
+            m_eff_plot_tool.write(cache);
+        }
+
+        for (auto const& [name, cache] : m_duplication_plot_caches) {
+            m_duplication_plot_tool.write(cache);
+        }
+    }
+
+    private:
+    config m_cfg;
+
+    TFile* m_output_file{nullptr};
+    /// Plot tool for efficiency
+    eff_plot_tool m_eff_plot_tool;
+    std::map<std::string, eff_plot_tool::eff_plot_cache> m_eff_plot_caches;
+
+    /// Plot tool for duplication rate
+    duplication_plot_tool m_duplication_plot_tool;
+    std::map<std::string, duplication_plot_tool::duplication_plot_cache>
+        m_duplication_plot_caches;
+
+    size_t m_n_total_seeds = 0;
+    size_t m_n_total_matched_seeds = 0;
+    size_t m_n_total_particles = 0;
+    size_t m_n_total_matched_particles = 0;
+    size_t m_n_total_duplicated_particles = 0;
+
+    measurement_particle_map m_measurement_particle_map;
+    particle_map m_particle_map;
+};
+
+}  // namespace traccc

--- a/examples/performance/include/traccc/efficiency/track_classification.hpp
+++ b/examples/performance/include/traccc/efficiency/track_classification.hpp
@@ -1,0 +1,64 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/edm/particle.hpp"
+#include "traccc/edm/seed.hpp"
+#include "traccc/io/mapper.hpp"
+
+namespace traccc {
+
+struct particle_hit_count {
+    particle ptc;
+    std::size_t hit_counts;
+};
+
+inline bool operator==(const particle_hit_count& lhs, const particle& rhs) {
+    if (lhs.ptc.particle_id == rhs.particle_id) {
+        return true;
+    }
+    return false;
+}
+
+inline bool operator<(const particle_hit_count& lhs,
+                      const particle_hit_count& rhs) {
+    if (lhs.hit_counts < rhs.hit_counts) {
+        return true;
+    }
+    return false;
+}
+
+std::vector<particle_hit_count> identify_contributing_particles(
+    const std::vector<measurement>& measurements,
+    measurement_particle_map& m_p_map) {
+
+    std::vector<particle_hit_count> result;
+
+    for (const auto& meas : measurements) {
+        const auto& ptcs = m_p_map[meas];
+
+        for (auto const& [ptc, count] : ptcs) {
+            auto it = std::find(result.begin(), result.end(), ptc);
+
+            // particle has been already added to the result vector
+            if (it != result.end()) {
+                it->hit_counts += count;
+            }
+            // particle has not been added
+            else {
+                result.push_back({ptc, count});
+            }
+        }
+    }
+
+    std::sort(result.rbegin(), result.rend());
+
+    return result;
+}
+
+}  // namespace traccc

--- a/examples/performance/include/traccc/event/event_map.hpp
+++ b/examples/performance/include/traccc/event/event_map.hpp
@@ -1,0 +1,41 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/io/mapper.hpp"
+
+namespace traccc {
+
+struct event_map {
+
+    event_map() = delete;
+
+    event_map(std::size_t event, const std::string& detector_file,
+              const std::string& cell_dir, const std::string& hit_dir,
+              const std::string particle_dir,
+              vecmem::memory_resource& resource) {
+
+        ptc_map = generate_particle_map(event, particle_dir);
+        meas_ptc_map = generate_measurement_particle_map(
+            event, detector_file, cell_dir, hit_dir, particle_dir, resource);
+    }
+
+    event_map(std::size_t event, const std::string& detector_file,
+              const std::string& hit_dir, const std::string particle_dir,
+              vecmem::memory_resource& resource) {
+
+        ptc_map = generate_particle_map(event, particle_dir);
+        meas_ptc_map = generate_measurement_particle_map(
+            event, detector_file, hit_dir, particle_dir, resource);
+    }
+
+    particle_map ptc_map;
+    measurement_particle_map meas_ptc_map;
+};
+
+}  // namespace traccc

--- a/examples/run/cpu/CMakeLists.txt
+++ b/examples/run/cpu/CMakeLists.txt
@@ -4,8 +4,13 @@
 #
 # Mozilla Public License Version 2.0
 
+traccc_add_executable( seeding_example "seeding_example.cpp"
+   LINK_LIBRARIES vecmem::core traccc::core traccc::algorithms traccc::io 
+   traccc::performance Boost::program_options)
+
 traccc_add_executable( seq_example "seq_example.cpp"
-   LINK_LIBRARIES vecmem::core traccc::core traccc::algorithms traccc::io Boost::program_options)
+   LINK_LIBRARIES vecmem::core traccc::core traccc::algorithms traccc::io 
+   traccc::performance Boost::program_options)
 
 traccc_add_executable( ccl_example "ccl_example.cpp"
    LINK_LIBRARIES vecmem::core traccc::core traccc::algorithms traccc::io)

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -1,0 +1,136 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// io
+#include "traccc/io/csv.hpp"
+#include "traccc/io/reader.hpp"
+#include "traccc/io/writer.hpp"
+
+// algorithms
+#include "traccc/seeding/track_params_estimation.hpp"
+#include "traccc/track_finding/seeding_algorithm.hpp"
+
+// performance
+#include "traccc/efficiency/seeding_performance_writer.hpp"
+
+// Boost
+#include <boost/program_options.hpp>
+
+// System include(s).
+#include <iostream>
+
+namespace po = boost::program_options;
+
+int seq_run(const std::string& detector_file, const std::string& hit_dir,
+            unsigned int events, const std::string& particle_dir,
+            const bool check_performance) {
+
+    // Read the surface transforms
+    auto surface_transforms = traccc::read_geometry(detector_file);
+
+    // Output stats
+    uint64_t n_spacepoints = 0;
+    uint64_t n_seeds = 0;
+
+    // Memory resource used by the EDM.
+    vecmem::host_memory_resource host_mr;
+
+    traccc::seeding_algorithm sa(host_mr);
+    traccc::track_params_estimation tp(host_mr);
+
+    // performance writer
+    traccc::seeding_performance_writer sd_performance_writer(
+        traccc::seeding_performance_writer::config{});
+    sd_performance_writer.add_cache("CPU");
+
+    // Loop over events
+    for (unsigned int event = 0; event < events; ++event) {
+
+        // Read the hits from the relevant event file
+        traccc::host_spacepoint_container spacepoints_per_event =
+            traccc::read_spacepoints_from_event(event, hit_dir,
+                                                surface_transforms, host_mr);
+
+        /*----------------
+             Seeding
+          ---------------*/
+
+        auto seeds = sa(spacepoints_per_event);
+
+        /*----------------
+             Statistics
+          ---------------*/
+
+        n_spacepoints += spacepoints_per_event.total_size();
+        n_seeds += seeds.size();
+
+        /*------------
+          Writer
+          ------------*/
+
+        if (check_performance) {
+            traccc::event_map evt_map(event, detector_file, hit_dir,
+                                      particle_dir, host_mr);
+            sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
+                                        evt_map);
+        }
+    }
+
+    sd_performance_writer.finalize();
+
+    std::cout << "==> Statistics ... " << std::endl;
+    std::cout << "- read    " << n_spacepoints << " spacepoints" << std::endl;
+    std::cout << "- created (cpu)  " << n_seeds << " seeds" << std::endl;
+
+    return 0;
+}
+
+// The main routine
+//
+int main(int argc, char* argv[]) {
+    po::options_description desc("Allowed options");
+    desc.add_options()("detector_file", po::value<std::string>()->required(),
+                       "specify detector file");
+    desc.add_options()("hit_directory", po::value<std::string>()->required(),
+                       "specify the directory of hit files");
+    desc.add_options()("events", po::value<int>()->required(),
+                       "number of events");
+    desc.add_options()("particle_directory",
+                       po::value<std::string>()->default_value(""),
+                       "specify the directory of particle files");
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+
+    // Print a help message if the user asked for it.
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return 0;
+    }
+
+    // Handle any and all errors.
+    try {
+        po::notify(vm);
+    } catch (const std::exception& ex) {
+        std::cerr << "Couldn't interpret command line options because of:\n\n"
+                  << ex.what() << "\n\n"
+                  << desc << std::endl;
+        return 1;
+    }
+
+    auto detector_file = vm["detector_file"].as<std::string>();
+    auto hit_directory = vm["hit_directory"].as<std::string>();
+    auto events = vm["events"].as<int>();
+    auto particle_directory = vm["particle_directory"].as<std::string>();
+    auto check_performance = vm.count("particle_directory");
+
+    std::cout << "Running " << argv[0] << " " << detector_file << " "
+              << hit_directory << " " << events << std::endl;
+
+    return seq_run(detector_file, hit_directory, events, particle_directory,
+                   check_performance);
+}

--- a/examples/run/cuda/CMakeLists.txt
+++ b/examples/run/cuda/CMakeLists.txt
@@ -9,7 +9,9 @@ include( traccc-compiler-options-cuda )
 
 traccc_add_executable( seq_example_cuda "seq_example_cuda.cpp"
    LINK_LIBRARIES vecmem::core vecmem::cuda
-                  traccc::io traccc::algorithms traccc::algorithms_cuda Boost::program_options)
+                  traccc::io traccc::algorithms traccc::algorithms_cuda traccc::performance 
+                  Boost::program_options)
 traccc_add_executable( seeding_example_cuda "seeding_example_cuda.cpp"
    LINK_LIBRARIES vecmem::core vecmem::cuda
-                  traccc::io traccc::algorithms traccc::algorithms_cuda Boost::program_options)
+                  traccc::io traccc::algorithms traccc::algorithms_cuda traccc::performance
+                  Boost::program_options)

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -18,6 +18,9 @@
 #include "traccc/seeding/track_params_estimation.hpp"
 #include "traccc/track_finding/seeding_algorithm.hpp"
 
+// performance
+#include "traccc/efficiency/seeding_performance_writer.hpp"
+
 // vecmem
 #include <vecmem/memory/cuda/managed_memory_resource.hpp>
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -34,7 +37,9 @@
 namespace po = boost::program_options;
 
 int seq_run(const std::string& detector_file, const std::string& cells_dir,
-            unsigned int events, bool run_cpu) {
+            unsigned int events, const std::string& hit_dir,
+            const std::string& particle_dir, const bool check_performance,
+            bool run_cpu) {
 
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(detector_file);
@@ -68,6 +73,12 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
 
     traccc::cuda::seeding_algorithm sa_cuda(mng_mr);
     traccc::cuda::track_params_estimation tp_cuda(mng_mr);
+
+    // performance writer
+    traccc::seeding_performance_writer sd_performance_writer(
+        traccc::seeding_performance_writer::config{});
+    sd_performance_writer.add_cache("CPU");
+    sd_performance_writer.add_cache("CUDA");
 
     /*time*/ auto start_wall_time = std::chrono::system_clock::now();
 
@@ -213,6 +224,18 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
              Writer
           ------------*/
 
+        if (check_performance) {
+            traccc::event_map evt_map(event, detector_file, hit_dir,
+                                      particle_dir, host_mr);
+            sd_performance_writer.write("CUDA", seeds_cuda,
+                                        spacepoints_per_event, evt_map);
+
+            if (run_cpu) {
+                sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
+                                            evt_map);
+            }
+        }
+
         if (run_cpu) {
             traccc::write_measurements(event, measurements_per_event);
             traccc::write_spacepoints(event, spacepoints_per_event);
@@ -226,6 +249,8 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
         end_wall_time - start_wall_time;
 
     /*time*/ wall_time += time_wall_time.count();
+
+    sd_performance_writer.finalize();
 
     std::cout << "==> Statistics ... " << std::endl;
     std::cout << "- read    " << n_spacepoints << " spacepoints from "
@@ -273,6 +298,12 @@ int main(int argc, char* argv[]) {
                        "number of events");
     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
+    desc.add_options()("hit_directory",
+                       po::value<std::string>()->default_value(""),
+                       "specify the directory of hit files");
+    desc.add_options()("particle_directory",
+                       po::value<std::string>()->default_value(""),
+                       "specify the directory of particle files");
 
     // Interpret the program options.
     po::variables_map vm;
@@ -298,9 +329,14 @@ int main(int argc, char* argv[]) {
     auto cell_directory = vm["cell_directory"].as<std::string>();
     auto events = vm["events"].as<int>();
     auto run_cpu = vm["run_cpu"].as<bool>();
+    auto hit_directory = vm["hit_directory"].as<std::string>();
+    auto particle_directory = vm["particle_directory"].as<std::string>();
+    auto check_performance =
+        vm.count("hit_directory") && vm.count("particle_directory");
 
     std::cout << "Running " << argv[0] << " " << detector_file << " "
               << cell_directory << " " << events << std::endl;
 
-    return seq_run(detector_file, cell_directory, events, run_cpu);
+    return seq_run(detector_file, cell_directory, events, hit_directory,
+                   particle_directory, check_performance, run_cpu);
 }

--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -17,9 +17,9 @@ traccc_add_executable( traccc_sycl_language_example
 # SYCL seeding executable(s).
 traccc_add_executable( seeding_example_sycl "seeding_example_sycl.sycl"
    LINK_LIBRARIES Boost::program_options vecmem::core vecmem::sycl traccc::io
-                  traccc::algorithms traccc::algorithms_sycl )
+                  traccc::algorithms traccc::algorithms_sycl traccc::performance)
 target_compile_definitions( traccc_seeding_example_sycl PRIVATE EIGEN_NO_CUDA )
 traccc_add_executable( seq_example_sycl "seq_example_sycl.sycl"
    LINK_LIBRARIES Boost::program_options vecmem::core vecmem::sycl traccc::io
-                  traccc::algorithms traccc::algorithms_sycl )
+                  traccc::algorithms traccc::algorithms_sycl traccc::performance)
 target_compile_definitions( traccc_seq_example_sycl PRIVATE EIGEN_NO_CUDA )

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -35,7 +35,8 @@
 namespace po = boost::program_options;
 
 int seq_run(const std::string& detector_file, const std::string& hits_dir,
-            unsigned int events, bool run_cpu) {
+            unsigned int events, const std::string& particle_dir,
+            const bool check_performance, bool run_cpu) {
 
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(detector_file);
@@ -70,6 +71,12 @@ int seq_run(const std::string& detector_file, const std::string& hits_dir,
 
     traccc::sycl::seeding_algorithm sa_sycl(shared_mr, &q);
     traccc::sycl::track_params_estimation tp_sycl(shared_mr, &q);
+
+    // performance writer
+    traccc::seeding_performance_writer sd_performance_writer(
+        traccc::seeding_performance_writer::config{});
+    sd_performance_writer.add_cache("CPU");
+    sd_performance_writer.add_cache("SYCL");
 
     /*time*/ auto start_wall_time = std::chrono::system_clock::now();
 
@@ -196,6 +203,17 @@ int seq_run(const std::string& detector_file, const std::string& hits_dir,
           Writer
           ------------*/
 
+        if (check_performance) {
+            traccc::event_map evt_map(event, detector_file, hits_dir,
+                                      particle_dir, host_mr);
+            sd_performance_writer.write("SYCL", seeds_sycl,
+                                        spacepoints_per_event, evt_map);
+            if (run_cpu) {
+                sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
+                                            evt_map);
+            }
+        }
+
         if (run_cpu) {
             traccc::write_spacepoints(event, spacepoints_per_event);
             traccc::write_seeds(event, spacepoints_per_event, seeds);
@@ -208,6 +226,8 @@ int seq_run(const std::string& detector_file, const std::string& hits_dir,
         end_wall_time - start_wall_time;
 
     /*time*/ wall_time += time_wall_time.count();
+
+    sd_performance_writer.finalize();
 
     std::cout << "==> Statistics ... " << std::endl;
     std::cout << "- read    " << n_spacepoints << " spacepoints from "
@@ -244,6 +264,9 @@ int main(int argc, char* argv[]) {
                        "specify the directory of hit files");
     desc.add_options()("events", po::value<int>()->required(),
                        "number of events");
+    desc.add_options()("particle_directory",
+                       po::value<std::string>()->default_value(""),
+                       "specify the directory of particle files");
     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
@@ -270,10 +293,13 @@ int main(int argc, char* argv[]) {
     auto detector_file = vm["detector_file"].as<std::string>();
     auto hit_directory = vm["hit_directory"].as<std::string>();
     auto events = vm["events"].as<int>();
+    auto particle_directory = vm["particle_directory"].as<std::string>();
     auto run_cpu = vm["run_cpu"].as<bool>();
+    auto check_performance = vm.count("particle_directory");
 
     std::cout << "Running " << argv[0] << " " << detector_file << " "
               << hit_directory << " " << events << std::endl;
 
-    return seq_run(detector_file, hit_directory, events, run_cpu);
+    return seq_run(detector_file, hit_directory, events, particle_directory,
+                   check_performance, run_cpu);
 }

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -19,6 +19,9 @@
 #include "traccc/io/reader.hpp"
 #include "traccc/io/writer.hpp"
 
+// performance
+#include "traccc/efficiency/seeding_performance_writer.hpp"
+
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
 #include <vecmem/memory/sycl/shared_memory_resource.hpp>

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -37,7 +37,9 @@
 namespace po = boost::program_options;
 
 int seq_run(const std::string& detector_file, const std::string& cells_dir,
-            unsigned int events, bool run_cpu) {
+            unsigned int events, const std::string& hit_dir,
+            const std::string& particle_dir, const bool check_performance,
+            bool run_cpu) {
 
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(detector_file);
@@ -78,6 +80,12 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
 
     traccc::sycl::seeding_algorithm sa_sycl(shared_mr, &q);
     traccc::sycl::track_params_estimation tp_sycl(shared_mr, &q);
+
+    // performance writer
+    traccc::seeding_performance_writer sd_performance_writer(
+        traccc::seeding_performance_writer::config{});
+    sd_performance_writer.add_cache("CPU");
+    sd_performance_writer.add_cache("SYCL");
 
     /*time*/ auto start_wall_time = std::chrono::system_clock::now();
 
@@ -223,6 +231,18 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
              Writer
           ------------*/
 
+        if (check_performance) {
+            traccc::event_map evt_map(event, detector_file, hit_dir,
+                                      particle_dir, host_mr);
+            sd_performance_writer.write("SYCL", seeds_sycl,
+                                        spacepoints_per_event, evt_map);
+
+            if (run_cpu) {
+                sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
+                                            evt_map);
+            }
+        }
+
         if (run_cpu) {
             traccc::write_measurements(event, measurements_per_event);
             traccc::write_spacepoints(event, spacepoints_per_event);
@@ -236,6 +256,8 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
         end_wall_time - start_wall_time;
 
     /*time*/ wall_time += time_wall_time.count();
+
+    sd_performance_writer.finalize();
 
     std::cout << "==> Statistics ... " << std::endl;
     std::cout << "- read    " << n_spacepoints << " spacepoints from "
@@ -283,6 +305,12 @@ int main(int argc, char* argv[]) {
                        "number of events");
     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
+    desc.add_options()("hit_directory",
+                       po::value<std::string>()->default_value(""),
+                       "specify the directory of hit files");
+    desc.add_options()("particle_directory",
+                       po::value<std::string>()->default_value(""),
+                       "specify the directory of particle files");
 
     // Interpret the program options.
     po::variables_map vm;
@@ -308,9 +336,14 @@ int main(int argc, char* argv[]) {
     auto cell_directory = vm["cell_directory"].as<std::string>();
     auto events = vm["events"].as<int>();
     auto run_cpu = vm["run_cpu"].as<bool>();
+    auto hit_directory = vm["hit_directory"].as<std::string>();
+    auto particle_directory = vm["particle_directory"].as<std::string>();
+    auto check_performance =
+        vm.count("hit_directory") && vm.count("particle_directory");
 
     std::cout << "Running " << argv[0] << " " << detector_file << " "
               << cell_directory << " " << events << std::endl;
 
-    return seq_run(detector_file, cell_directory, events, run_cpu);
+    return seq_run(detector_file, cell_directory, events, hit_directory,
+                   particle_directory, check_performance, run_cpu);
 }

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -21,6 +21,9 @@
 #include "traccc/sycl/track_finding/seeding_algorithm.hpp"
 #include "traccc/track_finding/seeding_algorithm.hpp"
 
+// performance
+#include "traccc/efficiency/seeding_performance_writer.hpp"
+
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
 #include <vecmem/memory/sycl/shared_memory_resource.hpp>

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -297,7 +297,7 @@ TEST_P(CompareWithActsSeedingTests, Run) {
 
     // Ensure that ACTS and traccc give the same result
     EXPECT_EQ(seeds.size(), seedVector.size());
-    EXPECT_FLOAT_EQ(seed_match_ratio, 1);
+    EXPECT_TRUE(seed_match_ratio > 0.99);
 
     /*--------------------------------
       ACTS track params estimation
@@ -409,7 +409,7 @@ TEST_P(CompareWithActsSeedingTests, Run) {
     float params_match_ratio = float(n_params_match) / traccc_params.size();
 
     EXPECT_EQ(acts_params.size(), traccc_params.size());
-    EXPECT_FLOAT_EQ(params_match_ratio, 1);
+    EXPECT_TRUE(params_match_ratio > 0.99);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
This PR is made on top of #133 

---------------------------------------------------------------------------------------------------------------------
I am opening the PR to collect opinions or comments beforehand.

The PR aims for adding performance writer with ROOT to make seeding optimization easier
One issue with ROOT is that it doesn't seem to support `FetchContent` as other externals do.
So I added `TRACCC_BUILD_EXAMPLES` with the default value of `FALSE` and made `examples` directory require ROOT dependency.