### PR TITLE
SYCL HIP Backend Compatibility, main branch (2022.03.01.)

### DIFF
--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -47,3 +47,6 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
 target_link_libraries( traccc_sycl
   PUBLIC vecmem::core traccc::core
   PRIVATE vecmem::sycl )
+
+# Prevent Eigen from getting confused when building code for a HIP backend.
+target_compile_definitions( traccc_sycl PRIVATE EIGEN_NO_CUDA )

--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -16,8 +16,10 @@ traccc_add_executable( traccc_sycl_language_example
 
 # SYCL seeding executable(s).
 traccc_add_executable( seeding_example_sycl "seeding_example_sycl.sycl"
-   LINK_LIBRARIES vecmem::core vecmem::sycl traccc::io
-                  traccc::algorithms traccc::algorithms_sycl Boost::program_options)
+   LINK_LIBRARIES Boost::program_options vecmem::core vecmem::sycl traccc::io
+                  traccc::algorithms traccc::algorithms_sycl )
+target_compile_definitions( traccc_seeding_example_sycl PRIVATE EIGEN_NO_CUDA )
 traccc_add_executable( seq_example_sycl "seq_example_sycl.sycl"
-   LINK_LIBRARIES vecmem::core vecmem::sycl traccc::io
-                  traccc::algorithms traccc::algorithms_sycl Boost::program_options)
+   LINK_LIBRARIES Boost::program_options vecmem::core vecmem::sycl traccc::io
+                  traccc::algorithms traccc::algorithms_sycl )
+target_compile_definitions( traccc_seq_example_sycl PRIVATE EIGEN_NO_CUDA )


### PR DESCRIPTION
[Victory music playing faintly in the background...]

I made it possible to build the SYCL code for a HIP backend with Intel's compiler!

Eigen unfortunately gets confused out of the box in that setup, thinking that it is being compiled by `nvcc`, and trying to include `<math_constants.h>`. Using `EIGEN_NO_CUDA` prevents it from trying to use CUDA code. Which for the SYCL code should always be a safe choice anyway.

With this minor CMake tweak I get the following:

```
[bash][Legolas]:build > echo $SYCLCXX
/home/krasznaa/software/intel/clang/nightly-20220301/x86_64-ubuntu2004-gcc9-opt/bin/clang++ -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx803 -Wno-linker-warnings
[bash][Legolas]:build > clang++ -v
clang version 15.0.0 (https://github.com/intel/llvm.git 08b14da9181c88c6184f3200e99ed36b121cd33d)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/krasznaa/software/intel/clang/nightly-20220301/x86_64-ubuntu2004-gcc9-opt/bin
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/7
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/7.5.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/8
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/9
Selected GCC installation: /usr/lib/gcc/x86_64-linux-gnu/9
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Candidate multilib: x32;@mx32
Selected multilib: .;@m64
Found CUDA installation: /home/krasznaa/software/cuda/11.5.2/x86_64-ubuntu2004, version 11.5
Found HIP installation: /opt/rocm, version 4.2.21155-37cb3a34
[bash][Legolas]:build > SYCL_DEVICE_FILTER=hip ./bin/traccc_seeding_example_sycl --detector_file=tml_detector/trackml-detector.csv --hit_directory=tml_hits/ --events=1 --run_cpu=true
Running ./bin/traccc_seeding_example_sycl tml_detector/trackml-detector.csv tml_hits/ 1
Running on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
event 0
 seed matching rate: 0.992949
 track parameters matching rate: 0.998024
==> Statistics ... 
- read    48109 spacepoints from 0 modules
- created (cpu)  18722 seeds
- created (sycl) 18990 seeds
==> Elpased time ... 
wall time           8.15699   
hit reading (cpu)   3.59935   
seeding_time (cpu)  2.87989   
seeding_time (sycl) 0.84454   
tr_par_esti_time (cpu)    0.00622071
tr_par_esti_time (sycl)   0.00307646
[bash][Legolas]:build >
```

[Victory music intensifies... :smile:]