### PR TITLE
Detray Update, main branch (2022.04.26.)

### DIFF
--- a/core/include/traccc/definitions/primitives.hpp
+++ b/core/include/traccc/definitions/primitives.hpp
@@ -46,24 +46,3 @@ template <unsigned int kSize>
 using traccc_sym_matrix = Eigen::Matrix<scalar, kSize, kSize>;
 
 }  // namespace traccc
-
-namespace detray {
-
-using scalar = traccc::scalar;
-
-template <typename value_type, unsigned int kDIM>
-using darray = traccc::darray<value_type, kDIM>;
-
-template <typename value_type>
-using dvector = traccc::dvector<value_type>;
-
-template <typename value_type>
-using djagged_vector = traccc::djagged_vector<value_type>;
-
-template <typename key_type, typename value_type>
-using dmap = traccc::dmap<key_type, value_type>;
-
-template <class... types>
-using dtuple = traccc::dtuple<types...>;
-
-}  // namespace detray

--- a/core/include/traccc/edm/internal_spacepoint.hpp
+++ b/core/include/traccc/edm/internal_spacepoint.hpp
@@ -11,7 +11,7 @@
 #include "traccc/edm/spacepoint.hpp"
 
 // detray core
-#include <detray/definitions/invalid_values.hpp>
+#include <detray/utils/invalid_values.hpp>
 
 // VecMem include(s).
 #include <vecmem/containers/data/jagged_vector_buffer.hpp>

--- a/core/include/traccc/seeding/detail/spacepoint_grid.hpp
+++ b/core/include/traccc/seeding/detail/spacepoint_grid.hpp
@@ -11,11 +11,11 @@
 #include "traccc/edm/internal_spacepoint.hpp"
 
 // detray core
+#include <detray/definitions/indexing.hpp>
 #include <detray/grids/axis.hpp>
 #include <detray/grids/grid2.hpp>
 #include <detray/grids/populator.hpp>
 #include <detray/grids/serializer2.hpp>
-#include <detray/utils/indexing.hpp>
 
 namespace traccc {
 

--- a/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
@@ -59,7 +59,8 @@ class seeding_algorithm
 
         output_type seeds(&m_mr.get());
         auto internal_sp_g2 = sb->operator()(std::move(spacepoints));
-        seeds = sf->operator()(std::move(spacepoints), internal_sp_g2);
+        seeds =
+            sf->operator()(std::move(spacepoints), std::move(internal_sp_g2));
 
         return seeds;
     }

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.4.0.tar.gz;URL_MD5;850f8618b88f2e0189be03c986cf611a"
+   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.6.0.tar.gz;URL_MD5;95460aabbf1091f350e153320b7ef952"
    CACHE STRING "Source for Detray, when built as part of this project" )
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
 FetchContent_Declare( Detray ${TRACCC_DETRAY_SOURCE} )

--- a/plugins/algebra/array/CMakeLists.txt
+++ b/plugins/algebra/array/CMakeLists.txt
@@ -8,6 +8,6 @@
 traccc_add_library( traccc_array array TYPE INTERFACE
   "include/traccc/plugins/algebra/array_definitions.hpp" )
 target_link_libraries( traccc_array
-  INTERFACE algebra::array_cmath vecmem::core )
+  INTERFACE algebra::array_cmath detray::array vecmem::core )
 target_compile_definitions( traccc_array
   INTERFACE TRACCC_CUSTOM_SCALARTYPE=${TRACCC_CUSTOM_SCALARTYPE} )

--- a/plugins/algebra/array/include/traccc/plugins/algebra/array_definitions.hpp
+++ b/plugins/algebra/array/include/traccc/plugins/algebra/array_definitions.hpp
@@ -8,6 +8,9 @@
 
 #pragma once
 
+// Detray include(s).
+#include "detray/plugins/algebra/array_definitions.hpp"
+
 // Algebra Plugins include(s).
 #include <algebra/array_cmath.hpp>
 

