### PR TITLE
Sycl seeding intel fix 20220222

### DIFF
--- a/device/sycl/src/seeding/doublet_finding.sycl
+++ b/device/sycl/src/seeding/doublet_finding.sycl
@@ -93,9 +93,9 @@ class DupletFind {
             auto& isp = internal_sp_per_bin[sp_idx];
 
             // find the reference (start) index of the doublet container item
-            // vector, where the doublets are recorded The start index is calculated
-            // by accumulating the number of doublets of all previous compatible
-            // middle spacepoints
+            // vector, where the doublets are recorded The start index is
+            // calculated by accumulating the number of doublets of all previous
+            // compatible middle spacepoints
             unsigned int mid_bot_start_idx = 0;
             unsigned int mid_top_start_idx = 0;
             for (unsigned int i = 0; i < item_idx; i++) {
@@ -111,7 +111,8 @@ class DupletFind {
             auto i_p = phi_bins[0];
             auto i_z = z_bins[0];
 
-            for (unsigned int c = 0; c < m_config.get_max_neighbor_bins(); c++) {
+            for (unsigned int c = 0; c < m_config.get_max_neighbor_bins();
+                 c++) {
 
                 auto neighbors = internal_sp_device.bin(i_p, i_z);
                 auto neigh_bin = static_cast<unsigned int>(
@@ -119,18 +120,18 @@ class DupletFind {
 
                 // for (auto& neigh_isp: neighbors){
                 for (unsigned int spB_idx = 0; spB_idx < neighbors.size();
-                    spB_idx++) {
+                     spB_idx++) {
                     const auto& neigh_isp = neighbors[spB_idx];
 
                     // Check if middle and bottom sp can form a doublet
                     if (doublet_finding_helper::isCompatible(isp, neigh_isp,
-                                                            m_config, true)) {
+                                                             m_config, true)) {
                         auto spB_loc = sp_location({neigh_bin, spB_idx});
 
                         // Check conditions
-                        // 1) number of mid-bot doublets per spM should be smaller
-                        // than what is counted in doublet_counting (so it should be
-                        // true always) 2) prevent overflow
+                        // 1) number of mid-bot doublets per spM should be
+                        // smaller than what is counted in doublet_counting (so
+                        // it should be true always) 2) prevent overflow
                         if (n_mid_bot_per_spM <
                                 doublet_counter_per_bin[item_idx].n_mid_bot &&
                             num_mid_bot_doublets_per_bin <
@@ -152,13 +153,13 @@ class DupletFind {
 
                     // Check if middle and top sp can form a doublet
                     if (doublet_finding_helper::isCompatible(isp, neigh_isp,
-                                                            m_config, false)) {
+                                                             m_config, false)) {
                         auto spT_loc = sp_location({neigh_bin, spB_idx});
 
                         // Check conditions
-                        // 1) number of mid-top doublets per spM should be smaller
-                        // than what is counted in doublet_counting (so it should be
-                        // true always) 2) prevent overflow
+                        // 1) number of mid-top doublets per spM should be
+                        // smaller than what is counted in doublet_counting (so
+                        // it should be true always) 2) prevent overflow
                         if (n_mid_top_per_spM <
                                 doublet_counter_per_bin[item_idx].n_mid_top &&
                             num_mid_top_doublets_per_bin <

--- a/device/sycl/src/seeding/doublet_finding.sycl
+++ b/device/sycl/src/seeding/doublet_finding.sycl
@@ -83,116 +83,115 @@ class DupletFind {
         auto& n_mid_top_per_spM = num_mid_top_doublets_per_thread[workItemIdx];
 
         // prevent the tail threads referring the null doublet counter
-        if (item_idx >= num_compat_spM_per_bin) {
-            return;
-        }
+        if (item_idx < num_compat_spM_per_bin) {
 
-        // index of internal spacepoint in the item vector
-        auto sp_idx = doublet_counter_per_bin[item_idx].spM.sp_idx;
-        // middle spacepoint index
-        auto spM_loc = sp_location({bin_idx, sp_idx});
-        // middle spacepoint
-        auto& isp = internal_sp_per_bin[sp_idx];
+            // index of internal spacepoint in the item vector
+            auto sp_idx = doublet_counter_per_bin[item_idx].spM.sp_idx;
+            // middle spacepoint index
+            auto spM_loc = sp_location({bin_idx, sp_idx});
+            // middle spacepoint
+            auto& isp = internal_sp_per_bin[sp_idx];
 
-        // find the reference (start) index of the doublet container item
-        // vector, where the doublets are recorded The start index is calculated
-        // by accumulating the number of doublets of all previous compatible
-        // middle spacepoints
-        unsigned int mid_bot_start_idx = 0;
-        unsigned int mid_top_start_idx = 0;
-        for (unsigned int i = 0; i < item_idx; i++) {
-            mid_bot_start_idx += doublet_counter_per_bin[i].n_mid_bot;
-            mid_top_start_idx += doublet_counter_per_bin[i].n_mid_top;
-        }
+            // find the reference (start) index of the doublet container item
+            // vector, where the doublets are recorded The start index is calculated
+            // by accumulating the number of doublets of all previous compatible
+            // middle spacepoints
+            unsigned int mid_bot_start_idx = 0;
+            unsigned int mid_top_start_idx = 0;
+            for (unsigned int i = 0; i < item_idx; i++) {
+                mid_bot_start_idx += doublet_counter_per_bin[i].n_mid_bot;
+                mid_top_start_idx += doublet_counter_per_bin[i].n_mid_top;
+            }
 
-        // get the neighbor indices
-        auto phi_bins = internal_sp_device.axis_p0().range(
-            isp.phi(), m_config.neighbor_scope);
-        auto z_bins = internal_sp_device.axis_p1().range(
-            isp.z(), m_config.neighbor_scope);
-        auto i_p = phi_bins[0];
-        auto i_z = z_bins[0];
+            // get the neighbor indices
+            auto phi_bins = internal_sp_device.axis_p0().range(
+                isp.phi(), m_config.neighbor_scope);
+            auto z_bins = internal_sp_device.axis_p1().range(
+                isp.z(), m_config.neighbor_scope);
+            auto i_p = phi_bins[0];
+            auto i_z = z_bins[0];
 
-        for (unsigned int c = 0; c < m_config.get_max_neighbor_bins(); c++) {
+            for (unsigned int c = 0; c < m_config.get_max_neighbor_bins(); c++) {
 
-            auto neighbors = internal_sp_device.bin(i_p, i_z);
-            auto neigh_bin = static_cast<unsigned int>(
-                i_p + i_z * internal_sp_device.axis_p0().bins());
+                auto neighbors = internal_sp_device.bin(i_p, i_z);
+                auto neigh_bin = static_cast<unsigned int>(
+                    i_p + i_z * internal_sp_device.axis_p0().bins());
 
-            // for (auto& neigh_isp: neighbors){
-            for (unsigned int spB_idx = 0; spB_idx < neighbors.size();
-                 spB_idx++) {
-                const auto& neigh_isp = neighbors[spB_idx];
+                // for (auto& neigh_isp: neighbors){
+                for (unsigned int spB_idx = 0; spB_idx < neighbors.size();
+                    spB_idx++) {
+                    const auto& neigh_isp = neighbors[spB_idx];
 
-                // Check if middle and bottom sp can form a doublet
-                if (doublet_finding_helper::isCompatible(isp, neigh_isp,
-                                                         m_config, true)) {
-                    auto spB_loc = sp_location({neigh_bin, spB_idx});
+                    // Check if middle and bottom sp can form a doublet
+                    if (doublet_finding_helper::isCompatible(isp, neigh_isp,
+                                                            m_config, true)) {
+                        auto spB_loc = sp_location({neigh_bin, spB_idx});
 
-                    // Check conditions
-                    // 1) number of mid-bot doublets per spM should be smaller
-                    // than what is counted in doublet_counting (so it should be
-                    // true always) 2) prevent overflow
-                    if (n_mid_bot_per_spM <
-                            doublet_counter_per_bin[item_idx].n_mid_bot &&
-                        num_mid_bot_doublets_per_bin <
-                            mid_bot_doublets_per_bin.size()) {
-                        unsigned int pos =
-                            mid_bot_start_idx + n_mid_bot_per_spM;
+                        // Check conditions
+                        // 1) number of mid-bot doublets per spM should be smaller
+                        // than what is counted in doublet_counting (so it should be
+                        // true always) 2) prevent overflow
+                        if (n_mid_bot_per_spM <
+                                doublet_counter_per_bin[item_idx].n_mid_bot &&
+                            num_mid_bot_doublets_per_bin <
+                                mid_bot_doublets_per_bin.size()) {
+                            unsigned int pos =
+                                mid_bot_start_idx + n_mid_bot_per_spM;
 
-                        // prevent overflow again
-                        if (pos >= mid_bot_doublets_per_bin.size()) {
-                            continue;
+                            // prevent overflow again
+                            if (pos >= mid_bot_doublets_per_bin.size()) {
+                                continue;
+                            }
+
+                            // write the doublet into the container
+                            mid_bot_doublets_per_bin[pos] =
+                                doublet({spM_loc, spB_loc});
+                            n_mid_bot_per_spM++;
                         }
+                    }
 
-                        // write the doublet into the container
-                        mid_bot_doublets_per_bin[pos] =
-                            doublet({spM_loc, spB_loc});
-                        n_mid_bot_per_spM++;
+                    // Check if middle and top sp can form a doublet
+                    if (doublet_finding_helper::isCompatible(isp, neigh_isp,
+                                                            m_config, false)) {
+                        auto spT_loc = sp_location({neigh_bin, spB_idx});
+
+                        // Check conditions
+                        // 1) number of mid-top doublets per spM should be smaller
+                        // than what is counted in doublet_counting (so it should be
+                        // true always) 2) prevent overflow
+                        if (n_mid_top_per_spM <
+                                doublet_counter_per_bin[item_idx].n_mid_top &&
+                            num_mid_top_doublets_per_bin <
+                                mid_top_doublets_per_bin.size()) {
+                            unsigned int pos =
+                                mid_top_start_idx + n_mid_top_per_spM;
+
+                            // prevent overflow again
+                            if (pos >= mid_top_doublets_per_bin.size()) {
+                                continue;
+                            }
+
+                            // write the doublet into the container
+                            mid_top_doublets_per_bin[pos] =
+                                doublet({spM_loc, spT_loc});
+                            n_mid_top_per_spM++;
+                        }
                     }
                 }
 
-                // Check if middle and top sp can form a doublet
-                if (doublet_finding_helper::isCompatible(isp, neigh_isp,
-                                                         m_config, false)) {
-                    auto spT_loc = sp_location({neigh_bin, spB_idx});
-
-                    // Check conditions
-                    // 1) number of mid-top doublets per spM should be smaller
-                    // than what is counted in doublet_counting (so it should be
-                    // true always) 2) prevent overflow
-                    if (n_mid_top_per_spM <
-                            doublet_counter_per_bin[item_idx].n_mid_top &&
-                        num_mid_top_doublets_per_bin <
-                            mid_top_doublets_per_bin.size()) {
-                        unsigned int pos =
-                            mid_top_start_idx + n_mid_top_per_spM;
-
-                        // prevent overflow again
-                        if (pos >= mid_top_doublets_per_bin.size()) {
-                            continue;
-                        }
-
-                        // write the doublet into the container
-                        mid_top_doublets_per_bin[pos] =
-                            doublet({spM_loc, spT_loc});
-                        n_mid_top_per_spM++;
-                    }
+                i_z++;
+                // terminate if we went through all neighbor bins
+                if (i_z > z_bins[1] && i_p == phi_bins[1]) {
+                    break;
                 }
-            }
 
-            i_z++;
-            // terminate if we went through all neighbor bins
-            if (i_z > z_bins[1] && i_p == phi_bins[1]) {
-                break;
-            }
-
-            // increse phi_index and reset i_z
-            // if i_z is larger than last neighbor index
-            if (i_z > z_bins[1]) {
-                i_p++;
-                i_p = i_p % internal_sp_device.axis_p0().bins();
-                i_z = z_bins[0];
+                // increse phi_index and reset i_z
+                // if i_z is larger than last neighbor index
+                if (i_z > z_bins[1]) {
+                    i_p++;
+                    i_p = i_p % internal_sp_device.axis_p0().bins();
+                    i_z = z_bins[0];
+                }
             }
         }
         // Calculate the number doublets per "block" with reducing sum technique

--- a/device/sycl/src/seeding/triplet_finding.sycl
+++ b/device/sycl/src/seeding/triplet_finding.sycl
@@ -99,114 +99,112 @@ class TripletFind {
         num_triplets_per_thread[workItemIdx] = 0;
 
         // prevent the tail threads referring the null triplet counter
-        if (item_idx >= num_compat_mb_per_bin) {
-            return;
-        }
+        if (item_idx < num_compat_mb_per_bin) {
 
-        // middle-bot doublet
-        const auto& mid_bot_doublet =
-            triplet_counter_per_bin[item_idx].mid_bot_doublet;
-        // middle spacepoint index
-        const auto& spM_idx = mid_bot_doublet.sp1.sp_idx;
-        // middle spacepoint
-        const auto& spM = internal_sp_per_bin[spM_idx];
-        // bin index of bottom spacepoint
-        const auto& spB_bin = mid_bot_doublet.sp2.bin_idx;
-        // bottom spacepoint index
-        const auto& spB_idx = mid_bot_doublet.sp2.sp_idx;
-        // bottom spacepoint
-        const auto& spB = internal_sp_device.bin(spB_bin)[spB_idx];
+            // middle-bot doublet
+            const auto& mid_bot_doublet =
+                triplet_counter_per_bin[item_idx].mid_bot_doublet;
+            // middle spacepoint index
+            const auto& spM_idx = mid_bot_doublet.sp1.sp_idx;
+            // middle spacepoint
+            const auto& spM = internal_sp_per_bin[spM_idx];
+            // bin index of bottom spacepoint
+            const auto& spB_bin = mid_bot_doublet.sp2.bin_idx;
+            // bottom spacepoint index
+            const auto& spB_idx = mid_bot_doublet.sp2.sp_idx;
+            // bottom spacepoint
+            const auto& spB = internal_sp_device.bin(spB_bin)[spB_idx];
 
-        // Apply the conformal transformation to middle-bot doublet
-        auto lb = doublet_finding_helper::transform_coordinates(spM, spB, true);
+            // Apply the conformal transformation to middle-bot doublet
+            auto lb = doublet_finding_helper::transform_coordinates(spM, spB, true);
 
-        // Calculate some physical quantities required for triplet compatibility
-        // check
-        scalar iSinTheta2 = 1 + lb.cotTheta() * lb.cotTheta();
-        scalar scatteringInRegion2 = m_config.maxScatteringAngle2 * iSinTheta2;
-        scatteringInRegion2 *=
-            m_config.sigmaScattering * m_config.sigmaScattering;
-        scalar curvature, impact_parameter;
+            // Calculate some physical quantities required for triplet compatibility
+            // check
+            scalar iSinTheta2 = 1 + lb.cotTheta() * lb.cotTheta();
+            scalar scatteringInRegion2 = m_config.maxScatteringAngle2 * iSinTheta2;
+            scatteringInRegion2 *=
+                m_config.sigmaScattering * m_config.sigmaScattering;
+            scalar curvature, impact_parameter;
 
-        // find the reference (start) index of the mid-top doublet container
-        // item vector, where the doublets are recorded The start index is
-        // calculated by accumulating the number of mid-top doublets of all
-        // previous compatible middle spacepoints
-        unsigned int mb_end_idx = 0;
-        unsigned int mt_start_idx = 0;
-        unsigned int mt_end_idx = 0;
-        unsigned int mb_idx;
+            // find the reference (start) index of the mid-top doublet container
+            // item vector, where the doublets are recorded The start index is
+            // calculated by accumulating the number of mid-top doublets of all
+            // previous compatible middle spacepoints
+            unsigned int mb_end_idx = 0;
+            unsigned int mt_start_idx = 0;
+            unsigned int mt_end_idx = 0;
+            unsigned int mb_idx;
 
-        // First, find the index of middle-bottom doublet
-        for (unsigned int i = 0; i < num_mid_bot_doublets_per_bin; i++) {
-            if (mid_bot_doublet == mid_bot_doublets_per_bin[i]) {
-                mb_idx = i;
-                break;
-            }
-        }
-
-        for (unsigned int i = 0; i < num_compat_spM_per_bin; ++i) {
-            mb_end_idx += doublet_counter_per_bin[i].n_mid_bot;
-            mt_end_idx += doublet_counter_per_bin[i].n_mid_top;
-
-            if (mb_end_idx > mb_idx) {
-                break;
+            // First, find the index of middle-bottom doublet
+            for (unsigned int i = 0; i < num_mid_bot_doublets_per_bin; i++) {
+                if (mid_bot_doublet == mid_bot_doublets_per_bin[i]) {
+                    mb_idx = i;
+                    break;
+                }
             }
 
-            mt_start_idx += doublet_counter_per_bin[i].n_mid_top;
-        }
+            for (unsigned int i = 0; i < num_compat_spM_per_bin; ++i) {
+                mb_end_idx += doublet_counter_per_bin[i].n_mid_bot;
+                mt_end_idx += doublet_counter_per_bin[i].n_mid_top;
 
-        if (mt_end_idx >= mid_top_doublets_per_bin.size()) {
-            mt_end_idx =
-                ::sycl::min(mid_top_doublets_per_bin.size(), mt_end_idx);
-        }
-
-        if (mt_start_idx >= mid_top_doublets_per_bin.size()) {
-            return;
-        }
-
-        // number of triplets per thread (or per middle-bot doublet)
-        unsigned int n_triplets_per_mb = 0;
-
-        // find the reference (start) index of the triplet container item
-        // vector, where the triplets are recorded
-        unsigned int triplet_start_idx = 0;
-
-        // The start index is calculated by accumulating the number of triplets
-        // of all previous compatible middle-bottom doublets
-        for (unsigned int i = 0; i < item_idx; i++) {
-            triplet_start_idx += triplet_counter_per_bin[i].n_triplets;
-        }
-
-        // iterate over mid-top doublets
-        for (unsigned int i = mt_start_idx; i < mt_end_idx; ++i) {
-            const auto& mid_top_doublet = mid_top_doublets_per_bin[i];
-
-            const auto& spT_bin = mid_top_doublet.sp2.bin_idx;
-            const auto& spT_idx = mid_top_doublet.sp2.sp_idx;
-            const auto& spT = internal_sp_device.bin(spT_bin)[spT_idx];
-            // Apply the conformal transformation to middle-top doublet
-            auto lt =
-                doublet_finding_helper::transform_coordinates(spM, spT, false);
-
-            // Check if mid-bot and mid-top doublets can form a triplet
-            if (triplet_finding_helper::isCompatible(
-                    spM, lb, lt, m_config, iSinTheta2, scatteringInRegion2,
-                    curvature, impact_parameter)) {
-                unsigned int pos = triplet_start_idx + n_triplets_per_mb;
-                // prevent the overflow
-                if (pos >= triplets_per_bin.size()) {
-                    continue;
+                if (mb_end_idx > mb_idx) {
+                    break;
                 }
 
-                triplets_per_bin[pos] = triplet(
-                    {mid_bot_doublet.sp2, mid_bot_doublet.sp1,
-                     mid_top_doublet.sp2, curvature,
-                     -impact_parameter * m_filter_config.impactWeightFactor,
-                     lb.Zo()});
+                mt_start_idx += doublet_counter_per_bin[i].n_mid_top;
+            }
 
-                num_triplets_per_thread[workItemIdx]++;
-                n_triplets_per_mb++;
+            if (mt_end_idx >= mid_top_doublets_per_bin.size()) {
+                mt_end_idx =
+                    ::sycl::min(mid_top_doublets_per_bin.size(), mt_end_idx);
+            }
+
+            if (mt_start_idx < mid_top_doublets_per_bin.size()) {
+
+                // number of triplets per thread (or per middle-bot doublet)
+                unsigned int n_triplets_per_mb = 0;
+
+                // find the reference (start) index of the triplet container item
+                // vector, where the triplets are recorded
+                unsigned int triplet_start_idx = 0;
+
+                // The start index is calculated by accumulating the number of triplets
+                // of all previous compatible middle-bottom doublets
+                for (unsigned int i = 0; i < item_idx; i++) {
+                    triplet_start_idx += triplet_counter_per_bin[i].n_triplets;
+                }
+
+                // iterate over mid-top doublets
+                for (unsigned int i = mt_start_idx; i < mt_end_idx; ++i) {
+                    const auto& mid_top_doublet = mid_top_doublets_per_bin[i];
+
+                    const auto& spT_bin = mid_top_doublet.sp2.bin_idx;
+                    const auto& spT_idx = mid_top_doublet.sp2.sp_idx;
+                    const auto& spT = internal_sp_device.bin(spT_bin)[spT_idx];
+                    // Apply the conformal transformation to middle-top doublet
+                    auto lt =
+                        doublet_finding_helper::transform_coordinates(spM, spT, false);
+
+                    // Check if mid-bot and mid-top doublets can form a triplet
+                    if (triplet_finding_helper::isCompatible(
+                            spM, lb, lt, m_config, iSinTheta2, scatteringInRegion2,
+                            curvature, impact_parameter)) {
+                        unsigned int pos = triplet_start_idx + n_triplets_per_mb;
+                        // prevent the overflow
+                        if (pos >= triplets_per_bin.size()) {
+                            continue;
+                        }
+
+                        triplets_per_bin[pos] = triplet(
+                            {mid_bot_doublet.sp2, mid_bot_doublet.sp1,
+                            mid_top_doublet.sp2, curvature,
+                            -impact_parameter * m_filter_config.impactWeightFactor,
+                            lb.Zo()});
+
+                        num_triplets_per_thread[workItemIdx]++;
+                        n_triplets_per_mb++;
+                    }
+                }
             }
         }
         // Calculate the number of triplets per "block" with reducing sum

--- a/device/sycl/src/seeding/triplet_finding.sycl
+++ b/device/sycl/src/seeding/triplet_finding.sycl
@@ -116,12 +116,14 @@ class TripletFind {
             const auto& spB = internal_sp_device.bin(spB_bin)[spB_idx];
 
             // Apply the conformal transformation to middle-bot doublet
-            auto lb = doublet_finding_helper::transform_coordinates(spM, spB, true);
+            auto lb =
+                doublet_finding_helper::transform_coordinates(spM, spB, true);
 
-            // Calculate some physical quantities required for triplet compatibility
-            // check
+            // Calculate some physical quantities required for triplet
+            // compatibility check
             scalar iSinTheta2 = 1 + lb.cotTheta() * lb.cotTheta();
-            scalar scatteringInRegion2 = m_config.maxScatteringAngle2 * iSinTheta2;
+            scalar scatteringInRegion2 =
+                m_config.maxScatteringAngle2 * iSinTheta2;
             scatteringInRegion2 *=
                 m_config.sigmaScattering * m_config.sigmaScattering;
             scalar curvature, impact_parameter;
@@ -164,12 +166,12 @@ class TripletFind {
                 // number of triplets per thread (or per middle-bot doublet)
                 unsigned int n_triplets_per_mb = 0;
 
-                // find the reference (start) index of the triplet container item
-                // vector, where the triplets are recorded
+                // find the reference (start) index of the triplet container
+                // item vector, where the triplets are recorded
                 unsigned int triplet_start_idx = 0;
 
-                // The start index is calculated by accumulating the number of triplets
-                // of all previous compatible middle-bottom doublets
+                // The start index is calculated by accumulating the number of
+                // triplets of all previous compatible middle-bottom doublets
                 for (unsigned int i = 0; i < item_idx; i++) {
                     triplet_start_idx += triplet_counter_per_bin[i].n_triplets;
                 }
@@ -182,24 +184,26 @@ class TripletFind {
                     const auto& spT_idx = mid_top_doublet.sp2.sp_idx;
                     const auto& spT = internal_sp_device.bin(spT_bin)[spT_idx];
                     // Apply the conformal transformation to middle-top doublet
-                    auto lt =
-                        doublet_finding_helper::transform_coordinates(spM, spT, false);
+                    auto lt = doublet_finding_helper::transform_coordinates(
+                        spM, spT, false);
 
                     // Check if mid-bot and mid-top doublets can form a triplet
                     if (triplet_finding_helper::isCompatible(
-                            spM, lb, lt, m_config, iSinTheta2, scatteringInRegion2,
-                            curvature, impact_parameter)) {
-                        unsigned int pos = triplet_start_idx + n_triplets_per_mb;
+                            spM, lb, lt, m_config, iSinTheta2,
+                            scatteringInRegion2, curvature, impact_parameter)) {
+                        unsigned int pos =
+                            triplet_start_idx + n_triplets_per_mb;
                         // prevent the overflow
                         if (pos >= triplets_per_bin.size()) {
                             continue;
                         }
 
-                        triplets_per_bin[pos] = triplet(
-                            {mid_bot_doublet.sp2, mid_bot_doublet.sp1,
-                            mid_top_doublet.sp2, curvature,
-                            -impact_parameter * m_filter_config.impactWeightFactor,
-                            lb.Zo()});
+                        triplets_per_bin[pos] =
+                            triplet({mid_bot_doublet.sp2, mid_bot_doublet.sp1,
+                                     mid_top_doublet.sp2, curvature,
+                                     -impact_parameter *
+                                         m_filter_config.impactWeightFactor,
+                                     lb.Zo()});
 
                         num_triplets_per_thread[workItemIdx]++;
                         n_triplets_per_mb++;


### PR DESCRIPTION
With this fix in place, the code can be run on the Intel backend without changing the workGroup sizes to `8` in the `doublet_finding` and `triplet_finding` kernels. 

It seems like on the Intel backend, the group synchronization call: `item.barrier()` needs to be visible by all work items - without any exception. This implies that we need to be careful with returning from a kernel call if the current item index is not in the desireable range e.g. 
```cpp
if (idx >= totalRange) return;
```
If after such statement, the call to `item.barrier()` will be invoked, some of the previously returned work items won't see it and so the result will be that the rest of the work group items will wait for them to join the `barrier` call - forever...

pinging @krasznaa :wink: 