### PR TITLE
Add measurement creation implementation in SYCL

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -27,7 +27,7 @@ traccc_add_library( traccc_core core TYPE INTERFACE
   # Geometry description.
   "include/traccc/geometry/module_map.hpp"
   "include/traccc/geometry/geometry.hpp"
-  "include/traccc/geometry/pixel_segmentation.hpp"
+  "include/traccc/geometry/pixel_data.hpp"
   # Utilities.
   "include/traccc/utils/algorithm.hpp"
   "include/traccc/utils/unit_vectors.hpp"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -37,6 +37,7 @@ traccc_add_library( traccc_core core TYPE INTERFACE
   "include/traccc/clusterization/clusterization_algorithm.hpp"
   "include/traccc/clusterization/spacepoint_formation.hpp"
   "include/traccc/clusterization/measurement_creation.hpp"
+  "include/traccc/clusterization/measurement_creation_helper.hpp"
   # Seed finding algorithmic code.
   "include/traccc/seeding/detail/lin_circle.hpp"
   "include/traccc/seeding/detail/doublet.hpp"

--- a/core/include/traccc/clusterization/clusterization_algorithm.hpp
+++ b/core/include/traccc/clusterization/clusterization_algorithm.hpp
@@ -68,7 +68,7 @@ class clusterization_algorithm
             // The algorithmic code part: start
             traccc::host_cluster_container clusters = cc->operator()(
                 cells_per_event.at(i).items, cells_per_event.at(i).header);
-            for (auto& cl_id : clusters.get_headers()){
+            for (auto& cl_id : clusters.get_headers()) {
                 cl_id.is_default = false;
                 cl_id.pixel = module.pixel;
             }

--- a/core/include/traccc/clusterization/clusterization_algorithm.hpp
+++ b/core/include/traccc/clusterization/clusterization_algorithm.hpp
@@ -69,7 +69,6 @@ class clusterization_algorithm
             traccc::host_cluster_container clusters = cc->operator()(
                 cells_per_event.at(i).items, cells_per_event.at(i).header);
             for (auto& cl_id : clusters.get_headers()) {
-                cl_id.is_default = false;
                 cl_id.pixel = module.pixel;
             }
 

--- a/core/include/traccc/clusterization/clusterization_algorithm.hpp
+++ b/core/include/traccc/clusterization/clusterization_algorithm.hpp
@@ -12,7 +12,7 @@
 #include "traccc/edm/internal_spacepoint.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
-#include "traccc/geometry/pixel_segmentation.hpp"
+#include "traccc/geometry/pixel_data.hpp"
 
 // clusterization
 #include "traccc/clusterization/component_connection.hpp"
@@ -68,8 +68,10 @@ class clusterization_algorithm
             // The algorithmic code part: start
             traccc::host_cluster_container clusters = cc->operator()(
                 cells_per_event.at(i).items, cells_per_event.at(i).header);
-            for (auto& cl_id : clusters.get_headers())
-                cl_id.position_from_cell = module.pixel;
+            for (auto& cl_id : clusters.get_headers()){
+                cl_id.is_default = false;
+                cl_id.pixel = module.pixel;
+            }
 
             traccc::host_measurement_collection measurements_per_module =
                 mt->operator()(clusters, module);

--- a/core/include/traccc/clusterization/measurement_creation.hpp
+++ b/core/include/traccc/clusterization/measurement_creation.hpp
@@ -86,8 +86,8 @@ struct measurement_creation
                 scalar weight = signal_cell_modelling(cell.activation);
                 if (weight > cl_id.threshold) {
                     totalWeight += cell.activation;
-                    const point2 cell_position = position_from_cell(
-                        cl_id.module_idx, cell, cl_id.pixel, cl_id.is_default);
+                    const point2 cell_position =
+                        position_from_cell(cell, cl_id.pixel, cl_id.is_default);
 
                     const point2 prev = mean;
                     const point2 diff = cell_position - prev;

--- a/core/include/traccc/clusterization/measurement_creation.hpp
+++ b/core/include/traccc/clusterization/measurement_creation.hpp
@@ -83,11 +83,11 @@ struct measurement_creation
 
             const auto &cl_id = clusters.at(0).header;
             for (const auto &cell : cluster) {
-                scalar weight = signal_cell_modelling(cell.activation);
+                scalar weight = signal_cell_modelling(cell.activation, cl_id);
                 if (weight > cl_id.threshold) {
                     totalWeight += cell.activation;
                     const point2 cell_position =
-                        position_from_cell(cell, cl_id.pixel, cl_id.is_default);
+                        position_from_cell(cell, cl_id);
 
                     const point2 prev = mean;
                     const point2 diff = cell_position - prev;

--- a/core/include/traccc/clusterization/measurement_creation.hpp
+++ b/core/include/traccc/clusterization/measurement_creation.hpp
@@ -86,8 +86,8 @@ struct measurement_creation
             const auto &cl_id = clusters.at(0).header;
 
             // Calculate the cluster properties
-            calc_cluster_properties<vecmem::vector>(cluster, cl_id, mean, var,
-                                                    totalWeight);
+            calc_cluster_properties<vecmem::vector, cell>(cluster, cl_id, mean,
+                                                          var, totalWeight);
 
             if (totalWeight > 0.) {
                 measurement m;

--- a/core/include/traccc/clusterization/measurement_creation.hpp
+++ b/core/include/traccc/clusterization/measurement_creation.hpp
@@ -83,7 +83,7 @@ struct measurement_creation
 
             const auto &cl_id = clusters.at(0).header;
             for (const auto &cell : cluster) {
-                scalar weight = cl_id.signal(cell.activation);
+                scalar weight = signal_cell_modelling(cell.activation);
                 if (weight > cl_id.threshold) {
                     totalWeight += cell.activation;
                     const point2 cell_position =

--- a/core/include/traccc/clusterization/measurement_creation.hpp
+++ b/core/include/traccc/clusterization/measurement_creation.hpp
@@ -59,8 +59,7 @@ struct measurement_creation
                     output_type &measurements) const {
 
         // Run the algorithm
-        const auto &cl_id = clusters.at(0).header;
-        auto pitch = get_pitch(cl_id.module_idx, cl_id.pixel);
+        auto pitch = module.pixel.get_pitch();
 
         measurements.reserve(clusters.size());
         for (const auto &cluster : clusters.get_items()) {
@@ -82,6 +81,7 @@ struct measurement_creation
                 continue;
             }
 
+            const auto &cl_id = clusters.at(0).header;
             for (const auto &cell : cluster) {
                 scalar weight = signal_cell_modelling(cell.activation);
                 if (weight > cl_id.threshold) {

--- a/core/include/traccc/clusterization/measurement_creation.hpp
+++ b/core/include/traccc/clusterization/measurement_creation.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "traccc/clusterization/measurement_creation_helper.hpp"
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/cluster.hpp"
@@ -82,23 +83,9 @@ struct measurement_creation
             }
 
             const auto &cl_id = clusters.at(0).header;
-            for (const auto &cell : cluster) {
-                scalar weight = signal_cell_modelling(cell.activation, cl_id);
-                if (weight > cl_id.threshold) {
-                    totalWeight += cell.activation;
-                    const point2 cell_position =
-                        position_from_cell(cell, cl_id);
+            for (const auto &cell : cluster)
+                calc_cluster_properties(cell, cl_id, mean, var, totalWeight);
 
-                    const point2 prev = mean;
-                    const point2 diff = cell_position - prev;
-
-                    mean = prev + (weight / totalWeight) * diff;
-                    for (std::size_t i = 0; i < 2; ++i) {
-                        var[i] = var[i] + weight * (diff[i]) *
-                                              (cell_position[i] - mean[i]);
-                    }
-                }
-            }
             if (totalWeight > 0.) {
                 measurement m;
                 // normalize the cell position

--- a/core/include/traccc/clusterization/measurement_creation.hpp
+++ b/core/include/traccc/clusterization/measurement_creation.hpp
@@ -59,7 +59,8 @@ struct measurement_creation
                     output_type &measurements) const {
 
         // Run the algorithm
-        auto pitch = module.pixel.get_pitch();
+        const auto &cl_id = clusters.at(0).header;
+        auto pitch = get_pitch(cl_id.module_idx, cl_id.pixel);
 
         measurements.reserve(clusters.size());
         for (const auto &cluster : clusters.get_items()) {
@@ -81,13 +82,12 @@ struct measurement_creation
                 continue;
             }
 
-            const auto &cl_id = clusters.at(0).header;
             for (const auto &cell : cluster) {
                 scalar weight = signal_cell_modelling(cell.activation);
                 if (weight > cl_id.threshold) {
                     totalWeight += cell.activation;
                     const point2 cell_position =
-                        cl_id.position_from_cell(cell.channel0, cell.channel1);
+                        position_from_cell(cl_id.module_idx, cell, cl_id.pixel, cl_id.is_default);
 
                     const point2 prev = mean;
                     const point2 diff = cell_position - prev;

--- a/core/include/traccc/clusterization/measurement_creation.hpp
+++ b/core/include/traccc/clusterization/measurement_creation.hpp
@@ -82,9 +82,12 @@ struct measurement_creation
                 continue;
             }
 
+            // Get the cluster id for this module
             const auto &cl_id = clusters.at(0).header;
-            for (const auto &cell : cluster)
-                calc_cluster_properties(cell, cl_id, mean, var, totalWeight);
+
+            // Calculate the cluster properties
+            calc_cluster_properties<vecmem::vector>(cluster, cl_id, mean, var,
+                                                    totalWeight);
 
             if (totalWeight > 0.) {
                 measurement m;

--- a/core/include/traccc/clusterization/measurement_creation.hpp
+++ b/core/include/traccc/clusterization/measurement_creation.hpp
@@ -86,8 +86,8 @@ struct measurement_creation
                 scalar weight = signal_cell_modelling(cell.activation);
                 if (weight > cl_id.threshold) {
                     totalWeight += cell.activation;
-                    const point2 cell_position =
-                        position_from_cell(cl_id.module_idx, cell, cl_id.pixel, cl_id.is_default);
+                    const point2 cell_position = position_from_cell(
+                        cl_id.module_idx, cell, cl_id.pixel, cl_id.is_default);
 
                     const point2 prev = mean;
                     const point2 diff = cell_position - prev;

--- a/core/include/traccc/clusterization/measurement_creation_helper.hpp
+++ b/core/include/traccc/clusterization/measurement_creation_helper.hpp
@@ -1,0 +1,57 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/common.hpp"
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/cluster.hpp"
+
+namespace traccc {
+
+TRACCC_HOST_DEVICE
+inline scalar signal_cell_modelling(scalar signal_in,
+                                    const cluster_id& /*cl_id*/) {
+    // Retrieve the signal based on the cl_id.module_idx
+    return signal_in;
+}
+
+/// Function for pixel segmentation
+TRACCC_HOST_DEVICE
+inline vector2 position_from_cell(cell c, cluster_id cl_id) {
+    // Retrieve the specific values based on module idx
+    return {cl_id.pixel.min_center_x + c.channel0 * cl_id.pixel.pitch_x,
+            cl_id.pixel.min_center_y + c.channel1 * cl_id.pixel.pitch_y};
+}
+
+TRACCC_HOST_DEVICE
+inline vector2 get_pitch(cluster_id cl_id) {
+    // return the values based on the module idx
+    return {cl_id.pixel.pitch_x, cl_id.pixel.pitch_y};
+}
+
+TRACCC_HOST_DEVICE
+inline void calc_cluster_properties(const cell& c, const cluster_id& cl_id,
+                                    point2& mean, point2& var,
+                                    scalar& totalWeight) {
+    scalar weight = signal_cell_modelling(c.activation, cl_id);
+    if (weight > cl_id.threshold) {
+        totalWeight += c.activation;
+        const point2 cell_position = position_from_cell(c, cl_id);
+        const point2 prev = mean;
+        const point2 diff = cell_position - prev;
+
+        mean = prev + (weight / totalWeight) * diff;
+        for (std::size_t i = 0; i < 2; ++i) {
+            var[i] = var[i] + weight * (diff[i]) * (cell_position[i] - mean[i]);
+        }
+    }
+}
+
+}  // namespace traccc

--- a/core/include/traccc/clusterization/measurement_creation_helper.hpp
+++ b/core/include/traccc/clusterization/measurement_creation_helper.hpp
@@ -38,10 +38,10 @@ inline vector2 get_pitch(cluster_id cl_id) {
 
 /// Function used for calculating the properties of the cluster inside
 /// measurement creation
-template <template <typename> class vector_type>
+template <template <typename> class vector_type, typename cell_t>
 TRACCC_HOST_DEVICE inline void calc_cluster_properties(
-    const cell_collection<vector_type>& cluster, const cluster_id& cl_id,
-    point2& mean, point2& var, scalar& totalWeight) {
+    const vector_type<cell_t>& cluster, const cluster_id& cl_id, point2& mean,
+    point2& var, scalar& totalWeight) {
     for (const auto& cell : cluster) {
         scalar weight = signal_cell_modelling(cell.activation, cl_id);
         if (weight > cl_id.threshold) {

--- a/core/include/traccc/clusterization/measurement_creation_helper.hpp
+++ b/core/include/traccc/clusterization/measurement_creation_helper.hpp
@@ -15,10 +15,10 @@
 
 namespace traccc {
 
+/// Function used for retrieving the cell signal based on the module id
 TRACCC_HOST_DEVICE
 inline scalar signal_cell_modelling(scalar signal_in,
                                     const cluster_id& /*cl_id*/) {
-    // Retrieve the signal based on the cl_id.module_idx
     return signal_in;
 }
 
@@ -36,20 +36,25 @@ inline vector2 get_pitch(cluster_id cl_id) {
     return {cl_id.pixel.pitch_x, cl_id.pixel.pitch_y};
 }
 
-TRACCC_HOST_DEVICE
-inline void calc_cluster_properties(const cell& c, const cluster_id& cl_id,
-                                    point2& mean, point2& var,
-                                    scalar& totalWeight) {
-    scalar weight = signal_cell_modelling(c.activation, cl_id);
-    if (weight > cl_id.threshold) {
-        totalWeight += c.activation;
-        const point2 cell_position = position_from_cell(c, cl_id);
-        const point2 prev = mean;
-        const point2 diff = cell_position - prev;
+/// Function used for calculating the properties of the cluster inside
+/// measurement creation
+template <template <typename> class vector_type>
+TRACCC_HOST_DEVICE inline void calc_cluster_properties(
+    const cell_collection<vector_type>& cluster, const cluster_id& cl_id,
+    point2& mean, point2& var, scalar& totalWeight) {
+    for (const auto& cell : cluster) {
+        scalar weight = signal_cell_modelling(cell.activation, cl_id);
+        if (weight > cl_id.threshold) {
+            totalWeight += cell.activation;
+            const point2 cell_position = position_from_cell(cell, cl_id);
+            const point2 prev = mean;
+            const point2 diff = cell_position - prev;
 
-        mean = prev + (weight / totalWeight) * diff;
-        for (std::size_t i = 0; i < 2; ++i) {
-            var[i] = var[i] + weight * (diff[i]) * (cell_position[i] - mean[i]);
+            mean = prev + (weight / totalWeight) * diff;
+            for (std::size_t i = 0; i < 2; ++i) {
+                var[i] =
+                    var[i] + weight * (diff[i]) * (cell_position[i] - mean[i]);
+            }
         }
     }
 }

--- a/core/include/traccc/edm/cell.hpp
+++ b/core/include/traccc/edm/cell.hpp
@@ -70,8 +70,22 @@ using cell_collection = vector_t<cell>;
 
 /// Convenience declaration for the cell collection type to use in host code
 using host_cell_collection = cell_collection<vecmem::vector>;
+
 /// Convenience declaration for the cell collection type to use in device code
 using device_cell_collection = cell_collection<vecmem::device_vector>;
+
+/// Container of cells belonging to one detector module (const)
+template <template <typename> class vector_t>
+using cell_const_collection = vector_t<const cell>;
+
+/// Convenience declaration for the cell collection type to use in host code
+/// (const)
+using host_cell_const_collection = cell_const_collection<vecmem::vector>;
+
+/// Convenience declaration for the cell collection type to use in device code
+/// (const)
+using device_cell_const_collection =
+    cell_const_collection<vecmem::device_vector>;
 
 /// Header information for all of the cells in a specific detector module
 ///

--- a/core/include/traccc/edm/cell.hpp
+++ b/core/include/traccc/edm/cell.hpp
@@ -91,15 +91,17 @@ struct cell_module {
     pixel_segmentation pixel{-8.425, -36.025, 0.05, 0.05};
 };  // struct cell_module
 
-/// Container of cell modules 
+/// Container of cell modules
 template <template <typename> class vector_t>
-using cell_module_collection = vector_t <cell_module>;
+using cell_module_collection = vector_t<cell_module>;
 
-/// Convenience declaration for the cell module collection type to use in host code
+/// Convenience declaration for the cell module collection type to use in host
+/// code
 using host_cell_module_collection = cell_module_collection<vecmem::vector>;
-/// Convenience declaration for the cell module collection type to use in device code
-using device_cell_module_collection = cell_module_collection<vecmem::device_vector>;
-
+/// Convenience declaration for the cell module collection type to use in device
+/// code
+using device_cell_module_collection =
+    cell_module_collection<vecmem::device_vector>;
 
 /// Convenience declaration for the cell container type to use in host code
 using host_cell_container = host_container<cell_module, cell>;

--- a/core/include/traccc/edm/cell.hpp
+++ b/core/include/traccc/edm/cell.hpp
@@ -91,6 +91,16 @@ struct cell_module {
     pixel_segmentation pixel{-8.425, -36.025, 0.05, 0.05};
 };  // struct cell_module
 
+/// Container of cell modules 
+template <template <typename> class vector_t>
+using cell_module_collection = vector_t <cell_module>;
+
+/// Convenience declaration for the cell module collection type to use in host code
+using host_cell_module_collection = cell_module_collection<vecmem::vector>;
+/// Convenience declaration for the cell module collection type to use in device code
+using device_cell_module_collection = cell_module_collection<vecmem::device_vector>;
+
+
 /// Convenience declaration for the cell container type to use in host code
 using host_cell_container = host_container<cell_module, cell>;
 

--- a/core/include/traccc/edm/cell.hpp
+++ b/core/include/traccc/edm/cell.hpp
@@ -10,7 +10,7 @@
 // traccc include(s).
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/container.hpp"
-#include "traccc/geometry/pixel_segmentation.hpp"
+#include "traccc/geometry/pixel_data.hpp"
 
 // VecMem include(s).
 #include <vecmem/containers/data/jagged_vector_buffer.hpp>
@@ -88,7 +88,7 @@ struct cell_module {
     channel_id range0[2] = {std::numeric_limits<channel_id>::max(), 0};
     channel_id range1[2] = {std::numeric_limits<channel_id>::max(), 0};
 
-    pixel_segmentation pixel{-8.425, -36.025, 0.05, 0.05};
+    pixel_data pixel{-8.425, -36.025, 0.05, 0.05};
 };  // struct cell_module
 
 /// Container of cell modules

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -60,23 +60,4 @@ using cluster_container_view = container_view<cluster_id, cell>;
 using cluster_container_const_view =
     container_view<const cluster_id, const cell>;
 
-/// Function for signal modelling
-inline scalar signal_cell_modelling(scalar signal_in,
-                                    const cluster_id& /*cl_id*/) {
-    // Retrieve the signal based on the cl_id.module_idx
-    return signal_in;
-}
-
-/// Function for pixel segmentation
-inline vector2 position_from_cell(cell c, cluster_id cl_id) {
-    // Retrieve the specific values based on module idx
-    return {cl_id.pixel.min_center_x + c.channel0 * cl_id.pixel.pitch_x,
-            cl_id.pixel.min_center_y + c.channel1 * cl_id.pixel.pitch_y};
-}
-
-inline vector2 get_pitch(cluster_id cl_id) {
-    // return the values based on the module idx
-    return {cl_id.pixel.pitch_x, cl_id.pixel.pitch_y};
-}
-
 }  // namespace traccc

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -17,32 +17,10 @@
 
 namespace traccc {
 
-/// Function for signal modelling
-inline scalar signal_cell_modelling(scalar signal_in) {
-    return signal_in;
-}
-
-/// Function for pixel segmentation
-inline vector2 position_from_cell(cell c, pixel_data pixel, bool is_default) {
-    if (is_default)
-        return {static_cast<scalar>(c.channel0),
-                static_cast<scalar>(c.channel1)};
-    else
-        // Retrieve the specific values based on module idx (for now hard-coded)
-        return {pixel.min_center_x + c.channel0 * pixel.pitch_x,
-                pixel.min_center_y + c.channel1 * pixel.pitch_y};
-}
-
-inline vector2 get_pitch(pixel_data pixel) {
-    // return the values based on the module idx (for now hard-coded)
-    return {pixel.pitch_x, pixel.pitch_y};
-}
-
-using position_estimation = std::function<vector2(channel_id, channel_id)>;
 struct cluster_id {
 
     event_id event = 0;
-    scalar module_idx = 0;
+    std::size_t module_idx = 0;
     geometry_id module = 0;
     transform3 placement = transform3{};
     scalar threshold = 0.;
@@ -83,5 +61,28 @@ using cluster_container_view = container_view<cluster_id, cell>;
 /// code (const)
 using cluster_container_const_view =
     container_view<const cluster_id, const cell>;
+
+/// Function for signal modelling
+inline scalar signal_cell_modelling(scalar signal_in,
+                                    const cluster_id& /*cl_id*/) {
+    // Retrieve the signal based on the cl_id.module_idx
+    return signal_in;
+}
+
+/// Function for pixel segmentation
+inline vector2 position_from_cell(cell c, cluster_id cl_id) {
+    if (cl_id.is_default)
+        return {static_cast<scalar>(c.channel0),
+                static_cast<scalar>(c.channel1)};
+    else
+        // Retrieve the specific values based on module idx
+        return {cl_id.pixel.min_center_x + c.channel0 * cl_id.pixel.pitch_x,
+                cl_id.pixel.min_center_y + c.channel1 * cl_id.pixel.pitch_y};
+}
+
+inline vector2 get_pitch(cluster_id cl_id) {
+    // return the values based on the module idx
+    return {cl_id.pixel.pitch_x, cl_id.pixel.pitch_y};
+}
 
 }  // namespace traccc

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -9,11 +9,13 @@
 
 // Project include(s).
 #include "traccc/edm/cell.hpp"
-#include "traccc/geometry/pixel_segmentation.hpp"
+#include "traccc/geometry/pixel_data.hpp"
 
 // System include(s).
 #include <functional>
 #include <vector>
+
+#include <iostream>
 
 namespace traccc {
 
@@ -22,6 +24,21 @@ inline scalar signal_cell_modelling(scalar signal_in) {
     return signal_in;
 }
 
+/// Function for pixel segmentation
+inline vector2 position_from_cell(scalar module_idx, cell c, pixel_data pixel, bool is_default) {
+    if (is_default) 
+        return {static_cast<scalar>(c.channel0), static_cast<scalar>(c.channel1)};
+    else
+        // Retrieve the specific values based on module idx (for now hard-coded)
+        return {pixel.min_center_x + c.channel0 * pixel.pitch_x, pixel.min_center_y + c.channel1 * pixel.pitch_y}; 
+}
+
+inline vector2 get_pitch(scalar module_idx, pixel_data pixel) {
+    // return the values based on the module idx (for now hard-coded)
+    return {pixel.pitch_x, pixel.pitch_y}; 
+}
+
+using position_estimation = std::function<vector2(channel_id, channel_id)>;
 struct cluster_id {
 
     event_id event = 0;
@@ -30,7 +47,8 @@ struct cluster_id {
     transform3 placement = transform3{};
     scalar threshold = 0.;
 
-    pixel_segmentation position_from_cell{};
+    pixel_data pixel;
+    bool is_default = true;
 };
 
 /// Convenience declaration for the cluster container type to use in host code

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -18,7 +18,7 @@
 namespace traccc {
 
 /// Function for signal modelling
-static scalar signal_cell_modelling(scalar signal_in) {
+static inline scalar signal_cell_modelling(scalar signal_in) {
     return signal_in; 
 }
 

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -24,9 +24,7 @@ struct cluster_id {
     geometry_id module = 0;
     transform3 placement = transform3{};
     scalar threshold = 0.;
-
     pixel_data pixel;
-    bool is_default = true;
 };
 
 /// Convenience declaration for the cluster container type to use in host code
@@ -71,13 +69,9 @@ inline scalar signal_cell_modelling(scalar signal_in,
 
 /// Function for pixel segmentation
 inline vector2 position_from_cell(cell c, cluster_id cl_id) {
-    if (cl_id.is_default)
-        return {static_cast<scalar>(c.channel0),
-                static_cast<scalar>(c.channel1)};
-    else
-        // Retrieve the specific values based on module idx
-        return {cl_id.pixel.min_center_x + c.channel0 * cl_id.pixel.pitch_x,
-                cl_id.pixel.min_center_y + c.channel1 * cl_id.pixel.pitch_y};
+    // Retrieve the specific values based on module idx
+    return {cl_id.pixel.min_center_x + c.channel0 * cl_id.pixel.pitch_x,
+            cl_id.pixel.min_center_y + c.channel1 * cl_id.pixel.pitch_y};
 }
 
 inline vector2 get_pitch(cluster_id cl_id) {

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/edm/cell.hpp"
+#include "traccc/geometry/pixel_segmentation.hpp"
 
 // System include(s).
 #include <functional>
@@ -16,24 +17,21 @@
 
 namespace traccc {
 
-using position_estimation = std::function<vector2(channel_id, channel_id)>;
-using signal_modeling = std::function<scalar(scalar)>;
+/// Function for signal modelling
+static scalar signal_cell_modelling(scalar signal_in) {
+    return signal_in; 
+}
 
 struct cluster_id {
 
     event_id event = 0;
+    scalar module_idx = 0;
     geometry_id module = 0;
     transform3 placement = transform3{};
-
-    position_estimation position_from_cell = [](channel_id ch0,
-                                                channel_id ch1) -> vector2 {
-        return {static_cast<scalar>(ch0), static_cast<scalar>(ch1)};
-    };
-
     scalar threshold = 0.;
-    signal_modeling signal = [](scalar signal_in) -> scalar {
-        return signal_in;
-    };
+
+    pixel_segmentation position_from_cell{};
+
 };
 
 /// Convenience declaration for the cluster container type to use in host code
@@ -42,9 +40,16 @@ using host_cluster_container = host_container<cluster_id, cell>;
 /// Convenience declaration for the cluster container type to use in device code
 using device_cluster_container = device_container<cluster_id, cell>;
 
+/// Convenience declaration for the cluster container type to use in device code (const)
+using device_cluster_const_container = device_container<const cluster_id, const cell>;
+
 /// Convenience declaration for the cluster container data type to use in host
 /// code
 using cluster_container_data = container_data<cluster_id, cell>;
+
+/// Convenience declaration for the cluster container data type to use in host
+/// code (const)
+using cluster_container_const_data = container_data<const cluster_id, const cell>;
 
 /// Convenience declaration for the cluster container buffer type to use in host
 /// code
@@ -53,5 +58,9 @@ using cluster_container_buffer = container_buffer<cluster_id, cell>;
 /// Convenience declaration for the cluster container view type to use in host
 /// code
 using cluster_container_view = container_view<cluster_id, cell>;
+
+/// Convenience declaration for the cluster container view type to use in host
+/// code (const)
+using cluster_container_const_view = container_view<const cluster_id, const cell>;
 
 }  // namespace traccc

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -19,7 +19,7 @@ namespace traccc {
 
 /// Function for signal modelling
 static inline scalar signal_cell_modelling(scalar signal_in) {
-    return signal_in; 
+    return signal_in;
 }
 
 struct cluster_id {
@@ -31,7 +31,6 @@ struct cluster_id {
     scalar threshold = 0.;
 
     pixel_segmentation position_from_cell{};
-
 };
 
 /// Convenience declaration for the cluster container type to use in host code
@@ -40,8 +39,10 @@ using host_cluster_container = host_container<cluster_id, cell>;
 /// Convenience declaration for the cluster container type to use in device code
 using device_cluster_container = device_container<cluster_id, cell>;
 
-/// Convenience declaration for the cluster container type to use in device code (const)
-using device_cluster_const_container = device_container<const cluster_id, const cell>;
+/// Convenience declaration for the cluster container type to use in device code
+/// (const)
+using device_cluster_const_container =
+    device_container<const cluster_id, const cell>;
 
 /// Convenience declaration for the cluster container data type to use in host
 /// code
@@ -49,7 +50,8 @@ using cluster_container_data = container_data<cluster_id, cell>;
 
 /// Convenience declaration for the cluster container data type to use in host
 /// code (const)
-using cluster_container_const_data = container_data<const cluster_id, const cell>;
+using cluster_container_const_data =
+    container_data<const cluster_id, const cell>;
 
 /// Convenience declaration for the cluster container buffer type to use in host
 /// code
@@ -61,6 +63,7 @@ using cluster_container_view = container_view<cluster_id, cell>;
 
 /// Convenience declaration for the cluster container view type to use in host
 /// code (const)
-using cluster_container_const_view = container_view<const cluster_id, const cell>;
+using cluster_container_const_view =
+    container_view<const cluster_id, const cell>;
 
 }  // namespace traccc

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -23,8 +23,7 @@ inline scalar signal_cell_modelling(scalar signal_in) {
 }
 
 /// Function for pixel segmentation
-inline vector2 position_from_cell(scalar module_idx, cell c, pixel_data pixel,
-                                  bool is_default) {
+inline vector2 position_from_cell(cell c, pixel_data pixel, bool is_default) {
     if (is_default)
         return {static_cast<scalar>(c.channel0),
                 static_cast<scalar>(c.channel1)};
@@ -34,7 +33,7 @@ inline vector2 position_from_cell(scalar module_idx, cell c, pixel_data pixel,
                 pixel.min_center_y + c.channel1 * pixel.pitch_y};
 }
 
-inline vector2 get_pitch(scalar module_idx, pixel_data pixel) {
+inline vector2 get_pitch(pixel_data pixel) {
     // return the values based on the module idx (for now hard-coded)
     return {pixel.pitch_x, pixel.pitch_y};
 }

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -18,7 +18,7 @@
 namespace traccc {
 
 /// Function for signal modelling
-static inline scalar signal_cell_modelling(scalar signal_in) {
+inline scalar signal_cell_modelling(scalar signal_in) {
     return signal_in;
 }
 

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -13,9 +13,8 @@
 
 // System include(s).
 #include <functional>
-#include <vector>
-
 #include <iostream>
+#include <vector>
 
 namespace traccc {
 
@@ -25,17 +24,20 @@ inline scalar signal_cell_modelling(scalar signal_in) {
 }
 
 /// Function for pixel segmentation
-inline vector2 position_from_cell(scalar module_idx, cell c, pixel_data pixel, bool is_default) {
-    if (is_default) 
-        return {static_cast<scalar>(c.channel0), static_cast<scalar>(c.channel1)};
+inline vector2 position_from_cell(scalar module_idx, cell c, pixel_data pixel,
+                                  bool is_default) {
+    if (is_default)
+        return {static_cast<scalar>(c.channel0),
+                static_cast<scalar>(c.channel1)};
     else
         // Retrieve the specific values based on module idx (for now hard-coded)
-        return {pixel.min_center_x + c.channel0 * pixel.pitch_x, pixel.min_center_y + c.channel1 * pixel.pitch_y}; 
+        return {pixel.min_center_x + c.channel0 * pixel.pitch_x,
+                pixel.min_center_y + c.channel1 * pixel.pitch_y};
 }
 
 inline vector2 get_pitch(scalar module_idx, pixel_data pixel) {
     // return the values based on the module idx (for now hard-coded)
-    return {pixel.pitch_x, pixel.pitch_y}; 
+    return {pixel.pitch_x, pixel.pitch_y};
 }
 
 using position_estimation = std::function<vector2(channel_id, channel_id)>;

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -13,7 +13,6 @@
 
 // System include(s).
 #include <functional>
-#include <iostream>
 #include <vector>
 
 namespace traccc {

--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -8,8 +8,8 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/common.hpp"
+#include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/container.hpp"
 

--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -36,6 +36,13 @@ inline bool operator<(const measurement& lhs, const measurement& rhs) {
     return false;
 }
 
+inline bool operator==(const measurement& lhs, const measurement& rhs) {
+    return (lhs.local[0] == rhs.local[0] &&
+            lhs.local[1] == rhs.local[1] &&
+            lhs.variance[0] == rhs.variance[0] &&
+            lhs.variance[1] == rhs.variance[1]); 
+}
+
 /// Container of measurements belonging to one detector module
 template <template <typename> class vector_t>
 using measurement_collection = vector_t<measurement>;

--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/common.hpp"
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/container.hpp"
 
@@ -37,10 +38,10 @@ inline bool operator<(const measurement& lhs, const measurement& rhs) {
 }
 
 inline bool operator==(const measurement& lhs, const measurement& rhs) {
-    return (lhs.local[0] == rhs.local[0] &&
-            lhs.local[1] == rhs.local[1] &&
-            lhs.variance[0] == rhs.variance[0] &&
-            lhs.variance[1] == rhs.variance[1]); 
+    return (std::abs(lhs.local[0] - rhs.local[0]) < float_epsilon &&
+            std::abs(lhs.local[1] - rhs.local[1]) < float_epsilon &&
+            std::abs(lhs.variance[0] - rhs.variance[0]) < float_epsilon &&
+            std::abs(lhs.variance[1] - rhs.variance[1]) < float_epsilon);
 }
 
 /// Container of measurements belonging to one detector module

--- a/core/include/traccc/geometry/pixel_data.hpp
+++ b/core/include/traccc/geometry/pixel_data.hpp
@@ -21,6 +21,8 @@ struct pixel_data {
     scalar min_center_y;
     scalar pitch_x;
     scalar pitch_y;
+
+    vector2 get_pitch() const { return {pitch_x, pitch_y}; };
 };
 
 }  // namespace traccc

--- a/core/include/traccc/geometry/pixel_data.hpp
+++ b/core/include/traccc/geometry/pixel_data.hpp
@@ -17,10 +17,10 @@ namespace traccc {
 /// No checking on out of bounds done
 struct pixel_data {
 
-    scalar min_center_x;
-    scalar min_center_y;
-    scalar pitch_x;
-    scalar pitch_y;
+    scalar min_center_x = 0.;
+    scalar min_center_y = 0.;
+    scalar pitch_x = 1.;
+    scalar pitch_y = 1.;
 
     vector2 get_pitch() const { return {pitch_x, pitch_y}; };
 };

--- a/core/include/traccc/geometry/pixel_data.hpp
+++ b/core/include/traccc/geometry/pixel_data.hpp
@@ -15,21 +15,12 @@ namespace traccc {
 /// a minimum corner and ptich x/y
 ///
 /// No checking on out of bounds done
-struct pixel_segmentation {
+struct pixel_data {
 
     scalar min_center_x;
     scalar min_center_y;
     scalar pitch_x;
     scalar pitch_y;
-
-    /// Translate @param ch0, @param ch1
-    /// into a vector2 at @return for a pixel segemntation
-    vector2 operator()(channel_id ch0, channel_id ch1) const {
-        return {min_center_x + ch0 * pitch_x, min_center_y + ch1 * pitch_y};
-    };
-
-    /// get width
-    vector2 get_pitch() const { return {pitch_x, pitch_y}; };
 };
 
 }  // namespace traccc

--- a/core/include/traccc/geometry/pixel_segmentation.hpp
+++ b/core/include/traccc/geometry/pixel_segmentation.hpp
@@ -24,7 +24,7 @@ struct pixel_segmentation {
 
     /// Translate @param ch0, @param ch1
     /// into a vector2 at @return for a pixel segemntation
-    vector2 operator()(channel_id ch0, channel_id ch1) {
+    vector2 operator()(channel_id ch0, channel_id ch1) const {
         return {min_center_x + ch0 * pitch_x, min_center_y + ch1 * pitch_y};
     };
 

--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -14,12 +14,15 @@ enable_language( SYCL )
 # Set up the build of the traccc::sycl library.
 traccc_add_library( traccc_sycl sycl TYPE SHARED
   # header files
-  "include/traccc/sycl/seeding/seed_finding.hpp"
+  "include/traccc/sycl/clusterization/clusterization_algorithm.hpp"
+  "include/traccc/sycl/clusterization/measurement_creation.hpp"
   "include/traccc/sycl/seeding/seeding_algorithm.hpp"
+  "include/traccc/sycl/seeding/seed_finding.hpp"
   "include/traccc/sycl/seeding/spacepoint_binning.hpp"
   "include/traccc/sycl/seeding/track_params_estimation.hpp"
   "include/traccc/sycl/utils/queue_wrapper.hpp"
   # implementation files
+  "src/clusterization/measurement_creation.sycl"
   "src/seeding/doublet_counter.hpp"
   "src/seeding/doublet_counting.hpp"
   "src/seeding/doublet_counting.sycl"

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -75,6 +75,10 @@ class clusterization_algorithm
                 cells_per_event.at(i).items, cells_per_event.at(i).header);
 
             // Save the clusters per module size 
+            // NOTE: the +1 comes from a crash while running the code on the CUDA backend
+            // In that case, the jagged vector buffer used for measurments seems not to have enough capacity 
+            // which seems wrong because the number of measurments per module (the inner vector)
+            // cannot exceed the number of clusters per module
             cluster_sizes[i] = clusters_per_module.size()+1;
 
             // Add module information to the cluster headers
@@ -89,9 +93,9 @@ class clusterization_algorithm
             }
         }
 
-        // Perform measurements creation in parallel on a GPU
+        // Perform measurement creation across clusters  from all modules in parallel 
         measurements_per_event =
-            mt->operator()(clusters, cluster_sizes, cells_per_event);
+            mt->operator()(clusters, cluster_sizes, cells_per_event.get_headers());
 
         // Perform the spacepoint creation
         for (std::size_t i = 0; i < cells_per_event.size(); ++i) {

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -63,9 +63,8 @@ class clusterization_algorithm
         // reserve the vector size
         spacepoints_per_event.reserve(cells_per_event.size());
 
-        // Container for all the clusters and the number of clusters per module
+        // Container for all the clusters 
         traccc::host_cluster_container clusters(&m_mr.get());
-        std::vector<std::size_t> cluster_sizes(cells_per_event.size());
 
         // The algorithmic code part: start
 
@@ -75,14 +74,6 @@ class clusterization_algorithm
 
             traccc::host_cluster_container clusters_per_module = cc->operator()(
                 cells_per_event.at(i).items, cells_per_event.at(i).header);
-
-            // Save the clusters per module size
-            // NOTE: the +1 comes from a crash while running the code on the
-            // CUDA backend In that case, the jagged vector buffer used for
-            // measurments seems not to have enough capacity which seems wrong
-            // because the number of measurments per module (the inner vector)
-            // cannot exceed the number of clusters per module
-            cluster_sizes[i] = clusters_per_module.size() + 1;
 
             // Add module information to the cluster headers
             for (std::size_t j = 0; j < clusters_per_module.size(); ++j) {
@@ -100,7 +91,7 @@ class clusterization_algorithm
 
         // Perform measurement creation across clusters from all modules in
         // parallel
-        measurements_per_event = mt->operator()(clusters, cluster_sizes,
+        measurements_per_event = mt->operator()(clusters,
                                                 cells_per_event.get_headers());
 
         // Perform the spacepoint creation

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -12,7 +12,7 @@
 #include "traccc/edm/internal_spacepoint.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
-#include "traccc/geometry/pixel_segmentation.hpp"
+#include "traccc/geometry/pixel_data.hpp"
 
 // clusterization
 #include "traccc/clusterization/component_connection.hpp"
@@ -88,8 +88,9 @@ class clusterization_algorithm
             for (std::size_t j = 0; j < clusters_per_module.size(); ++j) {
 
                 auto& cluster_id = clusters_per_module.at(j).header;
-                cluster_id.position_from_cell = module.pixel;
+                cluster_id.is_default = false;
                 cluster_id.module_idx = i;
+                cluster_id.pixel = module.pixel;
 
                 // Push the clusters from module to the total cluster container
                 clusters.push_back(std::move(clusters_per_module.at(j).header),

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -79,7 +79,6 @@ class clusterization_algorithm
             for (std::size_t j = 0; j < clusters_per_module.size(); ++j) {
 
                 auto& cluster_id = clusters_per_module.at(j).header;
-                cluster_id.is_default = false;
                 cluster_id.module_idx = i;
                 cluster_id.pixel = module.pixel;
 

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -7,9 +7,6 @@
 
 #pragma once
 
-#include "traccc/edm/cell.hpp"
-#include "traccc/edm/cluster.hpp"
-#include "traccc/edm/internal_spacepoint.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/geometry/pixel_data.hpp"
@@ -18,10 +15,6 @@
 #include "traccc/clusterization/component_connection.hpp"
 #include "traccc/clusterization/spacepoint_formation.hpp"
 #include "traccc/sycl/clusterization/measurement_creation.hpp"
-
-#ifdef _OPENMP
-#include "omp.h"
-#endif
 
 namespace traccc::sycl {
 

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -63,7 +63,7 @@ class clusterization_algorithm
         // reserve the vector size
         spacepoints_per_event.reserve(cells_per_event.size());
 
-        // Container for all the clusters 
+        // Container for all the clusters
         traccc::host_cluster_container clusters(&m_mr.get());
 
         // The algorithmic code part: start
@@ -91,8 +91,8 @@ class clusterization_algorithm
 
         // Perform measurement creation across clusters from all modules in
         // parallel
-        measurements_per_event = mt->operator()(clusters,
-                                                cells_per_event.get_headers());
+        measurements_per_event =
+            mt->operator()(clusters, cells_per_event.get_headers());
 
         // Perform the spacepoint creation
         for (std::size_t i = 0; i < cells_per_event.size(); ++i) {

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -75,7 +75,7 @@ class clusterization_algorithm
                 cells_per_event.at(i).items, cells_per_event.at(i).header);
 
             // Save the clusters per module size 
-            cluster_sizes[i] = clusters_per_module.size();
+            cluster_sizes[i] = clusters_per_module.size()+1;
 
             // Add module information to the cluster headers
             for (std::size_t j = 0; j < clusters_per_module.size(); ++j){

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -1,0 +1,116 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/edm/cell.hpp"
+#include "traccc/edm/cluster.hpp"
+#include "traccc/edm/internal_spacepoint.hpp"
+#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/spacepoint.hpp"
+#include "traccc/geometry/pixel_segmentation.hpp"
+
+// clusterization
+#include "traccc/clusterization/component_connection.hpp"
+#include "traccc/sycl/clusterization/measurement_creation.hpp"
+#include "traccc/clusterization/spacepoint_formation.hpp"
+
+#ifdef _OPENMP
+#include "omp.h"
+#endif
+
+namespace traccc::sycl {
+
+class clusterization_algorithm
+    : public algorithm<
+          std::pair<host_measurement_container, host_spacepoint_container>(
+              const host_cell_container&)> {
+
+    public:
+    /// Constructor for clusterization algorithm
+    ///
+    /// @param mr is the memory resource
+    clusterization_algorithm(vecmem::memory_resource& mr, ::sycl::queue* q = nullptr) : m_mr(mr) {
+
+        cc = std::make_shared<traccc::component_connection>(
+            traccc::component_connection(mr));
+        mt = std::make_shared<traccc::sycl::measurement_creation>(
+            traccc::sycl::measurement_creation(mr, q));
+        sp = std::make_shared<traccc::spacepoint_formation>(
+            traccc::spacepoint_formation(mr));
+    }
+
+    output_type operator()(
+        const host_cell_container& cells_per_event) const override {
+        output_type o({host_measurement_container(&m_mr.get()),
+                       host_spacepoint_container(&m_mr.get())});
+        this->operator()(cells_per_event, o);
+        return o;
+    }
+
+    void operator()(const host_cell_container& cells_per_event,
+                    output_type& o) const {
+        // output containers
+        auto& measurements_per_event = o.first;
+        auto& spacepoints_per_event = o.second;
+
+        // reserve the vector size
+        spacepoints_per_event.reserve(cells_per_event.size());
+
+        // Container for all the clusters and the number of clusters per module
+        traccc::host_cluster_container clusters(&m_mr.get());
+        std::vector<std::size_t> cluster_sizes(cells_per_event.size());
+
+        // The algorithmic code part: start
+
+        // Perform component connection per module
+        for (std::size_t i = 0; i < cells_per_event.size(); ++i) {
+            auto module = cells_per_event.at(i).header;
+
+            traccc::host_cluster_container clusters_per_module = cc->operator()(
+                cells_per_event.at(i).items, cells_per_event.at(i).header);
+
+            // Save the clusters per module size 
+            cluster_sizes[i] = clusters_per_module.size();
+
+            // Add module information to the cluster headers
+            for (std::size_t j = 0; j < clusters_per_module.size(); ++j){
+
+                auto& cluster_id = clusters_per_module.at(j).header;
+                cluster_id.position_from_cell = module.pixel;
+                cluster_id.module_idx = i;
+                
+                // Push the clusters from module to the total cluster container
+                clusters.push_back(std::move(clusters_per_module.at(j).header), std::move(clusters_per_module.at(j).items));
+            }
+        }
+
+        // Perform measurements creation in parallel on a GPU
+        measurements_per_event =
+            mt->operator()(clusters, cluster_sizes, cells_per_event);
+
+        // Perform the spacepoint creation
+        for (std::size_t i = 0; i < cells_per_event.size(); ++i) {
+            auto module = cells_per_event.at(i).header;
+            traccc::host_spacepoint_collection spacepoints_per_module =
+                sp->operator()(module, measurements_per_event.at(i).items);
+
+            spacepoints_per_event.push_back(module.module,
+                                            std::move(spacepoints_per_module));
+        } 
+        // The algorithmic code part: end
+    }
+
+    private:
+    // algorithms
+    std::shared_ptr<traccc::component_connection> cc;
+    std::shared_ptr<traccc::sycl::measurement_creation> mt;
+    std::shared_ptr<traccc::spacepoint_formation> sp;
+    std::reference_wrapper<vecmem::memory_resource> m_mr;
+};
+
+}  // namespace traccc::sycl

--- a/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
@@ -8,18 +8,21 @@
 #pragma once
 
 // SYCL library include(s).
+#include "traccc/sycl/utils/queue_wrapper.hpp"
+
+// Project include(s).
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/cluster.hpp"
 #include "traccc/edm/measurement.hpp"
-#include "traccc/sycl/utils/queue_wrapper.hpp"
 #include "traccc/utils/algorithm.hpp"
+
 
 namespace traccc::sycl {
 
 struct measurement_creation
     : public algorithm<host_measurement_container(
-          const host_cluster_container &, const std::vector<std::size_t> &,
+          const host_cluster_container &,
           const host_cell_module_collection &)> {
     public:
     /// Constructor for measurement_creation
@@ -38,7 +41,7 @@ struct measurement_creation
     /// measurements as items - usually same size or sometime slightly smaller
     /// than the input (cluster sizes)
     host_measurement_container operator()(
-        const host_cluster_container &c, const std::vector<std::size_t> &s,
+        const host_cluster_container &c, 
         const host_cell_module_collection &l) const override;
 
     /// Callable operator for measurement creation for all the modules
@@ -51,7 +54,6 @@ struct measurement_creation
     /// measurements as items - usually same size or sometime slightly smaller
     /// than the input (cluster sizes)
     void operator()(const host_cluster_container &clusters,
-                    const std::vector<std::size_t> &cluster_sizes,
                     const host_cell_module_collection &cell_modules_per_event,
                     output_type &measurements) const;
 

--- a/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
@@ -8,12 +8,11 @@
 #pragma once
 
 // SYCL library include(s).
-#include "traccc/sycl/utils/queue_wrapper.hpp"
-
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/cluster.hpp"
 #include "traccc/edm/measurement.hpp"
+#include "traccc/sycl/utils/queue_wrapper.hpp"
 #include "traccc/utils/algorithm.hpp"
 
 namespace traccc::sycl {
@@ -27,33 +26,34 @@ struct measurement_creation
     ///
     /// @param mr is the memory resource
     /// @param queue is the sycl queue for kernel invocation
-    measurement_creation(vecmem::memory_resource &mr, queue_wrapper queue); 
+    measurement_creation(vecmem::memory_resource &mr, queue_wrapper queue);
 
     /// Callable operator for measurement creation for all the modules
     ///
     /// @param clusters are the input cells into the connected component
     /// form all the modules
     /// @param cluster_sizes is a vector of number of clusters per each module
-    /// @param cell_modules_per_event is a collection of cell modules 
-    /// @return a measurement container with cell modules for headers and measurements as items - usually same size or sometime
-    /// slightly smaller than the input (cluster sizes)
+    /// @param cell_modules_per_event is a collection of cell modules
+    /// @return a measurement container with cell modules for headers and
+    /// measurements as items - usually same size or sometime slightly smaller
+    /// than the input (cluster sizes)
     host_measurement_container operator()(
-        const host_cluster_container &c,
-        const std::vector<std::size_t> &s,
-        const host_cell_module_collection &l) const override; 
+        const host_cluster_container &c, const std::vector<std::size_t> &s,
+        const host_cell_module_collection &l) const override;
 
     /// Callable operator for measurement creation for all the modules
     ///
     /// @param clusters are the input cells into the connected component
     /// form all the modules
     /// @param cluster_sizes is a vector of number of clusters per each module
-    /// @param cell_modules_per_event is a collection of cell modules 
-    /// @return a measurement container with cell modules for headers and measurements as items - usually same size or sometime
-    /// slightly smaller than the input (cluster sizes)
+    /// @param cell_modules_per_event is a collection of cell modules
+    /// @return a measurement container with cell modules for headers and
+    /// measurements as items - usually same size or sometime slightly smaller
+    /// than the input (cluster sizes)
     void operator()(const host_cluster_container &clusters,
                     const std::vector<std::size_t> &cluster_sizes,
                     const host_cell_module_collection &cell_modules_per_event,
-                    output_type &measurements) const; 
+                    output_type &measurements) const;
 
     private:
     std::reference_wrapper<vecmem::memory_resource> m_mr;

--- a/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
@@ -11,6 +11,7 @@
 #include "traccc/sycl/utils/queue_wrapper.hpp"
 
 // Project include(s).
+#include "traccc/clusterization/measurement_creation_helper.hpp"
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/cluster.hpp"

--- a/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
@@ -1,0 +1,69 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// SYCL library include(s).
+#include "traccc/sycl/utils/queue_wrapper.hpp"
+
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/edm/cell.hpp"
+#include "traccc/edm/cluster.hpp"
+#include "traccc/edm/measurement.hpp"
+#include "traccc/utils/algorithm.hpp"
+
+namespace traccc::sycl {
+
+/// Connected component labeling.
+struct measurement_creation
+    : public algorithm<host_measurement_container(
+          const host_cluster_container &, const std::vector<std::size_t> &,
+          const host_cell_container &)> {
+    public:
+    /// Constructor for measurement_creation
+    ///
+    /// @param mr is the memory resource
+    measurement_creation(vecmem::memory_resource &mr, queue_wrapper queue); 
+
+    /// Callable operator for the connected component, based on one single
+    /// module
+    ///
+    /// @param clusters are the input cells into the connected component, they
+    /// are
+    ///              per module and unordered
+    ///
+    /// C++20 piping interface
+    ///
+    /// @return a measurement collection - usually same size or sometime
+    /// slightly smaller than the input
+    host_measurement_container operator()(
+        const host_cluster_container &c,
+        const std::vector<std::size_t> &s,
+        const host_cell_container &l) const override; 
+
+    /// Callable operator for the connected component, based on one single
+    /// module
+    ///
+    /// @param clusters are the input cells into the connected component, they
+    /// are
+    ///              per module and unordered
+    ///
+    /// void interface
+    ///
+    /// @return a measurement collection - usually same size or sometime
+    /// slightly smaller than the input
+    void operator()(const host_cluster_container &clusters,
+                    const std::vector<std::size_t> &cluster_sizes,
+                    const host_cell_container &cells_per_event,
+                    output_type &measurements) const; 
+
+    private:
+    std::reference_wrapper<vecmem::memory_resource> m_mr;
+    mutable queue_wrapper m_queue;
+};
+
+}  // namespace traccc::sycl

--- a/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
@@ -18,47 +18,41 @@
 
 namespace traccc::sycl {
 
-/// Connected component labeling.
 struct measurement_creation
     : public algorithm<host_measurement_container(
           const host_cluster_container &, const std::vector<std::size_t> &,
-          const host_cell_container &)> {
+          const host_cell_module_collection &)> {
     public:
     /// Constructor for measurement_creation
     ///
     /// @param mr is the memory resource
+    /// @param queue is the sycl queue for kernel invocation
     measurement_creation(vecmem::memory_resource &mr, queue_wrapper queue); 
 
-    /// Callable operator for the connected component, based on one single
-    /// module
+    /// Callable operator for measurement creation for all the modules
     ///
-    /// @param clusters are the input cells into the connected component, they
-    /// are
-    ///              per module and unordered
-    ///
-    /// C++20 piping interface
-    ///
-    /// @return a measurement collection - usually same size or sometime
-    /// slightly smaller than the input
+    /// @param clusters are the input cells into the connected component
+    /// form all the modules
+    /// @param cluster_sizes is a vector of number of clusters per each module
+    /// @param cell_modules_per_event is a collection of cell modules 
+    /// @return a measurement container with cell modules for headers and measurements as items - usually same size or sometime
+    /// slightly smaller than the input (cluster sizes)
     host_measurement_container operator()(
         const host_cluster_container &c,
         const std::vector<std::size_t> &s,
-        const host_cell_container &l) const override; 
+        const host_cell_module_collection &l) const override; 
 
-    /// Callable operator for the connected component, based on one single
-    /// module
+    /// Callable operator for measurement creation for all the modules
     ///
-    /// @param clusters are the input cells into the connected component, they
-    /// are
-    ///              per module and unordered
-    ///
-    /// void interface
-    ///
-    /// @return a measurement collection - usually same size or sometime
-    /// slightly smaller than the input
+    /// @param clusters are the input cells into the connected component
+    /// form all the modules
+    /// @param cluster_sizes is a vector of number of clusters per each module
+    /// @param cell_modules_per_event is a collection of cell modules 
+    /// @return a measurement container with cell modules for headers and measurements as items - usually same size or sometime
+    /// slightly smaller than the input (cluster sizes)
     void operator()(const host_cluster_container &clusters,
                     const std::vector<std::size_t> &cluster_sizes,
-                    const host_cell_container &cells_per_event,
+                    const host_cell_module_collection &cell_modules_per_event,
                     output_type &measurements) const; 
 
     private:

--- a/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/measurement_creation.hpp
@@ -17,13 +17,11 @@
 #include "traccc/edm/measurement.hpp"
 #include "traccc/utils/algorithm.hpp"
 
-
 namespace traccc::sycl {
 
-struct measurement_creation
-    : public algorithm<host_measurement_container(
-          const host_cluster_container &,
-          const host_cell_module_collection &)> {
+struct measurement_creation : public algorithm<host_measurement_container(
+                                  const host_cluster_container &,
+                                  const host_cell_module_collection &)> {
     public:
     /// Constructor for measurement_creation
     ///
@@ -41,7 +39,7 @@ struct measurement_creation
     /// measurements as items - usually same size or sometime slightly smaller
     /// than the input (cluster sizes)
     host_measurement_container operator()(
-        const host_cluster_container &c, 
+        const host_cluster_container &c,
         const host_cell_module_collection &l) const override;
 
     /// Callable operator for measurement creation for all the modules

--- a/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
@@ -23,7 +23,7 @@ namespace traccc {
 namespace sycl {
 
 class seeding_algorithm
-    : public algorithm<host_seed_collection(host_spacepoint_container&&)> {
+    : public algorithm<host_seed_collection(const host_spacepoint_container&)> {
 
     public:
     seeding_algorithm(vecmem::memory_resource& mr, ::sycl::queue* q = nullptr)
@@ -57,7 +57,7 @@ class seeding_algorithm
     }
 
     output_type operator()(
-        host_spacepoint_container&& spacepoints) const override {
+        const host_spacepoint_container& spacepoints) const override {
         output_type seeds(&m_mr.get());
         sp_grid_buffer internal_sp_g2 = (*sb)(spacepoints);
         sp_grid sp_g2(internal_sp_g2._axis_p0, internal_sp_g2._axis_p1,

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -22,7 +22,7 @@ measurement_creation::measurement_creation(vecmem::memory_resource &mr, queue_wr
 host_measurement_container measurement_creation::operator()(
     const host_cluster_container &c,
     const std::vector<std::size_t> &s,
-    const host_cell_container &l) const {
+    const host_cell_module_collection &l) const {
     output_type measurements(&m_mr.get());
     this->operator()(c, s, l, measurements);
     return measurements;
@@ -30,39 +30,41 @@ host_measurement_container measurement_creation::operator()(
 
 void measurement_creation::operator()(const host_cluster_container &clusters,
                 const std::vector<std::size_t> &cluster_sizes,
-                const host_cell_container &cells_per_event,
+                const host_cell_module_collection &cell_modules_per_event,
                 output_type &measurements) const {
-
-    // Calculate the execution range for the kernel
-    // auto workGroupSize = 32;
-    // auto num = (clusters.size() + workGroupSize - 1) / workGroupSize;
-    // auto ndrange = ::sycl::nd_range<1>{::sycl::range<1>(num*workGroupSize), ::sycl::range<1>(workGroupSize)};
-    auto range = ::sycl::range<1>{clusters.size()};
 
     // Resizable buffer for the measurements that will later be copied to the host 
     vecmem::sycl::copy copy{m_queue.queue()};
+    unsigned int size_buf = cell_modules_per_event.size();
+
     vecmem::data::jagged_vector_buffer<measurement> measurements_buffer(std::vector<std::size_t>(cluster_sizes.size(), 0), cluster_sizes, m_mr.get());
-    copy.setup(measurements_buffer);
+    measurement_container_buffer measurement_b{{size_buf, m_mr.get()},
+        {std::vector<std::size_t>(cluster_sizes.size(), 0), cluster_sizes, m_mr.get()}};
+    copy.setup(measurement_b.items);
 
     // Vector views to move data to the device
     vecmem::data::jagged_vector_view<measurement> measurements_view = vecmem::get_data(measurements_buffer);
+    measurement_container_view measurement_view(measurement_b);
     auto clusters_data = get_data(clusters, &m_mr.get());
 
     cluster_container_const_view clusters_view(clusters_data);
     
+    // range of kernel execution
+    auto range = clusters.size();
+
     // Run the kernel
-    details::get_queue(m_queue).submit([&](::sycl::handler& h){
-        h.parallel_for<class measurementCreation>(range, [clusters_view, measurements_view]
-                                                          (::sycl::id<1> idx){
-            // get the thread index
-            // auto idx = item.get_global_linear_id();
+    details::get_queue(m_queue).parallel_for(range, [clusters_view, measurements_view, measurement_view](auto idx) {
 
             // Initialize device vectors
             device_cluster_const_container clusters_device({clusters_view.headers, clusters_view.items});
             vecmem::jagged_device_vector<measurement> measurements_device(measurements_view);
+            device_measurement_container measurement_device({measurement_view.headers, measurement_view.items});
+
             // Ignore if idx out of range 
             if (idx >= clusters_device.size()) return;
 
+            // items: cluster of cells at current idx
+            // header: cluster_id object with the information about the cell module 
             const auto& cluster = clusters_device.get_items().at(idx);
             const auto& cluster_id = clusters_device.get_headers().at(idx);
 
@@ -115,16 +117,18 @@ void measurement_creation::operator()(const host_cluster_container &clusters,
                                                     pitch[1] * pitch[1] / 12};
                 // @todo add variance estimation
                 measurements_device.at(module_idx).push_back(m);
+                measurement_device.get_items().at(module_idx).push_back(m);
             }
-        });
     }).wait_and_throw();
 
     vecmem::jagged_vector<measurement> measurements_jagged_vector(&m_mr.get());
+    copy(measurement_b.items, measurements.get_items());
     copy(measurements_buffer, measurements_jagged_vector);
 
-    for (std::size_t i = 0; i < cells_per_event.size(); ++i) {
-        auto module = cells_per_event.at(i).header;
-        measurements.push_back(module, std::move(measurements_jagged_vector[i]));
+    for (std::size_t i = 0; i < cell_modules_per_event.size(); ++i) {
+        auto module = cell_modules_per_event.at(i);
+        auto& m_header = measurements.get_headers().at(i);
+        m_header = module;
     }
 }
 

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -5,14 +5,14 @@
  * Mozilla Public License Version 2.0
  */
 
-// SYCL library include(s)
+// SYCL library include(s).
 #include "../utils/get_queue.hpp"
 #include "traccc/sycl/clusterization/measurement_creation.hpp"
 
-// SYCL include(s)
+// SYCL include(s).
 #include <CL/sycl.hpp>
 
-// Vecmem include(s)
+// Vecmem include(s).
 #include <vecmem/utils/sycl/copy.hpp>
 
 namespace traccc::sycl {
@@ -22,21 +22,31 @@ measurement_creation::measurement_creation(vecmem::memory_resource &mr,
     : m_mr(mr), m_queue(queue) {}
 
 host_measurement_container measurement_creation::operator()(
-    const host_cluster_container &c, const std::vector<std::size_t> &s,
+    const host_cluster_container &c,
     const host_cell_module_collection &l) const {
     output_type measurements(&m_mr.get());
-    this->operator()(c, s, l, measurements);
+    this->operator()(c, l, measurements);
     return measurements;
 }
 
 void measurement_creation::operator()(
     const host_cluster_container &clusters,
-    const std::vector<std::size_t> &cluster_sizes,
     const host_cell_module_collection &cell_modules_per_event,
     output_type &measurements) const {
 
     vecmem::sycl::copy copy{m_queue.queue()};
     unsigned int size_buf = cell_modules_per_event.size();
+
+    // Retrieve the number of clusters per each module
+    // NOTE: the +1 comes from a crash while running the code on the
+    // CUDA backend In that case, the jagged vector buffer used for
+    // measurments seems not to have enough capacity which seems wrong
+    // because the number of measurments per module (the inner vector)
+    // cannot exceed the number of clusters per module
+    std::vector<std::size_t> cluster_sizes(cell_modules_per_event.size(), 1);
+    for (const auto& cl_id : clusters.get_headers()){
+        cluster_sizes.at(cl_id.module_idx)++;
+    }
 
     // Resizable buffer for the measurements
     measurement_container_buffer measurement_buffer{

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -73,8 +73,7 @@ void measurement_creation::operator()(
                 const auto &cluster = clusters_device.get_items().at(idx);
                 const auto &cluster_id = clusters_device.get_headers().at(idx);
 
-                const auto pitch =
-                    get_pitch(cluster_id.module_idx, cluster_id.pixel);
+                const auto pitch = get_pitch(cluster_id.pixel);
                 const auto module_idx = cluster_id.module_idx;
 
                 scalar totalWeight = 0.;
@@ -101,8 +100,7 @@ void measurement_creation::operator()(
                     if (weight > cluster_id.threshold) {
                         totalWeight += cell.activation;
                         const point2 cell_position = position_from_cell(
-                            cluster_id.module_idx, cell, cluster_id.pixel,
-                            cluster_id.is_default);
+                            cell, cluster_id.pixel, cluster_id.is_default);
                         const point2 prev = mean;
                         const point2 diff = cell_position - prev;
 

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -1,0 +1,131 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL library include(s)
+#include "traccc/sycl/clusterization/measurement_creation.hpp"
+#include "../utils/get_queue.hpp"
+
+// SYCL include(s)
+#include <CL/sycl.hpp>
+
+// Vecmem include(s)
+#include <vecmem/utils/sycl/copy.hpp>
+
+namespace traccc::sycl {
+
+measurement_creation::measurement_creation(vecmem::memory_resource &mr, queue_wrapper queue) : m_mr(mr), m_queue(queue) {}
+
+host_measurement_container measurement_creation::operator()(
+    const host_cluster_container &c,
+    const std::vector<std::size_t> &s,
+    const host_cell_container &l) const {
+    output_type measurements(&m_mr.get());
+    this->operator()(c, s, l, measurements);
+    return measurements;
+}
+
+void measurement_creation::operator()(const host_cluster_container &clusters,
+                const std::vector<std::size_t> &cluster_sizes,
+                const host_cell_container &cells_per_event,
+                output_type &measurements) const {
+
+    // Calculate the execution range for the kernel
+    // auto workGroupSize = 32;
+    // auto num = (clusters.size() + workGroupSize - 1) / workGroupSize;
+    // auto ndrange = ::sycl::nd_range<1>{::sycl::range<1>(num*workGroupSize), ::sycl::range<1>(workGroupSize)};
+    auto range = ::sycl::range<1>{clusters.size()};
+
+    // Resizable buffer for the measurements that will later be copied to the host 
+    vecmem::sycl::copy copy{m_queue.queue()};
+    vecmem::data::jagged_vector_buffer<measurement> measurements_buffer(std::vector<std::size_t>(cluster_sizes.size(), 0), cluster_sizes, m_mr.get());
+    copy.setup(measurements_buffer);
+
+    // Vector views to move data to the device
+    vecmem::data::jagged_vector_view<measurement> measurements_view = vecmem::get_data(measurements_buffer);
+    auto clusters_data = get_data(clusters, &m_mr.get());
+
+    cluster_container_const_view clusters_view(clusters_data);
+    
+    // Run the kernel
+    details::get_queue(m_queue).submit([&](::sycl::handler& h){
+        h.parallel_for<class measurementCreation>(range, [clusters_view, measurements_view]
+                                                          (::sycl::id<1> idx){
+            // // get the thread index
+            // auto idx = item.get_global_linear_id();
+
+            // Initialize device vectors
+            device_cluster_const_container clusters_device({clusters_view.headers, clusters_view.items});
+            vecmem::jagged_device_vector<measurement> measurements_device(measurements_view);
+            // Ignore if idx out of range 
+            if (idx >= clusters_device.size()) return;
+
+            const auto& cluster = clusters_device.get_items().at(idx);
+            const auto& cluster_id = clusters_device.get_headers().at(idx);
+
+            const auto pitch = cluster_id.position_from_cell.get_pitch();
+            const auto module_idx = cluster_id.module_idx; 
+
+            scalar totalWeight = 0.;
+
+            // To calculate the mean and variance with high numerical stability
+            // we use a weighted variant of Welford's algorithm. This is a
+            // single-pass online algorithm that works well for large numbers
+            // of samples, as well as samples with very high values.
+            //
+            // To learn more about this algorithm please refer to:
+            // [1] https://doi.org/10.1080/00401706.1962.10490022
+            // [2] The Art of Computer Programming, Donald E. Knuth, second
+            //     edition, chapter 4.2.2.
+            point2 mean = {0., 0.}, var = {0., 0.};
+
+            // Should not happen
+            if (cluster.empty()) {
+                return;
+            }
+
+            for (const auto& cell : cluster) {
+                scalar weight = signal_cell_modelling(cell.activation);
+                if (weight > cluster_id.threshold) {
+                    totalWeight += cell.activation;
+                    const point2 cell_position =
+                            cluster_id.position_from_cell(cell.channel0, cell.channel1);
+                    const point2 prev = mean;
+                    const point2 diff = cell_position - prev;
+
+                    mean = prev + (weight / totalWeight) * diff;
+                    for (std::size_t i = 0; i < 2; ++i) {
+                        var[i] = var[i] + weight * (diff[i]) *
+                                                (cell_position[i] - mean[i]);
+                    }
+                }
+            }
+            if (totalWeight > 0.) {
+                measurement m;
+                // normalize the cell position
+                m.local = mean;
+                // normalize the variance
+                m.variance[0] = var[0] / totalWeight;
+                m.variance[1] = var[1] / totalWeight;
+                // plus pitch^2 / 12
+                m.variance = m.variance + point2{pitch[0] * pitch[0] / 12,
+                                                    pitch[1] * pitch[1] / 12};
+                // @todo add variance estimation
+                measurements_device.at(module_idx).push_back(m);
+            }
+        });
+    }).wait_and_throw();
+
+    vecmem::jagged_vector<measurement> measurements_jagged_vector(&m_mr.get());
+    copy(measurements_buffer, measurements_jagged_vector);
+
+    for (std::size_t i = 0; i < cells_per_event.size(); ++i) {
+        auto module = cells_per_event.at(i).header;
+        measurements.push_back(module, std::move(measurements_jagged_vector[i]));
+    }
+}
+
+}  // namespace traccc::sycl

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -56,9 +56,8 @@ void measurement_creation::operator()(
     copy.setup(measurement_buffer.items);
 
     // Vector views to move data to the device
-    auto clusters_data =
-        get_data(const_cast<host_cluster_container &>(clusters), &m_mr.get());
-    cluster_container_view clusters_view(clusters_data);
+    auto clusters_data = get_data(clusters, &m_mr.get());
+    cluster_container_const_view clusters_view(clusters_data);
     measurement_container_view measurement_view(measurement_buffer);
 
     // range of kernel execution
@@ -70,7 +69,7 @@ void measurement_creation::operator()(
             range,
             [clusters_view, measurement_view](auto idx) {
                 // Initialize device vectors
-                device_cluster_container clusters_device(clusters_view);
+                device_cluster_const_container clusters_device(clusters_view);
                 device_measurement_container measurement_device(
                     measurement_view);
 
@@ -81,7 +80,7 @@ void measurement_creation::operator()(
                 // items: cluster of cells at current idx
                 // header: cluster_id object with the information about the cell
                 // module
-                const device_cell_collection &cluster =
+                const device_cell_const_collection &cluster =
                     clusters_device.get_items().at(idx);
                 const cluster_id &cl_id = clusters_device.get_headers().at(idx);
 
@@ -107,7 +106,7 @@ void measurement_creation::operator()(
                     return;
                 }
 
-                calc_cluster_properties<vecmem::device_vector>(
+                calc_cluster_properties<vecmem::device_vector, const cell>(
                     cluster, cl_id, mean, var, totalWeight);
 
                 if (totalWeight > 0.) {

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -59,10 +59,9 @@ void measurement_creation::operator()(
             range,
             [clusters_view, measurement_view](auto idx) {
                 // Initialize device vectors
-                device_cluster_const_container clusters_device(
-                    {clusters_view.headers, clusters_view.items});
+                device_cluster_const_container clusters_device(clusters_view);
                 device_measurement_container measurement_device(
-                    {measurement_view.headers, measurement_view.items});
+                    measurement_view);
 
                 // Ignore if idx is out of range
                 if (idx >= clusters_device.size())

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -45,7 +45,7 @@ void measurement_creation::operator()(const host_cluster_container &clusters,
     copy.setup(measurements_buffer);
 
     // Vector views to move data to the device
-    vecmem::data::jagged_vector_view<measurement> measurements_view = vecmem::get_data(measurements_buffer);
+    vecmem::data::jagged_vector_view<measurement> measurements_view(measurements_buffer);
     auto clusters_data = get_data(clusters, &m_mr.get());
 
     cluster_container_const_view clusters_view(clusters_data);
@@ -54,7 +54,7 @@ void measurement_creation::operator()(const host_cluster_container &clusters,
     details::get_queue(m_queue).submit([&](::sycl::handler& h){
         h.parallel_for<class measurementCreation>(range, [clusters_view, measurements_view]
                                                           (::sycl::id<1> idx){
-            // // get the thread index
+            // get the thread index
             // auto idx = item.get_global_linear_id();
 
             // Initialize device vectors

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -54,7 +54,7 @@ void measurement_creation::operator()(const host_cluster_container &clusters,
     details::get_queue(m_queue).submit([&](::sycl::handler& h){
         h.parallel_for<class measurementCreation>(range, [clusters_view, measurements_view]
                                                           (::sycl::id<1> idx){
-            // get the thread index
+            // // get the thread index
             // auto idx = item.get_global_linear_id();
 
             // Initialize device vectors

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -45,7 +45,7 @@ void measurement_creation::operator()(const host_cluster_container &clusters,
     copy.setup(measurements_buffer);
 
     // Vector views to move data to the device
-    vecmem::data::jagged_vector_view<measurement> measurements_view(measurements_buffer);
+    vecmem::data::jagged_vector_view<measurement> measurements_view = vecmem::get_data(measurements_buffer);
     auto clusters_data = get_data(clusters, &m_mr.get());
 
     cluster_container_const_view clusters_view(clusters_data);

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -44,7 +44,7 @@ void measurement_creation::operator()(
     // because the number of measurments per module (the inner vector)
     // cannot exceed the number of clusters per module
     std::vector<std::size_t> cluster_sizes(cell_modules_per_event.size(), 1);
-    for (const auto& cl_id : clusters.get_headers()){
+    for (const auto &cl_id : clusters.get_headers()) {
         cluster_sizes.at(cl_id.module_idx)++;
     }
 

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -56,8 +56,9 @@ void measurement_creation::operator()(
     copy.setup(measurement_buffer.items);
 
     // Vector views to move data to the device
-    auto clusters_data = get_data(clusters, &m_mr.get());
-    cluster_container_const_view clusters_view(clusters_data);
+    auto clusters_data =
+        get_data(const_cast<host_cluster_container &>(clusters), &m_mr.get());
+    cluster_container_view clusters_view(clusters_data);
     measurement_container_view measurement_view(measurement_buffer);
 
     // range of kernel execution
@@ -69,7 +70,7 @@ void measurement_creation::operator()(
             range,
             [clusters_view, measurement_view](auto idx) {
                 // Initialize device vectors
-                device_cluster_const_container clusters_device(clusters_view);
+                device_cluster_container clusters_device(clusters_view);
                 device_measurement_container measurement_device(
                     measurement_view);
 
@@ -80,7 +81,7 @@ void measurement_creation::operator()(
                 // items: cluster of cells at current idx
                 // header: cluster_id object with the information about the cell
                 // module
-                const device_cell_const_collection &cluster =
+                const device_cell_collection &cluster =
                     clusters_device.get_items().at(idx);
                 const cluster_id &cl_id = clusters_device.get_headers().at(idx);
 
@@ -106,9 +107,8 @@ void measurement_creation::operator()(
                     return;
                 }
 
-                for (const auto &cell : cluster)
-                    calc_cluster_properties(cell, cl_id, mean, var,
-                                            totalWeight);
+                calc_cluster_properties<vecmem::device_vector>(
+                    cluster, cl_id, mean, var, totalWeight);
 
                 if (totalWeight > 0.) {
                     measurement m;

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -80,7 +80,7 @@ void measurement_creation::operator()(
                 // items: cluster of cells at current idx
                 // header: cluster_id object with the information about the cell
                 // module
-                const device_cell_const_collection &cluster =
+                device_cell_const_collection &cluster =
                     clusters_device.get_items().at(idx);
                 const cluster_id &cl_id = clusters_device.get_headers().at(idx);
 

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -70,11 +70,12 @@ void measurement_creation::operator()(
                 // items: cluster of cells at current idx
                 // header: cluster_id object with the information about the cell
                 // module
-                const auto &cluster = clusters_device.get_items().at(idx);
-                const auto &cluster_id = clusters_device.get_headers().at(idx);
+                const device_cell_const_collection &cluster =
+                    clusters_device.get_items().at(idx);
+                const cluster_id &cl_id = clusters_device.get_headers().at(idx);
 
-                const auto pitch = get_pitch(cluster_id.pixel);
-                const auto module_idx = cluster_id.module_idx;
+                const vector2 pitch = get_pitch(cl_id);
+                const auto module_idx = cl_id.module_idx;
 
                 scalar totalWeight = 0.;
 
@@ -96,11 +97,12 @@ void measurement_creation::operator()(
                 }
 
                 for (const auto &cell : cluster) {
-                    scalar weight = signal_cell_modelling(cell.activation);
-                    if (weight > cluster_id.threshold) {
+                    scalar weight =
+                        signal_cell_modelling(cell.activation, cl_id);
+                    if (weight > cl_id.threshold) {
                         totalWeight += cell.activation;
-                        const point2 cell_position = position_from_cell(
-                            cell, cluster_id.pixel, cluster_id.is_default);
+                        const point2 cell_position =
+                            position_from_cell(cell, cl_id);
                         const point2 prev = mean;
                         const point2 diff = cell_position - prev;
 

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -106,23 +106,10 @@ void measurement_creation::operator()(
                     return;
                 }
 
-                for (const auto &cell : cluster) {
-                    scalar weight =
-                        signal_cell_modelling(cell.activation, cl_id);
-                    if (weight > cl_id.threshold) {
-                        totalWeight += cell.activation;
-                        const point2 cell_position =
-                            position_from_cell(cell, cl_id);
-                        const point2 prev = mean;
-                        const point2 diff = cell_position - prev;
+                for (const auto &cell : cluster)
+                    calc_cluster_properties(cell, cl_id, mean, var,
+                                            totalWeight);
 
-                        mean = prev + (weight / totalWeight) * diff;
-                        for (std::size_t i = 0; i < 2; ++i) {
-                            var[i] = var[i] + weight * (diff[i]) *
-                                                  (cell_position[i] - mean[i]);
-                        }
-                    }
-                }
                 if (totalWeight > 0.) {
                     measurement m;
                     // normalize the cell position

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -6,8 +6,8 @@
  */
 
 // SYCL library include(s)
-#include "traccc/sycl/clusterization/measurement_creation.hpp"
 #include "../utils/get_queue.hpp"
+#include "traccc/sycl/clusterization/measurement_creation.hpp"
 
 // SYCL include(s)
 #include <CL/sycl.hpp>
@@ -17,118 +17,123 @@
 
 namespace traccc::sycl {
 
-measurement_creation::measurement_creation(vecmem::memory_resource &mr, queue_wrapper queue) : m_mr(mr), m_queue(queue) {}
+measurement_creation::measurement_creation(vecmem::memory_resource &mr,
+                                           queue_wrapper queue)
+    : m_mr(mr), m_queue(queue) {}
 
 host_measurement_container measurement_creation::operator()(
-    const host_cluster_container &c,
-    const std::vector<std::size_t> &s,
+    const host_cluster_container &c, const std::vector<std::size_t> &s,
     const host_cell_module_collection &l) const {
     output_type measurements(&m_mr.get());
     this->operator()(c, s, l, measurements);
     return measurements;
 }
 
-void measurement_creation::operator()(const host_cluster_container &clusters,
-                const std::vector<std::size_t> &cluster_sizes,
-                const host_cell_module_collection &cell_modules_per_event,
-                output_type &measurements) const {
+void measurement_creation::operator()(
+    const host_cluster_container &clusters,
+    const std::vector<std::size_t> &cluster_sizes,
+    const host_cell_module_collection &cell_modules_per_event,
+    output_type &measurements) const {
 
-    // Resizable buffer for the measurements that will later be copied to the host 
     vecmem::sycl::copy copy{m_queue.queue()};
     unsigned int size_buf = cell_modules_per_event.size();
 
-    vecmem::data::jagged_vector_buffer<measurement> measurements_buffer(std::vector<std::size_t>(cluster_sizes.size(), 0), cluster_sizes, m_mr.get());
-    measurement_container_buffer measurement_b{{size_buf, m_mr.get()},
-        {std::vector<std::size_t>(cluster_sizes.size(), 0), cluster_sizes, m_mr.get()}};
-    copy.setup(measurement_b.items);
+    // Resizable buffer for the measurements
+    measurement_container_buffer measurement_buffer{
+        {size_buf, m_mr.get()},
+        {std::vector<std::size_t>(cluster_sizes.size(), 0), cluster_sizes,
+         m_mr.get()}};
+    copy.setup(measurement_buffer.items);
 
     // Vector views to move data to the device
-    vecmem::data::jagged_vector_view<measurement> measurements_view = vecmem::get_data(measurements_buffer);
-    measurement_container_view measurement_view(measurement_b);
     auto clusters_data = get_data(clusters, &m_mr.get());
-
     cluster_container_const_view clusters_view(clusters_data);
-    
+    measurement_container_view measurement_view(measurement_buffer);
+
     // range of kernel execution
     auto range = clusters.size();
 
     // Run the kernel
-    details::get_queue(m_queue).parallel_for(range, [clusters_view, measurements_view, measurement_view](auto idx) {
+    details::get_queue(m_queue)
+        .parallel_for(
+            range,
+            [clusters_view, measurement_view](auto idx) {
+                // Initialize device vectors
+                device_cluster_const_container clusters_device(
+                    {clusters_view.headers, clusters_view.items});
+                device_measurement_container measurement_device(
+                    {measurement_view.headers, measurement_view.items});
 
-            // Initialize device vectors
-            device_cluster_const_container clusters_device({clusters_view.headers, clusters_view.items});
-            vecmem::jagged_device_vector<measurement> measurements_device(measurements_view);
-            device_measurement_container measurement_device({measurement_view.headers, measurement_view.items});
+                // Ignore if idx is out of range
+                if (idx >= clusters_device.size())
+                    return;
 
-            // Ignore if idx out of range 
-            if (idx >= clusters_device.size()) return;
+                // items: cluster of cells at current idx
+                // header: cluster_id object with the information about the cell
+                // module
+                const auto &cluster = clusters_device.get_items().at(idx);
+                const auto &cluster_id = clusters_device.get_headers().at(idx);
 
-            // items: cluster of cells at current idx
-            // header: cluster_id object with the information about the cell module 
-            const auto& cluster = clusters_device.get_items().at(idx);
-            const auto& cluster_id = clusters_device.get_headers().at(idx);
+                const auto pitch = cluster_id.position_from_cell.get_pitch();
+                const auto module_idx = cluster_id.module_idx;
 
-            const auto pitch = cluster_id.position_from_cell.get_pitch();
-            const auto module_idx = cluster_id.module_idx; 
+                scalar totalWeight = 0.;
 
-            scalar totalWeight = 0.;
+                // To calculate the mean and variance with high numerical
+                // stability we use a weighted variant of Welford's algorithm.
+                // This is a single-pass online algorithm that works well for
+                // large numbers of samples, as well as samples with very high
+                // values.
+                //
+                // To learn more about this algorithm please refer to:
+                // [1] https://doi.org/10.1080/00401706.1962.10490022
+                // [2] The Art of Computer Programming, Donald E. Knuth, second
+                //     edition, chapter 4.2.2.
+                point2 mean = {0., 0.}, var = {0., 0.};
 
-            // To calculate the mean and variance with high numerical stability
-            // we use a weighted variant of Welford's algorithm. This is a
-            // single-pass online algorithm that works well for large numbers
-            // of samples, as well as samples with very high values.
-            //
-            // To learn more about this algorithm please refer to:
-            // [1] https://doi.org/10.1080/00401706.1962.10490022
-            // [2] The Art of Computer Programming, Donald E. Knuth, second
-            //     edition, chapter 4.2.2.
-            point2 mean = {0., 0.}, var = {0., 0.};
+                // Should not happen
+                if (cluster.empty()) {
+                    return;
+                }
 
-            // Should not happen
-            if (cluster.empty()) {
-                return;
-            }
+                for (const auto &cell : cluster) {
+                    scalar weight = signal_cell_modelling(cell.activation);
+                    if (weight > cluster_id.threshold) {
+                        totalWeight += cell.activation;
+                        const point2 cell_position =
+                            cluster_id.position_from_cell(cell.channel0,
+                                                          cell.channel1);
+                        const point2 prev = mean;
+                        const point2 diff = cell_position - prev;
 
-            for (const auto& cell : cluster) {
-                scalar weight = signal_cell_modelling(cell.activation);
-                if (weight > cluster_id.threshold) {
-                    totalWeight += cell.activation;
-                    const point2 cell_position =
-                            cluster_id.position_from_cell(cell.channel0, cell.channel1);
-                    const point2 prev = mean;
-                    const point2 diff = cell_position - prev;
-
-                    mean = prev + (weight / totalWeight) * diff;
-                    for (std::size_t i = 0; i < 2; ++i) {
-                        var[i] = var[i] + weight * (diff[i]) *
-                                                (cell_position[i] - mean[i]);
+                        mean = prev + (weight / totalWeight) * diff;
+                        for (std::size_t i = 0; i < 2; ++i) {
+                            var[i] = var[i] + weight * (diff[i]) *
+                                                  (cell_position[i] - mean[i]);
+                        }
                     }
                 }
-            }
-            if (totalWeight > 0.) {
-                measurement m;
-                // normalize the cell position
-                m.local = mean;
-                // normalize the variance
-                m.variance[0] = var[0] / totalWeight;
-                m.variance[1] = var[1] / totalWeight;
-                // plus pitch^2 / 12
-                m.variance = m.variance + point2{pitch[0] * pitch[0] / 12,
-                                                    pitch[1] * pitch[1] / 12};
-                // @todo add variance estimation
-                measurements_device.at(module_idx).push_back(m);
-                measurement_device.get_items().at(module_idx).push_back(m);
-            }
-    }).wait_and_throw();
+                if (totalWeight > 0.) {
+                    measurement m;
+                    // normalize the cell position
+                    m.local = mean;
+                    // normalize the variance
+                    m.variance[0] = var[0] / totalWeight;
+                    m.variance[1] = var[1] / totalWeight;
+                    // plus pitch^2 / 12
+                    m.variance = m.variance + point2{pitch[0] * pitch[0] / 12,
+                                                     pitch[1] * pitch[1] / 12};
+                    // @todo add variance estimation
+                    measurement_device.get_items().at(module_idx).push_back(m);
+                }
+            })
+        .wait_and_throw();
 
-    vecmem::jagged_vector<measurement> measurements_jagged_vector(&m_mr.get());
-    copy(measurement_b.items, measurements.get_items());
-    copy(measurements_buffer, measurements_jagged_vector);
+    copy(measurement_buffer.items, measurements.get_items());
 
     for (std::size_t i = 0; i < cell_modules_per_event.size(); ++i) {
         auto module = cell_modules_per_event.at(i);
-        auto& m_header = measurements.get_headers().at(i);
-        m_header = module;
+        measurements.get_headers().push_back(std::move(module));
     }
 }
 

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -73,7 +73,8 @@ void measurement_creation::operator()(
                 const auto &cluster = clusters_device.get_items().at(idx);
                 const auto &cluster_id = clusters_device.get_headers().at(idx);
 
-                const auto pitch = get_pitch(cluster_id.module_idx, cluster_id.pixel);
+                const auto pitch =
+                    get_pitch(cluster_id.module_idx, cluster_id.pixel);
                 const auto module_idx = cluster_id.module_idx;
 
                 scalar totalWeight = 0.;
@@ -99,8 +100,9 @@ void measurement_creation::operator()(
                     scalar weight = signal_cell_modelling(cell.activation);
                     if (weight > cluster_id.threshold) {
                         totalWeight += cell.activation;
-                        const point2 cell_position =
-                            position_from_cell(cluster_id.module_idx, cell, cluster_id.pixel, cluster_id.is_default);
+                        const point2 cell_position = position_from_cell(
+                            cluster_id.module_idx, cell, cluster_id.pixel,
+                            cluster_id.is_default);
                         const point2 prev = mean;
                         const point2 diff = cell_position - prev;
 

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -73,7 +73,7 @@ void measurement_creation::operator()(
                 const auto &cluster = clusters_device.get_items().at(idx);
                 const auto &cluster_id = clusters_device.get_headers().at(idx);
 
-                const auto pitch = cluster_id.position_from_cell.get_pitch();
+                const auto pitch = get_pitch(cluster_id.module_idx, cluster_id.pixel);
                 const auto module_idx = cluster_id.module_idx;
 
                 scalar totalWeight = 0.;
@@ -100,8 +100,7 @@ void measurement_creation::operator()(
                     if (weight > cluster_id.threshold) {
                         totalWeight += cell.activation;
                         const point2 cell_position =
-                            cluster_id.position_from_cell(cell.channel0,
-                                                          cell.channel1);
+                            position_from_cell(cluster_id.module_idx, cell, cluster_id.pixel, cluster_id.is_default);
                         const point2 prev = mean;
                         const point2 diff = cell_position - prev;
 

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -80,7 +80,7 @@ void measurement_creation::operator()(
                 // items: cluster of cells at current idx
                 // header: cluster_id object with the information about the cell
                 // module
-                device_cell_const_collection &cluster =
+                const device_cell_const_collection &cluster =
                     clusters_device.get_items().at(idx);
                 const cluster_id &cl_id = clusters_device.get_headers().at(idx);
 

--- a/examples/run/openmp/io_dec_par_example.cpp
+++ b/examples/run/openmp/io_dec_par_example.cpp
@@ -59,14 +59,16 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data,
         for (size_t i = 0; i < cells_per_event.size(); ++i) {
             auto &module = cells_per_event.get_headers()[i];
             module.pixel =
-                traccc::pixel_segmentation{-8.425, -36.025, 0.05, 0.05};
+                traccc::pixel_data{-8.425, -36.025, 0.05, 0.05};
 
             // The algorithmic code part: start
             traccc::host_cluster_container clusters =
                 cc(cells_per_event.get_items()[i],
                    cells_per_event.get_headers()[i]);
-            for (auto &cl_id : clusters.get_headers())
-                cl_id.position_from_cell = module.pixel;
+            for (auto &cl_id : clusters.get_headers()) {
+                cl_id.is_default = false;
+                cl_id.pixel = module.pixel;
+            }
 
             traccc::host_measurement_collection measurements_per_module =
                 mt(clusters, module);

--- a/examples/run/openmp/io_dec_par_example.cpp
+++ b/examples/run/openmp/io_dec_par_example.cpp
@@ -58,8 +58,7 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data,
 #pragma omp parallel for
         for (size_t i = 0; i < cells_per_event.size(); ++i) {
             auto &module = cells_per_event.get_headers()[i];
-            module.pixel =
-                traccc::pixel_data{-8.425, -36.025, 0.05, 0.05};
+            module.pixel = traccc::pixel_data{-8.425, -36.025, 0.05, 0.05};
 
             // The algorithmic code part: start
             traccc::host_cluster_container clusters =

--- a/examples/run/openmp/io_dec_par_example.cpp
+++ b/examples/run/openmp/io_dec_par_example.cpp
@@ -65,7 +65,6 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data,
                 cc(cells_per_event.get_items()[i],
                    cells_per_event.get_headers()[i]);
             for (auto &cl_id : clusters.get_headers()) {
-                cl_id.is_default = false;
                 cl_id.pixel = module.pixel;
             }
 

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -13,7 +13,7 @@
 #include "traccc/edm/cluster.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
-#include "traccc/geometry/pixel_segmentation.hpp"
+#include "traccc/geometry/pixel_data.hpp"
 #include "traccc/io/csv.hpp"
 #include "traccc/io/reader.hpp"
 #include "traccc/io/utils.hpp"
@@ -81,13 +81,15 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
         for (std::size_t i = 0; i < cells_per_event.size(); ++i) {
             auto &module = cells_per_event.at(i).header;
             module.pixel =
-                traccc::pixel_segmentation{-8.425, -36.025, 0.05, 0.05};
+                traccc::pixel_data{-8.425, -36.025, 0.05, 0.05};
 
             // The algorithmic code part: start
             traccc::host_cluster_container clusters =
                 cc(cells_per_event.at(i).items, cells_per_event.at(i).header);
-            for (auto &cl_id : clusters.get_headers())
-                cl_id.position_from_cell = module.pixel;
+            for (auto &cl_id : clusters.get_headers()) {
+                cl_id.is_default = false;
+                cl_id.pixel = module.pixel;
+            }
 
             traccc::host_measurement_collection measurements_per_module =
                 mt(clusters, module);

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -80,8 +80,7 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
 #pragma omp parallel for
         for (std::size_t i = 0; i < cells_per_event.size(); ++i) {
             auto &module = cells_per_event.at(i).header;
-            module.pixel =
-                traccc::pixel_data{-8.425, -36.025, 0.05, 0.05};
+            module.pixel = traccc::pixel_data{-8.425, -36.025, 0.05, 0.05};
 
             // The algorithmic code part: start
             traccc::host_cluster_container clusters =

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -86,7 +86,6 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
             traccc::host_cluster_container clusters =
                 cc(cells_per_event.at(i).items, cells_per_event.at(i).header);
             for (auto &cl_id : clusters.get_headers()) {
-                cl_id.is_default = false;
                 cl_id.pixel = module.pixel;
             }
 

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -15,10 +15,10 @@
 #include "traccc/io/writer.hpp"
 
 // algorithms
-#include "traccc/sycl/clusterization/clusterization_algorithm.hpp"
 #include "traccc/clusterization/clusterization_algorithm.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
+#include "traccc/sycl/clusterization/clusterization_algorithm.hpp"
 #include "traccc/sycl/seeding/seeding_algorithm.hpp"
 #include "traccc/sycl/seeding/track_params_estimation.hpp"
 
@@ -43,9 +43,10 @@ namespace po = boost::program_options;
 
 // Simple asynchronous handler function
 auto handle_async_error = [](::sycl::exception_list elist) {
-    for (auto &e : elist) {
-        try{ std::rethrow_exception(e); }
-        catch ( ::sycl::exception& e ) {
+    for (auto& e : elist) {
+        try {
+            std::rethrow_exception(e);
+        } catch (::sycl::exception& e) {
             std::cout << "ASYNC EXCEPTION!!\n";
             std::cout << e.what() << "\n";
         }
@@ -110,7 +111,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
         /*time*/ auto start_file_reading_cpu = std::chrono::system_clock::now();
 
-        // Read the cells from the relevant event file for CPU algorithm 
+        // Read the cells from the relevant event file for CPU algorithm
         traccc::host_cell_container cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
                                           surface_transforms, host_mr);
@@ -121,19 +122,21 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         /*time*/ file_reading_cpu += time_file_reading_cpu.count();
 
         /*-----------------------------
-            Clusterization algorithm 
+            Clusterization algorithm
           -----------------------------*/
-        
+
         // SYCL
-        
-        /*time*/ auto start_clusterization_sycl = std::chrono::system_clock::now();
+
+        /*time*/ auto start_clusterization_sycl =
+            std::chrono::system_clock::now();
 
         auto ca_result_sycl = ca_sycl(cells_per_event);
         auto& measurements_per_event_sycl = ca_result_sycl.first;
         auto& spacepoints_per_event_sycl = ca_result_sycl.second;
 
-        /*time*/ auto end_clusterization_sycl = std::chrono::system_clock::now();
-        /*time*/ std::chrono::duration<double> time_clusterization_sycl = 
+        /*time*/ auto end_clusterization_sycl =
+            std::chrono::system_clock::now();
+        /*time*/ std::chrono::duration<double> time_clusterization_sycl =
             end_clusterization_sycl - start_clusterization_sycl;
         /*time*/ clusterization_sycl += time_clusterization_sycl.count();
 
@@ -190,8 +193,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         /*time*/ auto start_tp_estimating_sycl =
             std::chrono::system_clock::now();
 
-        auto params_sycl =
-            tp_sycl(std::move(spacepoints_per_event_sycl), std::move(seeds_sycl));
+        auto params_sycl = tp_sycl(std::move(spacepoints_per_event_sycl),
+                                   std::move(seeds_sycl));
 
         /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =
@@ -226,23 +229,28 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
             std::cout << " number of seeds (sycl): " << seeds_sycl.size()
                       << std::endl;
 
-            // measurements
+            // measurement matching rate
             int n_measurements_match = 0;
             for (uint64_t i = 0; i < measurements_per_event.size(); ++i) {
                 for (auto& m : measurements_per_event.get_items().at(i)) {
 
-                    if (std::find(measurements_per_event_sycl.get_items().at(i).begin(), 
-                                measurements_per_event_sycl.get_items().at(i).end(), m) 
-                                != 
-                                measurements_per_event_sycl.get_items().at(i).end()) {
+                    if (std::find(
+                            measurements_per_event_sycl.get_items()
+                                .at(i)
+                                .begin(),
+                            measurements_per_event_sycl.get_items().at(i).end(),
+                            m) !=
+                        measurements_per_event_sycl.get_items().at(i).end()) {
                         n_measurements_match++;
                     }
                 }
             }
-            float matching_rate = float(n_measurements_match) / measurements_per_event.total_size();
-            std::cout << " measurements matching rate: " << matching_rate << std::endl;
+            float matching_rate = float(n_measurements_match) /
+                                  measurements_per_event.total_size();
+            std::cout << " measurements matching rate: " << matching_rate
+                      << std::endl;
 
-            // seeding
+            // seeding matching rate
             int n_match = 0;
             for (auto& seed : seeds) {
                 if (std::find_if(
@@ -255,7 +263,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
             matching_rate = float(n_match) / seeds.size();
             std::cout << " seed matching rate: " << matching_rate << std::endl;
 
-            // track parameter estimation
+            // track parameter estimation matching rate
             n_match = 0;
             for (auto& param : params) {
                 if (std::find(params_sycl.begin(), params_sycl.end(), param) !=
@@ -320,8 +328,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
               << std::endl;
     std::cout << "- created        " << n_measurements << " meaurements     "
               << std::endl;
-    std::cout << "- created (sycl) " << n_measurements_sycl << " measurements     "
-              << std::endl;
+    std::cout << "- created (sycl) " << n_measurements_sycl
+              << " measurements     " << std::endl;
     std::cout << "- created        " << n_spacepoints << " spacepoints     "
               << std::endl;
 

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -138,7 +138,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         
         /*time*/ auto start_clusterization_sycl = std::chrono::system_clock::now();
 
-        auto ca_result_sycl = ca_sycl(cells_per_event_sycl);
+        auto ca_result_sycl = ca_sycl(cells_per_event);
         auto& measurements_per_event_sycl = ca_result_sycl.first;
         auto& spacepoints_per_event_sycl = ca_result_sycl.second;
 
@@ -161,13 +161,32 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
             end_clusterization_cpu - start_clusterization_cpu;
         /*time*/ clusterization_cpu += time_clusterization_cpu.count();
 
-        /// Checking if the spacepoitns match from sycl and cpu measurement creation
+        /*---------------------------------
+          Compare CPU and SYCL measurements 
+          --------------------------------*/
+
+        uint64_t n_measurements_match = 0;
+        for (uint64_t i = 0; i < measurements_per_event.size(); ++i) {
+            for (auto& m : measurements_per_event.get_items().at(i)) {
+
+                if (std::find(measurements_per_event_sycl.get_items().at(i).begin(), 
+                            measurements_per_event_sycl.get_items().at(i).end(), m) 
+                            != 
+                            measurements_per_event_sycl.get_items().at(i).end()) {
+                    n_measurements_match++;
+                }
+            }
+        }
+        std::cout << "measurements_match: " << float(n_measurements_match) / measurements_per_event.total_size() << "\n";
+
+        /*---------------------------------
+          Compare CPU and SYCL spacepoints 
+          --------------------------------*/
+
         int n_spacepoint_match = 0;
-        int module_match = 0;
-        for (std::size_t i = 0; i < spacepoints_per_event.size(); ++i){
-            if (spacepoints_per_event.get_headers().at(i) == spacepoints_per_event_sycl.get_headers().at(i)) module_match++;
-        
+        for (uint64_t i = 0; i < spacepoints_per_event.size(); ++i){
             for (auto& spacepoint : spacepoints_per_event.get_items().at(i)) {
+
                 if (std::find(spacepoints_per_event_sycl.get_items().at(i).begin(), 
                               spacepoints_per_event_sycl.get_items().at(i).end(), spacepoint) 
                               !=
@@ -176,7 +195,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
                 }
             }
         }
-        std::cout << "Module id match: " << float(module_match) / spacepoints_per_event.size() << "\n";
         std::cout << "Spacepoints match: " << float(n_spacepoint_match) / spacepoints_per_event.total_size() << "\n";
 
         /*----------------------------

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -93,7 +93,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
     // Memory resource used by the EDM.
     vecmem::host_memory_resource host_mr;
 
-    traccc::clusterization_algorithm ca(shared_mr);
+    traccc::clusterization_algorithm ca(host_mr);
     traccc::seeding_algorithm sa(host_mr);
     traccc::track_params_estimation tp(host_mr);
 
@@ -117,11 +117,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
         // Read the cells from the relevant event file for CPU algorithm 
         traccc::host_cell_container cells_per_event =
-            traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          surface_transforms, host_mr);
-
-        // Read the cells from the relevant event file for SYCL algorithm
-        traccc::host_cell_container cells_per_event_sycl =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
                                           surface_transforms, host_mr);
 
@@ -160,42 +155,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         /*time*/ std::chrono::duration<double> time_clusterization_cpu =
             end_clusterization_cpu - start_clusterization_cpu;
         /*time*/ clusterization_cpu += time_clusterization_cpu.count();
-
-        /*---------------------------------
-          Compare CPU and SYCL measurements 
-          --------------------------------*/
-
-        uint64_t n_measurements_match = 0;
-        for (uint64_t i = 0; i < measurements_per_event.size(); ++i) {
-            for (auto& m : measurements_per_event.get_items().at(i)) {
-
-                if (std::find(measurements_per_event_sycl.get_items().at(i).begin(), 
-                            measurements_per_event_sycl.get_items().at(i).end(), m) 
-                            != 
-                            measurements_per_event_sycl.get_items().at(i).end()) {
-                    n_measurements_match++;
-                }
-            }
-        }
-        std::cout << "measurements_match: " << float(n_measurements_match) / measurements_per_event.total_size() << "\n";
-
-        /*---------------------------------
-          Compare CPU and SYCL spacepoints 
-          --------------------------------*/
-
-        int n_spacepoint_match = 0;
-        for (uint64_t i = 0; i < spacepoints_per_event.size(); ++i){
-            for (auto& spacepoint : spacepoints_per_event.get_items().at(i)) {
-
-                if (std::find(spacepoints_per_event_sycl.get_items().at(i).begin(), 
-                              spacepoints_per_event_sycl.get_items().at(i).end(), spacepoint) 
-                              !=
-                              spacepoints_per_event_sycl.get_items().at(i).end()) {
-                    n_spacepoint_match++;
-                }
-            }
-        }
-        std::cout << "Spacepoints match: " << float(n_spacepoint_match) / spacepoints_per_event.total_size() << "\n";
 
         /*----------------------------
              Seeding algorithm
@@ -264,26 +223,41 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
           ----------------------------------*/
 
         if (run_cpu) {
-            // seeding
-            int n_match = 0;
-            // Extended comparison in case there are two spacepoint containers
-            // (from gpu nad cpu clusterization) If so, change the parameter
-            // spacepoints_per_event_sycl inside lambda capture
-            for (auto& seed : seeds) {
-                if (std::find_if(
-                        seeds_sycl.begin(), seeds_sycl.end(),
-                        traccc::is_same_seed<traccc::host_spacepoint_container>(
-                            seed, spacepoints_per_event,
-                            spacepoints_per_event)) != seeds_sycl.end())
-                    n_match++;
-            }
-            float matching_rate = float(n_match) / seeds.size();
 
+            // Initial information about number of seeds found
             std::cout << "event " << std::to_string(event) << std::endl;
             std::cout << " number of seeds (cpu): " << seeds.size()
                       << std::endl;
             std::cout << " number of seeds (sycl): " << seeds_sycl.size()
                       << std::endl;
+
+            // measurements
+            int n_measurements_match = 0;
+            for (uint64_t i = 0; i < measurements_per_event.size(); ++i) {
+                for (auto& m : measurements_per_event.get_items().at(i)) {
+
+                    if (std::find(measurements_per_event_sycl.get_items().at(i).begin(), 
+                                measurements_per_event_sycl.get_items().at(i).end(), m) 
+                                != 
+                                measurements_per_event_sycl.get_items().at(i).end()) {
+                        n_measurements_match++;
+                    }
+                }
+            }
+            float matching_rate = float(n_measurements_match) / measurements_per_event.total_size();
+            std::cout << " measurements matching rate: " << matching_rate << std::endl;
+
+            // seeding
+            int n_match = 0;
+            for (auto& seed : seeds) {
+                if (std::find_if(
+                        seeds_sycl.begin(), seeds_sycl.end(),
+                        traccc::is_same_seed<traccc::host_spacepoint_container>(
+                            seed, spacepoints_per_event,
+                            spacepoints_per_event_sycl)) != seeds_sycl.end())
+                    n_match++;
+            }
+            matching_rate = float(n_match) / seeds.size();
             std::cout << " seed matching rate: " << matching_rate << std::endl;
 
             // track parameter estimation
@@ -320,7 +294,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
                                       i_cfg.hit_directory,
                                       i_cfg.particle_directory, host_mr);
             sd_performance_writer.write("SYCL", seeds_sycl,
-                                        spacepoints_per_event, evt_map);
+                                        spacepoints_per_event_sycl, evt_map);
 
             if (run_cpu) {
                 sd_performance_writer.write("CPU", seeds, spacepoints_per_event,

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -123,7 +123,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         // Read the cells from the relevant event file for SYCL algorithm
         traccc::host_cell_container cells_per_event_sycl =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          surface_transforms, shared_mr);
+                                          surface_transforms, host_mr);
 
         /*time*/ auto end_file_reading_cpu = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_file_reading_cpu =
@@ -138,7 +138,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         
         /*time*/ auto start_clusterization_sycl = std::chrono::system_clock::now();
 
-        auto ca_result_sycl = ca_sycl(cells_per_event_sycl);
+        auto ca_result_sycl = ca_sycl(cells_per_event);
         auto& measurements_per_event_sycl = ca_result_sycl.first;
         auto& spacepoints_per_event_sycl = ca_result_sycl.second;
 
@@ -161,13 +161,32 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
             end_clusterization_cpu - start_clusterization_cpu;
         /*time*/ clusterization_cpu += time_clusterization_cpu.count();
 
-        /// Checking if the spacepoitns match from sycl and cpu measurement creation
+        /*---------------------------------
+          Compare CPU and SYCL measurements 
+          --------------------------------*/
+
+        uint64_t n_measurements_match = 0;
+        for (uint64_t i = 0; i < measurements_per_event.size(); ++i) {
+            for (auto& m : measurements_per_event.get_items().at(i)) {
+
+                if (std::find(measurements_per_event_sycl.get_items().at(i).begin(), 
+                            measurements_per_event_sycl.get_items().at(i).end(), m) 
+                            != 
+                            measurements_per_event_sycl.get_items().at(i).end()) {
+                    n_measurements_match++;
+                }
+            }
+        }
+        std::cout << "measurements_match: " << float(n_measurements_match) / measurements_per_event.total_size() << "\n";
+
+        /*---------------------------------
+          Compare CPU and SYCL spacepoints 
+          --------------------------------*/
+
         int n_spacepoint_match = 0;
-        int module_match = 0;
-        for (std::size_t i = 0; i < spacepoints_per_event.size(); ++i){
-            if (spacepoints_per_event.get_headers().at(i) == spacepoints_per_event_sycl.get_headers().at(i)) module_match++;
-        
+        for (uint64_t i = 0; i < spacepoints_per_event.size(); ++i){
             for (auto& spacepoint : spacepoints_per_event.get_items().at(i)) {
+
                 if (std::find(spacepoints_per_event_sycl.get_items().at(i).begin(), 
                               spacepoints_per_event_sycl.get_items().at(i).end(), spacepoint) 
                               !=
@@ -176,7 +195,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
                 }
             }
         }
-        std::cout << "Module id match: " << float(module_match) / spacepoints_per_event.size() << "\n";
         std::cout << "Spacepoints match: " << float(n_spacepoint_match) / spacepoints_per_event.total_size() << "\n";
 
         /*----------------------------

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -83,7 +83,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
     // Creating SYCL queue for the clusterization
-    // ::sycl::queue qM(::sycl::gpu_selector{}, handle_async_error);
+    // ::sycl::queue qM(::sycl::host_selector{}, handle_async_error);
     // std::cout << "Running Measurement creation on device: "
     //           << qM.get_device().get_info<::sycl::info::device::name>() << "\n";
 
@@ -115,10 +115,15 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
         /*time*/ auto start_file_reading_cpu = std::chrono::system_clock::now();
 
-        // Read the cells from the relevant event file
+        // Read the cells from the relevant event file for CPU algorithm 
         traccc::host_cell_container cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
                                           surface_transforms, host_mr);
+
+        // Read the cells from the relevant event file for SYCL algorithm
+        traccc::host_cell_container cells_per_event_sycl =
+            traccc::read_cells_from_event(event, i_cfg.cell_directory,
+                                          surface_transforms, shared_mr);
 
         /*time*/ auto end_file_reading_cpu = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_file_reading_cpu =
@@ -133,7 +138,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         
         /*time*/ auto start_clusterization_sycl = std::chrono::system_clock::now();
 
-        auto ca_result_sycl = ca_sycl(cells_per_event);
+        auto ca_result_sycl = ca_sycl(cells_per_event_sycl);
         auto& measurements_per_event_sycl = ca_result_sycl.first;
         auto& spacepoints_per_event_sycl = ca_result_sycl.second;
 
@@ -182,7 +187,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
         /*time*/ auto start_seeding_sycl = std::chrono::system_clock::now();
 
-        auto seeds_sycl = sa_sycl(std::move(spacepoints_per_event_sycl));
+        auto seeds_sycl = sa_sycl(spacepoints_per_event_sycl);
 
         /*time*/ auto end_seeding_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_seeding_sycl =
@@ -228,7 +233,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
         traccc::track_params_estimation::output_type params;
         if (run_cpu) {
-            params = tp(spacepoints_per_event_sycl, seeds);
+            params = tp(spacepoints_per_event, seeds);
         }
 
         /*time*/ auto end_tp_estimating_cpu = std::chrono::system_clock::now();
@@ -243,6 +248,9 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         if (run_cpu) {
             // seeding
             int n_match = 0;
+            // Extended comparison in case there are two spacepoint containers
+            // (from gpu nad cpu clusterization) If so, change the parameter
+            // spacepoints_per_event_sycl inside lambda capture
             for (auto& seed : seeds) {
                 if (std::find_if(
                         seeds_sycl.begin(), seeds_sycl.end(),

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -82,11 +82,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
     std::cout << "Running Seeding on device: "
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
-    // Creating SYCL queue for the clusterization
-    // ::sycl::queue qM(::sycl::host_selector{}, handle_async_error);
-    // std::cout << "Running Measurement creation on device: "
-    //           << qM.get_device().get_info<::sycl::info::device::name>() << "\n";
-
     // Memory resource used by the EDM.
     vecmem::sycl::shared_memory_resource shared_mr(&q);
 

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -83,7 +83,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
     // Creating SYCL queue for the clusterization
-    // ::sycl::queue qM(::sycl::host_selector{}, handle_async_error);
+    // ::sycl::queue qM(::sycl::gpu_selector{}, handle_async_error);
     // std::cout << "Running Measurement creation on device: "
     //           << qM.get_device().get_info<::sycl::info::device::name>() << "\n";
 
@@ -161,32 +161,13 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
             end_clusterization_cpu - start_clusterization_cpu;
         /*time*/ clusterization_cpu += time_clusterization_cpu.count();
 
-        /*---------------------------------
-          Compare CPU and SYCL measurements 
-          --------------------------------*/
-
-        uint64_t n_measurements_match = 0;
-        for (uint64_t i = 0; i < measurements_per_event.size(); ++i) {
-            for (auto& m : measurements_per_event.get_items().at(i)) {
-
-                if (std::find(measurements_per_event_sycl.get_items().at(i).begin(), 
-                            measurements_per_event_sycl.get_items().at(i).end(), m) 
-                            != 
-                            measurements_per_event_sycl.get_items().at(i).end()) {
-                    n_measurements_match++;
-                }
-            }
-        }
-        std::cout << "measurements_match: " << float(n_measurements_match) / measurements_per_event.total_size() << "\n";
-
-        /*---------------------------------
-          Compare CPU and SYCL spacepoints 
-          --------------------------------*/
-
+        /// Checking if the spacepoitns match from sycl and cpu measurement creation
         int n_spacepoint_match = 0;
-        for (uint64_t i = 0; i < spacepoints_per_event.size(); ++i){
+        int module_match = 0;
+        for (std::size_t i = 0; i < spacepoints_per_event.size(); ++i){
+            if (spacepoints_per_event.get_headers().at(i) == spacepoints_per_event_sycl.get_headers().at(i)) module_match++;
+        
             for (auto& spacepoint : spacepoints_per_event.get_items().at(i)) {
-
                 if (std::find(spacepoints_per_event_sycl.get_items().at(i).begin(), 
                               spacepoints_per_event_sycl.get_items().at(i).end(), spacepoint) 
                               !=
@@ -195,6 +176,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
                 }
             }
         }
+        std::cout << "Module id match: " << float(module_match) / spacepoints_per_event.size() << "\n";
         std::cout << "Spacepoints match: " << float(n_spacepoint_match) / spacepoints_per_event.total_size() << "\n";
 
         /*----------------------------
@@ -205,7 +187,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
         /*time*/ auto start_seeding_sycl = std::chrono::system_clock::now();
 
-        auto seeds_sycl = sa_sycl(spacepoints_per_event_sycl);
+        auto seeds_sycl = sa_sycl(std::move(spacepoints_per_event_sycl));
 
         /*time*/ auto end_seeding_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_seeding_sycl =
@@ -251,7 +233,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
         traccc::track_params_estimation::output_type params;
         if (run_cpu) {
-            params = tp(spacepoints_per_event, seeds);
+            params = tp(spacepoints_per_event_sycl, seeds);
         }
 
         /*time*/ auto end_tp_estimating_cpu = std::chrono::system_clock::now();

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -15,6 +15,7 @@
 #include "traccc/io/writer.hpp"
 
 // algorithms
+#include "traccc/sycl/clusterization/clusterization_algorithm.hpp"
 #include "traccc/clusterization/clusterization_algorithm.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
@@ -40,6 +41,17 @@
 
 namespace po = boost::program_options;
 
+// Simple asynchronous handler function
+auto handle_async_error = [](::sycl::exception_list elist) {
+    for (auto &e : elist) {
+        try{ std::rethrow_exception(e); }
+        catch ( ::sycl::exception& e ) {
+            std::cout << "ASYNC EXCEPTION!!\n";
+            std::cout << e.what() << "\n";
+        }
+    }
+};
+
 int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
     // Read the surface transforms
@@ -50,6 +62,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
     uint64_t n_modules = 0;
     // uint64_t n_clusters = 0;
     uint64_t n_measurements = 0;
+    uint64_t n_measurements_sycl = 0;
     uint64_t n_spacepoints = 0;
     uint64_t n_seeds = 0;
     uint64_t n_seeds_sycl = 0;
@@ -58,16 +71,21 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
     float wall_time(0);
     float file_reading_cpu(0);
     float clusterization_cpu(0);
+    float clusterization_sycl(0);
     float seeding_cpu(0);
-    // float clusterization_sycl(0);
     float seeding_sycl(0);
     float tp_estimating_cpu(0);
     float tp_estimating_sycl(0);
 
-    // Creating Sycl queue object
-    ::sycl::queue q(::sycl::gpu_selector{});
-    std::cout << "Running on device: "
+    // Creating SYCL queue object
+    ::sycl::queue q(::sycl::gpu_selector{}, handle_async_error);
+    std::cout << "Running Seeding on device: "
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
+
+    // Creating SYCL queue for the clusterization
+    // ::sycl::queue qM(::sycl::gpu_selector{}, handle_async_error);
+    // std::cout << "Running Measurement creation on device: "
+    //           << qM.get_device().get_info<::sycl::info::device::name>() << "\n";
 
     // Memory resource used by the EDM.
     vecmem::sycl::shared_memory_resource shared_mr(&q);
@@ -79,6 +97,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
     traccc::seeding_algorithm sa(host_mr);
     traccc::track_params_estimation tp(host_mr);
 
+    traccc::sycl::clusterization_algorithm ca_sycl(shared_mr, &q);
     traccc::sycl::seeding_algorithm sa_sycl(shared_mr, &q);
     traccc::sycl::track_params_estimation tp_sycl(shared_mr, &q);
 
@@ -107,8 +126,23 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         /*time*/ file_reading_cpu += time_file_reading_cpu.count();
 
         /*-----------------------------
-              Clusterization (cpu)
+            Clusterization algorithm 
           -----------------------------*/
+        
+        // SYCL
+        
+        /*time*/ auto start_clusterization_sycl = std::chrono::system_clock::now();
+
+        auto ca_result_sycl = ca_sycl(cells_per_event);
+        auto& measurements_per_event_sycl = ca_result_sycl.first;
+        auto& spacepoints_per_event_sycl = ca_result_sycl.second;
+
+        /*time*/ auto end_clusterization_sycl = std::chrono::system_clock::now();
+        /*time*/ std::chrono::duration<double> time_clusterization_sycl = 
+            end_clusterization_sycl - start_clusterization_sycl;
+        /*time*/ clusterization_sycl += time_clusterization_sycl.count();
+
+        // CPU
 
         /*time*/ auto start_clusterization_cpu =
             std::chrono::system_clock::now();
@@ -122,6 +156,24 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
             end_clusterization_cpu - start_clusterization_cpu;
         /*time*/ clusterization_cpu += time_clusterization_cpu.count();
 
+        /// Checking if the spacepoitns match from sycl and cpu measurement creation
+        int n_spacepoint_match = 0;
+        int module_match = 0;
+        for (std::size_t i = 0; i < spacepoints_per_event.size(); ++i){
+            if (spacepoints_per_event.get_headers().at(i) == spacepoints_per_event_sycl.get_headers().at(i)) module_match++;
+        
+            for (auto& spacepoint : spacepoints_per_event.get_items().at(i)) {
+                if (std::find(spacepoints_per_event_sycl.get_items().at(i).begin(), 
+                              spacepoints_per_event_sycl.get_items().at(i).end(), spacepoint) 
+                              !=
+                              spacepoints_per_event_sycl.get_items().at(i).end()) {
+                    n_spacepoint_match++;
+                }
+            }
+        }
+        std::cout << "Module id match: " << float(module_match) / spacepoints_per_event.size() << "\n";
+        std::cout << "Spacepoints match: " << float(n_spacepoint_match) / spacepoints_per_event.total_size() << "\n";
+
         /*----------------------------
              Seeding algorithm
           ----------------------------*/
@@ -130,7 +182,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
         /*time*/ auto start_seeding_sycl = std::chrono::system_clock::now();
 
-        auto seeds_sycl = sa_sycl(std::move(spacepoints_per_event));
+        auto seeds_sycl = sa_sycl(std::move(spacepoints_per_event_sycl));
 
         /*time*/ auto end_seeding_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_seeding_sycl =
@@ -162,7 +214,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
             std::chrono::system_clock::now();
 
         auto params_sycl =
-            tp_sycl(std::move(spacepoints_per_event), std::move(seeds_sycl));
+            tp_sycl(std::move(spacepoints_per_event_sycl), std::move(seeds_sycl));
 
         /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =
@@ -176,7 +228,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
         traccc::track_params_estimation::output_type params;
         if (run_cpu) {
-            params = tp(spacepoints_per_event, seeds);
+            params = tp(spacepoints_per_event_sycl, seeds);
         }
 
         /*time*/ auto end_tp_estimating_cpu = std::chrono::system_clock::now();
@@ -228,6 +280,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         n_modules += cells_per_event.size();
         n_cells += cells_per_event.total_size();
         n_measurements += measurements_per_event.total_size();
+        n_measurements_sycl += measurements_per_event_sycl.total_size();
         n_spacepoints += spacepoints_per_event.total_size();
         n_seeds_sycl += seeds_sycl.size();
         n_seeds += seeds.size();
@@ -272,6 +325,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
               << std::endl;
     std::cout << "- created        " << n_measurements << " meaurements     "
               << std::endl;
+    std::cout << "- created (sycl) " << n_measurements_sycl << " measurements     "
+              << std::endl;
     std::cout << "- created        " << n_spacepoints << " spacepoints     "
               << std::endl;
 
@@ -284,6 +339,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
               << file_reading_cpu << std::endl;
     std::cout << "clusterization_time (cpu) " << std::setw(10) << std::left
               << clusterization_cpu << std::endl;
+    std::cout << "clusterization_time (sycl) " << std::setw(10) << std::left
+              << clusterization_sycl << std::endl;
     std::cout << "seeding_time (cpu)        " << std::setw(10) << std::left
               << seeding_cpu << std::endl;
     std::cout << "seeding_time (sycl)       " << std::setw(10) << std::left

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -83,7 +83,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
     // Creating SYCL queue for the clusterization
-    // ::sycl::queue qM(::sycl::gpu_selector{}, handle_async_error);
+    // ::sycl::queue qM(::sycl::host_selector{}, handle_async_error);
     // std::cout << "Running Measurement creation on device: "
     //           << qM.get_device().get_info<::sycl::info::device::name>() << "\n";
 
@@ -138,7 +138,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         
         /*time*/ auto start_clusterization_sycl = std::chrono::system_clock::now();
 
-        auto ca_result_sycl = ca_sycl(cells_per_event);
+        auto ca_result_sycl = ca_sycl(cells_per_event_sycl);
         auto& measurements_per_event_sycl = ca_result_sycl.first;
         auto& spacepoints_per_event_sycl = ca_result_sycl.second;
 
@@ -187,7 +187,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
         /*time*/ auto start_seeding_sycl = std::chrono::system_clock::now();
 
-        auto seeds_sycl = sa_sycl(std::move(spacepoints_per_event_sycl));
+        auto seeds_sycl = sa_sycl(spacepoints_per_event_sycl);
 
         /*time*/ auto end_seeding_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_seeding_sycl =
@@ -233,7 +233,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
 
         traccc::track_params_estimation::output_type params;
         if (run_cpu) {
-            params = tp(spacepoints_per_event_sycl, seeds);
+            params = tp(spacepoints_per_event, seeds);
         }
 
         /*time*/ auto end_tp_estimating_cpu = std::chrono::system_clock::now();

--- a/io/include/traccc/io/mapper.hpp
+++ b/io/include/traccc/io/mapper.hpp
@@ -187,8 +187,10 @@ measurement_cell_map generate_measurement_cell_map(
         // The algorithmic code part: start
         host_cluster_container clusters =
             cc(cells_per_event.at(i).items, cells_per_event.at(i).header);
-        for (auto& cl_id : clusters.get_headers())
-            cl_id.position_from_cell = module.pixel;
+        for (auto& cl_id : clusters.get_headers()) {
+            cl_id.is_default = false;
+            cl_id.pixel = module.pixel;
+        }
 
         host_measurement_collection measurements_per_module =
             mt(clusters, module);

--- a/io/include/traccc/io/mapper.hpp
+++ b/io/include/traccc/io/mapper.hpp
@@ -188,7 +188,6 @@ measurement_cell_map generate_measurement_cell_map(
         host_cluster_container clusters =
             cc(cells_per_event.at(i).items, cells_per_event.at(i).header);
         for (auto& cl_id : clusters.get_headers()) {
-            cl_id.is_default = false;
             cl_id.pixel = module.pixel;
         }
 

--- a/tests/cpu/seq_single_module.cpp
+++ b/tests/cpu/seq_single_module.cpp
@@ -13,7 +13,7 @@
 #include "traccc/edm/cluster.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
-#include "traccc/geometry/pixel_segmentation.hpp"
+#include "traccc/geometry/pixel_data.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -40,7 +40,7 @@ TEST(algorithms, seq_single_module) {
 
     traccc::cell_module module;
     module.module = 0;
-    module.pixel = traccc::pixel_segmentation{0., 0., 1., 1.};
+    module.pixel = traccc::pixel_data{0., 0., 1., 1.};
     module.placement = traccc::transform3{};
 
     traccc::host_cluster_container clusters(&resource);
@@ -55,8 +55,10 @@ TEST(algorithms, seq_single_module) {
 
     // Algorithmic code: start
     clusters = cc(cells, module);
-    for (auto& cl_id : clusters.get_headers())
-        cl_id.position_from_cell = module.pixel;
+    for (auto& cl_id : clusters.get_headers()) {
+        cl_id.is_default = false;
+        cl_id.pixel = module.pixel;
+    }
     measurements = mt(clusters, module);
     spacepoints = sp(module, measurements);
 }

--- a/tests/cpu/seq_single_module.cpp
+++ b/tests/cpu/seq_single_module.cpp
@@ -56,7 +56,6 @@ TEST(algorithms, seq_single_module) {
     // Algorithmic code: start
     clusters = cc(cells, module);
     for (auto& cl_id : clusters.get_headers()) {
-        cl_id.is_default = false;
         cl_id.pixel = module.pixel;
     }
     measurements = mt(clusters, module);


### PR DESCRIPTION
This PR adds `SYCL clusterization algorithm` implementation to traccc - from which only `measurement creation` was so far ported to SYCL kernel. This opens a door for including SYCL component connection and spacepoint formation kernels - as the next steps. 

- Currently, the SYCL clusterization uses the CPU version of component connection algorithm from `traccc/core` and this step is done in a "per module" manner. 
-  Then, the SYCL measurement creation kernel performs the computation across clusters from all the modules combined. 
-  At last, the CPU spacepoint formation algorithm from `traccc/core` is used for each module to create the final `spacepoint_container`

The `Cluster EDM` was modified again as I realized that `std::function` cannot be used inside the kernel code. To work around that, I created a separate function: `signal_cell_modelling()` and the `position_estimation` member was replaced with `pixel_segmentation` functor similarly as in the `cell_module`.

pinging @krasznaa 