### PR TITLE
Program Options Improvements, main branch (2022.02.22.)

### DIFF
--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -20,6 +20,7 @@
 #include <boost/program_options.hpp>
 
 // System include(s).
+#include <exception>
 #include <iostream>
 
 namespace po = boost::program_options;
@@ -107,7 +108,10 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
 // The main routine
 //
 int main(int argc, char* argv[]) {
+
+    // Set up the program options.
     po::options_description desc("Allowed options");
+    desc.add_options()("help,h", "Give some help with the program's options");
     desc.add_options()("detector_file", po::value<std::string>()->required(),
                        "specify detector file");
     desc.add_options()("cell_directory", po::value<std::string>()->required(),
@@ -115,9 +119,25 @@ int main(int argc, char* argv[]) {
     desc.add_options()("events", po::value<int>()->required(),
                        "number of events");
 
+    // Interpret the program options.
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+
+    // Print a help message if the user asked for it.
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return 0;
+    }
+
+    // Handle any and all errors.
+    try {
+        po::notify(vm);
+    } catch (const std::exception& ex) {
+        std::cerr << "Couldn't interpret command line options because of:\n\n"
+                  << ex.what() << "\n\n"
+                  << desc << std::endl;
+        return 1;
+    }
 
     auto detector_file = vm["detector_file"].as<std::string>();
     auto cell_directory = vm["cell_directory"].as<std::string>();

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -25,6 +25,7 @@
 
 // System include(s).
 #include <chrono>
+#include <exception>
 #include <iomanip>
 #include <iostream>
 
@@ -223,7 +224,10 @@ int seq_run(const std::string& detector_file, const std::string& hits_dir,
 // The main routine
 //
 int main(int argc, char* argv[]) {
+
+    // Set up the program options.
     po::options_description desc("Allowed options");
+    desc.add_options()("help,h", "Give some help with the program's options");
     desc.add_options()("detector_file", po::value<std::string>()->required(),
                        "specify detector file");
     desc.add_options()("hit_directory", po::value<std::string>()->required(),
@@ -233,9 +237,25 @@ int main(int argc, char* argv[]) {
     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
+    // Interpret the program options.
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+
+    // Print a help message if the user asked for it.
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return 0;
+    }
+
+    // Handle any and all errors.
+    try {
+        po::notify(vm);
+    } catch (const std::exception& ex) {
+        std::cerr << "Couldn't interpret command line options because of:\n\n"
+                  << ex.what() << "\n\n"
+                  << desc << std::endl;
+        return 1;
+    }
 
     auto detector_file = vm["detector_file"].as<std::string>();
     auto hit_directory = vm["hit_directory"].as<std::string>();

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -27,6 +27,7 @@
 
 // System include(s).
 #include <chrono>
+#include <exception>
 #include <iomanip>
 #include <iostream>
 
@@ -260,7 +261,10 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
 // The main routine
 //
 int main(int argc, char* argv[]) {
+
+    // Set up the program options.
     po::options_description desc("Allowed options");
+    desc.add_options()("help,h", "Give some help with the program's options");
     desc.add_options()("detector_file", po::value<std::string>()->required(),
                        "specify detector file");
     desc.add_options()("cell_directory", po::value<std::string>()->required(),
@@ -270,9 +274,25 @@ int main(int argc, char* argv[]) {
     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
+    // Interpret the program options.
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+
+    // Print a help message if the user asked for it.
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return 0;
+    }
+
+    // Handle any and all errors.
+    try {
+        po::notify(vm);
+    } catch (const std::exception& ex) {
+        std::cerr << "Couldn't interpret command line options because of:\n\n"
+                  << ex.what() << "\n\n"
+                  << desc << std::endl;
+        return 1;
+    }
 
     auto detector_file = vm["detector_file"].as<std::string>();
     auto cell_directory = vm["cell_directory"].as<std::string>();

--- a/examples/run/openmp/io_dec_par_example.cpp
+++ b/examples/run/openmp/io_dec_par_example.cpp
@@ -20,6 +20,7 @@
 
 // System include(s).
 #include <chrono>
+#include <exception>
 #include <iostream>
 
 namespace po = boost::program_options;
@@ -109,7 +110,10 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data,
 
 // The main routine
 int main(int argc, char *argv[]) {
+
+    // Set up the program options.
     po::options_description desc("Allowed options");
+    desc.add_options()("help,h", "Give some help with the program's options");
     desc.add_options()("detector_file", po::value<std::string>()->required(),
                        "specify detector file");
     desc.add_options()("cell_directory", po::value<std::string>()->required(),
@@ -117,9 +121,25 @@ int main(int argc, char *argv[]) {
     desc.add_options()("events", po::value<int>()->required(),
                        "number of events");
 
+    // Interpret the program options.
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+
+    // Print a help message if the user asked for it.
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return 0;
+    }
+
+    // Handle any and all errors.
+    try {
+        po::notify(vm);
+    } catch (const std::exception &ex) {
+        std::cerr << "Couldn't interpret command line options because of:\n\n"
+                  << ex.what() << "\n\n"
+                  << desc << std::endl;
+        return 1;
+    }
 
     auto detector_file = vm["detector_file"].as<std::string>();
     auto cell_directory = vm["cell_directory"].as<std::string>();

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -29,6 +29,7 @@
 
 // System include(s).
 #include <chrono>
+#include <exception>
 #include <iostream>
 
 namespace po = boost::program_options;
@@ -148,7 +149,10 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
 // The main routine
 //
 int main(int argc, char *argv[]) {
+
+    // Set up the program options.
     po::options_description desc("Allowed options");
+    desc.add_options()("help,h", "Give some help with the program's options");
     desc.add_options()("detector_file", po::value<std::string>()->required(),
                        "specify detector file");
     desc.add_options()("cell_directory", po::value<std::string>()->required(),
@@ -156,9 +160,25 @@ int main(int argc, char *argv[]) {
     desc.add_options()("events", po::value<int>()->required(),
                        "number of events");
 
+    // Interpret the program options.
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+
+    // Print a help message if the user asked for it.
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return 0;
+    }
+
+    // Handle any and all errors.
+    try {
+        po::notify(vm);
+    } catch (const std::exception &ex) {
+        std::cerr << "Couldn't interpret command line options because of:\n\n"
+                  << ex.what() << "\n\n"
+                  << desc << std::endl;
+        return 1;
+    }
 
     auto detector_file = vm["detector_file"].as<std::string>();
     auto cell_directory = vm["cell_directory"].as<std::string>();

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -28,6 +28,7 @@
 
 // System include(s).
 #include <chrono>
+#include <exception>
 #include <iomanip>
 #include <iostream>
 
@@ -233,7 +234,10 @@ int seq_run(const std::string& detector_file, const std::string& hits_dir,
 // The main routine
 //
 int main(int argc, char* argv[]) {
+
+    // Set up the program options.
     po::options_description desc("Allowed options");
+    desc.add_options()("help,h", "Give some help with the program's options");
     desc.add_options()("detector_file", po::value<std::string>()->required(),
                        "specify detector file");
     desc.add_options()("hit_directory", po::value<std::string>()->required(),
@@ -243,9 +247,25 @@ int main(int argc, char* argv[]) {
     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
+    // Interpret the program options.
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+
+    // Print a help message if the user asked for it.
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return 0;
+    }
+
+    // Handle any and all errors.
+    try {
+        po::notify(vm);
+    } catch (const std::exception& ex) {
+        std::cerr << "Couldn't interpret command line options because of:\n\n"
+                  << ex.what() << "\n\n"
+                  << desc << std::endl;
+        return 1;
+    }
 
     auto detector_file = vm["detector_file"].as<std::string>();
     auto hit_directory = vm["hit_directory"].as<std::string>();

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -30,6 +30,7 @@
 
 // System include(s).
 #include <chrono>
+#include <exception>
 #include <iomanip>
 #include <iostream>
 
@@ -270,7 +271,10 @@ int seq_run(const std::string& detector_file, const std::string& cells_dir,
 // The main routine
 //
 int main(int argc, char* argv[]) {
+
+    // Set up the program options.
     po::options_description desc("Allowed options");
+    desc.add_options()("help,h", "Give some help with the program's options");
     desc.add_options()("detector_file", po::value<std::string>()->required(),
                        "specify detector file");
     desc.add_options()("cell_directory", po::value<std::string>()->required(),
@@ -280,9 +284,25 @@ int main(int argc, char* argv[]) {
     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
+    // Interpret the program options.
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+
+    // Print a help message if the user asked for it.
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return 0;
+    }
+
+    // Handle any and all errors.
+    try {
+        po::notify(vm);
+    } catch (const std::exception& ex) {
+        std::cerr << "Couldn't interpret command line options because of:\n\n"
+                  << ex.what() << "\n\n"
+                  << desc << std::endl;
+        return 1;
+    }
 
     auto detector_file = vm["detector_file"].as<std::string>();
     auto cell_directory = vm["cell_directory"].as<std::string>();


### PR DESCRIPTION
Added `--help` options to all of the (example) executables.

At the same time making sure that when an error is made on the command line, the printout would be a bit more helpful than it is now. Like:

```
[bash][atspot01]:build > ./bin/traccc_seq_example
Couldn't interpret command line options because of:

the option '--cell_directory' is required but missing

Allowed options:
  -h [ --help ]         Give some help with the program's options
  --detector_file arg   specify detector file
  --cell_directory arg  specify the directory of cell files
  --events arg          number of events

[bash][atspot01]:build >
```

Note that my overall views of clang-format have not improved too much in this exercise. :frowning: I was trying to format these calls like this:

https://gitlab.cern.ch/atlas/athena/-/blob/master/PhysicsAnalysis/D3PDMaker/D3PDMakerReader/src/apps/d3pdReaderMaker.cxx#L108-121

But clang-format made that really unreadable. :frowning:

Even weirder, note how in the exception handling `&` is put in a different place in the SYCL source files compared to the C\+\+ ones. :confused:

So yeah, not the biggest fan of clang-format still...