### PR TITLE
Update VecMem, main branch (2022.05.03.)

### DIFF
--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.13.0.tar.gz;URL_MD5;3bd1b13f6817ba6e7118217ea9a15186"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.14.0.tar.gz;URL_MD5;12bf988c5d49d35ae785022fa3bb4f72"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Updated the project to [VecMem 0.14.0](https://github.com/acts-project/vecmem/releases/tag/v0.14.0).

This is a sibling of #182, also needed for the upcoming seed-finder updates.