### PR TITLE
Command Line Argument Parsing Fixes, main branch (2022.04.05.)

### DIFF
--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -103,11 +103,11 @@ int main(int argc, char* argv[]) {
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
 
-    // Read options
-    seeding_input_cfg.read(vm);
-
     // Check errors
     traccc::handle_argument_errors(vm, desc);
+
+    // Read options
+    seeding_input_cfg.read(vm);
 
     std::cout << "Running " << argv[0] << " " << seeding_input_cfg.detector_file
               << " " << seeding_input_cfg.hit_directory << " "

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -139,11 +139,11 @@ int main(int argc, char* argv[]) {
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
 
-    // Read options
-    full_tracking_input_cfg.read(vm);
-
     // Check errors
     traccc::handle_argument_errors(vm, desc);
+
+    // Read options
+    full_tracking_input_cfg.read(vm);
 
     std::cout << "Running " << argv[0] << " "
               << full_tracking_input_cfg.detector_file << " "

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -260,12 +260,12 @@ int main(int argc, char* argv[]) {
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
 
+    // Check errors
+    traccc::handle_argument_errors(vm, desc);
+
     // Read options
     seeding_input_cfg.read(vm);
     auto run_cpu = vm["run_cpu"].as<bool>();
-
-    // Check errors
-    traccc::handle_argument_errors(vm, desc);
 
     std::cout << "Running " << argv[0] << " " << seeding_input_cfg.detector_file
               << " " << seeding_input_cfg.hit_directory << " "

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -298,12 +298,12 @@ int main(int argc, char* argv[]) {
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
 
+    // Check errors
+    traccc::handle_argument_errors(vm, desc);
+
     // Read options
     full_tracking_input_cfg.read(vm);
     auto run_cpu = vm["run_cpu"].as<bool>();
-
-    // Check errors
-    traccc::handle_argument_errors(vm, desc);
 
     std::cout << "Running " << argv[0] << " "
               << full_tracking_input_cfg.detector_file << " "

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -270,12 +270,12 @@ int main(int argc, char* argv[]) {
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
 
+    // Check errors
+    traccc::handle_argument_errors(vm, desc);
+
     // Read options
     seeding_input_cfg.read(vm);
     auto run_cpu = vm["run_cpu"].as<bool>();
-
-    // Check errors
-    traccc::handle_argument_errors(vm, desc);
 
     std::cout << "Running " << argv[0] << " " << seeding_input_cfg.detector_file
               << " " << seeding_input_cfg.hit_directory << " "

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -308,12 +308,12 @@ int main(int argc, char* argv[]) {
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
 
+    // Check errors
+    traccc::handle_argument_errors(vm, desc);
+
     // Read options
     full_tracking_input_cfg.read(vm);
     auto run_cpu = vm["run_cpu"].as<bool>();
-
-    // Check errors
-    traccc::handle_argument_errors(vm, desc);
 
     std::cout << "Running " << argv[0] << " "
               << full_tracking_input_cfg.detector_file << " "


### PR DESCRIPTION
Made the examples check for command line "errors" correctly. Most importantly to make it possible to use `-h` / `--help` with the executables.

Right now the executables do the following:

```
[bash][atspot01]:build > ./bin/traccc_seeding_example --help
terminate called after throwing an instance of 'boost::wrapexcept<boost::bad_any_cast>'
  what():  boost::bad_any_cast: failed conversion using boost::any_cast
Aborted (core dumped)
[bash][atspot01]:build > ./bin/traccc_seeding_example_sycl --help
terminate called after throwing an instance of 'boost::wrapexcept<boost::bad_any_cast>'
  what():  boost::bad_any_cast: failed conversion using boost::any_cast
Aborted (core dumped)
[bash][atspot01]:build >
```

With these updates we get:

```
[bash][atspot01]:build > ./bin/traccc_seeding_example --help
Allowed options:
  -h [ --help ]            Give some help with the program's options
  --detector_file arg      specify detector file
  --hit_directory arg      specify the directory of hit files
  --particle_directory arg specify the directory of particle files used for 
                           performance writer
  --events arg             number of events
  --skip arg (=0)          number of events to skip

[bash][atspot01]:build > ./bin/traccc_seeding_example_sycl --help
Allowed options:
  -h [ --help ]            Give some help with the program's options
  --detector_file arg      specify detector file
  --hit_directory arg      specify the directory of hit files
  --particle_directory arg specify the directory of particle files used for 
                           performance writer
  --events arg             number of events
  --skip arg (=0)          number of events to skip
  --run_cpu arg (=0)       run cpu tracking as well

[bash][atspot01]:build >
```