### PR TITLE
Return internal spacepoint members by value

### DIFF
--- a/core/include/traccc/edm/internal_spacepoint.hpp
+++ b/core/include/traccc/edm/internal_spacepoint.hpp
@@ -112,22 +112,22 @@ struct internal_spacepoint {
     TRACCC_HOST_DEVICE const scalar& x() const { return m_x; }
 
     TRACCC_HOST_DEVICE
-    const scalar& y() const { return m_y; }
+    scalar y() const { return m_y; }
 
     TRACCC_HOST_DEVICE
-    const scalar& z() const { return m_z; }
+    scalar z() const { return m_z; }
 
     TRACCC_HOST_DEVICE
-    const scalar& radius() const { return m_r; }
+    scalar radius() const { return m_r; }
 
     TRACCC_HOST_DEVICE
     scalar phi() const { return algebra::math::atan2(m_y, m_x); }
 
     TRACCC_HOST_DEVICE
-    const scalar& varianceR() const { return m_varianceR; }
+    scalar varianceR() const { return m_varianceR; }
 
     TRACCC_HOST_DEVICE
-    const scalar& varianceZ() const { return m_varianceZ; }
+    scalar varianceZ() const { return m_varianceZ; }
 };
 
 template <typename spacepoint_t>


### PR DESCRIPTION
Currently, we are returning a lot of the members of the internal spacepoint class by constant reference, which we really should not be doing. This commit changes all of these getter methods to use return-by-value semantics instead, which will be more maintainable and more performant.