### PR TITLE
Implement and test a CUDA version of the module map

### DIFF
--- a/core/include/traccc/geometry/module_map.hpp
+++ b/core/include/traccc/geometry/module_map.hpp
@@ -15,6 +15,11 @@
 #include <iostream>
 
 namespace traccc {
+namespace cuda {
+template <typename, typename>
+class module_map;
+}
+
 /**
  * @brief A fast and GPU-friendly map for consecutive module IDs to values.
  *
@@ -397,5 +402,7 @@ class module_map {
      * keep indices in this array instead of pointers.
      */
     std::vector<V> m_values;
+
+    friend class cuda::module_map<K, V>;
 };
 }  // namespace traccc

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -11,6 +11,8 @@ enable_language( CUDA )
 include( traccc-compiler-options-cpp )
 include( traccc-compiler-options-cuda )
 
+find_package(CUDAToolkit)
+
 # Set up the build of the traccc::cuda library.
 traccc_add_library( traccc_cuda cuda TYPE SHARED
   # Utility definitions.
@@ -47,4 +49,4 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
 target_compile_options( traccc_cuda
   PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr> )
 target_link_libraries( traccc_cuda
-  PUBLIC traccc::core vecmem::cuda )
+  PUBLIC traccc::core vecmem::cuda CUDA::cudart )

--- a/device/cuda/include/traccc/cuda/geometry/module_map.hpp
+++ b/device/cuda/include/traccc/cuda/geometry/module_map.hpp
@@ -1,0 +1,221 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <type_traits>
+
+// Project include(s).
+#include <cuda_runtime.h>
+
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/geometry/module_map.hpp"
+
+namespace traccc::cuda {
+template <typename, typename>
+class module_map_view;
+
+/**
+ * @brief CUDA implementation of the module map, owning data.
+ *
+ * The existing module map is designed to be GPU-friendly, and this is the
+ * realization of that idea. The CUDA module map comes in two flavours; the
+ * first is the owning module map, which allocates memory on the device when
+ * constructed and stores its data there. Then, we can create views from that.
+ *
+ * @tparam K Key type.
+ * @tparam V Value type.
+ */
+template <typename K = geometry_id, typename V = transform3>
+class module_map {
+    public:
+    /**
+     * @brief The type of the internal tree nodes.
+     */
+    using node_t = typename ::traccc::module_map<K, V>::module_map_node;
+
+    /**
+     * @brief Construct a CUDA module map from an existing CPU module map.
+     *
+     * @note This is the only way to construct a CUDA module map.
+     *
+     * @param[in] input The existing module map to convert.
+     */
+    module_map(const ::traccc::module_map<K, V>& input,
+               vecmem::memory_resource& mr)
+        : m_n_nodes(input.m_nodes.size()),
+          m_n_values(input.m_values.size()),
+          m_nodes(vecmem::make_unique_alloc<node_t[]>(
+              mr, m_n_nodes, input.m_nodes.data(),
+              std::bind(cudaMemcpy, std::placeholders::_1,
+                        std::placeholders::_2, std::placeholders::_3,
+                        cudaMemcpyHostToDevice))),
+          m_values(vecmem::make_unique_alloc<V[]>(
+              mr, m_n_values, input.m_values.data(),
+              std::bind(cudaMemcpy, std::placeholders::_1,
+                        std::placeholders::_2, std::placeholders::_3,
+                        cudaMemcpyHostToDevice))) {}
+
+    private:
+    /*
+     * Store the number of nodes and values, since we cannot get this from the
+     * vector anymore.
+     */
+    const std::size_t m_n_nodes;
+    const std::size_t m_n_values;
+
+    /**
+     * @brief The internal storage of the nodes in our binary search tree.
+     *
+     * This follows the well-known formalism where the root node resides at
+     * index 0, while for any node at position n, the left child is at index 2n
+     * + 1, and the right child is at index 2n + 2.
+     */
+    const vecmem::unique_alloc_ptr<node_t[]> m_nodes;
+
+    /**
+     * @brief This vector stores the values in a contiguous manner. Our nodes
+     * keep indices in this array instead of pointers.
+     */
+    const vecmem::unique_alloc_ptr<V[]> m_values;
+
+    /*
+     * Declare the view class as our friend, so that it can access our
+     * pointers.
+     */
+    friend class module_map_view<K, V>;
+};
+
+/**
+ * @brief CUDA implementation of the module map, non-owning view.
+ *
+ * This class represents a light-weight, non-owning, device-passable view of
+ * a module map. It contains all the same data, but only has a view copy of the
+ * pointers.
+ *
+ * @tparam K Key type.
+ * @tparam V Value type.
+ */
+template <typename K = geometry_id, typename V = transform3>
+class module_map_view {
+    /**
+     * @brief The type of the internal tree nodes.
+     */
+    public:
+    using node_t = typename module_map<K, V>::node_t;
+
+    /**
+     * @brief Construct a new module map view object fom a module map.
+     *
+     * @param input The module map to create a view from.
+     */
+    module_map_view(const module_map<K, V>& input)
+        : m_n_nodes(input.m_n_nodes),
+          m_n_values(input.m_n_values),
+          m_nodes(input.m_nodes.get()),
+          m_values(input.m_values.get()) {}
+
+    /**
+     * @brief Find a given key in the map.
+     *
+     * @param[in] i The key to look-up.
+     *
+     * @return The value associated with the given key.
+     *
+     * @warning This method does no bounds checking, and will result in
+     * undefined behaviour if the key does not exist in the map.
+     */
+    TRACCC_DEVICE const V* operator[](const K& i) const {
+        unsigned int n = 0;
+
+        while (true) {
+            /*
+             * For memory safety, if we are out of bounds we will exit.
+             */
+            if (n >= m_n_nodes) {
+                return nullptr;
+            }
+
+            /*
+             * Retrieve the current root node.
+             */
+            const node_t& node = m_nodes[n];
+
+            /*
+             * If the size is zero, it is essentially an invalid node (i.e. the
+             * node does not exist).
+             */
+            if (node.size == 0) {
+                return nullptr;
+            }
+
+            /*
+             * If the value we are looking for is past the start of the current
+             * node, there are three possibilities. Firstly, the value might be
+             * in the current node. Secondly, the value might be in the right
+             * child of the current node. Thirdly, the value might not be in the
+             * map at all.
+             */
+            if (i >= node.start) {
+                /*
+                 * Next, we check if the value is within the range represented
+                 * by the current node.
+                 */
+                if (i < node.start + node.size) {
+                    /*
+                     * Found it! Return a pointer to the value within the
+                     * contiguous range.
+                     */
+                    return &m_values[node.index + (i - node.start)];
+                } else {
+                    /*
+                     * Two possibilties remain, we need to check the right
+                     * subtree.
+                     */
+                    n = 2 * n + 2;
+                }
+            }
+            /*
+             * If the value we want to find is less then the start of this node,
+             * there are only two possibilities. Firstly, the value might be in
+             * the left subtree, or the value might not be in the map at all.
+             */
+            else {
+                n = 2 * n + 1;
+            }
+        }
+    }
+
+    /**
+     * @brief Get the total number of modules in the module map.
+     */
+    TRACCC_DEVICE std::size_t size(void) const { return m_n_values; }
+
+    /**
+     * @brief Check if a module map contains a given module.
+     */
+    TRACCC_DEVICE bool contains(const K& i) const {
+        return operator[](i) != nullptr;
+    }
+
+    /**
+     * @brief Check whether a module map is empty.
+     *
+     * Probably not.
+     */
+    TRACCC_DEVICE bool empty(void) const { return m_n_values == 0; }
+
+    const std::size_t m_n_nodes;
+    const std::size_t m_n_values;
+    const node_t* m_nodes;
+    const V* m_values;
+};
+}  // namespace traccc::cuda

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -29,8 +29,14 @@ traccc_add_test(
     # Define the sources for the test.
     test_basic.cu
     test_cca.cpp
+    test_module_map.cu
 
     LINK_LIBRARIES
+    traccc::core
+    traccc::cuda
+    traccc::io
+    vecmem::core
+    vecmem::cuda
     GTest::gtest
     traccc::core
     traccc::cuda

--- a/tests/cuda/test_module_map.cu
+++ b/tests/cuda/test_module_map.cu
@@ -1,0 +1,65 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+
+#include "traccc/cuda/geometry/module_map.hpp"
+#include "traccc/geometry/module_map.hpp"
+#include "traccc/io/reader.hpp"
+
+TEST(DeviceModuleMap, ViewSize) {
+    ASSERT_LE(sizeof(traccc::cuda::module_map_view<traccc::geometry_id,
+                                                   traccc::transform3>),
+              64);
+}
+
+__global__ void readMapKernel(
+    traccc::cuda::module_map_view<traccc::geometry_id, traccc::transform3> m,
+    traccc::geometry_id i, traccc::transform3 *o) {
+    *o = *(m[i]);
+}
+
+TEST(DeviceModuleMap, TrackML) {
+    vecmem::cuda::device_memory_resource mr;
+
+    std::string file = traccc::data_directory() +
+                       std::string("tml_detector/trackml-detector.csv");
+
+    traccc::surface_reader sreader(
+        file, {"geometry_id", "cx", "cy", "cz", "rot_xu", "rot_xv", "rot_xw",
+               "rot_zu", "rot_zv", "rot_zw"});
+    std::map<traccc::geometry_id, traccc::transform3> inp =
+        traccc::read_surfaces(sreader);
+
+    traccc::module_map tmp_map(inp);
+
+    traccc::cuda::module_map map(tmp_map, mr);
+
+    traccc::transform3 *ptr;
+
+    ASSERT_EQ(
+        cudaMalloc(reinterpret_cast<void **>(&ptr), sizeof(traccc::transform3)),
+        cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    for (const std::pair<const traccc::geometry_id, traccc::transform3> &i :
+         inp) {
+        traccc::transform3 res;
+
+        readMapKernel<<<1, 1>>>(map, i.first, ptr);
+
+        ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        ASSERT_EQ(cudaMemcpy(&res, ptr, sizeof(traccc::transform3),
+                             cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+
+        EXPECT_EQ(res, i.second);
+    }
+}


### PR DESCRIPTION
The module map was originally designed to be GPU friendly, and we now reap the fruits of that decision. This implementation of a CUDA version of that code is quite short and simple to understand. This pull request adds an owning CUDA version of the module map, as well as a light-weight non-owning view object which is designed to be passed to kernels. It also tests the class.

This pull request depends on #153.