### PR TITLE
Add infrastructure for CUDA testing

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,3 +16,7 @@ target_include_directories( traccc_tests_common
 add_subdirectory( core )
 add_subdirectory( cpu )
 add_subdirectory( io )
+
+if( TRACCC_BUILD_CUDA )
+    add_subdirectory( cuda )
+endif()

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -1,0 +1,35 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+include(traccc-compiler-options-cuda)
+
+enable_language(CUDA)
+
+find_package(CUDAToolkit REQUIRED)
+
+add_library(
+    traccc_tests_cuda_main
+    STATIC
+    cuda_main.cpp
+)
+
+target_link_libraries(
+    traccc_tests_cuda_main
+    PRIVATE
+    CUDA::cudart
+    GTest::gtest
+)
+
+traccc_add_test(
+    cuda
+
+    # Define the sources for the test.
+    test_basic.cu
+
+    LINK_LIBRARIES
+    GTest::gtest
+    traccc_tests_cuda_main
+)

--- a/tests/cuda/cuda_main.cpp
+++ b/tests/cuda/cuda_main.cpp
@@ -1,0 +1,25 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+
+    int r = RUN_ALL_TESTS();
+
+    cudaError_t cErr = cudaDeviceReset();
+
+    if (cErr == cudaSuccess || cErr == cudaErrorNoDevice ||
+        cErr == cudaErrorInsufficientDriver) {
+        return r;
+    } else {
+        return static_cast<int>(cErr);
+    }
+}

--- a/tests/cuda/test_basic.cu
+++ b/tests/cuda/test_basic.cu
@@ -1,0 +1,51 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+TEST(CUDABasic, DeviceCount) {
+    int nDev = -1;
+
+    ASSERT_EQ(cudaGetDeviceCount(&nDev), cudaSuccess);
+
+    ASSERT_GE(nDev, 1);
+}
+
+TEST(CUDABasic, Memory) {
+    void *ptr = nullptr;
+
+    ASSERT_EQ(cudaMalloc(&ptr, 1024), cudaSuccess);
+
+    ASSERT_NE(ptr, nullptr);
+
+    ASSERT_EQ(cudaFree(ptr), cudaSuccess);
+}
+
+__global__ void testKernel(int *output) {
+    *output = 0x0BADF00D;  // This test sponsored by R1.
+}
+
+TEST(CUDABasic, LaunchKernel) {
+    int *ptr = nullptr;
+    int val = 0;
+
+    ASSERT_EQ(cudaMalloc(&ptr, sizeof(int)), cudaSuccess);
+
+    ASSERT_NE(ptr, nullptr);
+
+    testKernel<<<1, 1>>>(ptr);
+
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+
+    ASSERT_EQ(cudaMemcpy(&val, ptr, sizeof(int), cudaMemcpyDeviceToHost),
+              cudaSuccess);
+
+    ASSERT_EQ(val, 0x0BADF00D);
+
+    ASSERT_EQ(cudaFree(ptr), cudaSuccess);
+}


### PR DESCRIPTION
This commit adds all the necessary infrastructure for testing CUDA code. In particular, this means adding the necessary build system features, adding a CUDA-appropriate Google Test main function, and adding some basic tests to make sure the CUDA device and the CUDA runtime are functional.