### PR TITLE
CUDA / Clang Compatibility, main branch (2022.04.12.)

### DIFF
--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -4,12 +4,12 @@
 #
 # Mozilla Public License Version 2.0
 
+# Enable CUDA as a language.
+enable_language( CUDA )
+
 # Project include(s).
 include( traccc-compiler-options-cpp )
 include( traccc-compiler-options-cuda )
-
-# Enable CUDA as a language.
-enable_language( CUDA )
 
 # Set up the build of the traccc::cuda library.
 traccc_add_library( traccc_cuda cuda TYPE SHARED

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -4,9 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
-include(traccc-compiler-options-cuda)
-
 enable_language(CUDA)
+
+include(traccc-compiler-options-cuda)
 
 find_package(CUDAToolkit REQUIRED)
 


### PR DESCRIPTION
I'm not sure when this started, but while trying to work with a recent version of the Intel compiler's nightlies (while working on #170), I bumped into these sort of errors:

```
[bash][atspot01]:build > cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTRACCC_BUILD_SYCL=TRUE ../traccc/
-- The CXX compiler identification is Clang 15.0.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /atlas/software/intel/clang/nightly-20220402/x86_64-ubuntu1804-gcc8-opt/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for a CUDA compiler
-- Looking for a CUDA compiler - /atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/nvcc
-- Looking for a CUDA host compiler - /atlas/software/intel/clang/nightly-20220402/x86_64-ubuntu1804-gcc8-opt/bin/clang++
-- Building VecMem as part of the TRACCC project
...
-- Found Python: /usr/bin/python3.6 (found version "3.6.9") found components: Interpreter 
-- Building with plugin type: ARRAY
CMake Error at /atlas/software/cmake/3.23.0/x86_64-ubuntu1804-gcc7-opt/share/cmake-3.23/Modules/CMakeDetermineCompilerId.cmake:743 (message):                                                                     
  Compiling the CUDA compiler identification source file                                                 
  "CMakeCUDACompilerId.cu" failed.                                                                       

  Compiler: /atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/nvcc                                       

  Build flags:                                                                                           

  Id flags:                                                                                              
  --keep;--keep-dir;tmp;-ccbin=/atlas/software/intel/clang/nightly-20220402/x86_64-ubuntu1804-gcc8-opt/bin/clang++;-gencode=arch=compute_52,code=sm_52                                                            
  -v                                                                                                     

                                                                                                         

  The output was:                                                                                        

  1                                                                                                      

  #$ _NVVM_BRANCH_=nvvm                                                                                  

  #$ _SPACE_=                                                                                            

  #$ _CUDART_=cudart                                                                                     

  #$ _HERE_=/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin                                            

  #$ _THERE_=/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin                                           

  #$ _TARGET_SIZE_=                                                                                      

  #$ _TARGET_DIR_=                                                                                       

  #$ _TARGET_DIR_=targets/x86_64-linux                                                                   

  #$ TOP=/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/..                                            

  #$                                                                                                     
  NVVMIR_LIBRARY_DIR=/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/../nvvm/libdevice                 


  #$                                                                                                     
  LD_LIBRARY_PATH=/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/../lib:/atlas/software/root/6.24.06/x86_64-ubuntu1804-gcc8-opt/lib:/atlas/software/xrootd/5.3.1/x86_64-ubuntu1804-gcc8-opt/lib:/atlas/software/tbb/2021.4.0/x86_64-ubuntu1804-gcc8-opt/lib:/atlas/software/boost/1.78.0/x86_64-ubuntu1804-gcc8-opt/lib:/atlas/software/intel/clang/nightly-20220402/x86_64-ubuntu1804-gcc8-opt/lib:/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/lib64                                                                                   


  #$                                                                                                     
  PATH=/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/../nvvm/bin:/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin:/atlas/software/cmake/3.23.0/x86_64-ubuntu1804-gcc7-opt/bin:/atlas/software/root/6.24.06/x86_64-ubuntu1804-gcc8-opt/bin:/atlas/software/xrootd/5.3.1/x86_64-ubuntu1804-gcc8-opt/bin:/atlas/software/intel/clang/nightly-20220402/x86_64-ubuntu1804-gcc8-opt/bin:/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin  


  #$                                                                                                     
  INCLUDES="-I/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/../targets/x86_64-linux/include"         


  #$ LIBRARIES=                                                                                          
  "-L/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/../targets/x86_64-linux/lib/stubs"                
  "-L/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/../targets/x86_64-linux/lib"                      


  #$ CUDAFE_FLAGS=                                                                                       

  #$ PTXAS_FLAGS=                                                                                        

  #$ rm tmp/a_dlink.reg.c                                                                                

  #$                                                                                                     
  "/atlas/software/intel/clang/nightly-20220402/x86_64-ubuntu1804-gcc8-opt/bin"/clang++                  
  -D__CUDA_ARCH__=520 -D__CUDA_ARCH_LIST__=520 -E -x c++                                                 
  -DCUDA_DOUBLE_MATH_FUNCTIONS -D__CUDACC__ -D__NVCC__                                                   
  "-I/atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/../targets/x86_64-linux/include"                  
  -D__CUDACC_VER_MAJOR__=11 -D__CUDACC_VER_MINOR__=5                                                     
  -D__CUDACC_VER_BUILD__=119 -D__CUDA_API_VER_MAJOR__=11                                                 
  -D__CUDA_API_VER_MINOR__=5 -D__NVCC_DIAG_PRAGMA_SUPPORT__=1 -include                                   
  "cuda_runtime.h" -m64 "CMakeCUDACompilerId.cu" -o                                                      
  "tmp/CMakeCUDACompilerId.cpp1.ii"                                                                      

  In file included from <built-in>:1:                                                                    

  In file included from                                                                                  
  /atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/../targets/x86_64-linux/include/cuda_runtime.h:83:   


                                                                                                         
  /atlas/software/cuda/11.5.2/x86_64-ubuntu1804/bin/../targets/x86_64-linux/include/crt/host_config.h:147:2:                                                                                                      
  error: -- unsupported clang version! clang version must be less than 13 and                            
  greater than 3.2 .  The nvcc flag '-allow-unsupported-compiler' can be used                            
  to override this version check; however, using an unsupported host compiler                            
  may cause compilation failure or incorrect run time execution.  Use at your                            
  own risk.                                                                                              

  #error -- unsupported clang version! clang version must be less than 13 and                            
  greater than 3.2 .  The nvcc flag '-allow-unsupported-compiler' can be used                            
  to override this version check; however, using an unsupported host compiler                            
  may cause compilation failure or incorrect run time execution.  Use at your                            
  own risk.                                                                                              

   ^                                                                                                     

  1 error generated.                                                                                     

  # --error 0x1 --                                                                                       

                                                                                                         

                                                                                                         

Call Stack (most recent call first):                                                                     
  /atlas/software/cmake/3.23.0/x86_64-ubuntu1804-gcc7-opt/share/cmake-3.23/Modules/CMakeDetermineCompilerId.cmake:6 (CMAKE_DETERMINE_COMPILER_ID_BUILD)                                                           
  /atlas/software/cmake/3.23.0/x86_64-ubuntu1804-gcc7-opt/share/cmake-3.23/Modules/CMakeDetermineCompilerId.cmake:48 (__determine_compiler_id_test)                                                               
  /atlas/software/cmake/3.23.0/x86_64-ubuntu1804-gcc7-opt/share/cmake-3.23/Modules/CMakeDetermineCUDACompiler.cmake:339 (CMAKE_DETERMINE_COMPILER_ID)                                                             
  device/cuda/CMakeLists.txt:12 (enable_language)                                                        


-- Configuring incomplete, errors occurred!
See also "/home/krasznaa/ATLAS/projects/traccc/build/CMakeFiles/CMakeOutput.log".
See also "/home/krasznaa/ATLAS/projects/traccc/build/CMakeFiles/CMakeError.log".
```

The way I understood the issue is that in order to force `nvcc` to accept the Intel compiler as the host compiler, I use the following environment setting:

```sh
export CUDAFLAGS="${CUDAFLAGS} -allow-unsupported-compiler"
```

The `CUDAFLAGS` environment variable is meant to be incorporated by CMake into `CMAKE_CUDA_FLAGS`. But not if `CMAKE_CUDA_FLAGS` already has some values assigned to it by the time CUDA is enabled as a language. In that case `-allow-unsupported-compiler` gets lost, and we end up with the above mentioned errors.

Long story short, just moving `enable_language(CUDA)` at the top of these files solves the issue. :wink: