### PR TITLE
Fix range-loop-construct warning in module map

### DIFF
--- a/core/include/traccc/geometry/module_map.hpp
+++ b/core/include/traccc/geometry/module_map.hpp
@@ -265,7 +265,7 @@ class module_map {
          */
         std::vector<K> keys;
         keys.reserve(input.size());
-        for (const std::pair<K, V>& i : input) {
+        for (const std::pair<const K, V>& i : input) {
             keys.push_back(i.first);
         }
 


### PR DESCRIPTION
Recent versions of gcc introduce a new `range-loop-construct` warning which detects non-explicit copies or references in for loops. This started throwing warnings for a particular loop in our module map, which then got escalated to an error. This commit fixes the problem and allows the code to compile with gcc 11.2.0.