### PR TITLE
Container Cleanup, main branch (2022.05.09.)

### DIFF
--- a/core/include/traccc/edm/container.hpp
+++ b/core/include/traccc/edm/container.hpp
@@ -19,6 +19,8 @@
 #include <vecmem/containers/data/jagged_vector_view.hpp>
 #include <vecmem/containers/data/vector_buffer.hpp>
 #include <vecmem/containers/data/vector_view.hpp>
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/containers/vector.hpp>
 
 // System include(s).
 #include <type_traits>
@@ -121,5 +123,63 @@ inline container_data<const header_t, const item_t> get_data(
     return {{vecmem::get_data(cc.get_headers())},
             {vecmem::get_data(cc.get_items(), resource)}};
 }
+
+/// Type trait defining all "collection types" for an EDM class
+template <typename item_t>
+struct collection_types {
+
+    /// @c item_t must not be a constant type
+    static_assert(std::is_const<item_t>::value == false,
+                  "The template parameter must not be a constant type");
+
+    /// Host collection for @c item_t
+    using host = vecmem::vector<item_t>;
+    /// Non-const device collection for @c item_t
+    using device = vecmem::device_vector<item_t>;
+    /// Constant device collection for @c item_t
+    using const_device = vecmem::device_vector<const item_t>;
+
+    /// Non-constant view of an @c item_t collection
+    using view = vecmem::data::vector_view<item_t>;
+    /// Constant view of an @c item_t collection
+    using const_view = vecmem::data::vector_view<const item_t>;
+
+    /// Buffer for an @c item_t collection
+    using buffer = vecmem::data::vector_buffer<item_t>;
+
+};  // struct collection_types
+
+/// Type trait defining all "container types" for an EDM class pair
+template <typename header_t, typename item_t>
+struct container_types {
+
+    /// @c header_t must not be a constant type
+    static_assert(std::is_const<header_t>::value == false,
+                  "The header type must not be constant");
+    /// @c item_t must not be a constant type
+    static_assert(std::is_const<item_t>::value == false,
+                  "The item type must not be constant");
+
+    /// Host container for @c header_t and @c item_t
+    using host = host_container<header_t, item_t>;
+    /// Non-const device container for @c header_t and @c item_t
+    using device = device_container<header_t, item_t>;
+    /// Constant device container for @c header_t and @c item_t
+    using const_device = device_container<const header_t, const item_t>;
+
+    /// Non-constant view of an @c header_t / @c item_t container
+    using view = container_view<header_t, item_t>;
+    /// Constant view of an @c header_t / @c item_t container
+    using const_view = container_view<const header_t, const item_t>;
+
+    /// Non-constant data for an @c header_t / @c item_t container
+    using data = container_data<header_t, item_t>;
+    /// Constant data for an @c header_t / @c item_t container
+    using const_data = container_data<const header_t, const item_t>;
+
+    /// Buffer for an @c header_t / @c item_t container
+    using buffer = container_buffer<header_t, item_t>;
+
+};  // struct container_types
 
 }  // namespace traccc

--- a/device/common/include/traccc/edm/device/doublet_counter.hpp
+++ b/device/common/include/traccc/edm/device/doublet_counter.hpp
@@ -57,58 +57,10 @@ struct doublet_counter {
 
 };  // struct doublet_counter
 
