### PR TITLE
Fix for SYCL Seeding on Intel GPU

### DIFF
--- a/device/sycl/src/seeding/doublet_finding.sycl
+++ b/device/sycl/src/seeding/doublet_finding.sycl
@@ -36,8 +36,6 @@ class DupletFind {
 
     void operator()(::sycl::nd_item<1> item) const {
 
-        // Equivalent to blockDim.x in cuda
-        auto groupDim = item.get_local_range(0);
         // Equivalent to threadIdx.x in cuda
         auto workItemIdx = item.get_local_id(0);
 
@@ -81,8 +79,8 @@ class DupletFind {
         auto mid_top_doublets_per_bin =
             mid_top_doublet_device.get_items().at(bin_idx);
 
-        auto num_mid_bot_doublets_per_thread = m_localMemBot;
-        auto num_mid_top_doublets_per_thread = m_localMemTop;
+        auto& num_mid_bot_doublets_per_thread = m_localMemBot;
+        auto& num_mid_top_doublets_per_thread = m_localMemTop;
         num_mid_bot_doublets_per_thread[workItemIdx] = 0;
         num_mid_top_doublets_per_thread[workItemIdx] = 0;
         // Convenient alias for the number of doublets per thread
@@ -203,37 +201,21 @@ class DupletFind {
             }
         }
         // Calculate the number doublets per "block" with reducing sum technique
-        // ::sycl::group_barrier(workGroup);
-        item.barrier();
         // Warp shuffle reduction algorithm
         // sycl_helper::reduceInShared(num_mid_bot_doublets_per_thread, item);
         // sycl_helper::reduceInShared(num_mid_top_doublets_per_thread, item);
 
-        // Another reduction variant (doesn't always work)
-        //  num_mid_bot_doublets_per_thread[0] =
-        //  ::sycl::reduce_over_group(workGroup,
-        //  num_mid_bot_doublets_per_thread[workItemIdx], ::sycl::plus<>());
-        //  num_mid_top_doublets_per_thread[0] =
-        //  ::sycl::reduce_over_group(workGroup,
-        //  num_mid_top_doublets_per_thread[workItemIdx], ::sycl::plus<>());
+        // SYCL group reduction algorithm 
+         num_mid_bot_doublets_per_thread[0] =
+         ::sycl::reduce_over_group(item.get_group(),
+         num_mid_bot_doublets_per_thread[workItemIdx], ::sycl::plus<>());
+         num_mid_top_doublets_per_thread[0] =
+         ::sycl::reduce_over_group(item.get_group(),
+         num_mid_top_doublets_per_thread[workItemIdx], ::sycl::plus<>());
 
         // Calculate the number doublets per bin by atomic-adding the number of
         // doublets per block
         if (workItemIdx == 0) {
-
-            // For loop reduction
-
-            uint32_t resultBottom = 0;
-            for (uint32_t i = 0; i < groupDim; ++i) {
-                resultBottom += num_mid_bot_doublets_per_thread[i];
-            }
-            num_mid_bot_doublets_per_thread[0] = resultBottom;
-
-            uint32_t resultTop = 0;
-            for (uint32_t i = 0; i < groupDim; ++i) {
-                resultTop += num_mid_top_doublets_per_thread[i];
-            }
-            num_mid_top_doublets_per_thread[0] = resultTop;
 
             vecmem::atomic<uint32_t> objB(&num_mid_bot_doublets_per_bin);
             objB.fetch_add(num_mid_bot_doublets_per_thread[0]);

--- a/device/sycl/src/seeding/doublet_finding.sycl
+++ b/device/sycl/src/seeding/doublet_finding.sycl
@@ -205,13 +205,13 @@ class DupletFind {
         // sycl_helper::reduceInShared(num_mid_bot_doublets_per_thread, item);
         // sycl_helper::reduceInShared(num_mid_top_doublets_per_thread, item);
 
-        // SYCL group reduction algorithm 
-         num_mid_bot_doublets_per_thread[0] =
-         ::sycl::reduce_over_group(item.get_group(),
-         num_mid_bot_doublets_per_thread[workItemIdx], ::sycl::plus<>());
-         num_mid_top_doublets_per_thread[0] =
-         ::sycl::reduce_over_group(item.get_group(),
-         num_mid_top_doublets_per_thread[workItemIdx], ::sycl::plus<>());
+        // SYCL group reduction algorithm
+        num_mid_bot_doublets_per_thread[0] = ::sycl::reduce_over_group(
+            item.get_group(), num_mid_bot_doublets_per_thread[workItemIdx],
+            ::sycl::plus<>());
+        num_mid_top_doublets_per_thread[0] = ::sycl::reduce_over_group(
+            item.get_group(), num_mid_top_doublets_per_thread[workItemIdx],
+            ::sycl::plus<>());
 
         // Calculate the number doublets per bin by atomic-adding the number of
         // doublets per block

--- a/device/sycl/src/seeding/doublet_finding.sycl
+++ b/device/sycl/src/seeding/doublet_finding.sycl
@@ -36,6 +36,8 @@ class DupletFind {
 
     void operator()(::sycl::nd_item<1> item) const {
 
+        // Equivalent to blockDim.x in cuda
+        auto groupDim = item.get_local_range(0);
         // Equivalent to threadIdx.x in cuda
         auto workItemIdx = item.get_local_id(0);
 
@@ -205,17 +207,35 @@ class DupletFind {
         // sycl_helper::reduceInShared(num_mid_bot_doublets_per_thread, item);
         // sycl_helper::reduceInShared(num_mid_top_doublets_per_thread, item);
 
-        // SYCL group reduction algorithm
-        num_mid_bot_doublets_per_thread[0] = ::sycl::reduce_over_group(
-            item.get_group(), num_mid_bot_doublets_per_thread[workItemIdx],
-            ::sycl::plus<>());
-        num_mid_top_doublets_per_thread[0] = ::sycl::reduce_over_group(
-            item.get_group(), num_mid_top_doublets_per_thread[workItemIdx],
-            ::sycl::plus<>());
+        // Following barrier can be removed after switching to the
+        // sycl::reduce_over_group
+        item.barrier();
+
+        // SYCL group reduction algorithm - from dpcpp 2022
+        // num_mid_bot_doublets_per_thread[0] = ::sycl::reduce_over_group(
+        //     item.get_group(), num_mid_bot_doublets_per_thread[workItemIdx],
+        //     ::sycl::plus<>());
+        // num_mid_top_doublets_per_thread[0] = ::sycl::reduce_over_group(
+        //     item.get_group(), num_mid_top_doublets_per_thread[workItemIdx],
+        //     ::sycl::plus<>());
 
         // Calculate the number doublets per bin by atomic-adding the number of
         // doublets per block
         if (workItemIdx == 0) {
+
+            // For loop reduction
+
+            uint32_t resultBottom = 0;
+            for (uint32_t i = 0; i < groupDim; ++i) {
+                resultBottom += num_mid_bot_doublets_per_thread[i];
+            }
+            num_mid_bot_doublets_per_thread[0] = resultBottom;
+
+            uint32_t resultTop = 0;
+            for (uint32_t i = 0; i < groupDim; ++i) {
+                resultTop += num_mid_top_doublets_per_thread[i];
+            }
+            num_mid_top_doublets_per_thread[0] = resultTop;
 
             vecmem::atomic<uint32_t> objB(&num_mid_bot_doublets_per_bin);
             objB.fetch_add(num_mid_bot_doublets_per_thread[0]);

--- a/device/sycl/src/seeding/seed_selecting.sycl
+++ b/device/sycl/src/seeding/seed_selecting.sycl
@@ -22,30 +22,28 @@ namespace traccc::sycl {
 
 // Sorting algorithm for sorting seeds in the local memory
 template <typename Comparator>
-static void insertionSort(
-    local_accessor<triplet>& arr,
-    const int& begin_idx,
-    const int& n, Comparator comp) {
+static void insertionSort(local_accessor<triplet>& arr, const int& begin_idx,
+                          const int& n, Comparator comp) {
     int j = 0;
     triplet key = arr[begin_idx];
     for (int i = 0; i < n; ++i) {
-        key = arr[begin_idx+i];
+        key = arr[begin_idx + i];
         j = i - 1;
-        while (j >= 0 && !comp(arr[begin_idx+j], key)) {
-            arr[begin_idx+j + 1] = arr[begin_idx+j];
+        while (j >= 0 && !comp(arr[begin_idx + j], key)) {
+            arr[begin_idx + j + 1] = arr[begin_idx + j];
             j = j - 1;
         }
-        arr[begin_idx+j + 1] = key;
+        arr[begin_idx + j + 1] = key;
     }
 }
 
 // Finding minimum element algorithm
 template <typename Comparator>
-static int min_elem(const local_accessor<triplet>& arr, const int& begin_idx, const int& end_idx, Comparator comp) {
+static int min_elem(const local_accessor<triplet>& arr, const int& begin_idx,
+                    const int& end_idx, Comparator comp) {
     int min_i = begin_idx;
     auto next = begin_idx;
-    while(next < end_idx-1) 
-    {
+    while (next < end_idx - 1) {
         ++next;
         if (comp(arr[min_i], arr[next])) {
             min_i = next;
@@ -161,9 +159,9 @@ class SeedSelect {
 
                     int min_index =
                         min_elem(triplets_per_spM, begin_idx, end_idx,
-                                         [&](triplet& lhs, triplet& rhs) {
-                                             return lhs.weight > rhs.weight;
-                                         }); 
+                                 [&](triplet& lhs, triplet& rhs) {
+                                     return lhs.weight > rhs.weight;
+                                 });
 
                     auto& min_weight = triplets_per_spM[min_index].weight;
 

--- a/device/sycl/src/seeding/seed_selecting.sycl
+++ b/device/sycl/src/seeding/seed_selecting.sycl
@@ -23,19 +23,35 @@ namespace traccc::sycl {
 // Sorting algorithm for sorting seeds in the local memory
 template <typename Comparator>
 static void insertionSort(
-    ::sycl::multi_ptr<triplet, ::sycl::access::address_space::local_space> arr,
-    int n, Comparator comp) {
+    local_accessor<triplet>& arr,
+    const int& begin_idx,
+    const int& n, Comparator comp) {
     int j = 0;
-    triplet key = arr[0];
-    for (int i = 1; i < n; ++i) {
-        key = arr[i];
+    triplet key = arr[begin_idx];
+    for (int i = 0; i < n; ++i) {
+        key = arr[begin_idx+i];
         j = i - 1;
-        while (j >= 0 && !comp(arr[j], key)) {
-            arr[j + 1] = arr[j];
+        while (j >= 0 && !comp(arr[begin_idx+j], key)) {
+            arr[begin_idx+j + 1] = arr[begin_idx+j];
             j = j - 1;
         }
-        arr[j + 1] = key;
+        arr[begin_idx+j + 1] = key;
     }
+}
+
+// Finding minimum element algorithm
+template <typename Comparator>
+static int min_elem(const local_accessor<triplet>& arr, const int& begin_idx, const int& end_idx, Comparator comp) {
+    int min_i = begin_idx;
+    auto next = begin_idx;
+    while(next < end_idx-1) 
+    {
+        ++next;
+        if (comp(arr[min_i], arr[next])) {
+            min_i = next;
+        }
+    }
+    return min_i;
 }
 
 // Kernel class for seed selecting
@@ -97,7 +113,7 @@ class SeedSelect {
             triplet_device.get_headers().at(bin_idx).n_triplets;
         auto triplets_per_bin = triplet_device.get_items().at(bin_idx);
 
-        auto triplets_per_spM = m_localMem.get_pointer();
+        auto triplets_per_spM = m_localMem;
 
         if (item_idx >= num_compat_spM_per_bin)
             return;
@@ -144,12 +160,10 @@ class SeedSelect {
                     int end_idx = stride + m_filter_config.max_triplets_per_spM;
 
                     int min_index =
-                        std::min_element(triplets_per_spM + begin_idx,
-                                         triplets_per_spM + end_idx,
+                        min_elem(triplets_per_spM, begin_idx, end_idx,
                                          [&](triplet& lhs, triplet& rhs) {
-                                             return lhs.weight < rhs.weight;
-                                         }) -
-                        triplets_per_spM;
+                                             return lhs.weight > rhs.weight;
+                                         }); 
 
                     auto& min_weight = triplets_per_spM[min_index].weight;
 
@@ -167,7 +181,7 @@ class SeedSelect {
         }
         // sort the triplets per spM
         insertionSort(
-            triplets_per_spM + stride, n_triplets_per_spM,
+            triplets_per_spM, stride, n_triplets_per_spM,
             [&](triplet& lhs, triplet& rhs) {
                 if (lhs.weight != rhs.weight) {
                     return lhs.weight > rhs.weight;

--- a/device/sycl/src/seeding/triplet_finding.sycl
+++ b/device/sycl/src/seeding/triplet_finding.sycl
@@ -44,6 +44,8 @@ class TripletFind {
 
     void operator()(::sycl::nd_item<1> item) const {
 
+        // Equivalent to blockDim.x in cuda
+        auto groupDim = item.get_local_range(0);
         // Equivalent to threadIdx.x in cuda
         auto workItemIdx = item.get_local_id(0);
 
@@ -224,15 +226,24 @@ class TripletFind {
         // technique
         // Warp shuffle reduction algorithm
         // sycl_helper::reduceInShared(num_triplets_per_thread, item);
+        item.barrier();
 
-        // SYCL group reduction algorithm
-        num_triplets_per_thread[0] = ::sycl::reduce_over_group(
-            item.get_group(), num_triplets_per_thread[workItemIdx],
-            ::sycl::plus<>());
+        // SYCL group reduction algorithm - from dpcpp 2022
+        // num_triplets_per_thread[0] = ::sycl::reduce_over_group(
+        //     item.get_group(), num_triplets_per_thread[workItemIdx],
+        //     ::sycl::plus<>());
 
         // Calculate the number of triplets per bin by atomic-adding the number
         // of triplets per block
         if (workItemIdx == 0) {
+
+            // For loop reduction
+            uint32_t resultTriplets = 0;
+            for (uint32_t i = 0; i < groupDim; ++i) {
+                resultTriplets += num_triplets_per_thread[i];
+            }
+            num_triplets_per_thread[0] = resultTriplets;
+
             vecmem::atomic<uint32_t> obj(&num_triplets_per_bin);
             obj.fetch_add(num_triplets_per_thread[0]);
         }

--- a/device/sycl/src/seeding/triplet_finding.sycl
+++ b/device/sycl/src/seeding/triplet_finding.sycl
@@ -44,8 +44,6 @@ class TripletFind {
 
     void operator()(::sycl::nd_item<1> item) const {
 
-        // Equivalent to blockDim.x in cuda
-        auto groupDim = item.get_local_range(0);
         // Equivalent to threadIdx.x in cuda
         auto workItemIdx = item.get_local_id(0);
 
@@ -106,7 +104,7 @@ class TripletFind {
             triplet_device.get_headers().at(bin_idx).n_triplets;
         auto triplets_per_bin = triplet_device.get_items().at(bin_idx);
 
-        auto num_triplets_per_thread = m_localMem.get_pointer();
+        auto& num_triplets_per_thread = m_localMem;
         num_triplets_per_thread[workItemIdx] = 0;
 
         // prevent the tail threads referring the null triplet counter
@@ -224,24 +222,16 @@ class TripletFind {
         }
         // Calculate the number of triplets per "block" with reducing sum
         // technique
-        // ::sycl::group_barrier(workGroup);
-        item.barrier();
         // Warp shuffle reduction algorithm
         // sycl_helper::reduceInShared(num_triplets_per_thread, item);
 
-        // Sycl group reduction algorithm - doesn't always work correctly
-        // num_triplets_per_thread[0] = ::sycl::reduce_over_group(workGroup,
-        // num_triplets_per_thread[workItemIdx], ::sycl::plus<>());
+        // SYCL group reduction algorithm
+        num_triplets_per_thread[0] = ::sycl::reduce_over_group(item.get_group(),
+        num_triplets_per_thread[workItemIdx], ::sycl::plus<>());
 
         // Calculate the number of triplets per bin by atomic-adding the number
         // of triplets per block
         if (workItemIdx == 0) {
-            // For loop reduction
-            uint32_t resultTriplets = 0;
-            for (uint32_t i = 0; i < groupDim; ++i) {
-                resultTriplets += num_triplets_per_thread[i];
-            }
-            num_triplets_per_thread[0] = resultTriplets;
             vecmem::atomic<uint32_t> obj(&num_triplets_per_bin);
             obj.fetch_add(num_triplets_per_thread[0]);
         }

--- a/device/sycl/src/seeding/triplet_finding.sycl
+++ b/device/sycl/src/seeding/triplet_finding.sycl
@@ -226,8 +226,9 @@ class TripletFind {
         // sycl_helper::reduceInShared(num_triplets_per_thread, item);
 
         // SYCL group reduction algorithm
-        num_triplets_per_thread[0] = ::sycl::reduce_over_group(item.get_group(),
-        num_triplets_per_thread[workItemIdx], ::sycl::plus<>());
+        num_triplets_per_thread[0] = ::sycl::reduce_over_group(
+            item.get_group(), num_triplets_per_thread[workItemIdx],
+            ::sycl::plus<>());
 
         // Calculate the number of triplets per bin by atomic-adding the number
         // of triplets per block


### PR DESCRIPTION
This PR fixes the poor matching rate of found seeds (CPU vs GPU)  when running on Intel Graphics. 

As expected, the problem was with the `seed_selecting` kernel. So far I've been using the `std::min_element()` to find the index of a triplet with the smallest weight.  According to this [oneDPL documentation](https://oneapi-src.github.io/oneDPL/api_for_dpcpp_kernels/tested_standard_cpp_api.html) `std::min_element` has not been yet properly tested inside Sycl kernel. 

For now I implemented `min_element` function by hand which now works correctly on an array in local memory:
```
Running ./bin/traccc_seeding_example_sycl tml_detector/trackml-detector.csv tml_hits/ 1
Running on device: Intel(R) UHD Graphics 630 [0x3e98]
event 0
 seed matching rate: 0.995513
 track parameters matching rate: 0.998504
==> Statistics ... 
- read    48109 spacepoints from 0 modules
- created (cpu)  18722 seeds
- created (sycl) 18785 seeds
==> Elpased time ... 
wall time           12.5363   
hit reading (cpu)   1.28505   
seeding_time (cpu)  2.86427   
seeding_time (sycl) 6.71012   
tr_par_esti_time (cpu)    0.00400986
tr_par_esti_time (sycl)   0.204552
```
The algorithm still performs very poorly here, running on Intel's integrated graphics, but I will try to improve this in future PRs. 

Other changes included here consist of switching to the `sycl::reduce_over_group()` algorithm for the work group reductions. This now works properly after the fix from #137 which made sure that all work items see the call to the group function. 

pinging @krasznaa 