### PR TITLE
Update min version for CMake to build project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Mozilla Public License Version 2.0
 
 # Set up the project.
-cmake_minimum_required( VERSION 3.18 )
+cmake_minimum_required( VERSION 3.9 )
 project( traccc VERSION 0.1.0 LANGUAGES CXX )
 
 # Set up the used C++ standard(s).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Mozilla Public License Version 2.0
 
 # Set up the project.
-cmake_minimum_required( VERSION 3.9 )
+cmake_minimum_required( VERSION 3.18 )
 project( traccc VERSION 0.1.0 LANGUAGES CXX )
 
 # Set up the used C++ standard(s).

--- a/cmake/traccc-compiler-options-cuda.cmake
+++ b/cmake/traccc-compiler-options-cuda.cmake
@@ -5,7 +5,7 @@
 # Mozilla Public License Version 2.0
 
 # FindCUDAToolkit needs at least CMake 3.17.
-cmake_minimum_required( VERSION 3.17 )
+cmake_minimum_required( VERSION 3.18 )
 
 # Include the helper function(s).
 include( traccc-functions )

--- a/cmake/traccc-compiler-options-cuda.cmake
+++ b/cmake/traccc-compiler-options-cuda.cmake
@@ -4,7 +4,7 @@
 #
 # Mozilla Public License Version 2.0
 
-# FindCUDAToolkit needs at least CMake 3.17.
+# FindCUDAToolkit needs at least CMake 3.18.
 cmake_minimum_required( VERSION 3.18 )
 
 # Include the helper function(s).

--- a/cmake/traccc-compiler-options-cuda.cmake
+++ b/cmake/traccc-compiler-options-cuda.cmake
@@ -4,7 +4,8 @@
 #
 # Mozilla Public License Version 2.0
 
-# FindCUDAToolkit needs at least CMake 3.18.
+# FindCUDAToolkit needs at least CMake 3.17, and C++17 support
+# (set in the project's main CMakeLists.txt file) needs CMake 3.18.
 cmake_minimum_required( VERSION 3.18 )
 
 # Include the helper function(s).


### PR DESCRIPTION
If using CMake v3.17.0, the build fails during the compilation of header files requiring c++17. E.g.:
```
[ 77%] Built target ActsCore
Scanning dependencies of target traccc_cuda
[ 77%] Building CUDA object device/cuda/CMakeFiles/traccc_cuda.dir/src/seeding/doublet_counting.cu.o
In file included from /home/nwachuch/traccc/build/_deps/vecmem-src/core/include/vecmem/containers/data/jagged_vector_buffer.hpp:12,
                 from /home/nwachuch/traccc/core/include/traccc/edm/container.hpp:14,
                 from /home/nwachuch/traccc/core/include/traccc/seeding/detail/singlet.hpp:11,
                 from /home/nwachuch/traccc/device/cuda/include/traccc/cuda/seeding/detail/doublet_counter.hpp:11,
                 from /home/nwachuch/traccc/device/cuda/include/traccc/cuda/seeding/doublet_counting.hpp:10,
                 from /home/nwachuch/traccc/device/cuda/src/seeding/[doublet_counting.cu:8](http://doublet_counting.cu:8/):
/home/nwachuch/traccc/build/_deps/vecmem-src/core/include/vecmem/memory/memory_resource.hpp:14:2: error: #error "This header can only be used in C++17 mode. " "Ideally it should only be used by the \"host compiler\"."
   14 | #error \
      |  ^~~~~
```
Project is successfully build using at least CMake 3.18.0.