-/// Convenience declaration for the doublet_counter collection type to use in
-/// host code
-using host_doublet_counter_collection = vecmem::vector<doublet_counter>;
-
-/// Convenience declaration for the doublet_counter collection type to use in
-/// device code (non-const)
-using device_doublet_counter_collection =
-    vecmem::device_vector<doublet_counter>;
-
-/// Convenience declaration for the doublet_counter collection type to use in
-/// device code (const)
-using device_doublet_counter_const_collection =
-    vecmem::device_vector<const doublet_counter>;
-
-/// Convenience declaration for the doublet_counter container type to use in
-/// host code
-using host_doublet_counter_container =
-    host_container<doublet_counter_header, doublet_counter>;
-
-/// Convenience declaration for the doublet_counter container type to use in
-/// device code (non-const)
-using device_doublet_counter_container =
-    device_container<doublet_counter_header, doublet_counter>;
-
-/// Convenience declaration for the doublet_counter container type to use in
-/// device code (const)
-using device_doublet_counter_const_container =
-    device_container<const doublet_counter_header, const doublet_counter>;
-
-/// Convenience declaration for the doublet_counter container data type to use
-/// in host code (non-const)
-using doublet_counter_container_data =
-    container_data<doublet_counter_header, doublet_counter>;
-
-/// Convenience declaration for the doublet_counter container data type to use
-/// in host code (const)
-using doublet_counter_container_const_data =
-    container_data<const doublet_counter_header, const doublet_counter>;
-
-/// Convenience declaration for the doublet_counter container buffer type to use
-/// in host code
-using doublet_counter_container_buffer =
-    container_buffer<doublet_counter_header, doublet_counter>;
-
-/// Convenience declaration for the doublet_counter container view type to use
-/// in host code (non-const)
-using doublet_counter_container_view =
-    container_view<doublet_counter_header, doublet_counter>;
-
-/// Convenience declaration for the doublet_counter container view type to use
-/// in host code (const)
-using doublet_counter_container_const_view =
-    container_view<const doublet_counter_header, const doublet_counter>;
+/// Declare all doublet counter collection types
+using doublet_counter_collection_types = collection_types<doublet_counter>;
+/// Declare all doublet counter container types
+using doublet_counter_container_types =
+    container_types<doublet_counter_header, doublet_counter>;
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/count_doublets.hpp
+++ b/device/common/include/traccc/seeding/device/count_doublets.hpp
@@ -35,7 +35,7 @@ void count_doublets(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>& sp_ps_view,
-    doublet_counter_container_view doublet_view);
+    doublet_counter_container_types::view doublet_view);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/seeding/device/find_doublets.hpp
+++ b/device/common/include/traccc/seeding/device/find_doublets.hpp
@@ -37,7 +37,7 @@ TRACCC_HOST_DEVICE
 void find_doublets(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
-    const device::doublet_counter_container_const_view& doublet_view,
+    const device::doublet_counter_container_types::const_view& doublet_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         doublet_ps_view,
     doublet_container_view mb_doublets_view,

--- a/device/common/include/traccc/seeding/device/impl/count_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_doublets.ipp
@@ -23,7 +23,7 @@ void count_doublets(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>& sp_ps_view,
-    doublet_counter_container_view doublet_view) {
+    doublet_counter_container_types::view doublet_view) {
 
     // Check if anything needs to be done.
     vecmem::device_vector<const prefix_sum_element_t> sp_prefix_sum(sp_ps_view);
@@ -36,7 +36,7 @@ void count_doublets(
 
     // Set up the device containers.
     const const_sp_grid_device sp_grid(sp_view);
-    device_doublet_counter_container doublet_counter(doublet_view);
+    doublet_counter_container_types::device doublet_counter(doublet_view);
 
     // Get the spacepoint that we're evaluating in this thread, and treat that
     // as the "middle" spacepoint.

--- a/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
@@ -22,7 +22,7 @@ TRACCC_HOST_DEVICE
 void find_doublets(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
-    const device::doublet_counter_container_const_view& doublet_view,
+    const device::doublet_counter_container_types::const_view& doublet_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         doublet_ps_view,
     doublet_container_view mb_doublets_view,
@@ -37,9 +37,9 @@ void find_doublets(
 
     // Get the middle spacepoint that we need to be looking at.
     const prefix_sum_element_t middle_sp_idx = doublet_prefix_sum[globalIndex];
-    const device::device_doublet_counter_const_container doublet_counts(
+    const device::doublet_counter_container_types::const_device doublet_counts(
         doublet_view);
-    const device::device_doublet_counter_const_collection
+    const device::doublet_counter_collection_types::const_device
         doublet_counts_in_bin =
             doublet_counts.get_items().at(middle_sp_idx.first);
     const device::doublet_counter middle_sp_counter =

--- a/device/common/include/traccc/seeding/device/make_doublet_buffers.hpp
+++ b/device/common/include/traccc/seeding/device/make_doublet_buffers.hpp
@@ -41,7 +41,7 @@ struct doublet_buffer_pair {
 /// @return Buffers usable by @c traccc::device::find_doublets
 ///
 doublet_buffer_pair make_doublet_buffers(
-    const doublet_counter_container_const_view& doublet_counter,
+    const doublet_counter_container_types::const_view& doublet_counter,
     vecmem::copy& copy, vecmem::memory_resource& mr,
     vecmem::memory_resource* mr_host = nullptr);
 

--- a/device/common/include/traccc/seeding/device/make_doublet_counter_buffer.hpp
+++ b/device/common/include/traccc/seeding/device/make_doublet_counter_buffer.hpp
@@ -31,7 +31,7 @@ namespace traccc::device {
 ///                buffer, in case @c mr is not host-accessible
 /// @return A buffer usable by @c traccc::device::count_doublets
 ///
-device::doublet_counter_container_buffer make_doublet_counter_buffer(
+doublet_counter_container_types::buffer make_doublet_counter_buffer(
     const sp_grid_const_view& spacepoint_grid, vecmem::copy& copy,
     vecmem::memory_resource& mr, vecmem::memory_resource* mr_host = nullptr);
 

--- a/device/common/src/seeding/make_doublet_buffers.cpp
+++ b/device/common/src/seeding/make_doublet_buffers.cpp
@@ -17,7 +17,7 @@
 namespace traccc::device {
 
 doublet_buffer_pair make_doublet_buffers(
-    const doublet_counter_container_const_view& doublet_counter,
+    const doublet_counter_container_types::const_view& doublet_counter,
     vecmem::copy& copy, vecmem::memory_resource& mr,
     vecmem::memory_resource* mr_host) {
 

--- a/device/common/src/seeding/make_doublet_counter_buffer.cpp
+++ b/device/common/src/seeding/make_doublet_counter_buffer.cpp
@@ -10,17 +10,17 @@
 
 namespace traccc::device {
 
-device::doublet_counter_container_buffer make_doublet_counter_buffer(
+device::doublet_counter_container_types::buffer make_doublet_counter_buffer(
     const sp_grid_const_view& spacepoint_grid, vecmem::copy& copy,
     vecmem::memory_resource& mr, vecmem::memory_resource* mr_host) {
 
     // Calculate the capacities for the buffer.
     auto grid_sizes = copy.get_sizes(spacepoint_grid._data_view);
-    const device::doublet_counter_container_buffer::header_vector::size_type
-        buffer_size = grid_sizes.size();
+    const device::doublet_counter_container_types::buffer::header_vector::
+        size_type buffer_size = grid_sizes.size();
 
     // Create the buffer object.
-    device::doublet_counter_container_buffer buffer{
+    device::doublet_counter_container_types::buffer buffer{
         {buffer_size, mr},
         {std::vector<std::size_t>(buffer_size, 0),
          std::vector<std::size_t>(grid_sizes.begin(), grid_sizes.end()), mr,

--- a/device/cuda/include/traccc/cuda/seeding/seed_selecting.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_selecting.hpp
@@ -35,7 +35,7 @@ void seed_selecting(
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
     const host_spacepoint_container& spacepoints,
     sp_grid_const_view internal_sp_view,
-    device::doublet_counter_container_const_view dcc_view,
+    device::doublet_counter_container_types::const_view dcc_view,
     triplet_counter_container_view tcc_view, triplet_container_view tc_view,
     vecmem::data::vector_buffer<seed>& seed_buffer,
     vecmem::memory_resource& resource);

--- a/device/cuda/include/traccc/cuda/seeding/triplet_counting.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/triplet_counting.hpp
@@ -31,14 +31,13 @@ namespace cuda {
 /// @param mid_top_doublet_container vecmem container for mid-top doublets
 /// @param triplet_counter_container vecmem container for triplet counters
 /// @resource vecmem memory resource
-void triplet_counting(const seedfinder_config& config,
-                      const vecmem::vector<doublet_per_bin>& mbc_headers,
-                      sp_grid_const_view internal_sp_view,
-                      device::doublet_counter_container_const_view dcc_view,
-                      doublet_container_view mbc_view,
-                      doublet_container_view mtc_view,
-                      triplet_counter_container_view tcc_view,
-                      vecmem::memory_resource& resource);
+void triplet_counting(
+    const seedfinder_config& config,
+    const vecmem::vector<doublet_per_bin>& mbc_headers,
+    sp_grid_const_view internal_sp_view,
+    device::doublet_counter_container_types::const_view dcc_view,
+    doublet_container_view mbc_view, doublet_container_view mtc_view,
+    triplet_counter_container_view tcc_view, vecmem::memory_resource& resource);
 
 }  // namespace cuda
 }  // namespace traccc

--- a/device/cuda/include/traccc/cuda/seeding/triplet_finding.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/triplet_finding.hpp
@@ -33,16 +33,14 @@ namespace cuda {
 /// @param triplet_counter_container vecmem container for triplet counters
 /// @param triplet_container vecmem container for triplets
 /// @param resource vecmem memory resource
-void triplet_finding(const seedfinder_config& config,
-                     const seedfilter_config& filter_config,
-                     const vecmem::vector<triplet_counter_per_bin>& tcc_headers,
-                     sp_grid_const_view internal_sp_view,
-                     device::doublet_counter_container_const_view dcc_view,
-                     doublet_container_view mbc_view,
-                     doublet_container_view mtc_view,
-                     triplet_counter_container_view tcc_view,
-                     triplet_container_view tc_view,
-                     vecmem::memory_resource& resource);
+void triplet_finding(
+    const seedfinder_config& config, const seedfilter_config& filter_config,
+    const vecmem::vector<triplet_counter_per_bin>& tcc_headers,
+    sp_grid_const_view internal_sp_view,
+    device::doublet_counter_container_types::const_view dcc_view,
+    doublet_container_view mbc_view, doublet_container_view mtc_view,
+    triplet_counter_container_view tcc_view, triplet_container_view tc_view,
+    vecmem::memory_resource& resource);
 
 }  // namespace cuda
 }  // namespace traccc

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -37,7 +37,7 @@ namespace kernels {
 __global__ void count_doublets(
     seedfinder_config config, sp_grid_const_view sp_grid,
     vecmem::data::vector_view<const device::prefix_sum_element_t> sp_prefix_sum,
-    device::doublet_counter_container_view doublet_counter) {
+    device::doublet_counter_container_types::view doublet_counter) {
 
     device::count_doublets(threadIdx.x + blockIdx.x * blockDim.x, config,
                            sp_grid, sp_prefix_sum, doublet_counter);
@@ -46,7 +46,7 @@ __global__ void count_doublets(
 /// CUDA kernel for running @c traccc::device::find_doublets
 __global__ void find_doublets(
     seedfinder_config config, sp_grid_const_view sp_grid,
-    device::doublet_counter_container_const_view doublet_counter,
+    device::doublet_counter_container_types::const_view doublet_counter,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         doublet_prefix_sum,
     doublet_container_view mb_doublets, doublet_container_view mt_doublets) {
@@ -74,7 +74,7 @@ seed_finding::output_type seed_finding::operator()(
         device::get_prefix_sum(g2_view._data_view, m_mr.get(), copy);
 
     // Set up the doublet counter buffer.
-    device::doublet_counter_container_buffer doublet_counter_buffer =
+    device::doublet_counter_container_types::buffer doublet_counter_buffer =
         device::make_doublet_counter_buffer(g2_view, copy, m_mr.get());
 
     // Calculate the number of threads and thread blocks to run the doublet

--- a/device/cuda/src/seeding/seed_selecting.cu
+++ b/device/cuda/src/seeding/seed_selecting.cu
@@ -34,7 +34,7 @@ __global__ void seed_selecting_kernel(
     const seedfilter_config filter_config,
     spacepoint_container_const_view spacepoints_view,
     sp_grid_const_view internal_sp_view,
-    device::doublet_counter_container_const_view doublet_counter_view,
+    device::doublet_counter_container_types::const_view doublet_counter_view,
     triplet_counter_container_view triplet_counter_view,
     triplet_container_view triplet_view,
     vecmem::data::vector_view<seed> seed_view);
@@ -44,7 +44,7 @@ void seed_selecting(
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
     const host_spacepoint_container& spacepoints,
     sp_grid_const_view internal_sp_view,
-    device::doublet_counter_container_const_view dcc_view,
+    device::doublet_counter_container_types::const_view dcc_view,
     triplet_counter_container_view tcc_view, triplet_container_view tc_view,
     vecmem::data::vector_buffer<seed>& seed_buffer,
     vecmem::memory_resource& resource) {
@@ -88,7 +88,7 @@ __global__ void seed_selecting_kernel(
     const seedfilter_config filter_config,
     spacepoint_container_const_view spacepoints_view,
     sp_grid_const_view internal_sp_view,
-    device::doublet_counter_container_const_view doublet_counter_view,
+    device::doublet_counter_container_types::const_view doublet_counter_view,
     triplet_counter_container_view triplet_counter_view,
     triplet_container_view triplet_view,
     vecmem::data::vector_view<seed> seed_view) {
@@ -97,8 +97,8 @@ __global__ void seed_selecting_kernel(
     device_spacepoint_const_container spacepoints_device(spacepoints_view);
     const_sp_grid_device internal_sp_device(internal_sp_view);
 
-    const device::device_doublet_counter_const_container doublet_counter_device(
-        doublet_counter_view);
+    const device::doublet_counter_container_types::const_device
+        doublet_counter_device(doublet_counter_view);
     device_triplet_counter_container triplet_counter_device(
         triplet_counter_view);
     device_triplet_container triplet_device(triplet_view);

--- a/device/cuda/src/seeding/triplet_counting.cu
+++ b/device/cuda/src/seeding/triplet_counting.cu
@@ -36,19 +36,19 @@ __global__ void set_zero_kernel(triplet_counter_container_view tcc_view) {
 /// @resource vecmem memory resource
 __global__ void triplet_counting_kernel(
     const seedfinder_config config, sp_grid_const_view internal_sp_view,
-    device::doublet_counter_container_const_view doublet_counter_view,
+    device::doublet_counter_container_types::const_view doublet_counter_view,
     doublet_container_view mid_bot_doublet_view,
     doublet_container_view mid_top_doublet_view,
     triplet_counter_container_view triplet_counter_view);
 
-void triplet_counting(const seedfinder_config& config,
-                      const vecmem::vector<doublet_per_bin>& mbc_headers,
-                      sp_grid_const_view internal_sp_view,
-                      device::doublet_counter_container_const_view dcc_view,
-                      doublet_container_view mbc_view,
-                      doublet_container_view mtc_view,
-                      triplet_counter_container_view tcc_view,
-                      vecmem::memory_resource& resource) {
+void triplet_counting(
+    const seedfinder_config& config,
+    const vecmem::vector<doublet_per_bin>& mbc_headers,
+    sp_grid_const_view internal_sp_view,
+    device::doublet_counter_container_types::const_view dcc_view,
+    doublet_container_view mbc_view, doublet_container_view mtc_view,
+    triplet_counter_container_view tcc_view,
+    vecmem::memory_resource& resource) {
 
     unsigned int nbins = internal_sp_view._data_view.m_size;
 
@@ -89,7 +89,7 @@ void triplet_counting(const seedfinder_config& config,
 
 __global__ void triplet_counting_kernel(
     const seedfinder_config config, sp_grid_const_view internal_sp_view,
-    device::doublet_counter_container_const_view doublet_counter_view,
+    device::doublet_counter_container_types::const_view doublet_counter_view,
     doublet_container_view mid_bot_doublet_view,
     doublet_container_view mid_top_doublet_view,
     triplet_counter_container_view triplet_counter_view) {
@@ -97,8 +97,8 @@ __global__ void triplet_counting_kernel(
     // Get device container for input parameters
     const_sp_grid_device internal_sp_device(internal_sp_view);
 
-    const device::device_doublet_counter_const_container doublet_counter_device(
-        doublet_counter_view);
+    const device::doublet_counter_container_types::const_device
+        doublet_counter_device(doublet_counter_view);
     device_doublet_container mid_bot_doublet_device(mid_bot_doublet_view);
     device_doublet_container mid_top_doublet_device(mid_top_doublet_view);
     device_triplet_counter_container triplet_counter_device(

--- a/device/cuda/src/seeding/triplet_finding.cu
+++ b/device/cuda/src/seeding/triplet_finding.cu
@@ -38,22 +38,20 @@ __global__ void set_zero_kernel(triplet_container_view tc_view) {
 __global__ void triplet_finding_kernel(
     const seedfinder_config config, const seedfilter_config filter_config,
     sp_grid_const_view internal_sp_view,
-    device::doublet_counter_container_const_view doublet_counter_view,
+    device::doublet_counter_container_types::const_view doublet_counter_view,
     doublet_container_view mid_bot_doublet_view,
     doublet_container_view mid_top_doublet_view,
     triplet_counter_container_view triplet_counter_view,
     triplet_container_view triplet_view);
 
-void triplet_finding(const seedfinder_config& config,
-                     const seedfilter_config& filter_config,
-                     const vecmem::vector<triplet_counter_per_bin>& tcc_headers,
-                     sp_grid_const_view internal_sp_view,
-                     device::doublet_counter_container_const_view dcc_view,
-                     doublet_container_view mbc_view,
-                     doublet_container_view mtc_view,
-                     triplet_counter_container_view tcc_view,
-                     triplet_container_view tc_view,
-                     vecmem::memory_resource& resource) {
+void triplet_finding(
+    const seedfinder_config& config, const seedfilter_config& filter_config,
+    const vecmem::vector<triplet_counter_per_bin>& tcc_headers,
+    sp_grid_const_view internal_sp_view,
+    device::doublet_counter_container_types::const_view dcc_view,
+    doublet_container_view mbc_view, doublet_container_view mtc_view,
+    triplet_counter_container_view tcc_view, triplet_container_view tc_view,
+    vecmem::memory_resource& resource) {
 
     unsigned int nbins = internal_sp_view._data_view.m_size;
 
@@ -99,7 +97,7 @@ void triplet_finding(const seedfinder_config& config,
 __global__ void triplet_finding_kernel(
     const seedfinder_config config, const seedfilter_config filter_config,
     sp_grid_const_view internal_sp_view,
-    device::doublet_counter_container_const_view doublet_counter_view,
+    device::doublet_counter_container_types::const_view doublet_counter_view,
     doublet_container_view mid_bot_doublet_view,
     doublet_container_view mid_top_doublet_view,
     triplet_counter_container_view triplet_counter_view,
@@ -108,8 +106,8 @@ __global__ void triplet_finding_kernel(
     // Get device container for input parameters
     const_sp_grid_device internal_sp_device(internal_sp_view);
 
-    const device::device_doublet_counter_const_container doublet_counter_device(
-        doublet_counter_view);
+    const device::doublet_counter_container_types::const_device
+        doublet_counter_device(doublet_counter_view);
     device_doublet_container mid_bot_doublet_device(mid_bot_doublet_view);
     device_doublet_container mid_top_doublet_device(mid_top_doublet_view);
 

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -56,7 +56,7 @@ seed_finding::output_type seed_finding::operator()(
     auto sp_grid_prefix_sum_view = vecmem::get_data(sp_grid_prefix_sum);
 
     // Set up the doublet counter buffer.
-    device::doublet_counter_container_buffer doublet_counter_buffer =
+    device::doublet_counter_container_types::buffer doublet_counter_buffer =
         device::make_doublet_counter_buffer(g2_view, copy, m_mr.get());
 
     // Calculate the range to run the doublet counting for.
@@ -69,7 +69,7 @@ seed_finding::output_type seed_finding::operator()(
                                           doubletCountLocalSize);
 
     // Count the number of doublets that we need to produce.
-    device::doublet_counter_container_view doublet_counter_view =
+    device::doublet_counter_container_types::view doublet_counter_view =
         doublet_counter_buffer;
     details::get_queue(m_queue)
         .submit([&](::sycl::handler& h) {

--- a/device/sycl/src/seeding/seed_selecting.hpp
+++ b/device/sycl/src/seeding/seed_selecting.hpp
@@ -40,7 +40,7 @@ void seed_selecting(
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
     host_spacepoint_container& spacepoints,
     const sp_grid_const_view& internal_sp,
-    const device::doublet_counter_container_const_view&
+    const device::doublet_counter_container_types::const_view&
         doublet_counter_container,
     host_triplet_counter_container& triplet_counter_container,
     host_triplet_container& triplet_container,

--- a/device/sycl/src/seeding/seed_selecting.sycl
+++ b/device/sycl/src/seeding/seed_selecting.sycl
@@ -55,15 +55,15 @@ static int min_elem(const local_accessor<triplet>& arr, const int& begin_idx,
 // Kernel class for seed selecting
 class SeedSelect {
     public:
-    SeedSelect(
-        const seedfilter_config filter_config,
-        spacepoint_container_view spacepoints_view,
-        sp_grid_const_view internal_sp_view,
-        device::doublet_counter_container_const_view doublet_counter_view,
-        triplet_counter_container_view triplet_counter_view,
-        triplet_container_view triplet_view,
-        vecmem::data::vector_buffer<seed>& seed_buffer,
-        local_accessor<triplet> localMem)
+    SeedSelect(const seedfilter_config filter_config,
+               spacepoint_container_view spacepoints_view,
+               sp_grid_const_view internal_sp_view,
+               device::doublet_counter_container_types::const_view
+                   doublet_counter_view,
+               triplet_counter_container_view triplet_counter_view,
+               triplet_container_view triplet_view,
+               vecmem::data::vector_buffer<seed>& seed_buffer,
+               local_accessor<triplet> localMem)
         : m_filter_config(filter_config),
           m_spacepoints_view(spacepoints_view),
           m_internal_sp_view(internal_sp_view),
@@ -83,8 +83,8 @@ class SeedSelect {
 
         const_sp_grid_device internal_sp_device(m_internal_sp_view);
 
-        device::device_doublet_counter_const_container doublet_counter_device(
-            m_doublet_counter_view);
+        device::doublet_counter_container_types::const_device
+            doublet_counter_device(m_doublet_counter_view);
         device_triplet_container triplet_device(m_triplet_view);
         device_seed_collection seed_device(m_seed_view);
 
@@ -245,7 +245,7 @@ class SeedSelect {
     const seedfilter_config m_filter_config;
     spacepoint_container_view m_spacepoints_view;
     sp_grid_const_view m_internal_sp_view;
-    device::doublet_counter_container_const_view m_doublet_counter_view;
+    device::doublet_counter_container_types::const_view m_doublet_counter_view;
     triplet_counter_container_view m_triplet_counter_view;
     triplet_container_view m_triplet_view;
     vecmem::data::vector_view<seed> m_seed_view;
@@ -257,7 +257,7 @@ void seed_selecting(
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
     host_spacepoint_container& spacepoints,
     const sp_grid_const_view& internal_sp,
-    const device::doublet_counter_container_const_view&
+    const device::doublet_counter_container_types::const_view&
         doublet_counter_container,
     host_triplet_counter_container& triplet_counter_container,
     host_triplet_container& triplet_container,

--- a/device/sycl/src/seeding/triplet_counting.hpp
+++ b/device/sycl/src/seeding/triplet_counting.hpp
@@ -37,7 +37,7 @@ namespace traccc::sycl {
 void triplet_counting(const seedfinder_config& config,
                       const vecmem::vector<doublet_per_bin>& mbc_headers,
                       const sp_grid_const_view& internal_sp,
-                      const device::doublet_counter_container_const_view&
+                      const device::doublet_counter_container_types::const_view&
                           doublet_counter_container,
                       doublet_container_view mid_bot_doublet_container,
                       doublet_container_view mid_top_doublet_container,

--- a/device/sycl/src/seeding/triplet_counting.sycl
+++ b/device/sycl/src/seeding/triplet_counting.sycl
@@ -24,12 +24,13 @@ namespace traccc::sycl {
 // Kernel class for triplet counting
 class TripletCount {
     public:
-    TripletCount(
-        const seedfinder_config config, sp_grid_const_view internal_sp_view,
-        device::doublet_counter_container_const_view doublet_counter_view,
-        doublet_container_view mid_bot_doublet_view,
-        doublet_container_view mid_top_doublet_view,
-        triplet_counter_container_view triplet_counter_view)
+    TripletCount(const seedfinder_config config,
+                 sp_grid_const_view internal_sp_view,
+                 device::doublet_counter_container_types::const_view
+                     doublet_counter_view,
+                 doublet_container_view mid_bot_doublet_view,
+                 doublet_container_view mid_top_doublet_view,
+                 triplet_counter_container_view triplet_counter_view)
         : m_config(config),
           m_internal_sp_view(internal_sp_view),
           m_doublet_counter_view(doublet_counter_view),
@@ -42,8 +43,8 @@ class TripletCount {
         // Get device container for input parameters
         const_sp_grid_device internal_sp_device(m_internal_sp_view);
 
-        device::device_doublet_counter_const_container doublet_counter_device(
-            m_doublet_counter_view);
+        device::doublet_counter_container_types::const_device
+            doublet_counter_device(m_doublet_counter_view);
         device_doublet_container mid_bot_doublet_device(m_mid_bot_doublet_view);
         device_doublet_container mid_top_doublet_device(m_mid_top_doublet_view);
         device_triplet_counter_container triplet_counter_device(
@@ -178,7 +179,7 @@ class TripletCount {
     private:
     const seedfinder_config m_config;
     sp_grid_const_view m_internal_sp_view;
-    device::doublet_counter_container_const_view m_doublet_counter_view;
+    device::doublet_counter_container_types::const_view m_doublet_counter_view;
     doublet_container_view m_mid_bot_doublet_view;
     doublet_container_view m_mid_top_doublet_view;
     triplet_counter_container_view m_triplet_counter_view;
@@ -187,7 +188,7 @@ class TripletCount {
 void triplet_counting(const seedfinder_config& config,
                       const vecmem::vector<doublet_per_bin>& mbc_headers,
                       const sp_grid_const_view& internal_sp,
-                      const device::doublet_counter_container_const_view&
+                      const device::doublet_counter_container_types::const_view&
                           doublet_counter_container,
                       doublet_container_view mid_bot_doublet_container,
                       doublet_container_view mid_top_doublet_container,

--- a/device/sycl/src/seeding/triplet_finding.hpp
+++ b/device/sycl/src/seeding/triplet_finding.hpp
@@ -39,7 +39,7 @@ namespace traccc::sycl {
 void triplet_finding(const seedfinder_config& config,
                      const seedfilter_config& filter_config,
                      const sp_grid_const_view& internal_sp,
-                     const device::doublet_counter_container_const_view&
+                     const device::doublet_counter_container_types::const_view&
                          doublet_counter_container,
                      doublet_container_view mid_bot_doublet_container,
                      doublet_container_view mid_top_doublet_container,

--- a/device/sycl/src/seeding/triplet_finding.sycl
+++ b/device/sycl/src/seeding/triplet_finding.sycl
@@ -23,14 +23,16 @@ namespace traccc::sycl {
 
 class TripletFind {
     public:
-    TripletFind(
-        const seedfinder_config config, const seedfilter_config filter_config,
-        sp_grid_const_view internal_sp_view,
-        device::doublet_counter_container_const_view doublet_counter_view,
-        doublet_container_view mid_bot_doublet_view,
-        doublet_container_view mid_top_doublet_view,
-        triplet_counter_container_view triplet_counter_view,
-        triplet_container_view triplet_view, local_accessor<int> localMem)
+    TripletFind(const seedfinder_config config,
+                const seedfilter_config filter_config,
+                sp_grid_const_view internal_sp_view,
+                device::doublet_counter_container_types::const_view
+                    doublet_counter_view,
+                doublet_container_view mid_bot_doublet_view,
+                doublet_container_view mid_top_doublet_view,
+                triplet_counter_container_view triplet_counter_view,
+                triplet_container_view triplet_view,
+                local_accessor<int> localMem)
         : m_config(config),
           m_filter_config(filter_config),
           m_internal_sp_view(internal_sp_view),
@@ -51,8 +53,8 @@ class TripletFind {
         // Get device container for input parameters
         const_sp_grid_device internal_sp_device(m_internal_sp_view);
 
-        device::device_doublet_counter_const_container doublet_counter_device(
-            m_doublet_counter_view);
+        device::doublet_counter_container_types::const_device
+            doublet_counter_device(m_doublet_counter_view);
         device_doublet_container mid_bot_doublet_device(m_mid_bot_doublet_view);
         device_doublet_container mid_top_doublet_device(m_mid_top_doublet_view);
 
@@ -249,7 +251,7 @@ class TripletFind {
     const seedfinder_config m_config;
     const seedfilter_config m_filter_config;
     sp_grid_const_view m_internal_sp_view;
-    device::doublet_counter_container_const_view m_doublet_counter_view;
+    device::doublet_counter_container_types::const_view m_doublet_counter_view;
     doublet_container_view m_mid_bot_doublet_view;
     doublet_container_view m_mid_top_doublet_view;
     triplet_counter_container_view m_triplet_counter_view;
@@ -260,7 +262,7 @@ class TripletFind {
 void triplet_finding(const seedfinder_config& config,
                      const seedfilter_config& filter_config,
                      const sp_grid_const_view& internal_sp,
-                     const device::doublet_counter_container_const_view&
+                     const device::doublet_counter_container_types::const_view&
                          doublet_counter_container,
                      doublet_container_view mid_bot_doublet_container,
                      doublet_container_view mid_top_doublet_container,


### PR DESCRIPTION
This is meant as a replacement for #186.

Instead of declaring "top level" types through macros, I introduced the `traccc::collection_types` and `traccc::container_types` trait structs for declaring all the types that one may want to use in (device) code.

I then updated `traccc::device::doublet_counter` to make use of these traits. Updating all of the code that uses this recently introduced type to make use of the trait types.

Note that replacing all EDM container types like this will be more work than what #186 would've required. But we can do those updates one-by-one, which should hopefully help with making the PRs palatable... And this way we can avoid using macros. Which, as I wrote in #186 as well, I didn't really like to begin with.

I'm curious what everybody will think about this. :smile: