### PR TITLE
Run tests only for CPU-based builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -49,6 +49,7 @@ jobs:
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
           cmake --build build
       - name: Test
+        if: "matrix.platform.name != 'CUDA'"
         run: |
           cd build
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}


### PR DESCRIPTION
As we start to add CUDA and SYCL tests, we are running into issues where the CI nodes are trying to run code for devices they don't have. This is a bad idea, because it causes those tests to fail. This commit modifies the CI setup such that the tests are only run for the CPU-based builds.