### PR TITLE
Avoid zero block case for track parameter estimation

### DIFF
--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -38,7 +38,7 @@ track_params_estimation::output_type track_params_estimation::operator()(
 
     // -- Num blocks
     // The dimension of grid is number_of_seeds / num_threads + 1
-    unsigned int num_blocks = (seeds.size() + num_threads - 1) / num_threads;
+    unsigned int num_blocks = seeds.size() / num_threads + 1;
 
     // run the kernel
     track_params_estimating_kernel<<<num_blocks, num_threads>>>(


### PR DESCRIPTION
I realized that the block number can be zero when the number of seeds is zero.