### PR TITLE
Container Improvements, main branch (2022.04.08.)

### DIFF
--- a/core/include/traccc/edm/details/container_base.hpp
+++ b/core/include/traccc/edm/details/container_base.hpp
@@ -77,16 +77,16 @@ class container_base {
      * @brief The type name of the element view which is returned by various
      * methods in this class.
      */
-    using element_view =
-        container_element<header_t, typename item_vector::value_type>;
+    using element_view = container_element<typename header_vector::reference,
+                                           typename item_vector::reference>;
 
     /**
      * @brief The type name of the constant element view which is returned
      * by various methods in this class.
      */
     using const_element_view =
-        container_element<const header_t,
-                          const typename item_vector::value_type>;
+        container_element<typename header_vector::const_reference,
+                          typename item_vector::const_reference>;
 
     /**
      * We need to assert that the header vector and the outer layer of the
@@ -98,8 +98,13 @@ class container_base {
                             typename item_vector::size_type>::value,
         "Size type for container header and item vectors must be the same.");
 
+    /// Default copy-constructor
+    container_base(const container_base&) = default;
+    /// Default move-constructor
+    container_base(container_base&&) = default;
+
     /**
-     * @brief Standard two-argument constructor.
+     * @brief (Copy) Constructor from a header and item vector
      *
      * To enforce the invariant that both vectors must be the same size, we
      * check this in the constructor. This is also checked in release
@@ -107,6 +112,21 @@ class container_base {
      */
     TRACCC_HOST
     container_base(const header_vector& hv, const item_vector& iv)
+        : m_headers(hv), m_items(iv) {
+        if (m_headers.size() != m_items.size()) {
+            throw std::logic_error("Header and item length not equal.");
+        }
+    }
+
+    /**
+     * @brief (Move) Constructor from a header and item vector
+     *
+     * To enforce the invariant that both vectors must be the same size, we
+     * check this in the constructor. This is also checked in release
+     * builds.
+     */
+    TRACCC_HOST
+    container_base(header_vector&& hv, item_vector&& iv)
         : m_headers(hv), m_items(iv) {
         if (m_headers.size() != m_items.size()) {
             throw std::logic_error("Header and item length not equal.");
@@ -147,6 +167,11 @@ class container_base {
      * @brief Default Constructor
      */
     container_base() = default;
+
+    /// Default (copy) assignment operator
+    container_base& operator=(const container_base&) = default;
+    /// Default (move) assignment operator
+    container_base& operator=(container_base&&) = default;
 
     /**
      * @brief Accessor method for the internal header vector.

--- a/core/include/traccc/edm/details/container_element.hpp
+++ b/core/include/traccc/edm/details/container_element.hpp
@@ -21,11 +21,17 @@ namespace traccc {
  * low-overhead access to the struct-of-arrays container class to emulate an
  * array-of-structs architecture.
  *
- * @tparam header_t The type of the header object.
- * @tparam vector_t The fully qualified vector type.
+ * @tparam header_reference_t The type of reference of the header object.
+ * @tparam vector_reference_t The fully qualified vector reference type.
  */
-template <typename header_t, typename vector_t>
+template <typename header_reference_t, typename vector_reference_t>
 struct container_element {
+
+    /// Header reference type
+    using header_reference = header_reference_t;
+    /// Vector reference type
+    using vector_reference = vector_reference_t;
+
     /**
      * @brief Construct a new container element view.
      *
@@ -37,10 +43,11 @@ struct container_element {
      * @param[in] v The vector object reference.
      */
     TRACCC_HOST_DEVICE
-    container_element(header_t& h, vector_t& v) : header(h), items(v) {}
+    container_element(header_reference h, vector_reference v)
+        : header(h), items(v) {}
 
-    header_t& header;
-    vector_t& items;
+    header_reference header;
+    vector_reference items;
 };  // struct container_element
 
 }  // namespace traccc

--- a/core/include/traccc/edm/details/device_container.hpp
+++ b/core/include/traccc/edm/details/device_container.hpp
@@ -34,6 +34,15 @@ class device_container
     /// Inherit all of the base class's constructors
     using base_type::base_type;
 
+    /// Constructor from a "view object"
+    ///
+    /// Note that it may also be a "data" or "buffer" object. It just needs to
+    /// look like a "view object".
+    ///
+    template <template <typename, typename> class view_t>
+    TRACCC_HOST_DEVICE device_container(const view_t<header_t, item_t>& view)
+        : base_type(view.headers, view.items) {}
+
     /**
      * @brief Bounds-checking mutable element accessor.
      */

--- a/device/cuda/src/seeding/counting_grid_capacities.cu
+++ b/device/cuda/src/seeding/counting_grid_capacities.cu
@@ -54,8 +54,7 @@ __global__ void counting_grid_capacities_kernel(
     vecmem::data::vector_view<unsigned int> grid_capacities_view) {
 
     // Get device container for input parameters
-    device_spacepoint_container spacepoints_device(
-        {spacepoints_view.headers, spacepoints_view.items});
+    device_spacepoint_container spacepoints_device(spacepoints_view);
     vecmem::device_vector<std::pair<unsigned int, unsigned int>>
         sp_container_indices(sp_container_indices_view);
     vecmem::device_vector<unsigned int> grid_capacities_device(

--- a/device/cuda/src/seeding/doublet_counting.cu
+++ b/device/cuda/src/seeding/doublet_counting.cu
@@ -14,8 +14,7 @@ namespace cuda {
 
 __global__ void set_zero_kernel(doublet_counter_container_view dcc_view) {
 
-    device_doublet_counter_container dcc_device(
-        {dcc_view.headers, dcc_view.items});
+    device_doublet_counter_container dcc_device(dcc_view);
 
     const std::size_t gid = blockIdx.x * blockDim.x + threadIdx.x;
     if (gid >= dcc_device.get_headers().size()) {
@@ -88,7 +87,7 @@ __global__ void doublet_counting_kernel(
     sp_grid_device internal_sp_device(internal_sp_view);
 
     device_doublet_counter_container doublet_counter_device(
-        {doublet_counter_view.headers, doublet_counter_view.items});
+        doublet_counter_view);
 
     // Get bin and spacepoint index
     unsigned int bin_idx(0), sp_idx(0);

--- a/device/cuda/src/seeding/doublet_finding.cu
+++ b/device/cuda/src/seeding/doublet_finding.cu
@@ -15,8 +15,8 @@ namespace cuda {
 __global__ void set_zero_kernel(doublet_container_view mbc_view,
                                 doublet_container_view mtc_view) {
 
-    device_doublet_container mbc_device({mbc_view.headers, mbc_view.items});
-    device_doublet_container mtc_device({mtc_view.headers, mtc_view.items});
+    device_doublet_container mbc_device(mbc_view);
+    device_doublet_container mtc_device(mtc_view);
 
     const std::size_t gid = blockIdx.x * blockDim.x + threadIdx.x;
     if (gid >= mbc_device.get_headers().size()) {
@@ -103,12 +103,10 @@ __global__ void doublet_finding_kernel(
     sp_grid_device internal_sp_device(internal_sp_view);
 
     device_doublet_counter_container doublet_counter_device(
-        {doublet_counter_view.headers, doublet_counter_view.items});
+        doublet_counter_view);
 
-    device_doublet_container mid_bot_doublet_device(
-        {mid_bot_doublet_view.headers, mid_bot_doublet_view.items});
-    device_doublet_container mid_top_doublet_device(
-        {mid_top_doublet_view.headers, mid_top_doublet_view.items});
+    device_doublet_container mid_bot_doublet_device(mid_bot_doublet_view);
+    device_doublet_container mid_top_doublet_device(mid_top_doublet_view);
 
     // Get the bin and item index
     unsigned int bin_idx(0), item_idx(0);

--- a/device/cuda/src/seeding/populating_grid.cu
+++ b/device/cuda/src/seeding/populating_grid.cu
@@ -48,8 +48,7 @@ __global__ void populating_grid_kernel(
 
     // Get device container for input parameters
     sp_grid_device g2_device(grid_view);
-    device_spacepoint_container spacepoints_device(
-        {spacepoints_view.headers, spacepoints_view.items});
+    device_spacepoint_container spacepoints_device(spacepoints_view);
     vecmem::device_vector<std::pair<unsigned int, unsigned int>>
         sp_container_indices(sp_container_indices_view);
 

--- a/device/cuda/src/seeding/seed_selecting.cu
+++ b/device/cuda/src/seeding/seed_selecting.cu
@@ -92,16 +92,14 @@ __global__ void seed_selecting_kernel(
     vecmem::data::vector_view<seed> seed_view) {
 
     // Get device container for input parameters
-    device_spacepoint_container spacepoints_device(
-        {spacepoints_view.headers, spacepoints_view.items});
+    device_spacepoint_container spacepoints_device(spacepoints_view);
     sp_grid_device internal_sp_device(internal_sp_view);
 
     device_doublet_counter_container doublet_counter_device(
-        {doublet_counter_view.headers, doublet_counter_view.items});
+        doublet_counter_view);
     device_triplet_counter_container triplet_counter_device(
-        {triplet_counter_view.headers, triplet_counter_view.items});
-    device_triplet_container triplet_device(
-        {triplet_view.headers, triplet_view.items});
+        triplet_counter_view);
+    device_triplet_container triplet_device(triplet_view);
     device_seed_collection seed_device(seed_view);
 
     // Get the bin and item index

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -57,10 +57,9 @@ __global__ void track_params_estimating_kernel(
     vecmem::data::vector_view<bound_track_parameters> params_view) {
 
     // Get device container for input parameters
-    device_spacepoint_container spacepoints_device(
-        {spacepoints_view.headers, spacepoints_view.items});
+    device_spacepoint_container spacepoints_device(spacepoints_view);
     device_seed_collection seeds_device(seeds_view);
-    device_bound_track_parameters_collection params_device({params_view});
+    device_bound_track_parameters_collection params_device(params_view);
 
     // vector index for threads
     unsigned int gid = threadIdx.x + blockIdx.x * blockDim.x;

--- a/device/cuda/src/seeding/triplet_counting.cu
+++ b/device/cuda/src/seeding/triplet_counting.cu
@@ -13,8 +13,7 @@ namespace cuda {
 
 __global__ void set_zero_kernel(triplet_counter_container_view tcc_view) {
 
-    device_triplet_counter_container tcc_device(
-        {tcc_view.headers, tcc_view.items});
+    device_triplet_counter_container tcc_device(tcc_view);
 
     const std::size_t gid = blockIdx.x * blockDim.x + threadIdx.x;
     if (gid >= tcc_device.get_headers().size()) {
@@ -99,13 +98,11 @@ __global__ void triplet_counting_kernel(
     sp_grid_device internal_sp_device(internal_sp_view);
 
     device_doublet_counter_container doublet_counter_device(
-        {doublet_counter_view.headers, doublet_counter_view.items});
-    device_doublet_container mid_bot_doublet_device(
-        {mid_bot_doublet_view.headers, mid_bot_doublet_view.items});
-    device_doublet_container mid_top_doublet_device(
-        {mid_top_doublet_view.headers, mid_top_doublet_view.items});
+        doublet_counter_view);
+    device_doublet_container mid_bot_doublet_device(mid_bot_doublet_view);
+    device_doublet_container mid_top_doublet_device(mid_top_doublet_view);
     device_triplet_counter_container triplet_counter_device(
-        {triplet_counter_view.headers, triplet_counter_view.items});
+        triplet_counter_view);
 
     // Get the bin and item index
     unsigned int bin_idx(0), mb_idx(0);

--- a/device/cuda/src/seeding/triplet_finding.cu
+++ b/device/cuda/src/seeding/triplet_finding.cu
@@ -13,7 +13,7 @@ namespace cuda {
 
 __global__ void set_zero_kernel(triplet_container_view tc_view) {
 
-    device_triplet_container tc_device({tc_view.headers, tc_view.items});
+    device_triplet_container tc_device(tc_view);
 
     const std::size_t gid = blockIdx.x * blockDim.x + threadIdx.x;
     if (gid >= tc_device.get_headers().size()) {
@@ -106,16 +106,13 @@ __global__ void triplet_finding_kernel(
     sp_grid_device internal_sp_device(internal_sp_view);
 
     device_doublet_counter_container doublet_counter_device(
-        {doublet_counter_view.headers, doublet_counter_view.items});
-    device_doublet_container mid_bot_doublet_device(
-        {mid_bot_doublet_view.headers, mid_bot_doublet_view.items});
-    device_doublet_container mid_top_doublet_device(
-        {mid_top_doublet_view.headers, mid_top_doublet_view.items});
+        doublet_counter_view);
+    device_doublet_container mid_bot_doublet_device(mid_bot_doublet_view);
+    device_doublet_container mid_top_doublet_device(mid_top_doublet_view);
 
     device_triplet_counter_container triplet_counter_device(
-        {triplet_counter_view.headers, triplet_counter_view.items});
-    device_triplet_container triplet_device(
-        {triplet_view.headers, triplet_view.items});
+        triplet_counter_view);
+    device_triplet_container triplet_device(triplet_view);
 
     // Get the bin and item index
     unsigned int bin_idx(0), item_idx(0);

--- a/device/cuda/src/seeding/weight_updating.cu
+++ b/device/cuda/src/seeding/weight_updating.cu
@@ -72,9 +72,8 @@ __global__ void weight_updating_kernel(
     sp_grid_device internal_sp_device(internal_sp_view);
 
     device_triplet_counter_container triplet_counter_device(
-        {triplet_counter_view.headers, triplet_counter_view.items});
-    device_triplet_container triplet_device(
-        {triplet_view.headers, triplet_view.items});
+        triplet_counter_view);
+    device_triplet_container triplet_device(triplet_view);
 
     // Get the bin and item index
     unsigned int bin_idx(0), tr_idx(0);

--- a/device/sycl/src/seeding/counting_grid_capacities.sycl
+++ b/device/sycl/src/seeding/counting_grid_capacities.sycl
@@ -45,8 +45,7 @@ class CountGridCapacities {
 
         // Get device container for input parameters
         sp_grid_device g2_device(m_grid_view);
-        device_spacepoint_container spacepoints_device(
-            {m_spacepoints_view.headers, m_spacepoints_view.items});
+        device_spacepoint_container spacepoints_device(m_spacepoints_view);
         vecmem::device_vector<const std::pair<unsigned int, unsigned int> >
             sp_container_indices(m_sp_container_indices_view);
         vecmem::device_vector<unsigned int> grid_capacities_device(

--- a/device/sycl/src/seeding/doublet_counting.sycl
+++ b/device/sycl/src/seeding/doublet_counting.sycl
@@ -35,7 +35,7 @@ class DupletCount {
         sp_grid_device internal_sp_device(m_internal_sp_view);
 
         device_doublet_counter_container doublet_counter_device(
-            {m_doublet_counter_view.headers, m_doublet_counter_view.items});
+            m_doublet_counter_view);
 
         // Get the bin index of spacepoint binning and reference block idx for
         // the bin index

--- a/device/sycl/src/seeding/doublet_finding.sycl
+++ b/device/sycl/src/seeding/doublet_finding.sycl
@@ -45,11 +45,9 @@ class DupletFind {
         sp_grid_device internal_sp_device(m_internal_sp_view);
 
         device_doublet_counter_container doublet_counter_device(
-            {m_doublet_counter_view.headers, m_doublet_counter_view.items});
-        device_doublet_container mid_bot_doublet_device(
-            {m_mid_bot_doublet_view.headers, m_mid_bot_doublet_view.items});
-        device_doublet_container mid_top_doublet_device(
-            {m_mid_top_doublet_view.headers, m_mid_top_doublet_view.items});
+            m_doublet_counter_view);
+        device_doublet_container mid_bot_doublet_device(m_mid_bot_doublet_view);
+        device_doublet_container mid_top_doublet_device(m_mid_top_doublet_view);
 
         // Get the bin index of spacepoint binning and reference block idx for
         // the bin index

--- a/device/sycl/src/seeding/populating_grid.sycl
+++ b/device/sycl/src/seeding/populating_grid.sycl
@@ -44,8 +44,7 @@ class PopulatingGrid {
 
         // Get device container for input parameters
         sp_grid_device g2_device(m_grid_view);
-        device_spacepoint_container spacepoints_device(
-            {m_spacepoints_view.headers, m_spacepoints_view.items});
+        device_spacepoint_container spacepoints_device(m_spacepoints_view);
         vecmem::device_vector<unsigned int> grid_sizes(m_grid_sizes_view);
         vecmem::device_vector<const std::pair<unsigned int, unsigned int>>
             sp_container_indices(m_sp_container_indices_view);

--- a/device/sycl/src/seeding/seed_selecting.sycl
+++ b/device/sycl/src/seeding/seed_selecting.sycl
@@ -78,15 +78,13 @@ class SeedSelect {
         auto workItemIdx = item.get_local_id(0);
 
         // Get device container for input parameters
-        device_spacepoint_container spacepoints_device(
-            {m_spacepoints_view.headers, m_spacepoints_view.items});
+        device_spacepoint_container spacepoints_device(m_spacepoints_view);
 
         sp_grid_device internal_sp_device(m_internal_sp_view);
 
         device_doublet_counter_container doublet_counter_device(
-            {m_doublet_counter_view.headers, m_doublet_counter_view.items});
-        device_triplet_container triplet_device(
-            {m_triplet_view.headers, m_triplet_view.items});
+            m_doublet_counter_view);
+        device_triplet_container triplet_device(m_triplet_view);
         device_seed_collection seed_device(m_seed_view);
 
         // Get the bin and item index

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -37,10 +37,9 @@ class TrackParamsEstimation {
         auto workItemIdx = item.get_local_id(0);
 
         // Get device container for input parameters
-        device_spacepoint_container spacepoints_device(
-            {m_spacepoints_view.headers, m_spacepoints_view.items});
+        device_spacepoint_container spacepoints_device(m_spacepoints_view);
         device_seed_collection seeds_device(m_seeds_view);
-        device_bound_track_parameters_collection params_device({m_params_view});
+        device_bound_track_parameters_collection params_device(m_params_view);
 
         // vector index for threads
         unsigned int gid = workItemIdx + groupIdx * groupDim;

--- a/device/sycl/src/seeding/triplet_counting.sycl
+++ b/device/sycl/src/seeding/triplet_counting.sycl
@@ -42,13 +42,11 @@ class TripletCount {
         sp_grid_device internal_sp_device(m_internal_sp_view);
 
         device_doublet_counter_container doublet_counter_device(
-            {m_doublet_counter_view.headers, m_doublet_counter_view.items});
-        device_doublet_container mid_bot_doublet_device(
-            {m_mid_bot_doublet_view.headers, m_mid_bot_doublet_view.items});
-        device_doublet_container mid_top_doublet_device(
-            {m_mid_top_doublet_view.headers, m_mid_top_doublet_view.items});
+            m_doublet_counter_view);
+        device_doublet_container mid_bot_doublet_device(m_mid_bot_doublet_view);
+        device_doublet_container mid_top_doublet_device(m_mid_top_doublet_view);
         device_triplet_counter_container triplet_counter_device(
-            {m_triplet_counter_view.headers, m_triplet_counter_view.items});
+            m_triplet_counter_view);
 
         // Get the bin and item index
         unsigned int bin_idx(0), mb_idx(0);

--- a/device/sycl/src/seeding/triplet_finding.sycl
+++ b/device/sycl/src/seeding/triplet_finding.sycl
@@ -53,16 +53,13 @@ class TripletFind {
         sp_grid_device internal_sp_device(m_internal_sp_view);
 
         device_doublet_counter_container doublet_counter_device(
-            {m_doublet_counter_view.headers, m_doublet_counter_view.items});
-        device_doublet_container mid_bot_doublet_device(
-            {m_mid_bot_doublet_view.headers, m_mid_bot_doublet_view.items});
-        device_doublet_container mid_top_doublet_device(
-            {m_mid_top_doublet_view.headers, m_mid_top_doublet_view.items});
+            m_doublet_counter_view);
+        device_doublet_container mid_bot_doublet_device(m_mid_bot_doublet_view);
+        device_doublet_container mid_top_doublet_device(m_mid_top_doublet_view);
 
         device_triplet_counter_container triplet_counter_device(
-            {m_triplet_counter_view.headers, m_triplet_counter_view.items});
-        device_triplet_container triplet_device(
-            {m_triplet_view.headers, m_triplet_view.items});
+            m_triplet_counter_view);
+        device_triplet_container triplet_device(m_triplet_view);
 
         // Get the bin and item index
         unsigned int bin_idx(0), item_idx(0);

--- a/device/sycl/src/seeding/weight_updating.sycl
+++ b/device/sycl/src/seeding/weight_updating.sycl
@@ -36,9 +36,8 @@ class WeightUpdate {
         sp_grid_device internal_sp_device(m_internal_sp_view);
 
         device_triplet_counter_container triplet_counter_device(
-            {m_triplet_counter_view.headers, m_triplet_counter_view.items});
-        device_triplet_container triplet_device(
-            {m_triplet_view.headers, m_triplet_view.items});
+            m_triplet_counter_view);
+        device_triplet_container triplet_device(m_triplet_view);
 
         // Get the bin and item index
         unsigned int bin_idx(0), tr_idx(0);


### PR DESCRIPTION
Following up from #165, I ended up working with the container code a bit more before getting to the algorithmic code tweaks for #167...

After @stephenswat's nagging (re-)Introduced some move constructors and assignment operators, in case we end up making use of them.

Introduced a specific constructor for `traccc::device_container` that would allow constructing such objects directly from "view objects". Then updated all CUDA and SYCL code to make use of this more convenient way of creating the device containers.

Finally updated `traccc::container_element` to make it usable in device code. Since as @konradkusiak97 found, such things couldn't actually be constructed in device code so far. This is because [vecmem::jagged_device_vector](https://github.com/acts-project/vecmem/blob/main/core/include/vecmem/containers/jagged_device_vector.hpp) doesn't actually return references to [vecmem::device_vector](https://github.com/acts-project/vecmem/blob/main/core/include/vecmem/containers/device_vector.hpp) for technical reasons...

https://github.com/acts-project/vecmem/blob/main/core/include/vecmem/containers/jagged_device_vector.hpp#L60-L63