--- a/plugins/algebra/eigen/CMakeLists.txt
+++ b/plugins/algebra/eigen/CMakeLists.txt
@@ -8,6 +8,6 @@
 traccc_add_library( traccc_eigen eigen TYPE INTERFACE
   "include/traccc/plugins/algebra/eigen_definitions.hpp" )
 target_link_libraries( traccc_eigen
-  INTERFACE algebra::eigen_eigen vecmem::core )
+  INTERFACE algebra::eigen_eigen detray::eigen vecmem::core )
 target_compile_definitions( traccc_eigen
   INTERFACE TRACCC_CUSTOM_SCALARTYPE=${TRACCC_CUSTOM_SCALARTYPE} )

--- a/plugins/algebra/eigen/include/traccc/plugins/algebra/eigen_definitions.hpp
+++ b/plugins/algebra/eigen/include/traccc/plugins/algebra/eigen_definitions.hpp
@@ -8,6 +8,9 @@
 
 #pragma once
 
+// Detray include(s).
+#include "detray/plugins/algebra/eigen_definitions.hpp"
+
 // Algebra Plugins include(s).
 #include <algebra/eigen_eigen.hpp>
 

--- a/plugins/algebra/smatrix/CMakeLists.txt
+++ b/plugins/algebra/smatrix/CMakeLists.txt
@@ -8,6 +8,6 @@
 traccc_add_library( traccc_smatrix smatrix TYPE INTERFACE
   "include/traccc/plugins/algebra/smatrix_definitions.hpp" )
 target_link_libraries( traccc_smatrix
-  INTERFACE algebra::smatrix_smatrix vecmem::core )
+  INTERFACE algebra::smatrix_smatrix detray::smatrix vecmem::core )
 target_compile_definitions( traccc_smatrix
   INTERFACE TRACCC_CUSTOM_SCALARTYPE=${TRACCC_CUSTOM_SCALARTYPE} )

--- a/plugins/algebra/smatrix/include/traccc/plugins/algebra/smatrix_definitions.hpp
+++ b/plugins/algebra/smatrix/include/traccc/plugins/algebra/smatrix_definitions.hpp
@@ -8,6 +8,9 @@
 
 #pragma once
 
+// Detray include(s).
+#include "detray/plugins/algebra/smatrix_definitions.hpp"
+
 // Algebra Plugins include(s).
 #include <algebra/smatrix_smatrix.hpp>
 

--- a/plugins/algebra/vc/CMakeLists.txt
+++ b/plugins/algebra/vc/CMakeLists.txt
@@ -8,6 +8,6 @@
 traccc_add_library( traccc_vc vc TYPE INTERFACE
   "include/traccc/plugins/algebra/vc_definitions.hpp" )
 target_link_libraries( traccc_vc
-  INTERFACE algebra::vc_vc vecmem::core )
+  INTERFACE algebra::vc_vc detray::vc_array vecmem::core )
 target_compile_definitions( traccc_vc
   INTERFACE TRACCC_CUSTOM_SCALARTYPE=${TRACCC_CUSTOM_SCALARTYPE} )

--- a/plugins/algebra/vc/include/traccc/plugins/algebra/vc_definitions.hpp
+++ b/plugins/algebra/vc/include/traccc/plugins/algebra/vc_definitions.hpp
@@ -8,6 +8,9 @@
 
 #pragma once
 
+// Detray include(s).
+#include "detray/plugins/algebra/vc_array_definitions.hpp"
+
 // Algebra Plugins include(s).
 #include <algebra/vc_vc.hpp>
 


### PR DESCRIPTION
Updated the project to [Detray v0.6.0](https://github.com/acts-project/detray/releases/tag/v0.6.0).

To make this happen, I updated the include paths of the headers that were moved in the new version. Which was the simple part of the whole thing.

What was more tricky is that Detray modified the definition of `detray::darray` in the new tag. Which made me realise that `detray::darray` was also declared in this project. Instead of updating this project's definition of `detray::darray` (and `traccc::darray`), I decided to re-write how [algebra-plugins](https://github.com/acts-project/algebra-plugins) would be set up in this project.

@beomki-yeo, of course things should become a **lot** cleaner once the plugins will be used as template arguments in Detray. But for now this was the best that I could come up with...

Note that this also revealed an interesting bug in the code, with a missing `std::move(...)` call in the CUDA code. Since the seed-finding algorithm needs an rvalue reference as input, it makes sense that we need to use `std::move(...)` there. But I was still surprised that this was only revealed by the compiler now, after the latest round on "`detray::grid2` cleanups".