### PR TITLE
Cluster EDM Update, main branch (2022.05.11.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -33,6 +33,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/utils/type_traits.hpp"
   "include/traccc/utils/unit_vectors.hpp"
   # Clusterization algorithmic code.
+  "include/traccc/clusterization/detail/measurement_creation_helper.hpp"
   "include/traccc/clusterization/detail/sparse_ccl.hpp"
   "include/traccc/clusterization/component_connection.hpp"
   "src/clusterization/component_connection.cpp"
@@ -40,7 +41,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "src/clusterization/clusterization_algorithm.cpp"
   "include/traccc/clusterization/spacepoint_formation.hpp"
   "include/traccc/clusterization/measurement_creation.hpp"
-  "include/traccc/clusterization/measurement_creation_helper.hpp"
+  "src/clusterization/measurement_creation.cpp"
   # Seed finding algorithmic code.
   "include/traccc/seeding/detail/lin_circle.hpp"
   "include/traccc/seeding/detail/doublet.hpp"

--- a/core/include/traccc/clusterization/component_connection.hpp
+++ b/core/include/traccc/clusterization/component_connection.hpp
@@ -12,6 +12,12 @@
 #include "traccc/edm/cluster.hpp"
 #include "traccc/utils/algorithm.hpp"
 
+// VecMem include(s).
+#include <vecmem/memory/memory_resource.hpp>
+
+// System include(s).
+#include <functional>
+
 namespace traccc {
 
 /// Connected component labelling
@@ -25,7 +31,7 @@ namespace traccc {
 /// implementation internally.
 ///
 class component_connection
-    : public algorithm<host_cluster_container(
+    : public algorithm<cluster_container_types::host(
           const cell_collection_types::host&, const cell_module&)> {
 
     public:
@@ -47,12 +53,13 @@ class component_connection
     /// c++20 piping interface:
     /// @return a cluster collection
     ///
-    host_cluster_container operator()(const cell_collection_types::host& cells,
-                                      const cell_module& module) const override;
+    output_type operator()(const cell_collection_types::host& cells,
+                           const cell_module& module) const override;
 
     /// @}
 
     private:
+    /// The memory resource used by the algorithm
     std::reference_wrapper<vecmem::memory_resource> m_mr;
 
 };  // class component_connection

--- a/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
+++ b/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
@@ -8,12 +8,12 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/definitions/common.hpp"
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/cell.hpp"
 #include "traccc/edm/cluster.hpp"
 
-namespace traccc {
+namespace traccc::detail {
 
 /// Function used for retrieving the cell signal based on the module id
 TRACCC_HOST_DEVICE
@@ -24,27 +24,42 @@ inline scalar signal_cell_modelling(scalar signal_in,
 
 /// Function for pixel segmentation
 TRACCC_HOST_DEVICE
-inline vector2 position_from_cell(cell c, cluster_id cl_id) {
+inline vector2 position_from_cell(const cell& c, const cluster_id& cl_id) {
     // Retrieve the specific values based on module idx
     return {cl_id.pixel.min_center_x + c.channel0 * cl_id.pixel.pitch_x,
             cl_id.pixel.min_center_y + c.channel1 * cl_id.pixel.pitch_y};
 }
 
 TRACCC_HOST_DEVICE
-inline vector2 get_pitch(cluster_id cl_id) {
+inline vector2 get_pitch(const cluster_id& cl_id) {
     // return the values based on the module idx
     return {cl_id.pixel.pitch_x, cl_id.pixel.pitch_y};
 }
 
-/// Function used for calculating the properties of the cluster inside
+/// Function used for calculating the properties of the cluster during
 /// measurement creation
-template <template <typename> class vector_type, typename cell_t>
+///
+/// @param[in] cluster The vector of cells describing the identified cluster
+/// @param[in] cl_id   The cluster identifier
+/// @param[out] mean   The mean position of the cluster/measurement
+/// @param[out] var    The variation on the mean position of the
+///                    cluster/measurement
+/// @param[out] totalWeight The total weight of the cluster/measurement
+///
 TRACCC_HOST_DEVICE inline void calc_cluster_properties(
-    const vector_type<cell_t>& cluster, const cluster_id& cl_id, point2& mean,
-    point2& var, scalar& totalWeight) {
-    for (const auto& cell : cluster) {
-        scalar weight = signal_cell_modelling(cell.activation, cl_id);
+    const cell_collection_types::const_device& cluster, const cluster_id& cl_id,
+    point2& mean, point2& var, scalar& totalWeight) {
+
+    // Loop over the cells of the cluster.
+    for (const cell& cell : cluster) {
+
+        // Translate the cell readout value into a weight.
+        const scalar weight = signal_cell_modelling(cell.activation, cl_id);
+
+        // Only consider cells over a minimum threshold.
         if (weight > cl_id.threshold) {
+
+            // Update all output properties with this cell.
             totalWeight += cell.activation;
             const point2 cell_position = position_from_cell(cell, cl_id);
             const point2 prev = mean;
@@ -59,4 +74,4 @@ TRACCC_HOST_DEVICE inline void calc_cluster_properties(
     }
 }
 
-}  // namespace traccc
+}  // namespace traccc::detail

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -7,16 +7,23 @@
 
 #pragma once
 
-// Project include(s).
+// Library include(s).
+#include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/cell.hpp"
+#include "traccc/edm/container.hpp"
 #include "traccc/geometry/pixel_data.hpp"
 
 // System include(s).
-#include <functional>
-#include <vector>
+#include <cstddef>
 
 namespace traccc {
 
+/// Cluster identifier
+///
+/// It associates the vector of cells (that make up the cluster) with
+/// the detector module, and additional necessary parameters, necessary
+/// for making use of the cluster.
+///
 struct cluster_id {
 
     event_id event = 0;
@@ -27,37 +34,7 @@ struct cluster_id {
     pixel_data pixel;
 };
 
-/// Convenience declaration for the cluster container type to use in host code
-using host_cluster_container = host_container<cluster_id, cell>;
-
-/// Convenience declaration for the cluster container type to use in device code
-using device_cluster_container = device_container<cluster_id, cell>;
-
-/// Convenience declaration for the cluster container type to use in device code
-/// (const)
-using device_cluster_const_container =
-    device_container<const cluster_id, const cell>;
-
-/// Convenience declaration for the cluster container data type to use in host
-/// code
-using cluster_container_data = container_data<cluster_id, cell>;
-
-/// Convenience declaration for the cluster container data type to use in host
-/// code (const)
-using cluster_container_const_data =
-    container_data<const cluster_id, const cell>;
-
-/// Convenience declaration for the cluster container buffer type to use in host
-/// code
-using cluster_container_buffer = container_buffer<cluster_id, cell>;
-
-/// Convenience declaration for the cluster container view type to use in host
-/// code
-using cluster_container_view = container_view<cluster_id, cell>;
-
-/// Convenience declaration for the cluster container view type to use in host
-/// code (const)
-using cluster_container_const_view =
-    container_view<const cluster_id, const cell>;
+/// Declare all cluster container types
+using cluster_container_types = container_types<cluster_id, cell>;
 
 }  // namespace traccc

--- a/core/src/clusterization/clusterization_algorithm.cpp
+++ b/core/src/clusterization/clusterization_algorithm.cpp
@@ -29,7 +29,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
             cells_per_module = cells.at(i).items;
 
         // Reconstruct all measurements for the current module.
-        traccc::host_cluster_container clusters =
+        traccc::cluster_container_types::host clusters =
             m_cc(cells_per_module, module);
         for (cluster_id& cl_id : clusters.get_headers()) {
             cl_id.pixel = module.pixel;

--- a/core/src/clusterization/component_connection.cpp
+++ b/core/src/clusterization/component_connection.cpp
@@ -16,11 +16,11 @@
 
 namespace traccc {
 
-host_cluster_container component_connection::operator()(
+component_connection::output_type component_connection::operator()(
     const cell_collection_types::host& cells, const cell_module& module) const {
 
     // Create the result container.
-    host_cluster_container result(&(m_mr.get()));
+    output_type result(&(m_mr.get()));
 
     // Set up a device collection on top of the host collection.
     const cell_collection_types::const_view cells_view =

--- a/core/src/clusterization/measurement_creation.cpp
+++ b/core/src/clusterization/measurement_creation.cpp
@@ -1,0 +1,86 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/clusterization/measurement_creation.hpp"
+
+#include "traccc/clusterization/detail/measurement_creation_helper.hpp"
+#include "traccc/definitions/primitives.hpp"
+
+namespace traccc {
+
+measurement_creation::measurement_creation(vecmem::memory_resource &mr)
+    : m_mr(mr) {}
+
+measurement_creation::output_type measurement_creation::operator()(
+    const cluster_container_types::host &clusters,
+    const cell_module &module) const {
+
+    // Create the result object.
+    output_type result(&(m_mr.get()));
+
+    // If there are no clusters for this detector module, exit early.
+    if (clusters.size() == 0) {
+        return result;
+    }
+
+    // Reserve memory for one measurement per cluster.
+    result.reserve(clusters.size());
+
+    // Get values used for every cluster's processing.
+    const vector2 pitch = module.pixel.get_pitch();
+    const cluster_id &cl_id = clusters[0].header;
+
+    // Process the clusters one-by-one.
+    for (std::size_t i = 0; i < clusters.size(); ++i) {
+
+        // To calculate the mean and variance with high numerical stability
+        // we use a weighted variant of Welford's algorithm. This is a
+        // single-pass online algorithm that works well for large numbers
+        // of samples, as well as samples with very high values.
+        //
+        // To learn more about this algorithm please refer to:
+        // [1] https://doi.org/10.1080/00401706.1962.10490022
+        // [2] The Art of Computer Programming, Donald E. Knuth, second
+        //     edition, chapter 4.2.2.
+
+        // Get the cluster.
+        const cluster_id &cl_id = clusters.at(i).header;
+        cluster_container_types::host::item_vector::const_reference cluster =
+            clusters.at(i).items;
+        cluster_container_types::const_device::item_vector::value_type
+            cluster_device(vecmem::get_data(cluster));
+
+        // A security check.
+        assert(cluster.empty() == false);
+
+        // Calculate the cluster properties
+        point2 mean{0., 0.}, var{0., 0.};
+        scalar totalWeight = 0.;
+        detail::calc_cluster_properties(cluster_device, cl_id, mean, var,
+                                        totalWeight);
+
+        if (totalWeight > 0.) {
+            measurement m;
+            // normalize the cell position
+            m.local = mean;
+            // normalize the variance
+            m.variance[0] = var[0] / totalWeight;
+            m.variance[1] = var[1] / totalWeight;
+            // plus pitch^2 / 12
+            m.variance = m.variance + point2{pitch[0] * pitch[0] / 12,
+                                             pitch[1] * pitch[1] / 12};
+            // @todo add variance estimation
+            result.push_back(std::move(m));
+        }
+    }
+
+    // Return the measurements.
+    return result;
+}
+
+}  // namespace traccc

--- a/device/sycl/include/traccc/sycl/clusterization/cluster_finding.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/cluster_finding.hpp
@@ -11,17 +11,17 @@
 #include "traccc/sycl/utils/queue_wrapper.hpp"
 
 // Project include(s).
-#include "traccc/clusterization/measurement_creation_helper.hpp"
-#include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/cell.hpp"
-#include "traccc/edm/cluster.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/utils/algorithm.hpp"
 
+// VecMem include(s).
+#include <vecmem/memory/memory_resource.hpp>
+
 namespace traccc::sycl {
 
-struct cluster_finding : public algorithm<host_measurement_container(
-                             const cell_container_types::host &)> {
+class cluster_finding : public algorithm<host_measurement_container(
+                            const cell_container_types::host &)> {
     public:
     /// Constructor for cluster_finding
     ///

--- a/device/sycl/src/clusterization/cluster_finding.cpp
+++ b/device/sycl/src/clusterization/cluster_finding.cpp
@@ -46,7 +46,7 @@ host_measurement_container cluster_finding::operator()(
     // Cluster container buffer for the clusters and headers (cluster ids)
     // assuming the worst case where 1 cell = 1 cluster
     // and max. number of cells per module is max. number of cells per cluster
-    cluster_container_buffer clusters_buffer{
+    cluster_container_types::buffer clusters_buffer{
         {cells_total_size, m_mr.get()},
         {std::vector<std::size_t>(cells_total_size, 0),
          std::vector<std::size_t>(cells_total_size, max_cluster_size),

--- a/device/sycl/src/clusterization/component_connection.hpp
+++ b/device/sycl/src/clusterization/component_connection.hpp
@@ -22,7 +22,7 @@ namespace traccc::sycl {
 /// Forward declaration of component connection function
 ///
 void component_connection(
-    cluster_container_view clusters_view,
+    cluster_container_types::view clusters_view,
     const cell_container_types::host& cells_per_event,
     vecmem::data::vector_view<unsigned int> clusters_count_view,
     vecmem::unique_alloc_ptr<unsigned int>& total_clusters,

--- a/device/sycl/src/clusterization/component_connection.sycl
+++ b/device/sycl/src/clusterization/component_connection.sycl
@@ -17,7 +17,7 @@
 namespace traccc::sycl {
 
 void component_connection(
-    cluster_container_view clusters_view,
+    cluster_container_types::view clusters_view,
     const cell_container_types::host& cells_per_event,
     vecmem::data::vector_view<unsigned int> clusters_count_view,
     vecmem::unique_alloc_ptr<unsigned int>& total_clusters,
@@ -62,7 +62,7 @@ void component_connection(
 
                 // Initialize the data on the device
                 cell_container_types::const_device cells_device(cells_view);
-                device_cluster_container clusters_device(clusters_view);
+                cluster_container_types::device clusters_device(clusters_view);
 
                 // Ignore if idx is out of range
                 if (idx >= cells_device.size())

--- a/device/sycl/src/clusterization/measurement_creation.hpp
+++ b/device/sycl/src/clusterization/measurement_creation.hpp
@@ -7,20 +7,19 @@
 
 #pragma once
 
+// Library include(s).
+#include "traccc/sycl/utils/queue_wrapper.hpp"
+
 // Project include(s).
-#include "traccc/clusterization/measurement_creation_helper.hpp"
 #include "traccc/edm/cluster.hpp"
 #include "traccc/edm/measurement.hpp"
-
-// Vecmem include(s).
-#include <vecmem/memory/memory_resource.hpp>
 
 namespace traccc::sycl {
 
 /// Forward decleration of measurement creation kernel
 ///
 void measurement_creation(measurement_container_view measurements_view,
-                          cluster_container_view clusters_view,
+                          cluster_container_types::const_view clusters_view,
                           const unsigned int& range, queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -7,17 +7,18 @@
 
 // SYCL library include(s).
 #include "../utils/get_queue.hpp"
+#include "measurement_creation.hpp"
+
+// Project include(s).
+#include "traccc/clusterization/detail/measurement_creation_helper.hpp"
 
 // SYCL include(s).
 #include <CL/sycl.hpp>
 
-// Project include(s).
-#include "measurement_creation.hpp"
-
 namespace traccc::sycl {
 
 void measurement_creation(measurement_container_view measurements_view,
-                          cluster_container_view clusters_view,
+                          cluster_container_types::const_view clusters_view,
                           const unsigned int &range, queue_wrapper queue) {
 
     // Run the kernel
@@ -26,7 +27,8 @@ void measurement_creation(measurement_container_view measurements_view,
             range,
             [clusters_view, measurements_view](auto idx) {
                 // Initialize device vectors
-                device_cluster_container clusters_device(clusters_view);
+                const cluster_container_types::const_device clusters_device(
+                    clusters_view);
                 device_measurement_container measurement_device(
                     measurements_view);
 
@@ -37,11 +39,12 @@ void measurement_creation(measurement_container_view measurements_view,
                 // items: cluster of cells at current idx
                 // header: cluster_id object with the information about the cell
                 // module
-                device_cluster_container::item_vector::reference cluster =
-                    clusters_device.get_items().at(idx);
+                cluster_container_types::const_device::item_vector::
+                    const_reference cluster =
+                        clusters_device.get_items().at(idx);
                 const cluster_id &cl_id = clusters_device.get_headers().at(idx);
 
-                const vector2 pitch = get_pitch(cl_id);
+                const vector2 pitch = detail::get_pitch(cl_id);
                 const auto module_idx = cl_id.module_idx;
 
                 scalar totalWeight = 0.;
@@ -59,12 +62,10 @@ void measurement_creation(measurement_container_view measurements_view,
                 point2 mean = {0., 0.}, var = {0., 0.};
 
                 // Should not happen
-                if (cluster.empty()) {
-                    return;
-                }
+                assert(cluster.empty() == false);
 
-                calc_cluster_properties<vecmem::device_vector, cell>(
-                    cluster, cl_id, mean, var, totalWeight);
+                detail::calc_cluster_properties(cluster, cl_id, mean, var,
+                                                totalWeight);
 
                 if (totalWeight > 0.) {
                     measurement m;

--- a/examples/run/cpu/ccl_example.cpp
+++ b/examples/run/cpu/ccl_example.cpp
@@ -80,7 +80,7 @@ void print_statistics(const traccc::cell_container_types::host& data) {
 void run_on_event(traccc::component_connection& cc,
                   traccc::cell_container_types::host& data) {
     for (std::size_t i = 0; i < data.size(); ++i) {
-        traccc::host_cluster_container clusters =
+        traccc::cluster_container_types::host clusters =
             cc(data.at(i).items, data.at(i).header);
     }
 }

--- a/io/include/traccc/io/csv.hpp
+++ b/io/include/traccc/io/csv.hpp
@@ -278,21 +278,21 @@ inline cell_container_types::host read_cells(
 /// @param resource The memory resource to use for the return value
 /// @param tfmap the (optional) transform map
 /// @param max_clusters the (optional) maximum number of cells to be read in
-inline std::vector<host_cluster_container> read_truth_clusters(
+inline std::vector<cluster_container_types::host> read_truth_clusters(
     cell_reader& creader, vecmem::memory_resource& resource,
     const std::map<geometry_id, transform3>& tfmap = {},
     unsigned int max_cells = std::numeric_limits<unsigned int>::max()) {
 
     // Reference for switching the container
     uint64_t reference_id = 0;
-    std::vector<host_cluster_container> clusters;
+    std::vector<cluster_container_types::host> clusters;
     // Reference for switching the cluster
     uint64_t truth_id = std::numeric_limits<uint64_t>::max();
 
     bool first_line_read = false;
     unsigned int read_cells = 0;
     csv_cell iocell;
-    host_cluster_container truth_clusters(&resource);
+    cluster_container_types::host truth_clusters(&resource);
     vecmem::vector<cell> truth_cells;
 
     while (creader.read(iocell)) {
@@ -310,7 +310,7 @@ inline std::vector<host_cluster_container> read_truth_clusters(
             // Sort in column major order
             clusters.push_back(truth_clusters);
             // Clear for next round
-            truth_clusters = host_cluster_container(&resource);
+            truth_clusters = cluster_container_types::host(&resource);
         }
 
         if (first_line_read and truth_id != iocell.hit_id) {

--- a/io/include/traccc/io/mapper.hpp
+++ b/io/include/traccc/io/mapper.hpp
@@ -186,7 +186,7 @@ measurement_cell_map generate_measurement_cell_map(
         auto module = cells_per_event.at(i).header;
 
         // The algorithmic code part: start
-        host_cluster_container clusters =
+        cluster_container_types::host clusters =
             cc(cells_per_event.at(i).items, cells_per_event.at(i).header);
         for (auto& cl_id : clusters.get_headers()) {
             cl_id.pixel = module.pixel;

--- a/tests/cpu/seq_single_module.cpp
+++ b/tests/cpu/seq_single_module.cpp
@@ -43,7 +43,7 @@ TEST(algorithms, seq_single_module) {
     module.pixel = traccc::pixel_data{0., 0., 1., 1.};
     module.placement = traccc::transform3{};
 
-    traccc::host_cluster_container clusters(&resource);
+    traccc::cluster_container_types::host clusters(&resource);
 
     traccc::host_measurement_collection measurements;
 

--- a/tests/cpu/test_cca.cpp
+++ b/tests/cpu/test_cca.cpp
@@ -32,11 +32,11 @@ traccc::cell_module module;
 
 std::function<traccc::host_measurement_collection(
     const traccc::cell_collection_types::host &)>
-    fp = traccc::compose(std::function<traccc::host_cluster_container(
+    fp = traccc::compose(std::function<traccc::cluster_container_types::host(
                              const traccc::cell_collection_types::host &)>(
                              std::bind(cc, std::placeholders::_1, module)),
                          std::function<traccc::host_measurement_collection(
-                             const traccc::host_cluster_container &)>(
+                             const traccc::cluster_container_types::host &)>(
                              std::bind(mc, std::placeholders::_1, module)));
 
 cca_function_t f = [](const traccc::cell_container_types::host &data) {


### PR DESCRIPTION
Continuing on from #188 and #189, here I update the definition of the cluster EDM container(s).

As before, this EDM update also triggered some algorithmic code update. I now hid the implementation of `traccc::measurement_creation` into `measurement_creation.cpp`, moved the helper functions used by measurement creation into the `traccc::detail` namespace, and then updated all the project for the name changes.

P.S. This might very well conflict with #187, so we'll need to be thoughtful about the order of their merge...