### PR TITLE
Update Algebra Plugins and Detray, main branch (2022.05.03.)

### DIFF
--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Algebra Plugins as part of the TRACCC project" )
 
 # Declare where to get Algebra Plugins from.
 set( TRACCC_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.8.0.tar.gz;URL_MD5;33554a09c16327078ceae1d70b525411"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.10.0.tar.gz;URL_MD5;91e04307f2cdeda5dc541104fedb6860"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced( TRACCC_ALGEBRA_PLUGINS_SOURCE )
 FetchContent_Declare( AlgebraPlugins ${TRACCC_ALGEBRA_PLUGINS_SOURCE} )

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.6.0.tar.gz;URL_MD5;95460aabbf1091f350e153320b7ef952"
+   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.7.0.tar.gz;URL_MD5;ffb160eb9db0dfd45a64b23c38c850a4"
    CACHE STRING "Source for Detray, when built as part of this project" )
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
 FetchContent_Declare( Detray ${TRACCC_DETRAY_SOURCE} )

--- a/extern/detray/README.md
+++ b/extern/detray/README.md
@@ -1,0 +1,4 @@
+# Build Recipe for Detray
+
+This directory holds a build recipe for the
+[detray](https://github.com/acts-project/detray) project.


### PR DESCRIPTION
Updated the versions of [Algebra Plugins](https://github.com/acts-project/algebra-plugins) and [Detray](https://github.com/acts-project/detray). These updates will be necessary for an upcoming PR with seed-finding code updates.

Note that [v0.10.0](https://github.com/acts-project/algebra-plugins/releases/tag/v0.10.0) is **not** the very latest version of Algebra Plugins. But since [Detray v0.7.0](https://github.com/acts-project/detray/releases/tag/v0.7.0) itself uses [Algebra Plugins v0.10.0](https://github.com/acts-project/algebra-plugins/releases/tag/v0.10.0), this seemed like the simplest thing to update to. But @beomki-yeo should speak up if it would be better to include a newer tag in this project instead.

At the same time added I a README file for the detray directory, just to soothe my OCD. :stuck_out_tongue: