### PR TITLE
Changed seed matching comparison

### DIFF
--- a/core/include/traccc/edm/seed.hpp
+++ b/core/include/traccc/edm/seed.hpp
@@ -62,6 +62,41 @@ inline bool operator==(const seed& lhs, const seed& rhs) {
             lhs.spT_link == rhs.spT_link);
 }
 
+template <typename spacepoint_container_t>
+bool is_same(const seed& seed1, const spacepoint_container_t& container1,
+             const seed& seed2, const spacepoint_container_t& container2) {
+
+    auto spB1 = container1.at(seed1.spB_link);
+    auto spM1 = container1.at(seed1.spM_link);
+    auto spT1 = container1.at(seed1.spT_link);
+
+    auto spB2 = container2.at(seed2.spB_link);
+    auto spM2 = container2.at(seed2.spM_link);
+    auto spT2 = container2.at(seed2.spT_link);
+
+    return (spB1 == spB2 && spM1 == spM2 && spT1 == spT2);
+}
+
+template <typename spacepoint_container_t>
+struct is_same_seed {
+
+    const seed m_ref_seed;
+    const spacepoint_container_t m_ref_spacepoints;
+    const spacepoint_container_t m_test_spacepoints;
+
+    is_same_seed(const seed& ref_seed,
+                 const spacepoint_container_t& ref_spacepoints,
+                 const spacepoint_container_t& test_spacepoints)
+        : m_ref_seed(ref_seed),
+          m_ref_spacepoints(ref_spacepoints),
+          m_test_spacepoints(test_spacepoints) {}
+
+    bool operator()(const seed& test_seed) {
+        return is_same<spacepoint_container_t>(m_ref_seed, m_ref_spacepoints,
+                                               test_seed, m_test_spacepoints);
+    }
+};
+
 /// Container of internal_spacepoint for an event
 template <template <typename> class vector_t>
 using seed_collection = vector_t<seed>;

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -161,24 +161,29 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
-            // Extended comparison in case there are two spacepoint containers (from gpu nad cpu clusterization)
-            // If so, change the parameter spacepoints_per_event_cuda inside lambda capture
+            // Extended comparison in case there are two spacepoint containers
+            // (from gpu nad cpu clusterization) If so, change the parameter
+            // spacepoints_per_event_cuda inside lambda capture
             for (auto& seed : seeds) {
-                if (std::find_if(seeds_cuda.begin(), seeds_cuda.end(), [&seed, &spacepoints_per_event, 
-                                                                        spacepoints_per_event_cuda = 
-                                                                        spacepoints_per_event](auto& seed_cuda){
+                if (std::find_if(
+                        seeds_cuda.begin(), seeds_cuda.end(),
+                        [&seed, &spacepoints_per_event,
+                         spacepoints_per_event_cuda =
+                             spacepoints_per_event](auto& seed_cuda) {
+                            auto spB = spacepoints_per_event.at(seed.spB_link);
+                            auto spM = spacepoints_per_event.at(seed.spM_link);
+                            auto spT = spacepoints_per_event.at(seed.spT_link);
 
-                    auto spB = spacepoints_per_event.at(seed.spB_link);
-                    auto spM = spacepoints_per_event.at(seed.spM_link);
-                    auto spT = spacepoints_per_event.at(seed.spT_link);
+                            auto spB_cuda = spacepoints_per_event_cuda.at(
+                                seed_cuda.spB_link);
+                            auto spM_cuda = spacepoints_per_event_cuda.at(
+                                seed_cuda.spM_link);
+                            auto spT_cuda = spacepoints_per_event_cuda.at(
+                                seed_cuda.spT_link);
 
-                    auto spB_cuda = spacepoints_per_event_cuda.at(seed_cuda.spB_link);
-                    auto spM_cuda = spacepoints_per_event_cuda.at(seed_cuda.spM_link);
-                    auto spT_cuda = spacepoints_per_event_cuda.at(seed_cuda.spT_link);
-
-                    return (spB == spB_cuda && spM == spM_cuda && spT == spT_cuda);
-                }) !=
-                    seeds_cuda.end()) {
+                            return (spB == spB_cuda && spM == spM_cuda &&
+                                    spT == spT_cuda);
+                        }) != seeds_cuda.end()) {
                     n_match++;
                 }
             }

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -161,31 +161,13 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
-            // Extended comparison in case there are two spacepoint containers
-            // (from gpu nad cpu clusterization) If so, change the parameter
-            // spacepoints_per_event_cuda inside lambda capture
             for (auto& seed : seeds) {
                 if (std::find_if(
                         seeds_cuda.begin(), seeds_cuda.end(),
-                        [&seed, &spacepoints_per_event,
-                         spacepoints_per_event_cuda =
-                             spacepoints_per_event](auto& seed_cuda) {
-                            auto spB = spacepoints_per_event.at(seed.spB_link);
-                            auto spM = spacepoints_per_event.at(seed.spM_link);
-                            auto spT = spacepoints_per_event.at(seed.spT_link);
-
-                            auto spB_cuda = spacepoints_per_event_cuda.at(
-                                seed_cuda.spB_link);
-                            auto spM_cuda = spacepoints_per_event_cuda.at(
-                                seed_cuda.spM_link);
-                            auto spT_cuda = spacepoints_per_event_cuda.at(
-                                seed_cuda.spT_link);
-
-                            return (spB == spB_cuda && spM == spM_cuda &&
-                                    spT == spT_cuda);
-                        }) != seeds_cuda.end()) {
+                        traccc::is_same_seed<traccc::host_spacepoint_container>(
+                            seed, spacepoints_per_event,
+                            spacepoints_per_event)) != seeds_cuda.end())
                     n_match++;
-                }
             }
             float matching_rate = float(n_match) / seeds.size();
             std::cout << "event " << std::to_string(event) << std::endl;

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -161,8 +161,23 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
+            // Extended comparison in case there are two spacepoint containers (from gpu nad cpu clusterization)
+            // If so, change the parameter spacepoints_per_event_cuda inside lambda capture
             for (auto& seed : seeds) {
-                if (std::find(seeds_cuda.begin(), seeds_cuda.end(), seed) !=
+                if (std::find_if(seeds_cuda.begin(), seeds_cuda.end(), [&seed, &spacepoints_per_event, 
+                                                                        spacepoints_per_event_cuda = 
+                                                                        spacepoints_per_event](auto& seed_cuda){
+
+                    auto spB = spacepoints_per_event.at(seed.spB_link);
+                    auto spM = spacepoints_per_event.at(seed.spM_link);
+                    auto spT = spacepoints_per_event.at(seed.spT_link);
+
+                    auto spB_cuda = spacepoints_per_event_cuda.at(seed_cuda.spB_link);
+                    auto spM_cuda = spacepoints_per_event_cuda.at(seed_cuda.spM_link);
+                    auto spT_cuda = spacepoints_per_event_cuda.at(seed_cuda.spT_link);
+
+                    return (spB == spB_cuda && spM == spM_cuda && spT == spT_cuda);
+                }) !=
                     seeds_cuda.end()) {
                     n_match++;
                 }

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -181,31 +181,13 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
-            // Extended comparison in case there are two spacepoint containers
-            // (from gpu nad cpu clusterization) If so, change the parameter
-            // spacepoints_per_event_cuda inside lambda capture
             for (auto& seed : seeds) {
                 if (std::find_if(
                         seeds_cuda.begin(), seeds_cuda.end(),
-                        [&seed, &spacepoints_per_event,
-                         spacepoints_per_event_cuda =
-                             spacepoints_per_event](auto& seed_cuda) {
-                            auto spB = spacepoints_per_event.at(seed.spB_link);
-                            auto spM = spacepoints_per_event.at(seed.spM_link);
-                            auto spT = spacepoints_per_event.at(seed.spT_link);
-
-                            auto spB_cuda = spacepoints_per_event_cuda.at(
-                                seed_cuda.spB_link);
-                            auto spM_cuda = spacepoints_per_event_cuda.at(
-                                seed_cuda.spM_link);
-                            auto spT_cuda = spacepoints_per_event_cuda.at(
-                                seed_cuda.spT_link);
-
-                            return (spB == spB_cuda && spM == spM_cuda &&
-                                    spT == spT_cuda);
-                        }) != seeds_cuda.end()) {
+                        traccc::is_same_seed<traccc::host_spacepoint_container>(
+                            seed, spacepoints_per_event,
+                            spacepoints_per_event)) != seeds_cuda.end())
                     n_match++;
-                }
             }
             float matching_rate = float(n_match) / seeds.size();
             std::cout << "event " << std::to_string(event) << std::endl;

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -181,24 +181,29 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
-            // Extended comparison in case there are two spacepoint containers (from gpu nad cpu clusterization)
-            // If so, change the parameter spacepoints_per_event_cuda inside lambda capture
+            // Extended comparison in case there are two spacepoint containers
+            // (from gpu nad cpu clusterization) If so, change the parameter
+            // spacepoints_per_event_cuda inside lambda capture
             for (auto& seed : seeds) {
-                if (std::find_if(seeds_cuda.begin(), seeds_cuda.end(), [&seed, &spacepoints_per_event, 
-                                                                        spacepoints_per_event_cuda = 
-                                                                        spacepoints_per_event](auto& seed_cuda){
+                if (std::find_if(
+                        seeds_cuda.begin(), seeds_cuda.end(),
+                        [&seed, &spacepoints_per_event,
+                         spacepoints_per_event_cuda =
+                             spacepoints_per_event](auto& seed_cuda) {
+                            auto spB = spacepoints_per_event.at(seed.spB_link);
+                            auto spM = spacepoints_per_event.at(seed.spM_link);
+                            auto spT = spacepoints_per_event.at(seed.spT_link);
 
-                    auto spB = spacepoints_per_event.at(seed.spB_link);
-                    auto spM = spacepoints_per_event.at(seed.spM_link);
-                    auto spT = spacepoints_per_event.at(seed.spT_link);
+                            auto spB_cuda = spacepoints_per_event_cuda.at(
+                                seed_cuda.spB_link);
+                            auto spM_cuda = spacepoints_per_event_cuda.at(
+                                seed_cuda.spM_link);
+                            auto spT_cuda = spacepoints_per_event_cuda.at(
+                                seed_cuda.spT_link);
 
-                    auto spB_cuda = spacepoints_per_event_cuda.at(seed_cuda.spB_link);
-                    auto spM_cuda = spacepoints_per_event_cuda.at(seed_cuda.spM_link);
-                    auto spT_cuda = spacepoints_per_event_cuda.at(seed_cuda.spT_link);
-
-                    return (spB == spB_cuda && spM == spM_cuda && spT == spT_cuda);
-                }) !=
-                    seeds_cuda.end()) {
+                            return (spB == spB_cuda && spM == spM_cuda &&
+                                    spT == spT_cuda);
+                        }) != seeds_cuda.end()) {
                     n_match++;
                 }
             }

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -181,8 +181,23 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
+            // Extended comparison in case there are two spacepoint containers (from gpu nad cpu clusterization)
+            // If so, change the parameter spacepoints_per_event_cuda inside lambda capture
             for (auto& seed : seeds) {
-                if (std::find(seeds_cuda.begin(), seeds_cuda.end(), seed) !=
+                if (std::find_if(seeds_cuda.begin(), seeds_cuda.end(), [&seed, &spacepoints_per_event, 
+                                                                        spacepoints_per_event_cuda = 
+                                                                        spacepoints_per_event](auto& seed_cuda){
+
+                    auto spB = spacepoints_per_event.at(seed.spB_link);
+                    auto spM = spacepoints_per_event.at(seed.spM_link);
+                    auto spT = spacepoints_per_event.at(seed.spT_link);
+
+                    auto spB_cuda = spacepoints_per_event_cuda.at(seed_cuda.spB_link);
+                    auto spM_cuda = spacepoints_per_event_cuda.at(seed_cuda.spM_link);
+                    auto spT_cuda = spacepoints_per_event_cuda.at(seed_cuda.spT_link);
+
+                    return (spB == spB_cuda && spM == spM_cuda && spT == spT_cuda);
+                }) !=
                     seeds_cuda.end()) {
                     n_match++;
                 }

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -171,23 +171,29 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
-            // Extended comparison in case there are two spacepoint containers (from gpu nad cpu clusterization)
-            // If so, change the parameter spacepoints_per_event_sycl inside lambda capture
+            // Extended comparison in case there are two spacepoint containers
+            // (from gpu nad cpu clusterization) If so, change the parameter
+            // spacepoints_per_event_sycl inside lambda capture
             for (auto& seed : seeds) {
-                if (std::find_if(seeds_sycl.begin(), seeds_sycl.end(), [&seed, &spacepoints_per_event, 
-                                                                        spacepoints_per_event_sycl = 
-                                                                        spacepoints_per_event](auto& seed_sycl){
-                    auto spB = spacepoints_per_event.at(seed.spB_link);
-                    auto spM = spacepoints_per_event.at(seed.spM_link);
-                    auto spT = spacepoints_per_event.at(seed.spT_link);
+                if (std::find_if(
+                        seeds_sycl.begin(), seeds_sycl.end(),
+                        [&seed, &spacepoints_per_event,
+                         spacepoints_per_event_sycl =
+                             spacepoints_per_event](auto& seed_sycl) {
+                            auto spB = spacepoints_per_event.at(seed.spB_link);
+                            auto spM = spacepoints_per_event.at(seed.spM_link);
+                            auto spT = spacepoints_per_event.at(seed.spT_link);
 
-                    auto spB_sycl = spacepoints_per_event_sycl.at(seed_sycl.spB_link);
-                    auto spM_sycl = spacepoints_per_event_sycl.at(seed_sycl.spM_link);
-                    auto spT_sycl = spacepoints_per_event_sycl.at(seed_sycl.spT_link);
+                            auto spB_sycl = spacepoints_per_event_sycl.at(
+                                seed_sycl.spB_link);
+                            auto spM_sycl = spacepoints_per_event_sycl.at(
+                                seed_sycl.spM_link);
+                            auto spT_sycl = spacepoints_per_event_sycl.at(
+                                seed_sycl.spT_link);
 
-                    return (spB == spB_sycl && spM == spM_sycl && spT == spT_sycl);
-                }) !=
-                    seeds_sycl.end()) {
+                            return (spB == spB_sycl && spM == spM_sycl &&
+                                    spT == spT_sycl);
+                        }) != seeds_sycl.end()) {
                     n_match++;
                 }
             }

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -171,8 +171,22 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
+            // Extended comparison in case there are two spacepoint containers (from gpu nad cpu clusterization)
+            // If so, change the parameter spacepoints_per_event_sycl inside lambda capture
             for (auto& seed : seeds) {
-                if (std::find(seeds_sycl.begin(), seeds_sycl.end(), seed) !=
+                if (std::find_if(seeds_sycl.begin(), seeds_sycl.end(), [&seed, &spacepoints_per_event, 
+                                                                        spacepoints_per_event_sycl = 
+                                                                        spacepoints_per_event](auto& seed_sycl){
+                    auto spB = spacepoints_per_event.at(seed.spB_link);
+                    auto spM = spacepoints_per_event.at(seed.spM_link);
+                    auto spT = spacepoints_per_event.at(seed.spT_link);
+
+                    auto spB_sycl = spacepoints_per_event_sycl.at(seed_sycl.spB_link);
+                    auto spM_sycl = spacepoints_per_event_sycl.at(seed_sycl.spM_link);
+                    auto spT_sycl = spacepoints_per_event_sycl.at(seed_sycl.spT_link);
+
+                    return (spB == spB_sycl && spM == spM_sycl && spT == spT_sycl);
+                }) !=
                     seeds_sycl.end()) {
                     n_match++;
                 }

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -171,31 +171,13 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
-            // Extended comparison in case there are two spacepoint containers
-            // (from gpu nad cpu clusterization) If so, change the parameter
-            // spacepoints_per_event_sycl inside lambda capture
             for (auto& seed : seeds) {
                 if (std::find_if(
                         seeds_sycl.begin(), seeds_sycl.end(),
-                        [&seed, &spacepoints_per_event,
-                         spacepoints_per_event_sycl =
-                             spacepoints_per_event](auto& seed_sycl) {
-                            auto spB = spacepoints_per_event.at(seed.spB_link);
-                            auto spM = spacepoints_per_event.at(seed.spM_link);
-                            auto spT = spacepoints_per_event.at(seed.spT_link);
-
-                            auto spB_sycl = spacepoints_per_event_sycl.at(
-                                seed_sycl.spB_link);
-                            auto spM_sycl = spacepoints_per_event_sycl.at(
-                                seed_sycl.spM_link);
-                            auto spT_sycl = spacepoints_per_event_sycl.at(
-                                seed_sycl.spT_link);
-
-                            return (spB == spB_sycl && spM == spM_sycl &&
-                                    spT == spT_sycl);
-                        }) != seeds_sycl.end()) {
+                        traccc::is_same_seed<traccc::host_spacepoint_container>(
+                            seed, spacepoints_per_event,
+                            spacepoints_per_event)) != seeds_sycl.end())
                     n_match++;
-                }
             }
             float matching_rate = float(n_match) / seeds.size();
             std::cout << "event " << std::to_string(event) << std::endl;

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -191,13 +191,28 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
+            // Extended comparison in case there are two spacepoint containers (from gpu nad cpu clusterization)
+            // If so, change the parameter spacepoints_per_event_sycl inside lambda capture
             for (auto& seed : seeds) {
-                if (std::find(seeds_sycl.begin(), seeds_sycl.end(), seed) !=
+                if (std::find_if(seeds_sycl.begin(), seeds_sycl.end(), [&seed, &spacepoints_per_event, 
+                                                                        spacepoints_per_event_sycl = 
+                                                                        spacepoints_per_event](auto& seed_sycl){
+                    auto spB = spacepoints_per_event.at(seed.spB_link);
+                    auto spM = spacepoints_per_event.at(seed.spM_link);
+                    auto spT = spacepoints_per_event.at(seed.spT_link);
+
+                    auto spB_sycl = spacepoints_per_event_sycl.at(seed_sycl.spB_link);
+                    auto spM_sycl = spacepoints_per_event_sycl.at(seed_sycl.spM_link);
+                    auto spT_sycl = spacepoints_per_event_sycl.at(seed_sycl.spT_link);
+
+                    return (spB == spB_sycl && spM == spM_sycl && spT == spT_sycl);
+                }) !=
                     seeds_sycl.end()) {
                     n_match++;
                 }
             }
             float matching_rate = float(n_match) / seeds.size();
+
             std::cout << "event " << std::to_string(event) << std::endl;
             std::cout << " number of seeds (cpu): " << seeds.size()
                       << std::endl;

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -191,31 +191,13 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
-            // Extended comparison in case there are two spacepoint containers
-            // (from gpu nad cpu clusterization) If so, change the parameter
-            // spacepoints_per_event_sycl inside lambda capture
             for (auto& seed : seeds) {
                 if (std::find_if(
                         seeds_sycl.begin(), seeds_sycl.end(),
-                        [&seed, &spacepoints_per_event,
-                         spacepoints_per_event_sycl =
-                             spacepoints_per_event](auto& seed_sycl) {
-                            auto spB = spacepoints_per_event.at(seed.spB_link);
-                            auto spM = spacepoints_per_event.at(seed.spM_link);
-                            auto spT = spacepoints_per_event.at(seed.spT_link);
-
-                            auto spB_sycl = spacepoints_per_event_sycl.at(
-                                seed_sycl.spB_link);
-                            auto spM_sycl = spacepoints_per_event_sycl.at(
-                                seed_sycl.spM_link);
-                            auto spT_sycl = spacepoints_per_event_sycl.at(
-                                seed_sycl.spT_link);
-
-                            return (spB == spB_sycl && spM == spM_sycl &&
-                                    spT == spT_sycl);
-                        }) != seeds_sycl.end()) {
+                        traccc::is_same_seed<traccc::host_spacepoint_container>(
+                            seed, spacepoints_per_event,
+                            spacepoints_per_event)) != seeds_sycl.end())
                     n_match++;
-                }
             }
             float matching_rate = float(n_match) / seeds.size();
 

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -191,23 +191,29 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
-            // Extended comparison in case there are two spacepoint containers (from gpu nad cpu clusterization)
-            // If so, change the parameter spacepoints_per_event_sycl inside lambda capture
+            // Extended comparison in case there are two spacepoint containers
+            // (from gpu nad cpu clusterization) If so, change the parameter
+            // spacepoints_per_event_sycl inside lambda capture
             for (auto& seed : seeds) {
-                if (std::find_if(seeds_sycl.begin(), seeds_sycl.end(), [&seed, &spacepoints_per_event, 
-                                                                        spacepoints_per_event_sycl = 
-                                                                        spacepoints_per_event](auto& seed_sycl){
-                    auto spB = spacepoints_per_event.at(seed.spB_link);
-                    auto spM = spacepoints_per_event.at(seed.spM_link);
-                    auto spT = spacepoints_per_event.at(seed.spT_link);
+                if (std::find_if(
+                        seeds_sycl.begin(), seeds_sycl.end(),
+                        [&seed, &spacepoints_per_event,
+                         spacepoints_per_event_sycl =
+                             spacepoints_per_event](auto& seed_sycl) {
+                            auto spB = spacepoints_per_event.at(seed.spB_link);
+                            auto spM = spacepoints_per_event.at(seed.spM_link);
+                            auto spT = spacepoints_per_event.at(seed.spT_link);
 
-                    auto spB_sycl = spacepoints_per_event_sycl.at(seed_sycl.spB_link);
-                    auto spM_sycl = spacepoints_per_event_sycl.at(seed_sycl.spM_link);
-                    auto spT_sycl = spacepoints_per_event_sycl.at(seed_sycl.spT_link);
+                            auto spB_sycl = spacepoints_per_event_sycl.at(
+                                seed_sycl.spB_link);
+                            auto spM_sycl = spacepoints_per_event_sycl.at(
+                                seed_sycl.spM_link);
+                            auto spT_sycl = spacepoints_per_event_sycl.at(
+                                seed_sycl.spT_link);
 
-                    return (spB == spB_sycl && spM == spM_sycl && spT == spT_sycl);
-                }) !=
-                    seeds_sycl.end()) {
+                            return (spB == spB_sycl && spM == spM_sycl &&
+                                    spT == spT_sycl);
+                        }) != seeds_sycl.end()) {
                     n_match++;
                 }
             }


### PR DESCRIPTION
It turns out that so far we've been comparing found seeds from CPU vs GPU by checking if the indices of bottom/top/middle spacepoints are the same. So for instance:
```cpp
...
if (lhs.spB_link == rhs.spB_link && 
    lhs.spM_link == rhs.spM_link &&
    lhs.spT_link == rhs.spT_link) return true;
...
```
This of course doesn't work if both seed collection from CPU and seed collection from GPU refer with their indices to two different spacepoint containers (which could potentially have the spacepoints in different order). 

To make this work, I changed it so we compare if the actual spacepoints are the same.
pinging @krasznaa @beomki-yeo 