### PR TITLE
Const Correctness Updates, main branch (2022.05.05.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -30,6 +30,7 @@ traccc_add_library( traccc_core core TYPE INTERFACE
   "include/traccc/geometry/pixel_data.hpp"
   # Utilities.
   "include/traccc/utils/algorithm.hpp"
+  "include/traccc/utils/type_traits.hpp"
   "include/traccc/utils/unit_vectors.hpp"
   # Clusterization algorithmic code.
   "include/traccc/clusterization/detail/sparse_ccl.hpp"

--- a/core/include/traccc/edm/container.hpp
+++ b/core/include/traccc/edm/container.hpp
@@ -11,6 +11,7 @@
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/details/device_container.hpp"
 #include "traccc/edm/details/host_container.hpp"
+#include "traccc/utils/type_traits.hpp"
 
 // VecMem include(s).
 #include <vecmem/containers/data/jagged_vector_buffer.hpp>
@@ -18,6 +19,9 @@
 #include <vecmem/containers/data/jagged_vector_view.hpp>
 #include <vecmem/containers/data/vector_buffer.hpp>
 #include <vecmem/containers/data/vector_view.hpp>
+
+// System include(s).
+#include <type_traits>
 
 namespace traccc {
 
@@ -54,12 +58,34 @@ template <typename header_t, typename item_t>
 struct container_view {
 
     /// Constructor from a @c container_data object
-    container_view(const container_data<header_t, item_t>& data)
+    template <
+        typename other_header_t, typename other_item_t,
+        std::enable_if_t<details::is_same_nc<header_t, other_header_t>::value,
+                         bool> = true,
+        std::enable_if_t<details::is_same_nc<item_t, other_item_t>::value,
+                         bool> = true>
+    container_view(const container_data<other_header_t, other_item_t>& data)
         : headers(data.headers), items(data.items) {}
 
     /// Constructor from a @c container_buffer object
-    container_view(const container_buffer<header_t, item_t>& buffer)
+    template <
+        typename other_header_t, typename other_item_t,
+        std::enable_if_t<details::is_same_nc<header_t, other_header_t>::value,
+                         bool> = true,
+        std::enable_if_t<details::is_same_nc<item_t, other_item_t>::value,
+                         bool> = true>
+    container_view(const container_buffer<other_header_t, other_item_t>& buffer)
         : headers(buffer.headers), items(buffer.items) {}
+
+    /// Constructor from a non-const view
+    template <
+        typename other_header_t, typename other_item_t,
+        std::enable_if_t<details::is_same_nc<header_t, other_header_t>::value,
+                         bool> = true,
+        std::enable_if_t<details::is_same_nc<item_t, other_item_t>::value,
+                         bool> = true>
+    container_view(const container_view<other_header_t, other_item_t>& parent)
+        : headers(parent.headers), items(parent.items) {}
 
     /// View of the data describing the headers
     vecmem::data::vector_view<header_t> headers;

--- a/core/include/traccc/edm/container.hpp
+++ b/core/include/traccc/edm/container.hpp
@@ -31,15 +31,19 @@ namespace traccc {
 /// Structure holding (some of the) data about the container in host code
 template <typename header_t, typename item_t>
 struct container_data {
-    vecmem::data::vector_view<header_t> headers;
-    vecmem::data::jagged_vector_data<item_t> items;
+    using header_vector = vecmem::data::vector_view<header_t>;
+    using item_vector = vecmem::data::jagged_vector_data<item_t>;
+    header_vector headers;
+    item_vector items;
 };
 
 /// Structure holding (all of the) data about the container in host code
 template <typename header_t, typename item_t>
 struct container_buffer {
-    vecmem::data::vector_buffer<header_t> headers;
-    vecmem::data::jagged_vector_buffer<item_t> items;
+    using header_vector = vecmem::data::vector_buffer<header_t>;
+    using item_vector = vecmem::data::jagged_vector_buffer<item_t>;
+    header_vector headers;
+    item_vector items;
 };
 
 /// Structure used to send the data about the container to device code
@@ -56,6 +60,11 @@ struct container_buffer {
 ///
 template <typename header_t, typename item_t>
 struct container_view {
+
+    /// Type for the header vector (view)
+    using header_vector = vecmem::data::vector_view<header_t>;
+    /// Type for the item vector (view)
+    using item_vector = vecmem::data::jagged_vector_view<item_t>;
 
     /// Constructor from a @c container_data object
     template <
@@ -88,10 +97,10 @@ struct container_view {
         : headers(parent.headers), items(parent.items) {}
 
     /// View of the data describing the headers
-    vecmem::data::vector_view<header_t> headers;
+    header_vector headers;
 
     /// View of the data describing the items
-    vecmem::data::jagged_vector_view<item_t> items;
+    item_vector items;
 };
 
 /// Helper function for making a "simple" object out of the container

--- a/core/include/traccc/seeding/detail/spacepoint_grid.hpp
+++ b/core/include/traccc/seeding/detail/spacepoint_grid.hpp
@@ -29,9 +29,19 @@ using sp_grid_device = detray::grid2<
     detray::attach_populator, detray::axis::circular, detray::axis::regular,
     detray::serializer2, vecmem::device_vector, vecmem::jagged_device_vector,
     detray::darray, detray::dtuple, internal_spacepoint<spacepoint>, false>;
+using const_sp_grid_device =
+    detray::grid2<detray::attach_populator, detray::axis::circular,
+                  detray::axis::regular, detray::serializer2,
+                  vecmem::device_vector, vecmem::jagged_device_vector,
+                  detray::darray, detray::dtuple,
+                  const internal_spacepoint<spacepoint>, false>;
 
 using sp_grid_data = detray::grid2_data<sp_grid>;
+using sp_grid_const_data = detray::const_grid2_data<sp_grid>;
+
 using sp_grid_view = detray::grid2_view<sp_grid>;
+using sp_grid_const_view = detray::const_grid2_view<sp_grid>;
+
 using sp_grid_buffer = detray::grid2_buffer<sp_grid>;
 
 }  // namespace traccc

--- a/core/include/traccc/utils/type_traits.hpp
+++ b/core/include/traccc/utils/type_traits.hpp
@@ -1,0 +1,32 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::details {
+
+/// Helper trait for detecting when a type is a non-const version of another
+///
+/// This comes into play multiple times to enable certain constructors
+/// conditionally through SFINAE.
+///
+template <typename CTYPE, typename NCTYPE>
+struct is_same_nc {
+    static constexpr bool value = false;
+};
+
+template <typename TYPE>
+struct is_same_nc<TYPE, TYPE> {
+    static constexpr bool value = true;
+};
+
+template <typename TYPE>
+struct is_same_nc<const TYPE, TYPE> {
+    static constexpr bool value = true;
+};
+
+}  // namespace traccc::details


### PR DESCRIPTION
As the final bite-sized update before the monster that will unify the CUDA and SYCL doublet finding implementations, this PR is simply making it possible to access constant and non-constant host objects through constant views in device code.

@beomki-yeo, you may recognise `traccc::details::is_same_nc` from https://github.com/acts-project/detray/pull/252. :wink: Although this version is just a tiny bit different from `detray::details::is_same_nc` (and `vecmem::details::is_same_nc`).

Since hopefully this is not too controversial, if it could be approved quickly, I could still open that "monster PR" still today. :wink: (Pinging @stephenswat and @paulgessinger for good measure...)