### PR TITLE
Remove variance from spacepoint EDM

### DIFF
--- a/core/include/traccc/clusterization/spacepoint_formation.hpp
+++ b/core/include/traccc/clusterization/spacepoint_formation.hpp
@@ -62,10 +62,8 @@ struct spacepoint_formation
         for (const auto& m : measurements) {
             point3 local_3d = {m.local[0], m.local[1], 0.};
             point3 global = module.placement.point_to_global(local_3d);
-            variance3 variance = {0, 0, 0};
-            spacepoint s({global, variance, m});
+            spacepoint s({global, m});
 
-            // @todo add variance estimation
             spacepoints.push_back(std::move(s));
         }
     }

--- a/core/include/traccc/edm/internal_spacepoint.hpp
+++ b/core/include/traccc/edm/internal_spacepoint.hpp
@@ -40,8 +40,6 @@ struct internal_spacepoint {
     scalar m_y;
     scalar m_z;
     scalar m_r;
-    scalar m_varianceR;
-    scalar m_varianceZ;
 
     internal_spacepoint() = default;
 
@@ -55,10 +53,6 @@ struct internal_spacepoint {
         m_y = sp.global[1] - offsetXY[1];
         m_z = sp.global[2];
         m_r = std::sqrt(m_x * m_x + m_y * m_y);
-
-        // Need to fix this part
-        m_varianceR = sp.variance[0];
-        m_varianceZ = sp.variance[1];
     }
 
     TRACCC_HOST_DEVICE
@@ -68,8 +62,6 @@ struct internal_spacepoint {
         m_y = 0;
         m_z = 0;
         m_r = 0;
-        m_varianceR = 0;
-        m_varianceZ = 0;
     }
 
     TRACCC_HOST_DEVICE
@@ -80,8 +72,6 @@ struct internal_spacepoint {
         m_y = sp.m_y;
         m_z = sp.m_z;
         m_r = sp.m_r;
-        m_varianceR = sp.m_varianceR;
-        m_varianceZ = sp.m_varianceZ;
     }
 
     TRACCC_HOST_DEVICE
@@ -94,8 +84,6 @@ struct internal_spacepoint {
         m_y = sp.m_y;
         m_z = sp.m_z;
         m_r = sp.m_r;
-        m_varianceR = sp.m_varianceR;
-        m_varianceZ = sp.m_varianceZ;
 
         return *this;
     }
@@ -124,10 +112,10 @@ struct internal_spacepoint {
     scalar phi() const { return algebra::math::atan2(m_y, m_x); }
 
     TRACCC_HOST_DEVICE
-    scalar varianceR() const { return m_varianceR; }
+    scalar varianceR() const { return 0.; }
 
     TRACCC_HOST_DEVICE
-    scalar varianceZ() const { return m_varianceZ; }
+    scalar varianceZ() const { return 0.; }
 };
 
 template <typename spacepoint_t>

--- a/core/include/traccc/edm/spacepoint.hpp
+++ b/core/include/traccc/edm/spacepoint.hpp
@@ -22,13 +22,12 @@ namespace traccc {
 /// A spacepoint definition: global position and errors
 struct spacepoint {
     point3 global = {0., 0., 0.};
-    variance3 variance = {0., 0., 0.};
     measurement meas;
 
     TRACCC_HOST_DEVICE
     static inline spacepoint invalid_value() {
         measurement ms = measurement::invalid_value();
-        return spacepoint({{0., 0., 0.}, {0., 0., 0.}, ms});
+        return spacepoint({{0., 0., 0.}, ms});
     }
 
     TRACCC_HOST_DEVICE

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -130,7 +130,7 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
 
             for (const auto &spacepoint : spacepoints_per_module) {
                 const auto &pos = spacepoint.global;
-                spwriter.append({module, pos[0], pos[1], pos[2], 0., 0., 0.});
+                spwriter.append({module, pos[0], pos[1], pos[2]});
             }
         }
     }

--- a/io/include/traccc/io/csv.hpp
+++ b/io/include/traccc/io/csv.hpp
@@ -123,9 +123,8 @@ struct csv_spacepoint {
 
     uint64_t geometry_id = 0;
     scalar x, y, z;
-    scalar var_x, var_y, var_z;
 
-    DFE_NAMEDTUPLE(csv_spacepoint, geometry_id, x, y, z, var_x, var_y, var_z);
+    DFE_NAMEDTUPLE(csv_spacepoint, geometry_id, x, y, z);
 };
 
 using spacepoint_writer = dfe::NamedTupleCsvWriter<csv_spacepoint>;
@@ -405,10 +404,9 @@ inline host_spacepoint_container read_hits(
         auto placement = (*tfmap)[geom_id];
 
         point3 position({iohit.tx, iohit.ty, iohit.tz});
-        variance3 variance({0, 0, 0});
         auto local = placement.point_to_local(position);
         measurement m({point2({local[0], local[1]}), variance2({0., 0.})});
-        spacepoint sp({position, variance, m});
+        spacepoint sp({position, m});
 
         const host_spacepoint_container::header_vector& headers =
             result.get_headers();

--- a/io/include/traccc/io/writer.hpp
+++ b/io/include/traccc/io/writer.hpp
@@ -44,7 +44,7 @@ inline void write_spacepoints(
         auto module = spacepoints_per_event.get_headers()[i];
         for (const auto &spacepoint : spacepoints_per_module) {
             const auto &pos = spacepoint.global;
-            spwriter.append({module, pos[0], pos[1], pos[2], 0., 0., 0.});
+            spwriter.append({module, pos[0], pos[1], pos[2]});
         }
     }
 }


### PR DESCRIPTION
As it stands, the spacepoint EDM contains a measure of variance which is underdefined and unused. I've discussed with Andi, and we've concluded that this serves no purpose at all but to slow down our development, and that we'd be better served by trimming the fat out of our EDM. This commit does just that; it removes the variance from the spacepoint, and amends any code that uses it (which no code did meaningfully).