### PR TITLE
VecMem Update, main branch (2022.04.05.)

### DIFF
--- a/device/sycl/src/seeding/counting_grid_capacities.sycl
+++ b/device/sycl/src/seeding/counting_grid_capacities.sycl
@@ -84,7 +84,8 @@ class CountGridCapacities {
                 phi_axis.bin(isp.phi()) + phi_axis.bins() * z_axis.bin(isp.z());
 
             /// increase the capacity for the grid bin
-            vecmem::atomic<uint32_t> obj(&grid_capacities_device[bin_index]);
+            vecmem::device_atomic_ref<uint32_t> obj(
+                grid_capacities_device[bin_index]);
             obj.fetch_add(1);
         }
     }

--- a/device/sycl/src/seeding/doublet_counting.sycl
+++ b/device/sycl/src/seeding/doublet_counting.sycl
@@ -122,13 +122,13 @@ class DupletCount {
         // larger than 0, the entry is added to the doublet counter
         if (n_mid_bot > 0 && n_mid_top > 0) {
 
-            vecmem::atomic<uint32_t> obj(&num_compat_spM_per_bin);
+            vecmem::device_atomic_ref<uint32_t> obj(num_compat_spM_per_bin);
             auto pos = obj.fetch_add(1);
 
-            vecmem::atomic<uint32_t> objBot(&num_mid_bot_per_bin);
+            vecmem::device_atomic_ref<uint32_t> objBot(num_mid_bot_per_bin);
             objBot.fetch_add(n_mid_bot);
 
-            vecmem::atomic<uint32_t> objTop(&num_mid_top_per_bin);
+            vecmem::device_atomic_ref<uint32_t> objTop(num_mid_top_per_bin);
             objTop.fetch_add(n_mid_top);
 
             doublet_counter_per_bin[pos] = {spM_loc, n_mid_bot, n_mid_top};

--- a/device/sycl/src/seeding/doublet_finding.sycl
+++ b/device/sycl/src/seeding/doublet_finding.sycl
@@ -237,10 +237,12 @@ class DupletFind {
             }
             num_mid_top_doublets_per_thread[0] = resultTop;
 
-            vecmem::atomic<uint32_t> objB(&num_mid_bot_doublets_per_bin);
+            vecmem::device_atomic_ref<uint32_t> objB(
+                num_mid_bot_doublets_per_bin);
             objB.fetch_add(num_mid_bot_doublets_per_thread[0]);
 
-            vecmem::atomic<uint32_t> objT(&num_mid_top_doublets_per_bin);
+            vecmem::device_atomic_ref<uint32_t> objT(
+                num_mid_top_doublets_per_bin);
             objT.fetch_add(num_mid_top_doublets_per_thread[0]);
         }
     }

--- a/device/sycl/src/seeding/populating_grid.sycl
+++ b/device/sycl/src/seeding/populating_grid.sycl
@@ -82,7 +82,7 @@ class PopulatingGrid {
                 phi_axis.bin(isp.phi()) + phi_axis.bins() * z_axis.bin(isp.z());
 
             /// increase the size for the grid bin
-            vecmem::atomic<uint32_t> obj(&grid_sizes[bin_index]);
+            vecmem::device_atomic_ref<uint32_t> obj(grid_sizes[bin_index]);
             auto pos = obj.fetch_add(1);
 
             /// replace the value

--- a/device/sycl/src/seeding/triplet_counting.sycl
+++ b/device/sycl/src/seeding/triplet_counting.sycl
@@ -167,9 +167,9 @@ class TripletCount {
         // if the number of triplets per mb is larger than 0, write the triplet
         // counter into the container
         if (num_triplets_per_mb > 0) {
-            vecmem::atomic<uint32_t> obj(&num_compat_mb_per_bin);
+            vecmem::device_atomic_ref<uint32_t> obj(num_compat_mb_per_bin);
             auto pos = obj.fetch_add(1);
-            vecmem::atomic<uint32_t> objT(&num_triplets);
+            vecmem::device_atomic_ref<uint32_t> objT(num_triplets);
             objT.fetch_add(num_triplets_per_mb);
             triplet_counter_per_bin[pos] = {mid_bot_doublet,
                                             num_triplets_per_mb};

--- a/device/sycl/src/seeding/triplet_finding.sycl
+++ b/device/sycl/src/seeding/triplet_finding.sycl
@@ -244,7 +244,7 @@ class TripletFind {
             }
             num_triplets_per_thread[0] = resultTriplets;
 
-            vecmem::atomic<uint32_t> obj(&num_triplets_per_bin);
+            vecmem::device_atomic_ref<uint32_t> obj(num_triplets_per_bin);
             obj.fetch_add(num_triplets_per_thread[0]);
         }
     }

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.10.0.tar.gz;URL_MD5;712888e704d2e4c915ac1f25f28da467"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.12.0.tar.gz;URL_MD5;1817ac5c961d1d52b40bc3cff6268a14"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Switched the project to [VecMem 0.12.0](https://github.com/acts-project/vecmem/releases/tag/v0.12.0).

At the same time updated all references to `vecmem::atomic` (only present in the SYCL code at the moment) to use the "new" `vecmem::device_atomic_ref` type instead.

The main reason for this update is to avoid warnings from the now deprecated `sycl::atomic` type.