### PR TITLE
Add binary file I/O

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(options)
 add_subdirectory(performance)
 add_subdirectory(run)
+add_subdirectory(io)

--- a/examples/io/CMakeLists.txt
+++ b/examples/io/CMakeLists.txt
@@ -1,0 +1,8 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+traccc_add_executable( create_binaries "create_binaries.cpp"
+   LINK_LIBRARIES vecmem::core traccc::core traccc::io traccc::options)

--- a/examples/io/create_binaries.cpp
+++ b/examples/io/create_binaries.cpp
@@ -30,11 +30,13 @@ int create_binaries(const std::string& detector_file,
 
             // Read the cells from the relevant event file
             traccc::host_cell_container cells_csv =
-                traccc::read_cells_from_event(event, cell_directory, "csv",
+                traccc::read_cells_from_event(event, cell_directory,
+                                              traccc::data_format::csv,
                                               surface_transforms, host_mr);
 
             // Write binary file
-            traccc::write_cells(event, cell_directory, "binary", cells_csv);
+            traccc::write_cells(event, cell_directory,
+                                traccc::data_format::binary, cells_csv);
         }
 
         if (!hit_directory.empty()) {
@@ -42,10 +44,12 @@ int create_binaries(const std::string& detector_file,
             // Read the hits from the relevant event file
             traccc::host_spacepoint_container spacepoints_csv =
                 traccc::read_spacepoints_from_event(
-                    event, hit_directory, "csv", surface_transforms, host_mr);
+                    event, hit_directory, traccc::data_format::csv,
+                    surface_transforms, host_mr);
 
             // Write binary file
-            traccc::write_spacepoints(event, hit_directory, "binary",
+            traccc::write_spacepoints(event, hit_directory,
+                                      traccc::data_format::binary,
                                       spacepoints_csv);
         }
     }

--- a/examples/io/create_binaries.cpp
+++ b/examples/io/create_binaries.cpp
@@ -1,0 +1,92 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/io/reader.hpp"
+#include "traccc/io/writer.hpp"
+#include "traccc/options/handle_argument_errors.hpp"
+
+namespace po = boost::program_options;
+
+int create_binaries(const std::string& detector_file,
+                    const std::string& cell_directory,
+                    const std::string& hit_directory,
+                    const unsigned int n_events, const int skip) {
+
+    // Read the surface transforms
+    auto surface_transforms = traccc::read_geometry(detector_file);
+
+    // Memory resource used by the EDM.
+    vecmem::host_memory_resource host_mr;
+
+    // Loop over events
+    for (unsigned int event = skip; event < n_events + skip; ++event) {
+
+        if (!cell_directory.empty()) {
+
+            // Read the cells from the relevant event file
+            traccc::host_cell_container cells_csv =
+                traccc::read_cells_from_event(event, cell_directory, "csv",
+                                              surface_transforms, host_mr);
+
+            // Write binary file
+            traccc::write_cells(event, cell_directory, "binary", cells_csv);
+        }
+
+        if (!hit_directory.empty()) {
+
+            // Read the hits from the relevant event file
+            traccc::host_spacepoint_container spacepoints_csv =
+                traccc::read_spacepoints_from_event(
+                    event, hit_directory, "csv", surface_transforms, host_mr);
+
+            // Write binary file
+            traccc::write_spacepoints(event, hit_directory, "binary",
+                                      spacepoints_csv);
+        }
+    }
+
+    return 0;
+}
+
+// The main routine
+//
+int main(int argc, char* argv[]) {
+    // Set up the program options
+    po::options_description desc("Allowed options");
+
+    // Add options
+    desc.add_options()("help,h", "Give some help with the program's options");
+    desc.add_options()("detector_file", po::value<std::string>()->required(),
+                       "specify detector file");
+    desc.add_options()("cell_directory",
+                       po::value<std::string>()->default_value(""),
+                       "specify the directory of cell files");
+    desc.add_options()("hit_directory",
+                       po::value<std::string>()->default_value(""),
+                       "specify the directory of hit files");
+    desc.add_options()("events", po::value<unsigned int>()->required(),
+                       "number of events");
+    desc.add_options()("skip", po::value<int>()->default_value(0),
+                       "number of events to skip");
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+
+    // Check errors
+    traccc::handle_argument_errors(vm, desc);
+
+    // Read options
+    auto detector_file = vm["detector_file"].as<std::string>();
+    auto cell_directory = vm["cell_directory"].as<std::string>();
+    auto hit_directory = vm["hit_directory"].as<std::string>();
+    auto events = vm["events"].as<unsigned int>();
+    auto skip = vm["skip"].as<int>();
+
+    return create_binaries(detector_file, cell_directory, hit_directory, events,
+                           skip);
+}

--- a/examples/options/CMakeLists.txt
+++ b/examples/options/CMakeLists.txt
@@ -7,10 +7,12 @@
 # Set up the "build" of the traccc::option library.
 traccc_add_library( traccc_options options TYPE SHARED
   # header files
+  "include/traccc/options/common_options.hpp"
   "include/traccc/options/handle_argument_errors.hpp"
   "include/traccc/options/seeding_input_options.hpp"
   "include/traccc/options/full_tracking_input_options.hpp" 
   # source files
+  "src/options/common_options.cpp"
   "src/options/handle_argument_errors.cpp"
   "src/options/seeding_input_options.cpp"
   "src/options/full_tracking_input_options.cpp"

--- a/examples/options/CMakeLists.txt
+++ b/examples/options/CMakeLists.txt
@@ -15,4 +15,4 @@ traccc_add_library( traccc_options options TYPE SHARED
   "src/options/seeding_input_options.cpp"
   "src/options/full_tracking_input_options.cpp"
   )
-target_link_libraries( traccc_options PUBLIC Boost::program_options)
+target_link_libraries( traccc_options PUBLIC traccc::io Boost::program_options)

--- a/examples/options/include/traccc/options/common_options.hpp
+++ b/examples/options/include/traccc/options/common_options.hpp
@@ -16,7 +16,7 @@ namespace traccc {
 namespace po = boost::program_options;
 
 struct common_options {
-    traccc::data_format data_format = traccc::data_format::csv;
+    traccc::data_format input_data_format = traccc::data_format::csv;
     unsigned int events;
     int skip;
 

--- a/examples/options/include/traccc/options/common_options.hpp
+++ b/examples/options/include/traccc/options/common_options.hpp
@@ -15,16 +15,12 @@ namespace traccc {
 
 namespace po = boost::program_options;
 
-struct seeding_input_config {
-    std::string detector_file;
-    std::string hit_directory;
+struct common_options {
     traccc::data_format data_format = traccc::data_format::csv;
-    std::string particle_directory;
-    bool check_seeding_performance;
     unsigned int events;
     int skip;
 
-    seeding_input_config(po::options_description& desc);
+    common_options(po::options_description& desc);
     void read(const po::variables_map& vm);
 };
 

--- a/examples/options/include/traccc/options/full_tracking_input_options.hpp
+++ b/examples/options/include/traccc/options/full_tracking_input_options.hpp
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// Project include(s)
+#include "traccc/io/data_format.hpp"
+
 // Boost
 #include <boost/program_options.hpp>
 
@@ -15,7 +18,7 @@ namespace po = boost::program_options;
 struct full_tracking_input_config {
     std::string detector_file;
     std::string cell_directory;
-    std::string data_format;
+    traccc::data_format data_format = traccc::data_format::csv;
     std::string hit_directory;
     std::string particle_directory;
     bool check_seeding_performance;

--- a/examples/options/include/traccc/options/full_tracking_input_options.hpp
+++ b/examples/options/include/traccc/options/full_tracking_input_options.hpp
@@ -5,9 +5,6 @@
  * Mozilla Public License Version 2.0
  */
 
-// Project include(s)
-#include "traccc/io/data_format.hpp"
-
 // Boost
 #include <boost/program_options.hpp>
 
@@ -18,12 +15,9 @@ namespace po = boost::program_options;
 struct full_tracking_input_config {
     std::string detector_file;
     std::string cell_directory;
-    traccc::data_format data_format = traccc::data_format::csv;
     std::string hit_directory;
     std::string particle_directory;
     bool check_seeding_performance;
-    unsigned int events;
-    int skip;
 
     full_tracking_input_config(po::options_description& desc);
     void read(const po::variables_map& vm);

--- a/examples/options/include/traccc/options/full_tracking_input_options.hpp
+++ b/examples/options/include/traccc/options/full_tracking_input_options.hpp
@@ -15,6 +15,7 @@ namespace po = boost::program_options;
 struct full_tracking_input_config {
     std::string detector_file;
     std::string cell_directory;
+    std::string data_format;
     std::string hit_directory;
     std::string particle_directory;
     bool check_seeding_performance;

--- a/examples/options/include/traccc/options/seeding_input_options.hpp
+++ b/examples/options/include/traccc/options/seeding_input_options.hpp
@@ -5,9 +5,6 @@
  * Mozilla Public License Version 2.0
  */
 
-// Project include(s)
-#include "traccc/io/data_format.hpp"
-
 // Boost
 #include <boost/program_options.hpp>
 
@@ -18,11 +15,8 @@ namespace po = boost::program_options;
 struct seeding_input_config {
     std::string detector_file;
     std::string hit_directory;
-    traccc::data_format data_format = traccc::data_format::csv;
     std::string particle_directory;
     bool check_seeding_performance;
-    unsigned int events;
-    int skip;
 
     seeding_input_config(po::options_description& desc);
     void read(const po::variables_map& vm);

--- a/examples/options/include/traccc/options/seeding_input_options.hpp
+++ b/examples/options/include/traccc/options/seeding_input_options.hpp
@@ -15,6 +15,7 @@ namespace po = boost::program_options;
 struct seeding_input_config {
     std::string detector_file;
     std::string hit_directory;
+    std::string data_format;
     std::string particle_directory;
     bool check_seeding_performance;
     unsigned int events;

--- a/examples/options/src/options/common_options.cpp
+++ b/examples/options/src/options/common_options.cpp
@@ -8,25 +8,22 @@
 // options
 #include "traccc/options/common_options.hpp"
 
-traccc::common_options::common_options(
-    po::options_description& desc){
+traccc::common_options::common_options(po::options_description& desc) {
 
-    desc.add_options()("input-csv", po::value<bool>()->default_value(false),
-                       "Use csv input file")(
-        "input-binary", po::value<bool>()->default_value(false),
-        "Use binary input file");
+    desc.add_options()("input-csv", "Use csv input file");
+    desc.add_options()("input-binary", "Use binary input file");
     desc.add_options()("events", po::value<unsigned int>()->required(),
                        "number of events");
     desc.add_options()("skip", po::value<int>()->default_value(0),
                        "number of events to skip");
 }
 
-void traccc::common_options::read(const po::variables_map& vm) {    
+void traccc::common_options::read(const po::variables_map& vm) {
 
-    if (vm["input-csv"].as<bool>() == true) {
-        data_format == traccc::data_format::csv;
-    } else if (vm["input-binary"].as<bool>() == true) {
-        data_format == traccc::data_format::binary;
+    if (vm.count("input-csv")) {
+        input_data_format = traccc::data_format::csv;
+    } else if (vm.count("input-binary")) {
+        input_data_format = traccc::data_format::binary;
     }
     events = vm["events"].as<unsigned int>();
     skip = vm["skip"].as<int>();

--- a/examples/options/src/options/common_options.cpp
+++ b/examples/options/src/options/common_options.cpp
@@ -1,0 +1,33 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// options
+#include "traccc/options/common_options.hpp"
+
+traccc::common_options::common_options(
+    po::options_description& desc){
+
+    desc.add_options()("input-csv", po::value<bool>()->default_value(false),
+                       "Use csv input file")(
+        "input-binary", po::value<bool>()->default_value(false),
+        "Use binary input file");
+    desc.add_options()("events", po::value<unsigned int>()->required(),
+                       "number of events");
+    desc.add_options()("skip", po::value<int>()->default_value(0),
+                       "number of events to skip");
+}
+
+void traccc::common_options::read(const po::variables_map& vm) {    
+
+    if (vm["input-csv"].as<bool>() == true) {
+        data_format == traccc::data_format::csv;
+    } else if (vm["input-binary"].as<bool>() == true) {
+        data_format == traccc::data_format::binary;
+    }
+    events = vm["events"].as<unsigned int>();
+    skip = vm["skip"].as<int>();
+}

--- a/examples/options/src/options/full_tracking_input_options.cpp
+++ b/examples/options/src/options/full_tracking_input_options.cpp
@@ -16,6 +16,9 @@ traccc::full_tracking_input_config::full_tracking_input_config(
     desc.add_options()("cell_directory", po::value<std::string>()->required(),
                        "specify the directory of cell files");
     desc.add_options()(
+        "data_format", po::value<std::string>()->default_value("csv"),
+        "specify the data format (csv, binary) of input cell file");
+    desc.add_options()(
         "hit_directory", po::value<std::string>()->default_value(""),
         "specify the directory of hit files used for performance writer");
     desc.add_options()(
@@ -30,6 +33,7 @@ traccc::full_tracking_input_config::full_tracking_input_config(
 void traccc::full_tracking_input_config::read(const po::variables_map& vm) {
     detector_file = vm["detector_file"].as<std::string>();
     cell_directory = vm["cell_directory"].as<std::string>();
+    data_format = vm["data_format"].as<std::string>();
     hit_directory = vm["hit_directory"].as<std::string>();
     particle_directory = vm["particle_directory"].as<std::string>();
     events = vm["events"].as<unsigned int>();

--- a/examples/options/src/options/full_tracking_input_options.cpp
+++ b/examples/options/src/options/full_tracking_input_options.cpp
@@ -15,9 +15,10 @@ traccc::full_tracking_input_config::full_tracking_input_config(
                        "specify detector file");
     desc.add_options()("cell_directory", po::value<std::string>()->required(),
                        "specify the directory of cell files");
-    desc.add_options()(
-        "data_format", po::value<std::string>()->default_value("csv"),
-        "specify the data format (csv, binary) of input cell file");
+    desc.add_options()("input-csv", po::value<bool>()->default_value(false),
+                       "Use csv input file")(
+        "input-binary", po::value<bool>()->default_value(false),
+        "Use binary input file");
     desc.add_options()(
         "hit_directory", po::value<std::string>()->default_value(""),
         "specify the directory of hit files used for performance writer");
@@ -33,7 +34,13 @@ traccc::full_tracking_input_config::full_tracking_input_config(
 void traccc::full_tracking_input_config::read(const po::variables_map& vm) {
     detector_file = vm["detector_file"].as<std::string>();
     cell_directory = vm["cell_directory"].as<std::string>();
-    data_format = vm["data_format"].as<std::string>();
+
+    if (vm["input-csv"].as<bool>() == true) {
+        data_format == traccc::data_format::csv;
+    } else if (vm["input-binary"].as<bool>() == true) {
+        data_format == traccc::data_format::binary;
+    }
+
     hit_directory = vm["hit_directory"].as<std::string>();
     particle_directory = vm["particle_directory"].as<std::string>();
     events = vm["events"].as<unsigned int>();

--- a/examples/options/src/options/full_tracking_input_options.cpp
+++ b/examples/options/src/options/full_tracking_input_options.cpp
@@ -15,36 +15,19 @@ traccc::full_tracking_input_config::full_tracking_input_config(
                        "specify detector file");
     desc.add_options()("cell_directory", po::value<std::string>()->required(),
                        "specify the directory of cell files");
-    desc.add_options()("input-csv", po::value<bool>()->default_value(false),
-                       "Use csv input file")(
-        "input-binary", po::value<bool>()->default_value(false),
-        "Use binary input file");
     desc.add_options()(
         "hit_directory", po::value<std::string>()->default_value(""),
         "specify the directory of hit files used for performance writer");
     desc.add_options()(
         "particle_directory", po::value<std::string>()->default_value(""),
         "specify the directory of particle files used for performance writer");
-    desc.add_options()("events", po::value<unsigned int>()->required(),
-                       "number of events");
-    desc.add_options()("skip", po::value<int>()->default_value(0),
-                       "number of events to skip");
 }
 
 void traccc::full_tracking_input_config::read(const po::variables_map& vm) {
     detector_file = vm["detector_file"].as<std::string>();
     cell_directory = vm["cell_directory"].as<std::string>();
-
-    if (vm["input-csv"].as<bool>() == true) {
-        data_format == traccc::data_format::csv;
-    } else if (vm["input-binary"].as<bool>() == true) {
-        data_format == traccc::data_format::binary;
-    }
-
     hit_directory = vm["hit_directory"].as<std::string>();
     particle_directory = vm["particle_directory"].as<std::string>();
-    events = vm["events"].as<unsigned int>();
-    skip = vm["skip"].as<int>();
     check_seeding_performance =
-        (particle_directory != "") && (hit_directory != "");
+        (!particle_directory.empty()) && (!hit_directory.empty());
 }

--- a/examples/options/src/options/seeding_input_options.cpp
+++ b/examples/options/src/options/seeding_input_options.cpp
@@ -16,6 +16,9 @@ traccc::seeding_input_config::seeding_input_config(
     desc.add_options()("hit_directory", po::value<std::string>()->required(),
                        "specify the directory of hit files");
     desc.add_options()(
+        "data_format", po::value<std::string>()->default_value("csv"),
+        "specify the data format (csv, binary) of input hit file");
+    desc.add_options()(
         "particle_directory", po::value<std::string>()->default_value(""),
         "specify the directory of particle files used for performance writer");
     desc.add_options()("events", po::value<unsigned int>()->required(),
@@ -27,6 +30,7 @@ traccc::seeding_input_config::seeding_input_config(
 void traccc::seeding_input_config::read(const po::variables_map& vm) {
     detector_file = vm["detector_file"].as<std::string>();
     hit_directory = vm["hit_directory"].as<std::string>();
+    data_format = vm["data_format"].as<std::string>();
     particle_directory = vm["particle_directory"].as<std::string>();
     events = vm["events"].as<unsigned int>();
     skip = vm["skip"].as<int>();

--- a/examples/options/src/options/seeding_input_options.cpp
+++ b/examples/options/src/options/seeding_input_options.cpp
@@ -15,31 +15,14 @@ traccc::seeding_input_config::seeding_input_config(
                        "specify detector file");
     desc.add_options()("hit_directory", po::value<std::string>()->required(),
                        "specify the directory of hit files");
-    desc.add_options()("input-csv", po::value<bool>()->default_value(false),
-                       "Use csv input file")(
-        "input-binary", po::value<bool>()->default_value(false),
-        "Use binary input file");
     desc.add_options()(
         "particle_directory", po::value<std::string>()->default_value(""),
         "specify the directory of particle files used for performance writer");
-    desc.add_options()("events", po::value<unsigned int>()->required(),
-                       "number of events");
-    desc.add_options()("skip", po::value<int>()->default_value(0),
-                       "number of events to skip");
 }
 
 void traccc::seeding_input_config::read(const po::variables_map& vm) {
     detector_file = vm["detector_file"].as<std::string>();
     hit_directory = vm["hit_directory"].as<std::string>();
-
-    if (vm["input-csv"].as<bool>() == true) {
-        data_format == traccc::data_format::csv;
-    } else if (vm["input-binary"].as<bool>() == true) {
-        data_format == traccc::data_format::binary;
-    }
-
     particle_directory = vm["particle_directory"].as<std::string>();
-    events = vm["events"].as<unsigned int>();
-    skip = vm["skip"].as<int>();
-    check_seeding_performance = (particle_directory != "");
+    check_seeding_performance = (!particle_directory.empty());
 }

--- a/examples/options/src/options/seeding_input_options.cpp
+++ b/examples/options/src/options/seeding_input_options.cpp
@@ -15,9 +15,10 @@ traccc::seeding_input_config::seeding_input_config(
                        "specify detector file");
     desc.add_options()("hit_directory", po::value<std::string>()->required(),
                        "specify the directory of hit files");
-    desc.add_options()(
-        "data_format", po::value<std::string>()->default_value("csv"),
-        "specify the data format (csv, binary) of input hit file");
+    desc.add_options()("input-csv", po::value<bool>()->default_value(false),
+                       "Use csv input file")(
+        "input-binary", po::value<bool>()->default_value(false),
+        "Use binary input file");
     desc.add_options()(
         "particle_directory", po::value<std::string>()->default_value(""),
         "specify the directory of particle files used for performance writer");
@@ -30,7 +31,13 @@ traccc::seeding_input_config::seeding_input_config(
 void traccc::seeding_input_config::read(const po::variables_map& vm) {
     detector_file = vm["detector_file"].as<std::string>();
     hit_directory = vm["hit_directory"].as<std::string>();
-    data_format = vm["data_format"].as<std::string>();
+
+    if (vm["input-csv"].as<bool>() == true) {
+        data_format == traccc::data_format::csv;
+    } else if (vm["input-binary"].as<bool>() == true) {
+        data_format == traccc::data_format::binary;
+    }
+
     particle_directory = vm["particle_directory"].as<std::string>();
     events = vm["events"].as<unsigned int>();
     skip = vm["skip"].as<int>();

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -53,6 +53,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg) {
         // Read the hits from the relevant event file
         traccc::host_spacepoint_container spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
+                                                i_cfg.data_format,
                                                 surface_transforms, host_mr);
 
         /*----------------

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -18,6 +18,7 @@
 #include "traccc/efficiency/seeding_performance_writer.hpp"
 
 // options
+#include "traccc/options/common_options.hpp"
 #include "traccc/options/handle_argument_errors.hpp"
 #include "traccc/options/seeding_input_options.hpp"
 
@@ -26,7 +27,8 @@
 
 namespace po = boost::program_options;
 
-int seq_run(const traccc::seeding_input_config& i_cfg) {
+int seq_run(const traccc::seeding_input_config& i_cfg,
+            const traccc::common_options& common_opts) {
 
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
@@ -47,13 +49,13 @@ int seq_run(const traccc::seeding_input_config& i_cfg) {
     sd_performance_writer.add_cache("CPU");
 
     // Loop over events
-    for (unsigned int event = i_cfg.skip; event < i_cfg.events + i_cfg.skip;
+    for (unsigned int event = common_opts.skip; event < common_opts.events + common_opts.skip;
          ++event) {
 
         // Read the hits from the relevant event file
         traccc::host_spacepoint_container spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
-                                                i_cfg.data_format,
+                                                common_opts.data_format,
                                                 surface_transforms, host_mr);
 
         /*----------------
@@ -99,6 +101,7 @@ int main(int argc, char* argv[]) {
 
     // Add options
     desc.add_options()("help,h", "Give some help with the program's options");
+    traccc::common_options common_opts(desc);
     traccc::seeding_input_config seeding_input_cfg(desc);
 
     po::variables_map vm;
@@ -108,11 +111,12 @@ int main(int argc, char* argv[]) {
     traccc::handle_argument_errors(vm, desc);
 
     // Read options
+    common_opts.read(vm);
     seeding_input_cfg.read(vm);
 
     std::cout << "Running " << argv[0] << " " << seeding_input_cfg.detector_file
               << " " << seeding_input_cfg.hit_directory << " "
-              << seeding_input_cfg.events << std::endl;
+              << common_opts.events << std::endl;
 
-    return seq_run(seeding_input_cfg);
+    return seq_run(seeding_input_cfg, common_opts);
 }

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -49,13 +49,13 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     sd_performance_writer.add_cache("CPU");
 
     // Loop over events
-    for (unsigned int event = common_opts.skip; event < common_opts.events + common_opts.skip;
-         ++event) {
+    for (unsigned int event = common_opts.skip;
+         event < common_opts.events + common_opts.skip; ++event) {
 
         // Read the hits from the relevant event file
         traccc::host_spacepoint_container spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
-                                                common_opts.data_format,
+                                                common_opts.input_data_format,
                                                 surface_transforms, host_mr);
 
         /*----------------

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -56,14 +56,14 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     sd_performance_writer.add_cache("CPU");
 
     // Loop over events
-    for (unsigned int event = common_opts.skip; event < common_opts.events + common_opts.skip;
-         ++event) {
+    for (unsigned int event = common_opts.skip;
+         event < common_opts.events + common_opts.skip; ++event) {
 
         // Read the cells from the relevant event file
         traccc::host_cell_container cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          common_opts.data_format, surface_transforms,
-                                          host_mr);
+                                          common_opts.input_data_format,
+                                          surface_transforms, host_mr);
 
         /*-------------------
             Clusterization

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -60,7 +60,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg) {
         // Read the cells from the relevant event file
         traccc::host_cell_container cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          surface_transforms, host_mr);
+                                          i_cfg.data_format, surface_transforms,
+                                          host_mr);
 
         /*-------------------
             Clusterization
@@ -80,8 +81,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg) {
           Track params estimation
           ----------------------------*/
 
-        auto tp_output = tp(spacepoints_per_event, seeds);
-        auto& params = tp_output;
+        auto params = tp(spacepoints_per_event, seeds);
 
         /*----------------------------
           Statistics
@@ -105,11 +105,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg) {
             sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
                                         evt_map);
         }
-
-        traccc::write_measurements(event, measurements_per_event);
-        traccc::write_spacepoints(event, spacepoints_per_event);
-        traccc::write_seeds(event, spacepoints_per_event, seeds);
-        traccc::write_estimated_track_parameters(event, params);
     }
 
     sd_performance_writer.finalize();

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -20,6 +20,7 @@
 #include "traccc/efficiency/seeding_performance_writer.hpp"
 
 // options
+#include "traccc/options/common_options.hpp"
 #include "traccc/options/handle_argument_errors.hpp"
 #include "traccc/options/seeding_input_options.hpp"
 
@@ -35,7 +36,8 @@
 
 namespace po = boost::program_options;
 
-int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
+int seq_run(const traccc::seeding_input_config& i_cfg,
+            const traccc::common_options& common_opts, bool run_cpu) {
 
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
@@ -73,7 +75,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
     /*time*/ auto start_wall_time = std::chrono::system_clock::now();
 
     // Loop over events
-    for (unsigned int event = i_cfg.skip; event < i_cfg.events + i_cfg.skip;
+    for (unsigned int event = common_opts.skip; event < common_opts.events + common_opts.skip;
          ++event) {
 
         /*-----------------
@@ -85,7 +87,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
         // Read the hits from the relevant event file
         traccc::host_spacepoint_container spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
-                                                i_cfg.data_format,
+                                                common_opts.data_format,
                                                 surface_transforms, mng_mr);
 
         /*time*/ auto end_hit_reading_cpu = std::chrono::system_clock::now();
@@ -250,6 +252,7 @@ int main(int argc, char* argv[]) {
 
     // Add options
     desc.add_options()("help,h", "Give some help with the program's options");
+    traccc::common_options common_opts(desc);
     traccc::seeding_input_config seeding_input_cfg(desc);
     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
@@ -261,12 +264,13 @@ int main(int argc, char* argv[]) {
     traccc::handle_argument_errors(vm, desc);
 
     // Read options
+    common_opts.read(vm);
     seeding_input_cfg.read(vm);
     auto run_cpu = vm["run_cpu"].as<bool>();
 
     std::cout << "Running " << argv[0] << " " << seeding_input_cfg.detector_file
               << " " << seeding_input_cfg.hit_directory << " "
-              << seeding_input_cfg.events << std::endl;
+              << common_opts.events << std::endl;
 
-    return seq_run(seeding_input_cfg, run_cpu);
+    return seq_run(seeding_input_cfg, common_opts, run_cpu);
 }

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -85,6 +85,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
         // Read the hits from the relevant event file
         traccc::host_spacepoint_container spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
+                                                i_cfg.data_format,
                                                 surface_transforms, mng_mr);
 
         /*time*/ auto end_hit_reading_cpu = std::chrono::system_clock::now();
@@ -208,12 +209,6 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
                 sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
                                             evt_map);
             }
-        }
-
-        if (run_cpu) {
-            traccc::write_spacepoints(event, spacepoints_per_event);
-            traccc::write_seeds(event, spacepoints_per_event, seeds);
-            traccc::write_estimated_track_parameters(event, params);
         }
     }
 

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -75,8 +75,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     /*time*/ auto start_wall_time = std::chrono::system_clock::now();
 
     // Loop over events
-    for (unsigned int event = common_opts.skip; event < common_opts.events + common_opts.skip;
-         ++event) {
+    for (unsigned int event = common_opts.skip;
+         event < common_opts.events + common_opts.skip; ++event) {
 
         /*-----------------
           hit file reading
@@ -87,7 +87,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         // Read the hits from the relevant event file
         traccc::host_spacepoint_container spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
-                                                common_opts.data_format,
+                                                common_opts.input_data_format,
                                                 surface_transforms, mng_mr);
 
         /*time*/ auto end_hit_reading_cpu = std::chrono::system_clock::now();

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -89,7 +89,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         // Read the cells from the relevant event file
         traccc::host_cell_container cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          surface_transforms, host_mr);
+                                          i_cfg.data_format, surface_transforms,
+                                          host_mr);
 
         /*time*/ auto end_file_reading_cpu = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_file_reading_cpu =
@@ -236,13 +237,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
                 sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
                                             evt_map);
             }
-        }
-
-        if (run_cpu) {
-            traccc::write_measurements(event, measurements_per_event);
-            traccc::write_spacepoints(event, spacepoints_per_event);
-            traccc::write_seeds(event, spacepoints_per_event, seeds);
-            traccc::write_estimated_track_parameters(event, params);
         }
     }
 

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -83,16 +83,16 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     /*time*/ auto start_wall_time = std::chrono::system_clock::now();
 
     // Loop over events
-    for (unsigned int event = common_opts.skip; event < common_opts.events + common_opts.skip;
-         ++event) {
+    for (unsigned int event = common_opts.skip;
+         event < common_opts.events + common_opts.skip; ++event) {
 
         /*time*/ auto start_file_reading_cpu = std::chrono::system_clock::now();
 
         // Read the cells from the relevant event file
         traccc::host_cell_container cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          common_opts.data_format, surface_transforms,
-                                          host_mr);
+                                          common_opts.input_data_format,
+                                          surface_transforms, host_mr);
 
         /*time*/ auto end_file_reading_cpu = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_file_reading_cpu =

--- a/examples/run/openmp/io_dec_par_example.cpp
+++ b/examples/run/openmp/io_dec_par_example.cpp
@@ -144,6 +144,7 @@ int main(int argc, char *argv[]) {
 
     auto detector_file = vm["detector_file"].as<std::string>();
     auto cell_directory = vm["cell_directory"].as<std::string>();
+    auto data_format = vm["data_format"].as<std::string>();
     auto events = vm["events"].as<int>();
 
     std::cout << "Running " << argv[0] << " " << detector_file << " "
@@ -152,10 +153,6 @@ int main(int argc, char *argv[]) {
     auto start = std::chrono::system_clock::now();
     vecmem::host_memory_resource resource;
     set_default_resource(&resource);
-
-    traccc::write(
-        run(traccc::read(events, detector_file, cell_directory, resource),
-            resource));
 
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> diff = end - start;

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -109,30 +109,6 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
                     module.module, std::move(spacepoints_per_module));
             }
         }
-
-        traccc::measurement_writer mwriter{
-            traccc::get_event_filename(event, "-measurements.csv")};
-        for (size_t i = 0; i < measurements_per_event.size(); ++i) {
-            auto measurements_per_module = measurements_per_event.at(i).items;
-            auto module = measurements_per_event.at(i).header;
-            for (const auto &measurement : measurements_per_module) {
-                const auto &local = measurement.local;
-                mwriter.append({module.module, "", local[0], local[1], 0., 0.,
-                                0., 0., 0., 0., 0., 0.});
-            }
-        }
-
-        traccc::spacepoint_writer spwriter{
-            traccc::get_event_filename(event, "-spacepoints.csv")};
-        for (size_t i = 0; i < spacepoints_per_event.size(); ++i) {
-            auto spacepoints_per_module = spacepoints_per_event.at(i).items;
-            auto module = spacepoints_per_event.at(i).header;
-
-            for (const auto &spacepoint : spacepoints_per_module) {
-                const auto &pos = spacepoint.global;
-                spwriter.append({module, pos[0], pos[1], pos[2]});
-            }
-        }
     }
 
     std::cout << "==> Statistics ... " << std::endl;

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -95,6 +95,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
         // Read the hits from the relevant event file
         traccc::host_spacepoint_container spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
+                                                i_cfg.data_format,
                                                 surface_transforms, shared_mr);
 
         /*time*/ auto end_hit_reading_cpu = std::chrono::system_clock::now();
@@ -218,12 +219,6 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
                 sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
                                             evt_map);
             }
-        }
-
-        if (run_cpu) {
-            traccc::write_spacepoints(event, spacepoints_per_event);
-            traccc::write_seeds(event, spacepoints_per_event, seeds);
-            traccc::write_estimated_track_parameters(event, params);
         }
     }
 

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -23,6 +23,7 @@
 #include "traccc/efficiency/seeding_performance_writer.hpp"
 
 // options
+#include "traccc/options/common_options.hpp"
 #include "traccc/options/handle_argument_errors.hpp"
 #include "traccc/options/seeding_input_options.hpp"
 
@@ -38,7 +39,8 @@
 
 namespace po = boost::program_options;
 
-int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
+int seq_run(const traccc::seeding_input_config& i_cfg,
+            const traccc::common_options& common_opts, bool run_cpu) {
 
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
@@ -83,8 +85,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
     /*time*/ auto start_wall_time = std::chrono::system_clock::now();
 
     // Loop over events
-    for (unsigned int event = i_cfg.skip; event < i_cfg.events + i_cfg.skip;
-         ++event) {
+    for (unsigned int event = common_opts.skip;
+         event < common_opts.events + common_opts.skip; ++event) {
 
         /*-----------------
           hit file reading
@@ -95,7 +97,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg, bool run_cpu) {
         // Read the hits from the relevant event file
         traccc::host_spacepoint_container spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
-                                                i_cfg.data_format,
+                                                common_opts.data_format,
                                                 surface_transforms, shared_mr);
 
         /*time*/ auto end_hit_reading_cpu = std::chrono::system_clock::now();
@@ -260,6 +262,7 @@ int main(int argc, char* argv[]) {
 
     // Add options
     desc.add_options()("help,h", "Give some help with the program's options");
+    traccc::common_options common_opts(desc);
     traccc::seeding_input_config seeding_input_cfg(desc);
     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
@@ -271,12 +274,13 @@ int main(int argc, char* argv[]) {
     traccc::handle_argument_errors(vm, desc);
 
     // Read options
+    common_opts.read(vm);
     seeding_input_cfg.read(vm);
     auto run_cpu = vm["run_cpu"].as<bool>();
 
     std::cout << "Running " << argv[0] << " " << seeding_input_cfg.detector_file
               << " " << seeding_input_cfg.hit_directory << " "
-              << seeding_input_cfg.events << std::endl;
+              << common_opts.events << std::endl;
 
-    return seq_run(seeding_input_cfg, run_cpu);
+    return seq_run(seeding_input_cfg, common_opts, run_cpu);
 }

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -97,7 +97,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         // Read the hits from the relevant event file
         traccc::host_spacepoint_container spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
-                                                common_opts.data_format,
+                                                common_opts.input_data_format,
                                                 surface_transforms, shared_mr);
 
         /*time*/ auto end_hit_reading_cpu = std::chrono::system_clock::now();

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -116,7 +116,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         // Read the cells from the relevant event file for CPU algorithm
         traccc::host_cell_container cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          common_opts.data_format,
+                                          common_opts.input_data_format,
                                           surface_transforms, host_mr);
 
         /*time*/ auto end_file_reading_cpu = std::chrono::system_clock::now();

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -26,6 +26,7 @@
 #include "traccc/efficiency/seeding_performance_writer.hpp"
 
 // options
+#include "traccc/options/common_options.hpp"
 #include "traccc/options/full_tracking_input_options.hpp"
 #include "traccc/options/handle_argument_errors.hpp"
 
@@ -53,7 +54,8 @@ auto handle_async_error = [](::sycl::exception_list elist) {
     }
 };
 
-int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
+int seq_run(const traccc::full_tracking_input_config& i_cfg,
+            const traccc::common_options& common_opts, bool run_cpu) {
 
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
@@ -106,16 +108,16 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
     /*time*/ auto start_wall_time = std::chrono::system_clock::now();
 
     // Loop over events
-    for (unsigned int event = i_cfg.skip; event < i_cfg.events + i_cfg.skip;
-         ++event) {
+    for (unsigned int event = common_opts.skip;
+         event < common_opts.events + common_opts.skip; ++event) {
 
         /*time*/ auto start_file_reading_cpu = std::chrono::system_clock::now();
 
         // Read the cells from the relevant event file for CPU algorithm
         traccc::host_cell_container cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          i_cfg.data_format, surface_transforms,
-                                          host_mr);
+                                          common_opts.data_format,
+                                          surface_transforms, host_mr);
 
         /*time*/ auto end_file_reading_cpu = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_file_reading_cpu =
@@ -358,6 +360,7 @@ int main(int argc, char* argv[]) {
 
     // Add options
     desc.add_options()("help,h", "Give some help with the program's options");
+    traccc::common_options common_opts(desc);
     traccc::full_tracking_input_config full_tracking_input_cfg(desc);
     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
@@ -369,13 +372,14 @@ int main(int argc, char* argv[]) {
     traccc::handle_argument_errors(vm, desc);
 
     // Read options
+    common_opts.read(vm);
     full_tracking_input_cfg.read(vm);
     auto run_cpu = vm["run_cpu"].as<bool>();
 
     std::cout << "Running " << argv[0] << " "
               << full_tracking_input_cfg.detector_file << " "
               << full_tracking_input_cfg.cell_directory << " "
-              << full_tracking_input_cfg.events << std::endl;
+              << common_opts.events << std::endl;
 
-    return seq_run(full_tracking_input_cfg, run_cpu);
+    return seq_run(full_tracking_input_cfg, common_opts, run_cpu);
 }

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -114,7 +114,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
         // Read the cells from the relevant event file for CPU algorithm
         traccc::host_cell_container cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          surface_transforms, host_mr);
+                                          i_cfg.data_format, surface_transforms,
+                                          host_mr);
 
         /*time*/ auto end_file_reading_cpu = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_file_reading_cpu =
@@ -303,13 +304,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg, bool run_cpu) {
                 sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
                                             evt_map);
             }
-        }
-
-        if (run_cpu) {
-            traccc::write_measurements(event, measurements_per_event);
-            traccc::write_spacepoints(event, spacepoints_per_event);
-            traccc::write_seeds(event, spacepoints_per_event, seeds);
-            traccc::write_estimated_track_parameters(event, params);
         }
     }
 

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -8,6 +8,7 @@
 traccc_add_library( traccc_io io TYPE INTERFACE
   "include/traccc/io/binary.hpp"
   "include/traccc/io/csv.hpp"
+  "include/traccc/io/data_format.hpp"
   "include/traccc/io/demonstrator_edm.hpp"
   "include/traccc/io/mapper.hpp"
   "include/traccc/io/writer.hpp"

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 # Set up the "build" of the traccc::io library.
 traccc_add_library( traccc_io io TYPE INTERFACE
+  "include/traccc/io/binary.hpp"
   "include/traccc/io/csv.hpp"
   "include/traccc/io/demonstrator_edm.hpp"
   "include/traccc/io/mapper.hpp"

--- a/io/include/traccc/io/binary.hpp
+++ b/io/include/traccc/io/binary.hpp
@@ -1,0 +1,108 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/edm/container.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/utils/copy.hpp>
+
+// System include(s).
+#include <fstream>
+
+namespace traccc {
+
+/// Function for binary file writing
+///
+/// @param out_name is the output filename which includes the path
+/// @param container is the input traccc container
+template <typename container_t>
+void write_binary(const std::string& out_name, const container_t& container) {
+    std::ofstream out_file(out_name, std::ios::out | std::ios::binary);
+
+    const auto& headers = container.get_headers();
+    const auto& items = container.get_items();
+
+    typename container_t::header_vector::size_type headers_size =
+        container.size();
+
+    // Write size
+    out_file.write(reinterpret_cast<const char*>(&headers_size),
+                   sizeof(typename container_t::header_vector::size_type));
+
+    for (const auto& i : items) {
+        typename container_t::item_vector::size_type items_size = i.size();
+
+        out_file.write(reinterpret_cast<const char*>(&items_size),
+                       sizeof(typename container_t::item_vector::size_type));
+    }
+
+    // Write elements
+    out_file.write(reinterpret_cast<const char*>(&headers[0]),
+                   headers.size() * sizeof(typename container_t::header_type));
+
+    for (const auto& i : items) {
+        out_file.write(reinterpret_cast<const char*>(&i[0]),
+                       i.size() * sizeof(typename container_t::item_type));
+    }
+
+    out_file.close();
+}
+
+/// Function for binary file writing
+///
+/// @param in_name is the input filename which includes the path
+/// @param copy is the vecem copy helper object
+/// @param resource is the vecmem memory resource
+template <typename container_t>
+container_t read_binary(const std::string& in_name, vecmem::copy& copy,
+                        vecmem::memory_resource& resource) {
+    std::ifstream in_file(in_name, std::ios::binary);
+
+    // Read size
+    typename container_t::header_vector::size_type headers_size;
+    in_file.read(reinterpret_cast<char*>(&headers_size),
+                 sizeof(typename container_t::header_vector::size_type));
+
+    std::vector<typename container_t::item_vector::size_type> items_size(
+        headers_size);
+
+    in_file.read(
+        reinterpret_cast<char*>(&items_size[0]),
+        headers_size * sizeof(typename container_t::item_vector::size_type));
+
+    // Read element
+    container_t container(&resource);
+    container_buffer<typename container_t::header_type,
+                     typename container_t::item_type>
+        buffer{{static_cast<unsigned int>(headers_size), resource},
+               {items_size, resource}};
+
+    copy.setup(buffer.headers);
+    copy.setup(buffer.items);
+
+    in_file.read(reinterpret_cast<char*>(buffer.headers.ptr()),
+                 headers_size * sizeof(typename container_t::header_type));
+
+    for (std::size_t i = 0; i < headers_size; i++) {
+        in_file.read(
+            reinterpret_cast<char*>((buffer.items.host_ptr() + i)->ptr()),
+            items_size[i] * sizeof(typename container_t::item_type));
+    }
+
+    copy(buffer.headers, container.get_headers());
+    copy(buffer.items, container.get_items());
+
+    in_file.close();
+
+    return container;
+}
+
+}  // namespace traccc

--- a/io/include/traccc/io/binary.hpp
+++ b/io/include/traccc/io/binary.hpp
@@ -16,6 +16,7 @@
 
 // System include(s).
 #include <fstream>
+#include <type_traits>
 
 namespace traccc {
 
@@ -25,6 +26,12 @@ namespace traccc {
 /// @param container is the input traccc container
 template <typename container_t>
 void write_binary(const std::string& out_name, const container_t& container) {
+
+    static_assert(std::is_standard_layout_v<typename container_t::header_type>,
+                  "Container header type must be standard layout.");
+    static_assert(std::is_standard_layout_v<typename container_t::item_type>,
+                  "Container item type must be standard layout.");
+
     std::ofstream out_file(out_name, std::ios::out | std::ios::binary);
 
     const auto& headers = container.get_headers();
@@ -64,6 +71,12 @@ void write_binary(const std::string& out_name, const container_t& container) {
 template <typename container_t>
 container_t read_binary(const std::string& in_name, vecmem::copy& copy,
                         vecmem::memory_resource& resource) {
+
+    static_assert(std::is_standard_layout_v<typename container_t::header_type>,
+                  "Container header type must be standard layout.");
+    static_assert(std::is_standard_layout_v<typename container_t::item_type>,
+                  "Container item type must be standard layout.");
+
     std::ifstream in_file(in_name, std::ios::binary);
 
     // Read size

--- a/io/include/traccc/io/data_format.hpp
+++ b/io/include/traccc/io/data_format.hpp
@@ -1,0 +1,17 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc {
+
+enum data_format : int {
+    csv = 0,
+    binary = 1,
+};
+
+}  // namespace traccc

--- a/io/include/traccc/io/mapper.hpp
+++ b/io/include/traccc/io/mapper.hpp
@@ -178,8 +178,9 @@ measurement_cell_map generate_measurement_cell_map(
     auto surface_transforms = read_geometry(detector_file);
 
     // Read the cells from the relevant event file
-    host_cell_container cells_per_event = read_cells_from_event(
-        event, cells_dir, "csv", surface_transforms, resource);
+    host_cell_container cells_per_event =
+        read_cells_from_event(event, cells_dir, traccc::data_format::csv,
+                              surface_transforms, resource);
 
     for (std::size_t i = 0; i < cells_per_event.size(); ++i) {
         auto module = cells_per_event.at(i).header;
@@ -242,8 +243,8 @@ measurement_particle_map generate_measurement_particle_map(
 
     // Read the spacepoints from the relevant event file
     host_spacepoint_container spacepoints_per_event =
-        read_spacepoints_from_event(event, hits_dir, "csv", surface_transforms,
-                                    resource);
+        read_spacepoints_from_event(event, hits_dir, traccc::data_format::csv,
+                                    surface_transforms, resource);
 
     for (std::size_t i = 0; i < spacepoints_per_event.size(); ++i) {
         const auto& spacepoints_per_module = spacepoints_per_event.at(i).items;

--- a/io/include/traccc/io/mapper.hpp
+++ b/io/include/traccc/io/mapper.hpp
@@ -178,8 +178,8 @@ measurement_cell_map generate_measurement_cell_map(
     auto surface_transforms = read_geometry(detector_file);
 
     // Read the cells from the relevant event file
-    host_cell_container cells_per_event =
-        read_cells_from_event(event, cells_dir, surface_transforms, resource);
+    host_cell_container cells_per_event = read_cells_from_event(
+        event, cells_dir, "csv", surface_transforms, resource);
 
     for (std::size_t i = 0; i < cells_per_event.size(); ++i) {
         auto module = cells_per_event.at(i).header;
@@ -242,7 +242,7 @@ measurement_particle_map generate_measurement_particle_map(
 
     // Read the spacepoints from the relevant event file
     host_spacepoint_container spacepoints_per_event =
-        read_spacepoints_from_event(event, hits_dir, surface_transforms,
+        read_spacepoints_from_event(event, hits_dir, "csv", surface_transforms,
                                     resource);
 
     for (std::size_t i = 0; i < spacepoints_per_event.size(); ++i) {

--- a/io/include/traccc/io/reader.hpp
+++ b/io/include/traccc/io/reader.hpp
@@ -13,14 +13,17 @@
 #include "traccc/edm/measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/geometry/geometry.hpp"
+#include "traccc/io/binary.hpp"
 #include "traccc/io/csv.hpp"
 #include "traccc/io/demonstrator_edm.hpp"
 #include "traccc/io/utils.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/utils/copy.hpp>
 
 // System include(s).
+#include <fstream>
 #include <functional>
 
 namespace traccc {
@@ -34,39 +37,84 @@ inline traccc::geometry read_geometry(const std::string &detector_file) {
     return traccc::read_surfaces(sreader);
 }
 
+/// Function for cell file reading. The output is traccc container.
+///
+/// @param event is the event index
+/// @param cells_directory is the directory of cell file
+/// @param data_format is the data format (e.g. csv or binary) of output file
+/// @param surface_transforms is the input geometry data
+/// @param resource is the vecmem resource
 inline traccc::host_cell_container read_cells_from_event(
-    size_t event, const std::string &cells_dir,
-    traccc::geometry surface_transforms, vecmem::memory_resource &resource) {
+    size_t event, const std::string &cells_directory,
+    const std::string &data_format, traccc::geometry surface_transforms,
+    vecmem::memory_resource &resource) {
+
     // Read the cells from the relevant event file
-    std::string io_cells_file =
-        data_directory() + cells_dir + get_event_filename(event, "-cells.csv");
-    traccc::cell_reader creader(
-        io_cells_file,
-        {"geometry_id", "hit_id", "cannel0", "channel1", "activation", "time"});
-    return traccc::read_cells(creader, resource, &surface_transforms);
+    if (data_format == "csv") {
+        std::string io_cells_file = data_directory() + cells_directory +
+                                    get_event_filename(event, "-cells.csv");
+
+        traccc::cell_reader creader(
+            io_cells_file, {"geometry_id", "hit_id", "cannel0", "channel1",
+                            "activation", "time"});
+        return traccc::read_cells(creader, resource, &surface_transforms);
+
+    } else if (data_format == "binary") {
+        std::string io_cells_file = data_directory() + cells_directory +
+                                    get_event_filename(event, "-cells.dat");
+
+        vecmem::copy copy;
+
+        return traccc::read_binary<traccc::host_cell_container>(io_cells_file,
+                                                                copy, resource);
+    } else {
+        throw std::invalid_argument("Allowed data format is csv or binary");
+    }
 }
 
+/// Function for spacepoint file reading. The output is traccc container.
+///
+/// @param event is the event index
+/// @param hits_directory is the directory of cell file
+/// @param data_format is the data format (e.g. csv or binary) of output file
+/// @param surface_transforms is the input geometry data
+/// @param resource is the vecmem resource
 inline traccc::host_spacepoint_container read_spacepoints_from_event(
-    size_t event, const std::string &hits_dir,
-    traccc::geometry surface_transforms, vecmem::memory_resource &resource) {
+    size_t event, const std::string &hits_directory,
+    const std::string &data_format, traccc::geometry surface_transforms,
+    vecmem::memory_resource &resource) {
+
     // Read the cells from the relevant event file
-    std::string io_hits_file =
-        data_directory() + hits_dir + get_event_filename(event, "-hits.csv");
-    traccc::fatras_hit_reader hreader(
-        io_hits_file,
-        {"particle_id", "geometry_id", "tx", "ty", "tz", "tt", "tpx", "tpy",
-         "tpz", "te", "deltapx", "deltapy", "deltapz", "deltae", "index"});
-    return traccc::read_hits(hreader, resource, &surface_transforms);
+    if (data_format == "csv") {
+        std::string io_hits_file = data_directory() + hits_directory +
+                                   get_event_filename(event, "-hits.csv");
+        traccc::fatras_hit_reader hreader(
+            io_hits_file,
+            {"particle_id", "geometry_id", "tx", "ty", "tz", "tt", "tpx", "tpy",
+             "tpz", "te", "deltapx", "deltapy", "deltapz", "deltae", "index"});
+        return traccc::read_hits(hreader, resource, &surface_transforms);
+    } else if (data_format == "binary") {
+        std::string io_hits_file = data_directory() + hits_directory +
+                                   get_event_filename(event, "-hits.dat");
+
+        vecmem::copy copy;
+
+        return traccc::read_binary<traccc::host_spacepoint_container>(
+            io_hits_file, copy, resource);
+    } else {
+        throw std::invalid_argument("Allowed data format is csv or binary");
+    }
 }
 
 inline traccc::demonstrator_input read(size_t events,
                                        const std::string &detector_file,
                                        const std::string &cell_directory,
+                                       const std::string &data_format,
                                        vecmem::host_memory_resource &resource) {
     using namespace std::placeholders;
     auto geom = read_geometry(detector_file);
-    auto readFn =
-        std::bind(read_cells_from_event, _1, cell_directory, geom, resource);
+    auto readFn = std::bind(read_cells_from_event, _1, cell_directory,
+                            data_format, geom, resource);
     traccc::demonstrator_input input_data(events, &resource);
 
 #if defined(_OPENMP)

--- a/io/include/traccc/io/reader.hpp
+++ b/io/include/traccc/io/reader.hpp
@@ -15,6 +15,7 @@
 #include "traccc/geometry/geometry.hpp"
 #include "traccc/io/binary.hpp"
 #include "traccc/io/csv.hpp"
+#include "traccc/io/data_format.hpp"
 #include "traccc/io/demonstrator_edm.hpp"
 #include "traccc/io/utils.hpp"
 
@@ -46,11 +47,11 @@ inline traccc::geometry read_geometry(const std::string &detector_file) {
 /// @param resource is the vecmem resource
 inline traccc::host_cell_container read_cells_from_event(
     size_t event, const std::string &cells_directory,
-    const std::string &data_format, traccc::geometry surface_transforms,
+    const traccc::data_format &data_format, traccc::geometry surface_transforms,
     vecmem::memory_resource &resource) {
 
     // Read the cells from the relevant event file
-    if (data_format == "csv") {
+    if (data_format == traccc::data_format::csv) {
         std::string io_cells_file = data_directory() + cells_directory +
                                     get_event_filename(event, "-cells.csv");
 
@@ -59,7 +60,7 @@ inline traccc::host_cell_container read_cells_from_event(
                             "activation", "time"});
         return traccc::read_cells(creader, resource, &surface_transforms);
 
-    } else if (data_format == "binary") {
+    } else if (data_format == traccc::data_format::binary) {
         std::string io_cells_file = data_directory() + cells_directory +
                                     get_event_filename(event, "-cells.dat");
 
@@ -81,11 +82,11 @@ inline traccc::host_cell_container read_cells_from_event(
 /// @param resource is the vecmem resource
 inline traccc::host_spacepoint_container read_spacepoints_from_event(
     size_t event, const std::string &hits_directory,
-    const std::string &data_format, traccc::geometry surface_transforms,
+    const traccc::data_format &data_format, traccc::geometry surface_transforms,
     vecmem::memory_resource &resource) {
 
     // Read the cells from the relevant event file
-    if (data_format == "csv") {
+    if (data_format == traccc::data_format::csv) {
         std::string io_hits_file = data_directory() + hits_directory +
                                    get_event_filename(event, "-hits.csv");
         traccc::fatras_hit_reader hreader(
@@ -93,7 +94,7 @@ inline traccc::host_spacepoint_container read_spacepoints_from_event(
             {"particle_id", "geometry_id", "tx", "ty", "tz", "tt", "tpx", "tpy",
              "tpz", "te", "deltapx", "deltapy", "deltapz", "deltae", "index"});
         return traccc::read_hits(hreader, resource, &surface_transforms);
-    } else if (data_format == "binary") {
+    } else if (data_format == traccc::data_format::binary) {
         std::string io_hits_file = data_directory() + hits_directory +
                                    get_event_filename(event, "-hits.dat");
 
@@ -109,7 +110,7 @@ inline traccc::host_spacepoint_container read_spacepoints_from_event(
 inline traccc::demonstrator_input read(size_t events,
                                        const std::string &detector_file,
                                        const std::string &cell_directory,
-                                       const std::string &data_format,
+                                       const traccc::data_format &data_format,
                                        vecmem::host_memory_resource &resource) {
     using namespace std::placeholders;
     auto geom = read_geometry(detector_file);

--- a/io/include/traccc/io/writer.hpp
+++ b/io/include/traccc/io/writer.hpp
@@ -7,102 +7,54 @@
 
 #pragma once
 
+// Project include(s).
 #include "traccc/edm/cell.hpp"
-#include "traccc/edm/cluster.hpp"
-#include "traccc/edm/measurement.hpp"
-#include "traccc/edm/seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
-#include "traccc/io/csv.hpp"
-#include "traccc/io/demonstrator_edm.hpp"
+#include "traccc/io/binary.hpp"
 #include "traccc/io/utils.hpp"
 
 namespace traccc {
 
-inline void write_measurements(
-    size_t event,
-    const traccc::host_measurement_container &measurements_per_event) {
-    traccc::measurement_writer mwriter{
-        get_event_filename(event, "-measurements.csv")};
-    for (size_t i = 0; i < measurements_per_event.size(); ++i) {
-        auto measurements_per_module = measurements_per_event.get_items()[i];
-        auto module = measurements_per_event.get_headers()[i];
-        for (const auto &measurement : measurements_per_module) {
-            const auto &local = measurement.local;
-            mwriter.append({module.module, "", local[0], local[1], 0., 0., 0.,
-                            0., 0., 0., 0., 0.});
-        }
+/// Function for cell file writing
+///
+/// @param event is the event index
+/// @param cells_directory is the directory of cell file
+/// @param data_format is the data format (e.g. csv or binary) of output file
+/// @param cells_per_event is input cell container
+inline void write_cells(size_t event, const std::string &cells_directory,
+                        const std::string &data_format,
+                        const traccc::host_cell_container &cells_per_event) {
+
+    if (data_format == "binary") {
+
+        std::string io_cells_file = data_directory() + cells_directory +
+                                    get_event_filename(event, "-cells.dat");
+
+        traccc::write_binary(io_cells_file, cells_per_event);
+    } else {
+        throw std::invalid_argument("Allowed data format is binary");
     }
 }
 
+/// Function for hit file writing
+///
+/// @param event is the event index
+/// @param hits_directory is the directory of hit file
+/// @param data_format is the data format (e.g. csv or binary) of output file
+/// @param spacepoints_per_event is input spacepoint container
 inline void write_spacepoints(
-    size_t event,
+    size_t event, const std::string &hits_directory,
+    const std::string &data_format,
     const traccc::host_spacepoint_container &spacepoints_per_event) {
-    traccc::spacepoint_writer spwriter{
-        get_event_filename(event, "-spacepoints.csv")};
-    for (size_t i = 0; i < spacepoints_per_event.size(); ++i) {
-        auto spacepoints_per_module = spacepoints_per_event.get_items()[i];
-        auto module = spacepoints_per_event.get_headers()[i];
-        for (const auto &spacepoint : spacepoints_per_module) {
-            const auto &pos = spacepoint.global;
-            spwriter.append({module, pos[0], pos[1], pos[2]});
-        }
-    }
-}
 
-inline void write_seeds(size_t event,
-                        const traccc::host_spacepoint_container &sp_container,
-                        const traccc::host_seed_collection &seeds) {
-    traccc::seed_writer sd_writer{
-        traccc::get_event_filename(event, "-seeds.csv")};
-    for (auto &seed : seeds) {
-        auto weight = seed.weight;
-        auto z_vertex = seed.z_vertex;
-        const auto &spB = sp_container.at(seed.spB_link);
-        const auto &spM = sp_container.at(seed.spM_link);
-        const auto &spT = sp_container.at(seed.spT_link);
+    if (data_format == "binary") {
 
-        sd_writer.append({weight, z_vertex, spB.x(), spB.y(), spB.z(), 0, 0,
-                          spM.x(), spM.y(), spM.z(), 0, 0, spT.x(), spT.y(),
-                          spT.z(), 0, 0});
-    }
-}
+        std::string io_hits_file = data_directory() + hits_directory +
+                                   get_event_filename(event, "-hits.dat");
 
-inline void write_estimated_track_parameters(
-    size_t event,
-    const traccc::host_bound_track_parameters_collection &params) {
-    traccc::bound_track_parameters_writer btp_writer{
-        traccc::get_event_filename(event, "-estimated_track_parameters.csv")};
-    for (auto param : params) {
-        auto &b_vec = param.vector();
-        auto &b_cov = param.covariance();
-        auto &surf_id = param.surface_id;
-
-        btp_writer.append({b_vec[e_bound_loc0],   b_vec[e_bound_loc1],
-                           b_vec[e_bound_theta],  b_vec[e_bound_phi],
-                           b_vec[e_bound_qoverp], b_vec[e_bound_time],
-                           b_cov(0, 0),           b_cov(0, 1),
-                           b_cov(1, 1),           b_cov(0, 2),
-                           b_cov(1, 2),           b_cov(2, 2),
-                           b_cov(0, 3),           b_cov(1, 3),
-                           b_cov(2, 3),           b_cov(3, 3),
-                           b_cov(0, 4),           b_cov(1, 4),
-                           b_cov(2, 4),           b_cov(3, 4),
-                           b_cov(4, 4),           b_cov(0, 5),
-                           b_cov(1, 5),           b_cov(2, 5),
-                           b_cov(3, 5),           b_cov(4, 5),
-                           b_cov(5, 5),           surf_id});
-    }
-}
-
-inline void write(traccc::demonstrator_result aggregated_results) {
-
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
-    for (size_t event = 0; event < aggregated_results.size(); ++event) {
-        auto &eventResult = aggregated_results.at(event);
-        write_measurements(event, eventResult.measurements);
-        write_spacepoints(event, eventResult.spacepoints);
+        traccc::write_binary(io_hits_file, spacepoints_per_event);
+    } else {
+        throw std::invalid_argument("Allowed data format is binary");
     }
 }
 

--- a/io/include/traccc/io/writer.hpp
+++ b/io/include/traccc/io/writer.hpp
@@ -11,6 +11,7 @@
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/io/binary.hpp"
+#include "traccc/io/data_format.hpp"
 #include "traccc/io/utils.hpp"
 
 namespace traccc {
@@ -22,10 +23,10 @@ namespace traccc {
 /// @param data_format is the data format (e.g. csv or binary) of output file
 /// @param cells_per_event is input cell container
 inline void write_cells(size_t event, const std::string &cells_directory,
-                        const std::string &data_format,
+                        const traccc::data_format &data_format,
                         const traccc::host_cell_container &cells_per_event) {
 
-    if (data_format == "binary") {
+    if (data_format == traccc::data_format::binary) {
 
         std::string io_cells_file = data_directory() + cells_directory +
                                     get_event_filename(event, "-cells.dat");
@@ -44,10 +45,10 @@ inline void write_cells(size_t event, const std::string &cells_directory,
 /// @param spacepoints_per_event is input spacepoint container
 inline void write_spacepoints(
     size_t event, const std::string &hits_directory,
-    const std::string &data_format,
+    const traccc::data_format &data_format,
     const traccc::host_spacepoint_container &spacepoints_per_event) {
 
-    if (data_format == "binary") {
+    if (data_format == traccc::data_format::binary) {
 
         std::string io_hits_file = data_directory() + hits_directory +
                                    get_event_filename(event, "-hits.dat");

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -130,8 +130,8 @@ TEST_P(CompareWithActsSeedingTests, Run) {
 
     // Read the hits from the relevant event file
     traccc::host_spacepoint_container spacepoints_per_event =
-        traccc::read_spacepoints_from_event(event, hits_dir, surface_transforms,
-                                            host_mr);
+        traccc::read_spacepoints_from_event(event, hits_dir, "csv",
+                                            surface_transforms, host_mr);
 
     /*--------------------------------
       TRACCC seeding

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -130,7 +130,8 @@ TEST_P(CompareWithActsSeedingTests, Run) {
 
     // Read the hits from the relevant event file
     traccc::host_spacepoint_container spacepoints_per_event =
-        traccc::read_spacepoints_from_event(event, hits_dir, "csv",
+        traccc::read_spacepoints_from_event(event, hits_dir,
+                                            traccc::data_format::csv,
                                             surface_transforms, host_mr);
 
     /*--------------------------------

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -5,6 +5,6 @@
 # Mozilla Public License Version 2.0
 
 # Declare the io library test(s).
-traccc_add_test( io "test_csv.cpp" "test_mapper.cpp"
+traccc_add_test( io "test_binary.cpp" "test_csv.cpp" "test_mapper.cpp"
    LINK_LIBRARIES GTest::gtest_main traccc_tests_common
                   traccc::core traccc::io )

--- a/tests/io/test_binary.cpp
+++ b/tests/io/test_binary.cpp
@@ -35,14 +35,17 @@ TEST(io_binary, cell) {
 
     // Read csv file
     traccc::host_cell_container cells_csv = traccc::read_cells_from_event(
-        event, cells_directory, "csv", surface_transforms, host_mr);
+        event, cells_directory, traccc::data_format::csv, surface_transforms,
+        host_mr);
 
     // Write binary file
-    traccc::write_cells(event, cells_directory, "binary", cells_csv);
+    traccc::write_cells(event, cells_directory, traccc::data_format::binary,
+                        cells_csv);
 
     // Read binary file
     traccc::host_cell_container cells_binary = traccc::read_cells_from_event(
-        event, cells_directory, "binary", surface_transforms, host_mr);
+        event, cells_directory, traccc::data_format::binary, surface_transforms,
+        host_mr);
 
     // Delete binary file
     std::string io_cells_file = traccc::data_directory() + cells_directory +
@@ -94,15 +97,18 @@ TEST(io_binary, spacepoint) {
 
     // Read csv file
     traccc::host_spacepoint_container spacepoints_csv =
-        traccc::read_spacepoints_from_event(event, hits_directory, "csv",
+        traccc::read_spacepoints_from_event(event, hits_directory,
+                                            traccc::data_format::csv,
                                             surface_transforms, host_mr);
 
     // Write binary file
-    traccc::write_spacepoints(event, hits_directory, "binary", spacepoints_csv);
+    traccc::write_spacepoints(event, hits_directory,
+                              traccc::data_format::binary, spacepoints_csv);
 
     // Read binary file
     traccc::host_spacepoint_container spacepoints_binary =
-        traccc::read_spacepoints_from_event(event, hits_directory, "binary",
+        traccc::read_spacepoints_from_event(event, hits_directory,
+                                            traccc::data_format::binary,
                                             surface_transforms, host_mr);
 
     // Delete binary file

--- a/tests/io/test_binary.cpp
+++ b/tests/io/test_binary.cpp
@@ -1,0 +1,140 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/io/reader.hpp"
+#include "traccc/io/writer.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+// System
+#include <cstdio>
+#include <fstream>
+
+// This defines the local frame test suite for binary cell container
+TEST(io_binary, cell) {
+
+    // Set event configuration
+    const std::size_t event = 0;
+    const std::string cells_directory = "tml_full/ttbar_mu200/";
+
+    // Memory resource used by the EDM.
+    vecmem::host_memory_resource host_mr;
+
+    // Read the surface transforms
+    auto surface_transforms =
+        traccc::read_geometry("tml_detector/trackml-detector.csv");
+
+    // Read csv file
+    traccc::host_cell_container cells_csv = traccc::read_cells_from_event(
+        event, cells_directory, "csv", surface_transforms, host_mr);
+
+    // Write binary file
+    traccc::write_cells(event, cells_directory, "binary", cells_csv);
+
+    // Read binary file
+    traccc::host_cell_container cells_binary = traccc::read_cells_from_event(
+        event, cells_directory, "binary", surface_transforms, host_mr);
+
+    // Delete binary file
+    std::string io_cells_file = traccc::data_directory() + cells_directory +
+                                traccc::get_event_filename(event, "-cells.dat");
+    std::remove(io_cells_file.c_str());
+
+    ASSERT_TRUE(!std::ifstream(io_cells_file));
+
+    // Check header size
+    ASSERT_TRUE(cells_csv.size() > 0);
+    ASSERT_EQ(cells_csv.size(), cells_binary.size());
+
+    auto& headers_csv = cells_csv.get_headers();
+    auto& headers_bin = cells_binary.get_headers();
+
+    for (std::size_t i = 0; i < cells_csv.size(); i++) {
+
+        // Check header content
+        ASSERT_EQ(headers_csv[i].module, headers_bin[i].module);
+        ASSERT_EQ(headers_csv[i].placement, headers_bin[i].placement);
+
+        auto& items_csv = cells_csv.get_items()[i];
+        auto& items_bin = cells_binary.get_items()[i];
+
+        // Check item size
+        ASSERT_TRUE(items_csv.size() > 0);
+        ASSERT_EQ(items_csv.size(), items_bin.size());
+
+        // Check item contents
+        for (std::size_t j = 0; j < items_csv.size(); j++) {
+            ASSERT_EQ(items_csv[j], items_bin[j]);
+        }
+    }
+}
+
+// This defines the local frame test suite for binary spacepoint container
+TEST(io_binary, spacepoint) {
+
+    // Set event configuration
+    const std::size_t event = 0;
+    const std::string hits_directory = "tml_full/ttbar_mu200/";
+
+    // Memory resource used by the EDM.
+    vecmem::host_memory_resource host_mr;
+
+    // Read the surface transforms
+    auto surface_transforms =
+        traccc::read_geometry("tml_detector/trackml-detector.csv");
+
+    // Read csv file
+    traccc::host_spacepoint_container spacepoints_csv =
+        traccc::read_spacepoints_from_event(event, hits_directory, "csv",
+                                            surface_transforms, host_mr);
+
+    // Write binary file
+    traccc::write_spacepoints(event, hits_directory, "binary", spacepoints_csv);
+
+    // Read binary file
+    traccc::host_spacepoint_container spacepoints_binary =
+        traccc::read_spacepoints_from_event(event, hits_directory, "binary",
+                                            surface_transforms, host_mr);
+
+    // Delete binary file
+    std::string io_spacepoints_file =
+        traccc::data_directory() + hits_directory +
+        traccc::get_event_filename(event, "-hits.dat");
+    std::remove(io_spacepoints_file.c_str());
+
+    ASSERT_TRUE(!std::ifstream(io_spacepoints_file));
+
+    // Check header size
+    ASSERT_TRUE(spacepoints_csv.size() > 0);
+    ASSERT_EQ(spacepoints_csv.size(), spacepoints_binary.size());
+
+    auto& headers_csv = spacepoints_csv.get_headers();
+    auto& headers_bin = spacepoints_binary.get_headers();
+
+    for (std::size_t i = 0; i < spacepoints_csv.size(); i++) {
+
+        // Check header content
+        ASSERT_EQ(headers_csv[i], headers_bin[i]);
+
+        auto& items_csv = spacepoints_csv.get_items()[i];
+        auto& items_bin = spacepoints_binary.get_items()[i];
+
+        // Check item size
+        ASSERT_TRUE(items_csv.size() > 0);
+        ASSERT_EQ(items_csv.size(), items_bin.size());
+
+        // Check item contents
+        for (std::size_t j = 0; j < items_csv.size(); j++) {
+            ASSERT_EQ(items_csv[j], items_bin[j]);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds binary I/O which makes file reading faster.  Fast file reading will make multi-process study (e.g. CUDA-MPS or MIG) much easier. 

------------------
### 1. How to use

User can run the existing examples with binary input file. :
```bash
# data_format options has default value of csv
./bin/traccc_seq_example --detector_file=tml_detector/trackml-detector.csv --cell_directory=tml_full/ttbar_mu200/  --events=1 --input-binary
```

Even though I am not going to add binary files into `traccc-data` repository, users can generate binary files by themselves using `traccc_create_binaries` example

```bash
# This will generate one binary file from event000000000-cells.csv
./bin/traccc_create_binaries --detector_file=tml_detector/trackml-detector.csv --cell_directory=tml_full/ttbar_mu200/  --events=1 

# This will generate one binary file from event000000000-hits.csv
./bin/traccc_create_binaries --detector_file=tml_detector/trackml-detector.csv --hit_directory=tml_full/ttbar_mu200/  --events=1 
```

------------------
### 2. Benchmark

Here is the cell file reading benchmark with one 200 pileup event.

  | host resource | cuda managed resource
-- | -- | --
csv file reading [sec] | 0.66 | 1.15
binary file reading [sec] | 0.007 | 0.14

Note that binary file reading with cuda managed memory takes 0.14 second, which is still much longer than cuda seeding (~0.02 second).

More details on profiling will be provided later. 

Update:
It's obvious most of time is taken by the bunch of cudaMalloc call for jagged vector :/ But I believe that we can minimize the effect with downstream memory caching later...
