### PR TITLE
VecMem 0.13.0 Update, main branch (2022.04.12.)

### DIFF
--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.12.0.tar.gz;URL_MD5;1817ac5c961d1d52b40bc3cff6268a14"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.13.0.tar.gz;URL_MD5;3bd1b13f6817ba6e7118217ea9a15186"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Upgraded the project to [VecMem 0.13.0](https://github.com/acts-project/vecmem/releases/tag/v0.13.0).

It will be needed for #170, as (amongst other things) it fixes an issue with jagged vector buffers that the code had to work around previously.