### PR TITLE
Container Cleanup, main branch (2022.05.06.)

### DIFF
--- a/core/include/traccc/edm/cell.hpp
+++ b/core/include/traccc/edm/cell.hpp
@@ -7,31 +7,23 @@
 
 #pragma once
 
-// traccc include(s).
+// Library include(s).
+#include "traccc/definitions/common.hpp"
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/container.hpp"
 #include "traccc/geometry/pixel_data.hpp"
 
-// VecMem include(s).
-#include <vecmem/containers/data/jagged_vector_buffer.hpp>
-#include <vecmem/containers/data/vector_buffer.hpp>
-#include <vecmem/containers/device_vector.hpp>
-#include <vecmem/containers/jagged_device_vector.hpp>
-#include <vecmem/containers/jagged_vector.hpp>
-#include <vecmem/containers/vector.hpp>
-
 // System include(s).
+#include <cmath>
 #include <limits>
 
 namespace traccc {
 
-/// @name Types to use in algorithmic code
-/// @{
-
-/// A cell definition:
+/// Definition for one detector cell
 ///
-/// maximum two channel identifiers
-/// and one activiation value, such as a time stamp
+/// It comes with two integer channel identifiers, an "activation value"
+/// and a time stamp.
+///
 struct cell {
     channel_id channel0 = 0;
     channel_id channel1 = 0;
@@ -39,53 +31,28 @@ struct cell {
     scalar time = 0.;
 };
 
+/// Comparison / ordering operator for cells
+TRACCC_HOST_DEVICE
 inline bool operator<(const cell& lhs, const cell& rhs) {
-    if (lhs.channel0 < rhs.channel0) {
-        return true;
-    } else if (lhs.channel0 == rhs.channel0) {
-        if (lhs.channel1 < rhs.channel1) {
-            return true;
-        } else if (lhs.channel1 == rhs.channel1) {
-            if (lhs.activation < rhs.activation) {
-                return true;
-            }
-            return false;
-        }
-        return false;
+
+    if (lhs.channel0 != rhs.channel0) {
+        return (lhs.channel0 < rhs.channel0);
+    } else if (lhs.channel1 != rhs.channel1) {
+        return (lhs.channel1 < rhs.channel1);
+    } else {
+        return lhs.activation < rhs.activation;
     }
-    return false;
 }
 
+/// Equality operator for cells
+TRACCC_HOST_DEVICE
 inline bool operator==(const cell& lhs, const cell& rhs) {
-    if (lhs.channel0 == rhs.channel0 && lhs.channel1 == rhs.channel1 &&
-        lhs.activation == rhs.activation && lhs.time == rhs.time) {
-        return true;
-    }
-    return false;
+
+    return (
+        (lhs.channel0 == rhs.channel0) && (lhs.channel1 == rhs.channel1) &&
+        (std::abs(lhs.activation - rhs.activation) < traccc::float_epsilon) &&
+        (std::abs(lhs.time - rhs.time) < traccc::float_epsilon));
 }
-
-/// Container of cells belonging to one detector module
-template <template <typename> class vector_t>
-using cell_collection = vector_t<cell>;
-
-/// Convenience declaration for the cell collection type to use in host code
-using host_cell_collection = cell_collection<vecmem::vector>;
-
-/// Convenience declaration for the cell collection type to use in device code
-using device_cell_collection = cell_collection<vecmem::device_vector>;
-
-/// Container of cells belonging to one detector module (const)
-template <template <typename> class vector_t>
-using cell_const_collection = vector_t<const cell>;
-
-/// Convenience declaration for the cell collection type to use in host code
-/// (const)
-using host_cell_const_collection = cell_const_collection<vecmem::vector>;
-
-/// Convenience declaration for the cell collection type to use in device code
-/// (const)
-using device_cell_const_collection =
-    cell_const_collection<vecmem::device_vector>;
 
 /// Header information for all of the cells in a specific detector module
 ///
@@ -103,47 +70,11 @@ struct cell_module {
     channel_id range1[2] = {std::numeric_limits<channel_id>::max(), 0};
 
     pixel_data pixel{-8.425, -36.025, 0.05, 0.05};
+
 };  // struct cell_module
 
-/// Container of cell modules
-template <template <typename> class vector_t>
-using cell_module_collection = vector_t<cell_module>;
-
-/// Convenience declaration for the cell module collection type to use in host
-/// code
-using host_cell_module_collection = cell_module_collection<vecmem::vector>;
-/// Convenience declaration for the cell module collection type to use in device
-/// code
-using device_cell_module_collection =
-    cell_module_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the cell container type to use in host code
-using host_cell_container = host_container<cell_module, cell>;
-
-/// Convenience declaration for the cell container type to use in device code
-using device_cell_container = device_container<cell_module, cell>;
-
-/// Convenience declaration for the cell container type to use in device code
-/// (const)
-using device_cell_const_container =
-    device_container<const cell_module, const cell>;
-
-/// Convenience declaration for the cell container data type to use in host code
-using cell_container_data = container_data<cell_module, cell>;
-
-/// Convenience declaration for the cell container data type to use in host code
-/// (const)
-using cell_container_const_data = container_data<const cell_module, const cell>;
-
-/// Convenience declaration for the cell container view type to use in host code
-/// (const)
-using cell_container_const_view = container_view<const cell_module, const cell>;
-
-/// Convenience declaration for the cell container buffer type to use in host
-/// code
-using cell_container_buffer = container_buffer<cell_module, cell>;
-
-/// Convenience declaration for the cell container view type to use in host code
-using cell_container_view = container_view<cell_module, cell>;
+// Declare all cell collection/container types
+TRACCC_DECLARE_COLLECTION_TYPES(cell);
+TRACCC_DECLARE_CONTAINER_TYPES(cell, cell_module, cell);
 
 }  // namespace traccc

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -7,57 +7,29 @@
 
 #pragma once
 
-// Project include(s).
+// Library include(s).
+#include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/cell.hpp"
+#include "traccc/edm/container.hpp"
 #include "traccc/geometry/pixel_data.hpp"
 
 // System include(s).
-#include <functional>
-#include <vector>
+#include <cstddef>
 
 namespace traccc {
 
+/// Header / identifier for every reconstructed cluster
 struct cluster_id {
 
-    event_id event = 0;
-    std::size_t module_idx = 0;
-    geometry_id module = 0;
-    transform3 placement = transform3{};
-    scalar threshold = 0.;
-    pixel_data pixel;
+    event_id event{0};
+    std::size_t module_idx{0};
+    geometry_id module{0};
+    transform3 placement{};
+    scalar threshold{0.};
+    pixel_data pixel{};
 };
 
-/// Convenience declaration for the cluster container type to use in host code
-using host_cluster_container = host_container<cluster_id, cell>;
-
-/// Convenience declaration for the cluster container type to use in device code
-using device_cluster_container = device_container<cluster_id, cell>;
-
-/// Convenience declaration for the cluster container type to use in device code
-/// (const)
-using device_cluster_const_container =
-    device_container<const cluster_id, const cell>;
-
-/// Convenience declaration for the cluster container data type to use in host
-/// code
-using cluster_container_data = container_data<cluster_id, cell>;
-
-/// Convenience declaration for the cluster container data type to use in host
-/// code (const)
-using cluster_container_const_data =
-    container_data<const cluster_id, const cell>;
-
-/// Convenience declaration for the cluster container buffer type to use in host
-/// code
-using cluster_container_buffer = container_buffer<cluster_id, cell>;
-
-/// Convenience declaration for the cluster container view type to use in host
-/// code
-using cluster_container_view = container_view<cluster_id, cell>;
-
-/// Convenience declaration for the cluster container view type to use in host
-/// code (const)
-using cluster_container_const_view =
-    container_view<const cluster_id, const cell>;
+// Declare all cluster container types
+TRACCC_DECLARE_CONTAINER_TYPES(cluster, cluster_id, cell);
 
 }  // namespace traccc

--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -10,69 +10,48 @@
 // Project include(s).
 #include "traccc/definitions/common.hpp"
 #include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/container.hpp"
 
 // System include(s).
-#include <vector>
+#include <cmath>
 
 namespace traccc {
 
-/// A measurement definition:
-/// fix to two-dimensional here
+/// Measurement expressed in local coordinates
+///
+/// It describes the 2D position and the uncertainty of that position
+/// of a measurement on a detector element.
+///
 struct measurement {
     point2 local = {0., 0.};
     variance2 variance = {0., 0.};
-
-    TRACCC_HOST_DEVICE
-    static inline measurement invalid_value() {
-        return measurement({{0., 0.}, {0., 0.}});
-    }
 };
 
+/// Comparison / ordering operator for measurements
+TRACCC_HOST_DEVICE
 inline bool operator<(const measurement& lhs, const measurement& rhs) {
-    if (lhs.local[0] < rhs.local[0]) {
-        return true;
+
+    if (std::abs(lhs.local[0] - rhs.local[0]) > float_epsilon) {
+        return (lhs.local[0] < rhs.local[0]);
+    } else {
+        return (lhs.local[1] < rhs.local[1]);
     }
-    return false;
 }
 
+/// Equality operator for measurements
+TRACCC_HOST_DEVICE
 inline bool operator==(const measurement& lhs, const measurement& rhs) {
-    return (std::abs(lhs.local[0] - rhs.local[0]) < float_epsilon &&
-            std::abs(lhs.local[1] - rhs.local[1]) < float_epsilon &&
-            std::abs(lhs.variance[0] - rhs.variance[0]) < float_epsilon &&
-            std::abs(lhs.variance[1] - rhs.variance[1]) < float_epsilon);
+
+    return ((std::abs(lhs.local[0] - rhs.local[0]) < float_epsilon) &&
+            (std::abs(lhs.local[1] - rhs.local[1]) < float_epsilon) &&
+            (std::abs(lhs.variance[0] - rhs.variance[0]) < float_epsilon) &&
+            (std::abs(lhs.variance[1] - rhs.variance[1]) < float_epsilon));
 }
 
-/// Container of measurements belonging to one detector module
-template <template <typename> class vector_t>
-using measurement_collection = vector_t<measurement>;
-
-/// Convenience declaration for the measurement collection type to use in host
-/// code
-using host_measurement_collection = measurement_collection<vecmem::vector>;
-/// Convenience declaration for the measurement collection type to use in device
-/// code
-using device_measurement_collection =
-    measurement_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the measurement container type to use in host
-/// code
-using host_measurement_container = host_container<cell_module, measurement>;
-
-/// Convenience declaration for the measurement container type to use in device
-/// code
-using device_measurement_container = device_container<cell_module, measurement>;
-/// Convenience declaration for the measurement container data type to use in
-/// host code
-using measurement_container_data = container_data<cell_module, measurement>;
-
-/// Convenience declaration for the measurement container buffer type to use in
-/// host code
-using measurement_container_buffer = container_buffer<cell_module, measurement>;
-
-/// Convenience declaration for the measurement container view type to use in
-/// host code
-using measurement_container_view = container_view<cell_module, measurement>;
+// Declare all measurement collection/container types
+TRACCC_DECLARE_COLLECTION_TYPES(measurement);
+TRACCC_DECLARE_CONTAINER_TYPES(measurement, cell_module, measurement);
 
 }  // namespace traccc

--- a/core/include/traccc/edm/particle.hpp
+++ b/core/include/traccc/edm/particle.hpp
@@ -7,8 +7,10 @@
 
 #pragma once
 
-// VecMem include(s).
-#include <vecmem/containers/vector.hpp>
+// Library include(s).
+#include "traccc/definitions/common.hpp"
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/container.hpp"
 
 namespace traccc {
 
@@ -24,19 +26,14 @@ struct particle {
     scalar charge;
 };
 
+/// Comparison / ordering operator for (truth) particles
+TRACCC_HOST_DEVICE
 inline bool operator<(const particle& lhs, const particle& rhs) {
-    if (lhs.particle_id < rhs.particle_id) {
-        return true;
-    }
-    return false;
+
+    return (lhs.particle_id < rhs.particle_id);
 }
 
-/// Container of particle for an event
-template <template <typename> class vector_t>
-using particle_collection = vector_t<particle>;
-
-/// Convenience declaration for the particle collection type to use
-/// in host code
-using host_particle_collection = particle_collection<vecmem::vector>;
+// Declare all (truth) particle collection types
+TRACCC_DECLARE_COLLECTION_TYPES(particle);
 
 }  // namespace traccc

--- a/core/include/traccc/edm/seed.hpp
+++ b/core/include/traccc/edm/seed.hpp
@@ -7,12 +7,13 @@
 
 #pragma once
 
+// Library include(s).
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/container.hpp"
 #include "traccc/edm/spacepoint.hpp"
 
 namespace traccc {
-
-/// Header: unsigned int for number of seeds
 
 /// Item: seed consisting of three spacepoints, z origin and weight
 struct seed {
@@ -75,36 +76,7 @@ TRACCC_HOST std::vector<std::array<spacepoint, 3>> get_spacepoint_vector(
     return result;
 }
 
-/// Container of internal_spacepoint for an event
-template <template <typename> class vector_t>
-using seed_collection = vector_t<seed>;
-
-/// Convenience declaration for the seed collection type to use
-/// in host code
-using host_seed_collection = seed_collection<vecmem::vector>;
-
-/// Convenience declaration for the seed collection type to use
-/// in device code
-using device_seed_collection = seed_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the seed container type to use in
-/// host code
-using host_seed_container = host_container<unsigned int, seed>;
-
-/// Convenience declaration for the seed container type to use in
-/// device code
-using device_seed_container = device_container<unsigned int, seed>;
-
-/// Convenience declaration for the seed container data type to
-/// use in host code
-using seed_container_data = container_data<unsigned int, seed>;
-
-/// Convenience declaration for the seed container buffer type to
-/// use in host code
-using seed_container_buffer = container_buffer<unsigned int, seed>;
-
-/// Convenience declaration for the seed container view type to
-/// use in host code
-using seed_container_view = container_view<unsigned int, seed>;
+// Declare all seed collection types
+TRACCC_DECLARE_COLLECTION_TYPES(seed);
 
 }  // namespace traccc

--- a/core/include/traccc/edm/spacepoint.hpp
+++ b/core/include/traccc/edm/spacepoint.hpp
@@ -15,7 +15,7 @@
 #include "traccc/edm/measurement.hpp"
 
 // System include(s).
-#include <vector>
+#include <cmath>
 
 namespace traccc {
 
@@ -23,12 +23,6 @@ namespace traccc {
 struct spacepoint {
     point3 global = {0., 0., 0.};
     measurement meas;
-
-    TRACCC_HOST_DEVICE
-    static inline spacepoint invalid_value() {
-        measurement ms = measurement::invalid_value();
-        return spacepoint({{0., 0., 0.}, ms});
-    }
 
     TRACCC_HOST_DEVICE
     const scalar& x() const { return global[0]; }
@@ -42,77 +36,31 @@ struct spacepoint {
     }
 };
 
+/// Comparison / ordering operator for spacepoints
+TRACCC_HOST_DEVICE
 inline bool operator<(const spacepoint& lhs, const spacepoint& rhs) {
-    if (lhs.global[0] < rhs.global[0]) {
-        return true;
+
+    if (std::abs(lhs.x() - rhs.x()) > float_epsilon) {
+        return (lhs.x() < rhs.x());
+    } else if (std::abs(lhs.y() - rhs.y()) > float_epsilon) {
+        return (lhs.y() < rhs.y());
+    } else {
+        return (lhs.z() < rhs.z());
     }
-    return false;
 }
 
+/// Equality operator for spacepoints
+TRACCC_HOST_DEVICE
 inline bool operator==(const spacepoint& lhs, const spacepoint& rhs) {
-    if (std::abs(lhs.global[0] - rhs.global[0]) < float_epsilon &&
-        std::abs(lhs.global[1] - rhs.global[1]) < float_epsilon &&
-        std::abs(lhs.global[2] - rhs.global[2]) < float_epsilon) {
-        return true;
-    }
-    return false;
+
+    return ((std::abs(lhs.global[0] - rhs.global[0]) < float_epsilon) &&
+            (std::abs(lhs.global[1] - rhs.global[1]) < float_epsilon) &&
+            (std::abs(lhs.global[2] - rhs.global[2]) < float_epsilon) &&
+            (lhs.meas == rhs.meas));
 }
 
-/// (Non-const) Container of spacepoints belonging to one detector module
-template <template <typename> class vector_t>
-using spacepoint_collection = vector_t<spacepoint>;
-
-/// (Const) Container of spacepoints belonging to one detector module
-template <template <typename> class vector_t>
-using spacepoint_const_collection = vector_t<const spacepoint>;
-
-/// Convenience declaration for the spacepoint collection type to use in host
-/// code
-using host_spacepoint_collection = spacepoint_collection<vecmem::vector>;
-
-/// Convenience declaration for the spacepoint collection type to use in device
-/// code (non-const)
-using device_spacepoint_collection =
-    spacepoint_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the spacepoint collection type to use in device
-/// code (const)
-using device_spacepoint_const_collection =
-    spacepoint_const_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the spacepoint container type to use in host
-/// code
-using host_spacepoint_container = host_container<geometry_id, spacepoint>;
-
-/// Convenience declaration for the spacepoint container type to use in device
-/// code (non-const)
-using device_spacepoint_container = device_container<geometry_id, spacepoint>;
-
-/// Convenience declaration for the spacepoint container type to use in device
-/// code (const)
-using device_spacepoint_const_container =
-    device_container<const geometry_id, const spacepoint>;
-
-/// Convenience declaration for the spacepoint container data type to use in
-/// host code (non-const)
-using spacepoint_container_data = container_data<geometry_id, spacepoint>;
-
-/// Convenience declaration for the spacepoint container data type to use in
-/// host code (const)
-using spacepoint_container_const_data =
-    container_data<const geometry_id, const spacepoint>;
-
-/// Convenience declaration for the spacepoint container buffer type to use in
-/// host code
-using spacepoint_container_buffer = container_buffer<geometry_id, spacepoint>;
-
-/// Convenience declaration for the spacepoint container view type to use in
-/// host code (non-const)
-using spacepoint_container_view = container_view<geometry_id, spacepoint>;
-
-/// Convenience declaration for the spacepoint container view type to use in
-/// host code (const)
-using spacepoint_container_const_view =
-    container_view<const geometry_id, const spacepoint>;
+// Declare all spacepoint collection/container types
+TRACCC_DECLARE_COLLECTION_TYPES(spacepoint);
+TRACCC_DECLARE_CONTAINER_TYPES(spacepoint, geometry_id, spacepoint);
 
 }  // namespace traccc

--- a/core/include/traccc/edm/track_parameters.hpp
+++ b/core/include/traccc/edm/track_parameters.hpp
@@ -7,10 +7,11 @@
 
 #pragma once
 
-// traccc include
+// Library include(s).
 #include "traccc/definitions/common.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/definitions/track_parametrization.hpp"
+#include "traccc/edm/container.hpp"
 #include "traccc/utils/unit_vectors.hpp"
 
 namespace traccc {
@@ -98,19 +99,8 @@ inline bool operator==(const bound_track_parameters& lhs,
     return false;
 }
 
-/// Collection of bound_track_parameters
-template <template <typename> class vector_t>
-using bound_track_parameters_collection = vector_t<bound_track_parameters>;
-
-/// Convenient declaration for the bound track parameters collection type to use
-/// in host code
-using host_bound_track_parameters_collection =
-    bound_track_parameters_collection<vecmem::vector>;
-
-/// Convenient declaration for the bound track parameters collection type to use
-/// in device code
-using device_bound_track_parameters_collection =
-    bound_track_parameters_collection<vecmem::device_vector>;
+// Declare all bound_track_parameters collection types
+TRACCC_DECLARE_COLLECTION_TYPES(bound_track_parameters);
 
 struct curvilinear_track_parameters {
     using vector_t = bound_vector;
@@ -126,6 +116,9 @@ struct curvilinear_track_parameters {
     TRACCC_HOST_DEVICE
     covariance_t& covariance() { return m_covariance; }
 };
+
+// Declare all curvilinear_track_parameters collection types
+TRACCC_DECLARE_COLLECTION_TYPES(curvilinear_track_parameters);
 
 struct free_track_parameters {
     using vector_t = free_vector;
@@ -175,5 +168,8 @@ struct free_track_parameters {
     TRACCC_HOST_DEVICE
     scalar& qop() { return m_vector[e_free_qoverp]; }
 };
+
+// Declare all free_track_parameters collection types
+TRACCC_DECLARE_COLLECTION_TYPES(free_track_parameters);
 
 }  // namespace traccc

--- a/core/include/traccc/seeding/detail/doublet.hpp
+++ b/core/include/traccc/seeding/detail/doublet.hpp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// Library include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/container.hpp"
 #include "traccc/seeding/detail/singlet.hpp"
 
 namespace traccc {
@@ -38,33 +41,8 @@ inline TRACCC_HOST_DEVICE bool operator==(const doublet& lhs,
             lhs.sp2.sp_idx == rhs.sp2.sp_idx);
 }
 
-/// Container of doublet belonging to one detector module
-template <template <typename> class vector_t>
-using doublet_collection = vector_t<doublet>;
-
-/// Convenience declaration for the doublet collection type to use in host code
-using host_doublet_collection = doublet_collection<vecmem::vector>;
-
-/// Convenience declaration for the doublet collection type to use in device
-/// code
-using device_doublet_collection = doublet_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the doublet container type to use in host code
-using host_doublet_container = host_container<doublet_per_bin, doublet>;
-
-/// Convenience declaration for the doublet container type to use in device code
-using device_doublet_container = device_container<doublet_per_bin, doublet>;
-
-/// Convenience declaration for the doublet container data type to use in host
-/// code
-using doublet_container_data = container_data<doublet_per_bin, doublet>;
-
-/// Convenience declaration for the doublet container buffer type to use in host
-/// code
-using doublet_container_buffer = container_buffer<doublet_per_bin, doublet>;
-
-/// Convenience declaration for the doublet container view type to use in host
-/// code
-using doublet_container_view = container_view<doublet_per_bin, doublet>;
+// Declare all doublet collection/container types
+TRACCC_DECLARE_COLLECTION_TYPES(doublet);
+TRACCC_DECLARE_CONTAINER_TYPES(doublet, doublet_per_bin, doublet);
 
 }  // namespace traccc

--- a/core/include/traccc/seeding/detail/lin_circle.hpp
+++ b/core/include/traccc/seeding/detail/lin_circle.hpp
@@ -7,12 +7,12 @@
 
 #pragma once
 
+// Library include(s).
+#include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/container.hpp"
 
 namespace traccc {
-
-/// Header: unsigned int for the number of lin_circles per spacepoint bin
 
 /// Item: transformed coordinate of doublet of middle-bottom or middle-top
 struct lin_circle {
@@ -48,37 +48,7 @@ struct lin_circle {
     const scalar& V() const { return m_V; }
 };
 
-/// Container of lin_circle belonging to one detector module
-template <template <typename> class vector_t>
-using lin_circle_collection = vector_t<lin_circle>;
-
-/// Convenience declaration for the lin_circle collection type to use in host
-/// code
-using host_lin_circle_collection = lin_circle_collection<vecmem::vector>;
-
-/// Convenience declaration for the lin_circle collection type to use in device
-/// code
-using device_lin_circle_collection =
-    lin_circle_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the lin_circle container type to use in host
-/// code
-using host_lin_circle_container = host_container<unsigned int, lin_circle>;
-
-/// Convenience declaration for the lin_circle container type to use in device
-/// code
-using device_lin_circle_container = device_container<unsigned int, lin_circle>;
-
-/// Convenience declaration for the lin_circle container data type to use in
-/// host code
-using lin_circle_container_data = container_data<unsigned int, lin_circle>;
-
-/// Convenience declaration for the lin_circle container buffer type to use in
-/// host code
-using lin_circle_container_buffer = container_buffer<unsigned int, lin_circle>;
-
-/// Convenience declaration for the lin_circle container view type to use in
-/// host code
-using lin_circle_container_view = container_view<unsigned int, lin_circle>;
+// Declare all lin_circle collection types
+TRACCC_DECLARE_COLLECTION_TYPES(lin_circle);
 
 }  // namespace traccc

--- a/core/include/traccc/seeding/detail/singlet.hpp
+++ b/core/include/traccc/seeding/detail/singlet.hpp
@@ -7,8 +7,8 @@
 
 #pragma once
 
+// Library include(s).
 #include "traccc/definitions/qualifiers.hpp"
-#include "traccc/edm/container.hpp"
 
 namespace traccc {
 
@@ -25,32 +25,4 @@ inline TRACCC_HOST_DEVICE bool operator==(const sp_location& lhs,
     return (lhs.bin_idx == rhs.bin_idx && lhs.sp_idx == rhs.sp_idx);
 }
 
-/// Container of singlet belonging to one detector module
-template <template <typename> class vector_t>
-using singlet_collection = vector_t<sp_location>;
-
-/// Convenience declaration for the singlet collection type to use in host code
-using host_singlet_collection = singlet_collection<vecmem::vector>;
-
-/// Convenience declaration for the singlet collection type to use in device
-/// code
-using device_singlet_collection = singlet_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the singlet container type to use in host code
-using host_singlet_container = host_container<unsigned int, sp_location>;
-
-/// Convenience declaration for the singlet container type to use in device code
-using device_singlet_container = device_container<unsigned int, sp_location>;
-
-/// Convenience declaration for the singlet container data type to use in host
-/// code
-using singlet_container_data = container_data<unsigned int, sp_location>;
-
-/// Convenience declaration for the singlet container buffer type to use in host
-/// code
-using singlet_container_buffer = container_buffer<unsigned int, sp_location>;
-
-/// Convenience declaration for the singlet container view type to use in host
-/// code
-using singlet_container_view = container_view<unsigned int, sp_location>;
 }  // namespace traccc

--- a/core/include/traccc/seeding/detail/triplet.hpp
+++ b/core/include/traccc/seeding/detail/triplet.hpp
@@ -7,8 +7,10 @@
 
 #pragma once
 
+// Library include(s).
 #include "traccc/definitions/primitives.hpp"
-#include "traccc/seeding/detail/doublet.hpp"
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/seeding/detail/singlet.hpp"
 
 namespace traccc {
 
@@ -39,48 +41,21 @@ struct triplet {
     scalar z_vertex;
 };
 
+/// Equality operator for triplets
 inline TRACCC_HOST_DEVICE bool operator==(const triplet& lhs,
                                           const triplet& rhs) {
-    return (lhs.sp1.bin_idx == rhs.sp1.bin_idx &&
-            lhs.sp1.sp_idx == rhs.sp1.sp_idx &&
-            lhs.sp2.bin_idx == rhs.sp2.bin_idx &&
-            lhs.sp2.sp_idx == rhs.sp2.sp_idx &&
-            lhs.sp3.bin_idx == rhs.sp3.bin_idx &&
-            lhs.sp3.sp_idx == rhs.sp3.sp_idx);
+    return ((lhs.sp1 == rhs.sp1) && (lhs.sp2 == rhs.sp2) &&
+            (lhs.sp3 == rhs.sp3));
 }
 
+/// Comparison / ordering operator for triplets
 inline TRACCC_HOST_DEVICE bool operator<(const triplet& lhs,
                                          const triplet& rhs) {
     return lhs.weight < rhs.weight;
 }
 
-/// Container of triplet belonging to one detector module
-template <template <typename> class vector_t>
-using triplet_collection = vector_t<triplet>;
-
-/// Convenience declaration for the triplet collection type to use in host code
-using host_triplet_collection = triplet_collection<vecmem::vector>;
-
-/// Convenience declaration for the triplet collection type to use in device
-/// code
-using device_triplet_collection = triplet_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the triplet container type to use in host code
-using host_triplet_container = host_container<triplet_per_bin, triplet>;
-
-/// Convenience declaration for the triplet container type to use in device code
-using device_triplet_container = device_container<triplet_per_bin, triplet>;
-
-/// Convenience declaration for the triplet container data type to use in host
-/// code
-using triplet_container_data = container_data<triplet_per_bin, triplet>;
-
-/// Convenience declaration for the triplet container buffer type to use in host
-/// code
-using triplet_container_buffer = container_buffer<triplet_per_bin, triplet>;
-
-/// Convenience declaration for the triplet container view type to use in host
-/// code
-using triplet_container_view = container_view<triplet_per_bin, triplet>;
+// Declare all triplet collection/container types
+TRACCC_DECLARE_COLLECTION_TYPES(triplet);
+TRACCC_DECLARE_CONTAINER_TYPES(triplet, triplet_per_bin, triplet);
 
 }  // namespace traccc

--- a/device/cuda/include/traccc/cuda/seeding/detail/doublet_counter.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/detail/doublet_counter.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/container.hpp"
 #include "traccc/seeding/detail/singlet.hpp"
 
 namespace traccc {

--- a/device/cuda/include/traccc/cuda/seeding/detail/triplet_counter.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/detail/triplet_counter.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/container.hpp"
 #include "traccc/seeding/detail/doublet.hpp"
 
 namespace traccc {

--- a/device/sycl/src/seeding/doublet_counter.hpp
+++ b/device/sycl/src/seeding/doublet_counter.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/container.hpp"
 #include "traccc/seeding/detail/singlet.hpp"
 
 namespace traccc {

--- a/device/sycl/src/seeding/triplet_counter.hpp
+++ b/device/sycl/src/seeding/triplet_counter.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/container.hpp"
 #include "traccc/seeding/detail/doublet.hpp"
 
 namespace traccc {


### PR DESCRIPTION
This is probably going to be a little controversial. Especially since I myself am also not 100% sure that this is the best way to go. But here it goes...

When I started setting up the `traccc::device::triplet_counter` type today as the next step after #185. I really got fed up with copy-pasting a bunch of standard type declarations. Which we have a **lot** of. And they are even a bit inconsistent here and there.

So I decided to set up the collection / container types through helper macros instead. I introduced `TRACCC_DECLARE_COLLECTION_TYPES(...)` and `TRACCC_DECLARE_CONTAINER_TYPES(...)`. Which one could use like:

```c++
// Declare all doublet collection/container types
TRACCC_DECLARE_COLLECTION_TYPES(doublet);
TRACCC_DECLARE_CONTAINER_TYPES(doublet, doublet_per_bin, doublet);
```

As the in-line documentation lists, `TRACCC_DECLARE_COLLECTION_TYPES` declares all of the following type names:
  - `foo::bar_collection<T>`
  - `foo::bar_const_collection<T>`
  - `foo::host_bar_collection`
  - `foo::device_bar_collection`
  - `foo::device_bar_const_collection`

While `TRACCC_DECLARE_CONTAINER_TYPES` sets up all the following:
  - `foo::host_bar_container`
  - `foo::device_bar_container`
  - `foo::device_bar_const_container`
  - `foo::bar_container_view`
  - `foo::bar_container_const_view`
  - `foo::bar_container_data`
  - `foo::bar_container_const_data`
  - `foo::bar_container_buffer`

All this ensures that all const and non-const types would always be declared, in a consistent way.

While at it, I also made some of the EDM functions a little nicer.

Now... Using macros in EDM declarations is quite evil. There is a reason why we've forbidden macro usage in the xAOD headers. So I'm not super happy about what this does to the readability of our code. At the same time, the code repetition is just going out of hand by now. :frowning: If not like this, I would go with trait classes for declaring all these types. Which may be a better idea in the end to be honest. (The reason I didn't start with that implementation is that I only thought of it right now... :stuck_out_tongue:)

So depending on what everyone thinks, we may or may not want to go with this macro-heavy implementation...