### PR TITLE
Remove dependency on ACTS unit test headers

### DIFF
--- a/tests/common/tests/atlas_cuts.hpp
+++ b/tests/common/tests/atlas_cuts.hpp
@@ -1,0 +1,94 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2018 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <algorithm>
+
+#include "Acts/Seeding/IExperimentCuts.hpp"
+
+namespace Acts {
+template <typename SpacePoint>
+class ATLASCuts : public IExperimentCuts<SpacePoint> {
+    public:
+    /// Returns seed weight bonus/malus depending on detector considerations.
+    /// @param bottom bottom space point of the current seed
+    /// @param middle middle space point of the current seed
+    /// @param top top space point of the current seed
+    /// @return seed weight to be added to the seed's weight
+    float seedWeight(const InternalSpacePoint<SpacePoint>& bottom,
+                     const InternalSpacePoint<SpacePoint>& middle,
+                     const InternalSpacePoint<SpacePoint>& top) const;
+    /// @param weight the current seed weight
+    /// @param bottom bottom space point of the current seed
+    /// @param middle middle space point of the current seed
+    /// @param top top space point of the current seed
+    /// @return true if the seed should be kept, false if the seed should be
+    /// discarded
+    bool singleSeedCut(float weight,
+                       const InternalSpacePoint<SpacePoint>& bottom,
+                       const InternalSpacePoint<SpacePoint>&,
+                       const InternalSpacePoint<SpacePoint>&) const;
+
+    /// @param seeds contains pairs of weight and seed created for one middle
+    /// space
+    /// point
+    /// @return vector of seeds that pass the cut
+    std::vector<
+        std::pair<float, std::unique_ptr<const InternalSeed<SpacePoint>>>>
+    cutPerMiddleSP(
+        std::vector<
+            std::pair<float, std::unique_ptr<const InternalSeed<SpacePoint>>>>
+            seeds) const;
+};
+
+template <typename SpacePoint>
+float ATLASCuts<SpacePoint>::seedWeight(
+    const InternalSpacePoint<SpacePoint>& bottom,
+    const InternalSpacePoint<SpacePoint>&,
+    const InternalSpacePoint<SpacePoint>& top) const {
+    float weight = 0;
+    if (bottom.radius() > 150) {
+        weight = 400;
+    }
+    if (top.radius() < 150) {
+        weight = 200;
+    }
+    return weight;
+}
+
+template <typename SpacePoint>
+bool ATLASCuts<SpacePoint>::singleSeedCut(
+    float weight, const InternalSpacePoint<SpacePoint>& b,
+    const InternalSpacePoint<SpacePoint>&,
+    const InternalSpacePoint<SpacePoint>&) const {
+    return !(b.radius() > 150. && weight < 380.);
+}
+
+template <typename SpacePoint>
+std::vector<std::pair<float, std::unique_ptr<const InternalSeed<SpacePoint>>>>
+ATLASCuts<SpacePoint>::cutPerMiddleSP(
+    std::vector<
+        std::pair<float, std::unique_ptr<const InternalSeed<SpacePoint>>>>
+        seeds) const {
+    std::vector<
+        std::pair<float, std::unique_ptr<const InternalSeed<SpacePoint>>>>
+        newSeedsVector;
+    if (seeds.size() > 1) {
+        newSeedsVector.push_back(std::move(seeds[0]));
+        size_t itLength = std::min(seeds.size(), size_t(5));
+        // don't cut first element
+        for (size_t i = 1; i < itLength; i++) {
+            if (seeds[i].first > 200. ||
+                seeds[i].second->sp[0]->radius() > 43.) {
+                newSeedsVector.push_back(std::move(seeds[i]));
+            }
+        }
+        return newSeedsVector;
+    }
+    return seeds;
+}
+}  // namespace Acts

--- a/tests/common/tests/space_point.hpp
+++ b/tests/common/tests/space_point.hpp
@@ -1,0 +1,32 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2018 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+struct SpacePoint {
+    float m_x;
+    float m_y;
+    float m_z;
+    float m_r;
+    int layer;
+    float varianceR;
+    float varianceZ;
+    float x() const { return m_x; }
+    float y() const { return m_y; }
+    float z() const { return m_z; }
+    float r() const { return m_r; }
+};
+
+bool operator==(SpacePoint a, SpacePoint b) {
+    if (fabs(a.m_x - b.m_x) < 1e-6 && fabs(a.m_y - b.m_y) < 1e-6 &&
+        fabs(a.m_z - b.m_z) < 1e-6) {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -16,9 +16,11 @@
 #include "traccc/seeding/spacepoint_binning.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
 
-// Acts
-#include "../../Tests/UnitTests/Core/Seeding/ATLASCuts.hpp"
-#include "../../Tests/UnitTests/Core/Seeding/SpacePoint.hpp"
+// tests
+#include "tests/atlas_cuts.hpp"
+#include "tests/space_point.hpp"
+
+// acts
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/MagneticField/ConstantBField.hpp"
 #include "Acts/Seeding/BinFinder.hpp"


### PR DESCRIPTION
Right now, our tests are relying on some ACTS-internal headers which are defined for the ACTS unit tests. This does not work, because those headers are not internal, and they are not exported or installed, leading to compiler errors when building traccc. This commit is a stop-gap solution that copies over the necessary files into the domain of traccc such that the code can compile.