### PR TITLE
Cell EDM Update, main branch (2022.05.10.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Mozilla Public License Version 2.0
 
 # Set up the "build" of the traccc::core library.
-traccc_add_library( traccc_core core TYPE INTERFACE
+traccc_add_library( traccc_core core TYPE SHARED
   # Common definitions.
   "include/traccc/definitions/track_parametrization.hpp"
   "include/traccc/definitions/primitives.hpp"
@@ -35,7 +35,9 @@ traccc_add_library( traccc_core core TYPE INTERFACE
   # Clusterization algorithmic code.
   "include/traccc/clusterization/detail/sparse_ccl.hpp"
   "include/traccc/clusterization/component_connection.hpp"
+  "src/clusterization/component_connection.cpp"
   "include/traccc/clusterization/clusterization_algorithm.hpp"
+  "src/clusterization/clusterization_algorithm.cpp"
   "include/traccc/clusterization/spacepoint_formation.hpp"
   "include/traccc/clusterization/measurement_creation.hpp"
   "include/traccc/clusterization/measurement_creation_helper.hpp"
@@ -60,4 +62,4 @@ traccc_add_library( traccc_core core TYPE INTERFACE
   "include/traccc/seeding/seed_finding.hpp"
   "include/traccc/seeding/spacepoint_binning.hpp" )
 target_link_libraries( traccc_core
-  INTERFACE Eigen3::Eigen vecmem::core detray::core ActsCore traccc::algebra )
+  PUBLIC Eigen3::Eigen vecmem::core detray::core ActsCore traccc::algebra )

--- a/core/include/traccc/clusterization/clusterization_algorithm.hpp
+++ b/core/include/traccc/clusterization/clusterization_algorithm.hpp
@@ -7,65 +7,59 @@
 
 #pragma once
 
-#include "traccc/edm/cell.hpp"
-#include "traccc/edm/cluster.hpp"
-#include "traccc/edm/measurement.hpp"
-#include "traccc/edm/spacepoint.hpp"
-#include "traccc/geometry/pixel_data.hpp"
-
-// clusterization
+// Library include(s).
 #include "traccc/clusterization/component_connection.hpp"
 #include "traccc/clusterization/measurement_creation.hpp"
+#include "traccc/edm/cell.hpp"
+#include "traccc/edm/measurement.hpp"
+#include "traccc/utils/algorithm.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/memory_resource.hpp>
+
+// System include(s).
+#include <functional>
 
 namespace traccc {
 
-class clusterization_algorithm
-    : public algorithm<host_measurement_container(const host_cell_container&)> {
+/// Clusterization algorithm, creating measurements from cells
+///
+/// This algorithm creates local/2D measurements separately for each detector
+/// module from the cells of the modules.
+///
+class clusterization_algorithm : public algorithm<host_measurement_container(
+                                     const cell_container_types::host&)> {
 
     public:
-    /// Constructor for clusterization algorithm
+    /// Clusterization algorithm constructor
     ///
-    /// @param mr is the memory resource
-    clusterization_algorithm(vecmem::memory_resource& mr) : m_mr(mr) {
+    /// @param mr The memory resource to use for the result objects
+    ///
+    clusterization_algorithm(vecmem::memory_resource& mr);
 
-        cc = std::make_shared<traccc::component_connection>(
-            traccc::component_connection(mr));
-        mt = std::make_shared<traccc::measurement_creation>(
-            traccc::measurement_creation(mr));
-    }
-
+    /// Construct measurements for each detector module
+    ///
+    /// @param cells The cells for every detector module in the event
+    /// @return The measurements reconstructed for every detector module
+    ///
     output_type operator()(
-        const host_cell_container& cells_per_event) const override {
-
-        output_type measurements_per_event(&m_mr.get());
-
-        measurements_per_event.reserve(cells_per_event.size());
-
-        for (std::size_t i = 0; i < cells_per_event.size(); ++i) {
-            auto module = cells_per_event.at(i).header;
-
-            // The algorithmic code part: start
-            traccc::host_cluster_container clusters = cc->operator()(
-                cells_per_event.at(i).items, cells_per_event.at(i).header);
-            for (auto& cl_id : clusters.get_headers()) {
-                cl_id.pixel = module.pixel;
-            }
-            traccc::host_measurement_collection measurements_per_module =
-                mt->operator()(clusters, module);
-
-            // The algorithmnic code part: end
-            measurements_per_event.push_back(
-                module, std::move(measurements_per_module));
-        }
-
-        return measurements_per_event;
-    }
+        const cell_container_types::host& cells) const override;
 
     private:
-    // algorithms
-    std::shared_ptr<traccc::component_connection> cc;
-    std::shared_ptr<traccc::measurement_creation> mt;
+    /// @name Sub-algorithms used by this algorithm
+    /// @{
+
+    /// Per-module cluster creation algorithm
+    component_connection m_cc;
+
+    /// Per-module measurement creation algorithm
+    measurement_creation m_mc;
+
+    /// @}
+
+    /// Reference to the host-accessible memory resource
     std::reference_wrapper<vecmem::memory_resource> m_mr;
-};
+
+};  // class clusterization_algorithm
 
 }  // namespace traccc

--- a/core/include/traccc/clusterization/component_connection.hpp
+++ b/core/include/traccc/clusterization/component_connection.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "traccc/clusterization/detail/sparse_ccl.hpp"
+// Library include(s).
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/cluster.hpp"
 #include "traccc/utils/algorithm.hpp"
@@ -25,17 +25,16 @@ namespace traccc {
 /// implementation internally.
 ///
 class component_connection
-    : public algorithm<host_cluster_container(const host_cell_collection&,
-                                              const cell_module&)> {
-    //   public algorithm<host_cluster_container(const device_cell_collection&,
-    //                                           const cell_module&)> {
+    : public algorithm<host_cluster_container(
+          const cell_collection_types::host&, const cell_module&)> {
+
     public:
     /// Constructor for component_connection
     ///
     /// @param mr is the memory resource
     component_connection(vecmem::memory_resource& mr) : m_mr(mr) {}
 
-    /// @name Operators to use in host code
+    /// @name Operator(s) to use in host code
     /// @{
 
     /// Callable operator for the connected component, based on one single
@@ -48,71 +47,10 @@ class component_connection
     /// c++20 piping interface:
     /// @return a cluster collection
     ///
-    host_cluster_container operator()(
-        const host_cell_collection& cells,
-        const cell_module& module) const override {
-        return this->operator()<vecmem::vector>(cells, module);
-    }
+    host_cluster_container operator()(const cell_collection_types::host& cells,
+                                      const cell_module& module) const override;
+
     /// @}
-
-    /// @name Operators to use in device code
-    /// @{
-
-    /// Callable operator for the connected component, based on one single
-    /// module
-    ///
-    /// This version of the function is meant to be used in device code.
-    ///
-    /// @param cells are the input cells into the connected component, they are
-    ///              per module and unordered
-    /// @param module The description of the module that the cells belong to
-    ///
-    /// c++20 piping interface:
-    /// @return a cluster collection
-    ///
-    // host_cluster_container operator()(
-    //     const device_cell_collection& cells,
-    //     const cell_module& module) const override {
-    //     return this->operator()<vecmem::device_vector>(cells, module);
-    // }
-
-    private:
-    /// Implementation for the public cell collection creation operators
-    template <template <typename> class vector_type>
-    host_cluster_container operator()(const cell_collection<vector_type>& cells,
-                                      const cell_module& module) const {
-        host_cluster_container clusters(&m_mr.get());
-        this->operator()<vector_type>(cells, module, clusters);
-        return clusters;
-    }
-
-    /// Implementation for the public cell collection creation operators
-    template <template <typename> class vector_type>
-    void operator()(const cell_collection<vector_type>& cells,
-                    const cell_module& module,
-                    host_cluster_container& clusters) const {
-
-        // Run the algorithm
-        unsigned int num_clusters = 0;
-        vector_type<unsigned int> connected_cells(cells.size(), &m_mr.get());
-        detail::sparse_ccl<vector_type, traccc::cell>(cells, connected_cells,
-                                                      num_clusters);
-
-        clusters.resize(num_clusters);
-        for (auto& cl_id : clusters.get_headers()) {
-            cl_id.module = module.module;
-            cl_id.placement = module.placement;
-        }
-
-        auto& cluster_items = clusters.get_items();
-        unsigned int icell = 0;
-        for (auto cell_label : connected_cells) {
-            auto cindex = static_cast<unsigned int>(cell_label - 1);
-            if (cindex < cluster_items.size()) {
-                cluster_items[cindex].push_back(cells[icell++]);
-            }
-        }
-    }
 
     private:
     std::reference_wrapper<vecmem::memory_resource> m_mr;

--- a/core/include/traccc/edm/cell.hpp
+++ b/core/include/traccc/edm/cell.hpp
@@ -8,30 +8,22 @@
 #pragma once
 
 // traccc include(s).
+#include "traccc/definitions/common.hpp"
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/container.hpp"
 #include "traccc/geometry/pixel_data.hpp"
 
-// VecMem include(s).
-#include <vecmem/containers/data/jagged_vector_buffer.hpp>
-#include <vecmem/containers/data/vector_buffer.hpp>
-#include <vecmem/containers/device_vector.hpp>
-#include <vecmem/containers/jagged_device_vector.hpp>
-#include <vecmem/containers/jagged_vector.hpp>
-#include <vecmem/containers/vector.hpp>
-
 // System include(s).
+#include <cmath>
 #include <limits>
 
 namespace traccc {
 
-/// @name Types to use in algorithmic code
-/// @{
-
-/// A cell definition:
+/// Definition for one detector cell
 ///
-/// maximum two channel identifiers
-/// and one activiation value, such as a time stamp
+/// It comes with two integer channel identifiers, an "activation value"
+/// and a time stamp.
+///
 struct cell {
     channel_id channel0 = 0;
     channel_id channel1 = 0;
@@ -39,53 +31,28 @@ struct cell {
     scalar time = 0.;
 };
 
+/// Comparison / ordering operator for cells
+TRACCC_HOST_DEVICE
 inline bool operator<(const cell& lhs, const cell& rhs) {
-    if (lhs.channel0 < rhs.channel0) {
-        return true;
-    } else if (lhs.channel0 == rhs.channel0) {
-        if (lhs.channel1 < rhs.channel1) {
-            return true;
-        } else if (lhs.channel1 == rhs.channel1) {
-            if (lhs.activation < rhs.activation) {
-                return true;
-            }
-            return false;
-        }
-        return false;
+
+    if (lhs.channel0 != rhs.channel0) {
+        return (lhs.channel0 < rhs.channel0);
+    } else if (lhs.channel1 != rhs.channel1) {
+        return (lhs.channel1 < rhs.channel1);
+    } else {
+        return lhs.activation < rhs.activation;
     }
-    return false;
 }
 
+/// Equality operator for cells
+TRACCC_HOST_DEVICE
 inline bool operator==(const cell& lhs, const cell& rhs) {
-    if (lhs.channel0 == rhs.channel0 && lhs.channel1 == rhs.channel1 &&
-        lhs.activation == rhs.activation && lhs.time == rhs.time) {
-        return true;
-    }
-    return false;
+
+    return (
+        (lhs.channel0 == rhs.channel0) && (lhs.channel1 == rhs.channel1) &&
+        (std::abs(lhs.activation - rhs.activation) < traccc::float_epsilon) &&
+        (std::abs(lhs.time - rhs.time) < traccc::float_epsilon));
 }
-
-/// Container of cells belonging to one detector module
-template <template <typename> class vector_t>
-using cell_collection = vector_t<cell>;
-
-/// Convenience declaration for the cell collection type to use in host code
-using host_cell_collection = cell_collection<vecmem::vector>;
-
-/// Convenience declaration for the cell collection type to use in device code
-using device_cell_collection = cell_collection<vecmem::device_vector>;
-
-/// Container of cells belonging to one detector module (const)
-template <template <typename> class vector_t>
-using cell_const_collection = vector_t<const cell>;
-
-/// Convenience declaration for the cell collection type to use in host code
-/// (const)
-using host_cell_const_collection = cell_const_collection<vecmem::vector>;
-
-/// Convenience declaration for the cell collection type to use in device code
-/// (const)
-using device_cell_const_collection =
-    cell_const_collection<vecmem::device_vector>;
 
 /// Header information for all of the cells in a specific detector module
 ///
@@ -103,47 +70,12 @@ struct cell_module {
     channel_id range1[2] = {std::numeric_limits<channel_id>::max(), 0};
 
     pixel_data pixel{-8.425, -36.025, 0.05, 0.05};
+
 };  // struct cell_module
 
-/// Container of cell modules
-template <template <typename> class vector_t>
-using cell_module_collection = vector_t<cell_module>;
-
-/// Convenience declaration for the cell module collection type to use in host
-/// code
-using host_cell_module_collection = cell_module_collection<vecmem::vector>;
-/// Convenience declaration for the cell module collection type to use in device
-/// code
-using device_cell_module_collection =
-    cell_module_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the cell container type to use in host code
-using host_cell_container = host_container<cell_module, cell>;
-
-/// Convenience declaration for the cell container type to use in device code
-using device_cell_container = device_container<cell_module, cell>;
-
-/// Convenience declaration for the cell container type to use in device code
-/// (const)
-using device_cell_const_container =
-    device_container<const cell_module, const cell>;
-
-/// Convenience declaration for the cell container data type to use in host code
-using cell_container_data = container_data<cell_module, cell>;
-
-/// Convenience declaration for the cell container data type to use in host code
-/// (const)
-using cell_container_const_data = container_data<const cell_module, const cell>;
-
-/// Convenience declaration for the cell container view type to use in host code
-/// (const)
-using cell_container_const_view = container_view<const cell_module, const cell>;
-
-/// Convenience declaration for the cell container buffer type to use in host
-/// code
-using cell_container_buffer = container_buffer<cell_module, cell>;
-
-/// Convenience declaration for the cell container view type to use in host code
-using cell_container_view = container_view<cell_module, cell>;
+/// Declare all cell collection types
+using cell_collection_types = collection_types<cell>;
+/// Declare all cell container types
+using cell_container_types = container_types<cell_module, cell>;
 
 }  // namespace traccc

--- a/core/src/clusterization/clusterization_algorithm.cpp
+++ b/core/src/clusterization/clusterization_algorithm.cpp
@@ -1,0 +1,48 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/clusterization/clusterization_algorithm.hpp"
+
+namespace traccc {
+
+clusterization_algorithm::clusterization_algorithm(vecmem::memory_resource& mr)
+    : m_cc(mr), m_mc(mr), m_mr(mr) {}
+
+clusterization_algorithm::output_type clusterization_algorithm::operator()(
+    const cell_container_types::host& cells) const {
+
+    // Create the result container.
+    output_type result(&(m_mr.get()));
+    result.reserve(cells.size());
+
+    // Loop over all of the detector modules.
+    for (std::size_t i = 0; i < cells.size(); ++i) {
+
+        // Get the cells for the current module.
+        cell_module module = cells.at(i).header;
+        cell_container_types::host::item_vector::const_reference
+            cells_per_module = cells.at(i).items;
+
+        // Reconstruct all measurements for the current module.
+        traccc::host_cluster_container clusters =
+            m_cc(cells_per_module, module);
+        for (cluster_id& cl_id : clusters.get_headers()) {
+            cl_id.pixel = module.pixel;
+        }
+        traccc::host_measurement_collection measurements =
+            m_mc(clusters, module);
+
+        // Save the measurements into the event-wide container.
+        result.push_back(module, std::move(measurements));
+    }
+
+    // Return the measurements for all detector modules.
+    return result;
+}
+
+}  // namespace traccc

--- a/core/src/clusterization/component_connection.cpp
+++ b/core/src/clusterization/component_connection.cpp
@@ -1,0 +1,58 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/clusterization/component_connection.hpp"
+
+#include "traccc/clusterization/detail/sparse_ccl.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/containers/vector.hpp>
+
+namespace traccc {
+
+host_cluster_container component_connection::operator()(
+    const cell_collection_types::host& cells, const cell_module& module) const {
+
+    // Create the result container.
+    host_cluster_container result(&(m_mr.get()));
+
+    // Set up a device collection on top of the host collection.
+    const cell_collection_types::const_view cells_view =
+        vecmem::get_data(cells);
+    const cell_collection_types::const_device cells_device(cells_view);
+
+    // Set up the index vector.
+    vecmem::vector<unsigned int> connected_cells(cells.size(), &(m_mr.get()));
+    vecmem::device_vector<unsigned int> connected_cells_device(
+        vecmem::get_data(connected_cells));
+
+    // Run the algorithm
+    unsigned int num_clusters = 0;
+    detail::sparse_ccl(cells_device, connected_cells_device, num_clusters);
+
+    result.resize(num_clusters);
+    for (auto& cl_id : result.get_headers()) {
+        cl_id.module = module.module;
+        cl_id.placement = module.placement;
+    }
+
+    auto& cluster_items = result.get_items();
+    unsigned int icell = 0;
+    for (auto cell_label : connected_cells) {
+        auto cindex = static_cast<unsigned int>(cell_label - 1);
+        if (cindex < cluster_items.size()) {
+            cluster_items[cindex].push_back(cells[icell++]);
+        }
+    }
+
+    // Return the cluster container.
+    return result;
+}
+
+}  // namespace traccc

--- a/device/cuda/include/traccc/cuda/cca/component_connection.hpp
+++ b/device/cuda/include/traccc/cuda/cca/component_connection.hpp
@@ -13,9 +13,9 @@
 #include "traccc/utils/algorithm.hpp"
 
 namespace traccc::cuda {
-struct component_connection
-    : algorithm<host_measurement_container(const host_cell_container& cells)> {
+struct component_connection : algorithm<host_measurement_container(
+                                  const cell_container_types::host& cells)> {
     host_measurement_container operator()(
-        const host_cell_container& cells) const;
+        const cell_container_types::host& cells) const;
 };
 }  // namespace traccc::cuda

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -453,7 +453,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK) void sparse_ccl_kernel(
 }
 
 vecmem::vector<details::ccl_partition> partition(
-    const host_cell_container& data, vecmem::memory_resource& mem) {
+    const cell_container_types::host& data, vecmem::memory_resource& mem) {
     vecmem::vector<details::ccl_partition> partitions(&mem);
     std::size_t index = 0;
     std::size_t size = 0;
@@ -493,7 +493,7 @@ vecmem::vector<details::ccl_partition> partition(
 }  // namespace details
 
 host_measurement_container component_connection::operator()(
-    const host_cell_container& data) const {
+    const cell_container_types::host& data) const {
     vecmem::cuda::managed_memory_resource upstream;
     vecmem::binary_page_memory_resource mem(upstream);
 

--- a/device/sycl/include/traccc/sycl/clusterization/cluster_finding.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/cluster_finding.hpp
@@ -21,7 +21,7 @@
 namespace traccc::sycl {
 
 struct cluster_finding : public algorithm<host_measurement_container(
-                             const host_cell_container &)> {
+                             const cell_container_types::host &)> {
     public:
     /// Constructor for cluster_finding
     ///
@@ -35,7 +35,8 @@ struct cluster_finding : public algorithm<host_measurement_container(
     /// and cells as the items jagged vector
     /// @return a measurement container with cell modules for headers and
     /// measurements as items
-    output_type operator()(const host_cell_container &cells_per_event) const;
+    output_type operator()(
+        const cell_container_types::host &cells_per_event) const;
 
     private:
     std::reference_wrapper<vecmem::memory_resource> m_mr;

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -12,8 +12,8 @@
 
 namespace traccc::sycl {
 
-class clusterization_algorithm
-    : public algorithm<host_measurement_container(const host_cell_container&)> {
+class clusterization_algorithm : public algorithm<host_measurement_container(
+                                     const cell_container_types::host&)> {
 
     public:
     /// Constructor for clusterization algorithm
@@ -28,7 +28,7 @@ class clusterization_algorithm
     }
 
     output_type operator()(
-        const host_cell_container& cells_per_event) const override {
+        const cell_container_types::host& cells_per_event) const override {
 
         output_type measurements_per_event(&m_mr.get());
 

--- a/device/sycl/src/clusterization/cluster_finding.cpp
+++ b/device/sycl/src/clusterization/cluster_finding.cpp
@@ -22,7 +22,7 @@ cluster_finding::cluster_finding(vecmem::memory_resource &mr,
     : m_mr(mr), m_queue(queue) {}
 
 host_measurement_container cluster_finding::operator()(
-    const host_cell_container &cells_per_event) const {
+    const cell_container_types::host &cells_per_event) const {
 
     // Number of modules
     unsigned int num_modules = cells_per_event.size();

--- a/device/sycl/src/clusterization/component_connection.hpp
+++ b/device/sycl/src/clusterization/component_connection.hpp
@@ -23,7 +23,7 @@ namespace traccc::sycl {
 ///
 void component_connection(
     cluster_container_view clusters_view,
-    const host_cell_container& cells_per_event,
+    const cell_container_types::host& cells_per_event,
     vecmem::data::vector_view<unsigned int> clusters_count_view,
     vecmem::unique_alloc_ptr<unsigned int>& total_clusters,
     vecmem::memory_resource& resource, queue_wrapper queue);

--- a/device/sycl/src/clusterization/component_connection.sycl
+++ b/device/sycl/src/clusterization/component_connection.sycl
@@ -18,7 +18,7 @@ namespace traccc::sycl {
 
 void component_connection(
     cluster_container_view clusters_view,
-    const host_cell_container& cells_per_event,
+    const cell_container_types::host& cells_per_event,
     vecmem::data::vector_view<unsigned int> clusters_count_view,
     vecmem::unique_alloc_ptr<unsigned int>& total_clusters,
     vecmem::memory_resource& resource, queue_wrapper queue) {
@@ -40,7 +40,7 @@ void component_connection(
 
     // Get the view of the cells container
     auto cells_data = get_data(cells_per_event, &resource);
-    cell_container_const_view cells_view(cells_data);
+    cell_container_types::const_view cells_view(cells_data);
 
     // Helper container for sparse CCL calculations
     vecmem::data::jagged_vector_buffer<unsigned int> cluster_indices{cell_sizes,
@@ -61,7 +61,7 @@ void component_connection(
                 auto idx = item.get_global_linear_id();
 
                 // Initialize the data on the device
-                device_cell_const_container cells_device(cells_view);
+                cell_container_types::const_device cells_device(cells_view);
                 device_cluster_container clusters_device(clusters_view);
 
                 // Ignore if idx is out of range
@@ -81,8 +81,7 @@ void component_connection(
                 auto cluster_indices = device_cluster_indices.at(idx);
 
                 // Run the sparse_ccl algorithm
-                detail::sparse_ccl<vecmem::device_vector, const traccc::cell>(
-                    cells, cluster_indices, num_clusters);
+                detail::sparse_ccl(cells, cluster_indices, num_clusters);
 
                 // Add the number of found clusers per module to the count
                 // vector

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -37,7 +37,7 @@ void measurement_creation(measurement_container_view measurements_view,
                 // items: cluster of cells at current idx
                 // header: cluster_id object with the information about the cell
                 // module
-                const device_cell_collection &cluster =
+                device_cluster_container::item_vector::reference cluster =
                     clusters_device.get_items().at(idx);
                 const cluster_id &cl_id = clusters_device.get_headers().at(idx);
 

--- a/examples/io/create_binaries.cpp
+++ b/examples/io/create_binaries.cpp
@@ -31,7 +31,7 @@ int create_binaries(const std::string& detector_file,
         if (!cell_directory.empty()) {
 
             // Read the cells from the relevant event file
-            traccc::host_cell_container cells_csv =
+            traccc::cell_container_types::host cells_csv =
                 traccc::read_cells_from_event(event, cell_directory,
                                               common_opts.input_data_format,
                                               surface_transforms, host_mr);

--- a/examples/run/cpu/ccl_example.cpp
+++ b/examples/run/cpu/ccl_example.cpp
@@ -29,7 +29,7 @@ double delta_ms(std::chrono::high_resolution_clock::time_point s,
 }
 }  // namespace
 
-void print_statistics(const traccc::host_cell_container& data) {
+void print_statistics(const traccc::cell_container_types::host& data) {
     static std::vector<std::size_t> bins_edges = {
         0,   1,   2,    3,    4,    6,    8,    11,   16,
         23,  32,  45,   64,   91,   128,  181,  256,  362,
@@ -78,7 +78,7 @@ void print_statistics(const traccc::host_cell_container& data) {
 }
 
 void run_on_event(traccc::component_connection& cc,
-                  traccc::host_cell_container& data) {
+                  traccc::cell_container_types::host& data) {
     for (std::size_t i = 0; i < data.size(); ++i) {
         traccc::host_cluster_container clusters =
             cc(data.at(i).items, data.at(i).header);
@@ -104,7 +104,7 @@ int main(int argc, char* argv[]) {
 
     traccc::cell_reader creader(event_file, {"geometry_id", "hit_id", "cannel0",
                                              "channel1", "activation", "time"});
-    traccc::host_cell_container data = traccc::read_cells(creader, mem);
+    traccc::cell_container_types::host data = traccc::read_cells(creader, mem);
 
     auto time_read_end = std::chrono::high_resolution_clock::now();
 

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -62,7 +62,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Read the cells from the relevant event file
-        traccc::host_cell_container cells_per_event =
+        traccc::cell_container_types::host cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
                                           common_opts.input_data_format,
                                           surface_transforms, host_mr);

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -92,7 +92,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         /*time*/ auto start_file_reading_cpu = std::chrono::system_clock::now();
 
         // Read the cells from the relevant event file
-        traccc::host_cell_container cells_per_event =
+        traccc::cell_container_types::host cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
                                           common_opts.input_data_format,
                                           surface_transforms, host_mr);

--- a/examples/run/openmp/io_dec_par_example.cpp
+++ b/examples/run/openmp/io_dec_par_example.cpp
@@ -48,7 +48,7 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data,
 
 #pragma omp parallel for reduction (+:n_modules, n_cells, n_measurements, n_spacepoints)
     for (size_t event = 0; event < input_data.size(); ++event) {
-        traccc::host_cell_container cells_per_event =
+        traccc::cell_container_types::host cells_per_event =
             input_data.operator[](event);
 
         /*-------------------

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -59,7 +59,7 @@ int par_run(const std::string &detector_file, const std::string &cells_dir,
     for (unsigned int event = 0; event < events; ++event) {
 
         // Read the cells from the relevant event file
-        traccc::host_cell_container cells_per_event =
+        traccc::cell_container_types::host cells_per_event =
             traccc::read_cells_from_event(event, cells_dir,
                                           traccc::data_format::csv,
                                           surface_transforms, resource);

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -83,7 +83,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     float tp_estimating_sycl(0);
 
     // Creating SYCL queue object
-    ::sycl::queue q(::sycl::gpu_selector{}, handle_async_error);
+    ::sycl::queue q(handle_async_error);
     std::cout << "Running Seeding on device: "
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
@@ -117,7 +117,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         /*time*/ auto start_file_reading_cpu = std::chrono::system_clock::now();
 
         // Read the cells from the relevant event file for CPU algorithm
-        traccc::host_cell_container cells_per_event =
+        traccc::cell_container_types::host cells_per_event =
             traccc::read_cells_from_event(event, i_cfg.cell_directory,
                                           common_opts.input_data_format,
                                           surface_transforms, shared_mr);

--- a/io/include/traccc/io/csv.hpp
+++ b/io/include/traccc/io/csv.hpp
@@ -212,18 +212,18 @@ inline std::map<geometry_id, transform3> read_surfaces(
 /// @param resource The memory resource to use for the return value
 /// @param tfmap the (optional) transform map
 /// @param max_cells the (optional) maximum number of cells to be read in
-inline host_cell_container read_cells(
+inline cell_container_types::host read_cells(
     cell_reader& creader, vecmem::memory_resource& resource,
     const traccc::geometry* tfmap = nullptr,
     unsigned int max_cells = std::numeric_limits<unsigned int>::max()) {
 
     uint64_t reference_id = 0;
-    host_cell_container result(&resource);
+    cell_container_types::host result(&resource);
 
     bool first_line_read = false;
     unsigned int read_cells = 0;
     csv_cell iocell;
-    host_cell_collection cells(&resource);
+    cell_collection_types::host cells(&resource);
     cell_module module;
     while (creader.read(iocell)) {
 
@@ -241,7 +241,7 @@ inline host_cell_container read_cells(
                       });
             result.push_back(std::move(module), std::move(cells));
             // Clear for next round
-            cells = host_cell_collection(&resource);
+            cells = cell_collection_types::host(&resource);
             module = cell_module();
         }
         first_line_read = true;

--- a/io/include/traccc/io/demonstrator_edm.hpp
+++ b/io/include/traccc/io/demonstrator_edm.hpp
@@ -17,6 +17,6 @@ struct result {
     traccc::host_spacepoint_container spacepoints;
 };
 
-using demonstrator_input = vecmem::vector<traccc::host_cell_container>;
+using demonstrator_input = vecmem::vector<cell_container_types::host>;
 using demonstrator_result = vecmem::vector<traccc::result>;
 }  // namespace traccc

--- a/io/include/traccc/io/mapper.hpp
+++ b/io/include/traccc/io/mapper.hpp
@@ -178,7 +178,7 @@ measurement_cell_map generate_measurement_cell_map(
     auto surface_transforms = read_geometry(detector_file);
 
     // Read the cells from the relevant event file
-    host_cell_container cells_per_event =
+    cell_container_types::host cells_per_event =
         read_cells_from_event(event, cells_dir, traccc::data_format::csv,
                               surface_transforms, resource);
 

--- a/io/include/traccc/io/reader.hpp
+++ b/io/include/traccc/io/reader.hpp
@@ -45,7 +45,7 @@ inline traccc::geometry read_geometry(const std::string &detector_file) {
 /// @param data_format is the data format (e.g. csv or binary) of output file
 /// @param surface_transforms is the input geometry data
 /// @param resource is the vecmem resource
-inline traccc::host_cell_container read_cells_from_event(
+inline traccc::cell_container_types::host read_cells_from_event(
     size_t event, const std::string &cells_directory,
     const traccc::data_format &data_format, traccc::geometry surface_transforms,
     vecmem::memory_resource &resource) {
@@ -66,8 +66,8 @@ inline traccc::host_cell_container read_cells_from_event(
 
         vecmem::copy copy;
 
-        return traccc::read_binary<traccc::host_cell_container>(io_cells_file,
-                                                                copy, resource);
+        return traccc::read_binary<traccc::cell_container_types::host>(
+            io_cells_file, copy, resource);
     } else {
         throw std::invalid_argument("Allowed data format is csv or binary");
     }
@@ -122,7 +122,7 @@ inline traccc::demonstrator_input read(size_t events,
 #pragma omp parallel for
 #endif
     for (size_t event = 0; event < events; ++event) {
-        traccc::host_cell_container cells_per_event = readFn(event);
+        traccc::cell_container_types::host cells_per_event = readFn(event);
 
 #if defined(_OPENMP)
 #pragma omp critical

--- a/io/include/traccc/io/writer.hpp
+++ b/io/include/traccc/io/writer.hpp
@@ -22,9 +22,10 @@ namespace traccc {
 /// @param cells_directory is the directory of cell file
 /// @param data_format is the data format (e.g. csv or binary) of output file
 /// @param cells_per_event is input cell container
-inline void write_cells(size_t event, const std::string &cells_directory,
-                        const traccc::data_format &data_format,
-                        const traccc::host_cell_container &cells_per_event) {
+inline void write_cells(
+    size_t event, const std::string &cells_directory,
+    const traccc::data_format &data_format,
+    const traccc::cell_container_types::host &cells_per_event) {
 
     if (data_format == traccc::data_format::binary) {
 

--- a/tests/common/tests/cca_test.hpp
+++ b/tests/common/tests/cca_test.hpp
@@ -23,7 +23,7 @@
 
 using cca_function_t = std::function<
     std::map<traccc::geometry_id, std::vector<traccc::measurement>>(
-        const traccc::host_cell_container &)>;
+        const traccc::cell_container_types::host &)>;
 
 class ConnectedComponentAnalysisTests
     : public traccc::tests::data_test,
@@ -85,7 +85,7 @@ class ConnectedComponentAnalysisTests
         traccc::cell_reader creader(file_hits);
 
         vecmem::host_memory_resource resource;
-        traccc::host_cell_container data =
+        traccc::cell_container_types::host data =
             traccc::read_cells(creader, resource);
 
         std::map<traccc::geometry_id, std::vector<traccc::measurement>> result =

--- a/tests/cpu/seq_single_module.cpp
+++ b/tests/cpu/seq_single_module.cpp
@@ -27,16 +27,16 @@ TEST(algorithms, seq_single_module) {
     vecmem::host_memory_resource resource;
 
     /// Following [DOI: 10.1109/DASIP48288.2019.9049184]
-    traccc::host_cell_collection cells = {{{1, 0, 1., 0.},
-                                           {8, 4, 2., 0.},
-                                           {10, 4, 3., 0.},
-                                           {9, 5, 4., 0.},
-                                           {10, 5, 5., 0},
-                                           {12, 12, 6, 0},
-                                           {3, 13, 7, 0},
-                                           {11, 13, 8, 0},
-                                           {4, 14, 9, 0}},
-                                          &resource};
+    traccc::cell_collection_types::host cells = {{{1, 0, 1., 0.},
+                                                  {8, 4, 2., 0.},
+                                                  {10, 4, 3., 0.},
+                                                  {9, 5, 4., 0.},
+                                                  {10, 5, 5., 0},
+                                                  {12, 12, 6, 0},
+                                                  {3, 13, 7, 0},
+                                                  {11, 13, 8, 0},
+                                                  {4, 14, 9, 0}},
+                                                 &resource};
 
     traccc::cell_module module;
     module.module = 0;

--- a/tests/cpu/test_cca.cpp
+++ b/tests/cpu/test_cca.cpp
@@ -31,15 +31,15 @@ traccc::measurement_creation mc(resource);
 traccc::cell_module module;
 
 std::function<traccc::host_measurement_collection(
-    const traccc::host_cell_collection &)>
+    const traccc::cell_collection_types::host &)>
     fp = traccc::compose(std::function<traccc::host_cluster_container(
-                             const traccc::host_cell_collection &)>(
+                             const traccc::cell_collection_types::host &)>(
                              std::bind(cc, std::placeholders::_1, module)),
                          std::function<traccc::host_measurement_collection(
                              const traccc::host_cluster_container &)>(
                              std::bind(mc, std::placeholders::_1, module)));
 
-cca_function_t f = [](const traccc::host_cell_container &data) {
+cca_function_t f = [](const traccc::cell_container_types::host &data) {
     std::map<traccc::geometry_id, std::vector<traccc::measurement>> result;
 
     for (std::size_t i = 0; i < data.size(); ++i) {

--- a/tests/cpu/test_component_connection.cpp
+++ b/tests/cpu/test_component_connection.cpp
@@ -23,16 +23,16 @@ TEST(algorithms, component_connection) {
     vecmem::host_memory_resource resource;
 
     /// Following [DOI: 10.1109/DASIP48288.2019.9049184]
-    traccc::host_cell_collection cells = {{{1, 0, 1., 0.},
-                                           {8, 4, 2., 0.},
-                                           {10, 4, 3., 0.},
-                                           {9, 5, 4., 0.},
-                                           {10, 5, 5., 0},
-                                           {12, 12, 6, 0},
-                                           {3, 13, 7, 0},
-                                           {11, 13, 8, 0},
-                                           {4, 14, 9, 0}},
-                                          &resource};
+    traccc::cell_collection_types::host cells = {{{1, 0, 1., 0.},
+                                                  {8, 4, 2., 0.},
+                                                  {10, 4, 3., 0.},
+                                                  {9, 5, 4., 0.},
+                                                  {10, 5, 5., 0},
+                                                  {12, 12, 6, 0},
+                                                  {3, 13, 7, 0},
+                                                  {11, 13, 8, 0},
+                                                  {4, 14, 9, 0}},
+                                                 &resource};
 
     traccc::cell_module module;
     module.module = 0;

--- a/tests/cuda/test_cca.cpp
+++ b/tests/cuda/test_cca.cpp
@@ -15,7 +15,7 @@
 namespace {
 traccc::cuda::component_connection cc;
 
-cca_function_t f = [](const traccc::host_cell_container &data) {
+cca_function_t f = [](const traccc::cell_container_types::host &data) {
     std::map<traccc::geometry_id, std::vector<traccc::measurement>> result;
 
     traccc::host_measurement_container mss = cc(data);

--- a/tests/io/test_binary.cpp
+++ b/tests/io/test_binary.cpp
@@ -34,18 +34,20 @@ TEST(io_binary, cell) {
         traccc::read_geometry("tml_detector/trackml-detector.csv");
 
     // Read csv file
-    traccc::host_cell_container cells_csv = traccc::read_cells_from_event(
-        event, cells_directory, traccc::data_format::csv, surface_transforms,
-        host_mr);
+    traccc::cell_container_types::host cells_csv =
+        traccc::read_cells_from_event(event, cells_directory,
+                                      traccc::data_format::csv,
+                                      surface_transforms, host_mr);
 
     // Write binary file
     traccc::write_cells(event, cells_directory, traccc::data_format::binary,
                         cells_csv);
 
     // Read binary file
-    traccc::host_cell_container cells_binary = traccc::read_cells_from_event(
-        event, cells_directory, traccc::data_format::binary, surface_transforms,
-        host_mr);
+    traccc::cell_container_types::host cells_binary =
+        traccc::read_cells_from_event(event, cells_directory,
+                                      traccc::data_format::binary,
+                                      surface_transforms, host_mr);
 
     // Delete binary file
     std::string io_cells_file = traccc::data_directory() + cells_directory +


### PR DESCRIPTION
Getting drunk on the success of #188, I went ahead with simplifying `cell.hpp`.

This required touching a good number of files, most of which were simple type name replacements.

But I decided to use this occasion to do a bit of a bigger re-write on the CCL code as part of the EDM changes. The `traccc::component_connection` algorithm was just not a nice thing in its latest implementation. :frowning:

The big update is that I removed **all** templating from the sparse CCL code. Since that code can really just be implemented on top of "constant views" of the cell EDM. So that's what I did, I made it use `traccc::cell_collection_types::const_device` in all cases. :smile: Even when using device code. Since setting up "device containers" in the host implementation is really no biggie. (Note that I also just switched to providing the "output array" to the CCL code through a bare pointer. Since all access to that memory was already done through non-protected array accesses anyway.)

As before, I ran some performance checks, just to be sure that nothing really bad happened as a result of the updates... These are the reported "clusterization times" from `traccc_seq_example_sycl`:

| &#965; | Current CPU | New CPU | Current SYCL | New SYCL |
|-|-|-|-|-|
| 40 | 0.0211379 | 0.0229111 | 0.397941 | 0.43047 |
| 80 | 0.0358985 | 0.0361159 | 0.570159 | 0.571931 |
| 200 | 0.0746189 | 0.0753304 | 1.06429 | 0.976579 |

Note that I would not expect these to change at all as a result of this update. And while one may see a systematic slowdown for the CPU times if looking at the numbers, I think that's dominantly a statistical uncertainty...

If you guys don't disagree, I'll go on to clusters next. :wink: