### PR TITLE
Add SYCL Spacepoint formation

### DIFF
--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -30,6 +30,8 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
   "src/clusterization/measurement_creation.hpp"
   "src/clusterization/component_connection.hpp"
   "src/clusterization/component_connection.sycl"
+  "src/clusterization/spacepoint_formation.hpp"
+  "src/clusterization/spacepoint_formation.sycl"
   "src/seeding/seed_finding.sycl"
   "src/seeding/seed_selecting.hpp"
   "src/seeding/seed_selecting.sycl"

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -14,6 +14,7 @@
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/cluster.hpp"
 #include "traccc/edm/measurement.hpp"
+#include "traccc/edm/spacepoint.hpp"
 #include "traccc/utils/algorithm.hpp"
 
 // VecMem include(s).
@@ -21,7 +22,7 @@
 
 namespace traccc::sycl {
 
-class clusterization_algorithm : public algorithm<host_measurement_container(
+class clusterization_algorithm : public algorithm<host_spacepoint_container(
                                      const cell_container_types::host&)> {
 
     public:
@@ -35,8 +36,7 @@ class clusterization_algorithm : public algorithm<host_measurement_container(
     ///
     /// @param cells_per_event is a container with cell modules as headers
     /// and cells as the items
-    /// @return a measurement container with cell modules as headers and
-    /// measurements as items
+    /// @return a measurement collection - vector of measurements
     output_type operator()(
         const cell_container_types::host& cells_per_event) const override;
 

--- a/device/sycl/src/clusterization/cluster_counting.hpp
+++ b/device/sycl/src/clusterization/cluster_counting.hpp
@@ -8,24 +8,23 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/device/get_prefix_sum.hpp"
 #include "traccc/edm/cell.hpp"
 
 // Vecmem include(s).
 #include <vecmem/containers/data/jagged_vector_view.hpp>
 #include <vecmem/containers/data/vector_view.hpp>
-#include <vecmem/memory/memory_resource.hpp>
-#include <vecmem/memory/unique_ptr.hpp>
 
 namespace traccc::sycl {
 
-/// Forward declaration of component connection function
+/// Forward declaration of cluster counting function
 ///
 void cluster_counting(
-    std::size_t num_modules,
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
     vecmem::data::vector_view<unsigned int> cluster_sizes_view,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
-    std::size_t cells_max, vecmem::memory_resource& resource,
+    vecmem::data::vector_view<const device::prefix_sum_element_t>
+        cells_prefix_sum_view,
     queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/clusterization/cluster_counting.sycl
+++ b/device/sycl/src/clusterization/cluster_counting.sycl
@@ -17,72 +17,67 @@
 namespace traccc::sycl {
 
 void cluster_counting(
-    std::size_t num_modules,
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
     vecmem::data::vector_view<unsigned int> cluster_sizes_view,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
-    std::size_t cells_max, vecmem::memory_resource& resource,
+    vecmem::data::vector_view<const device::prefix_sum_element_t>
+        cells_prefix_sum_view,
     queue_wrapper queue) {
 
-    // X dimension of the execution grid (the Y dim is the cells_max)
-    auto n_modules = vecmem::make_unique_alloc<std::size_t>(resource);
-    *n_modules = num_modules;
+    // The execution range of the kernel
+    auto n_cells = cells_prefix_sum_view.size();
 
-    // Calculate the 2-dim NDrange for the kernel
-    auto wGroupSize = 16;
-    auto numGroupsX = (*n_modules + wGroupSize - 1) / wGroupSize;
-    auto numGroupsY = (cells_max + wGroupSize - 1) / wGroupSize;
-    auto ndrange = ::sycl::nd_range<2>{
-        ::sycl::range<2>(numGroupsX * wGroupSize, numGroupsY * wGroupSize),
-        ::sycl::range<2>(wGroupSize, wGroupSize)};
-
-    // Get the raw pointer to pass to the kernel
-    auto n_modules_ptr = n_modules.get();
+    // Calculate the execution NDrange for the kernel
+    auto wGroupSize = 64;
+    auto num = (n_cells + wGroupSize - 1) / wGroupSize;
+    auto ndrange = ::sycl::nd_range<1>{::sycl::range<1>(num * wGroupSize),
+                                       ::sycl::range<1>(wGroupSize)};
 
     details::get_queue(queue)
-        .submit([&ndrange, &n_modules_ptr, &sparse_ccl_indices_view,
-                 &cluster_sizes_view,
-                 &cluster_prefix_sum_view](::sycl::handler& h) {
+        .submit([&ndrange, &sparse_ccl_indices_view, &cluster_sizes_view,
+                 &cluster_prefix_sum_view,
+                 &cells_prefix_sum_view](::sycl::handler& h) {
             h.parallel_for<class ClusterCounting>(
-                ndrange,
-                [sparse_ccl_indices_view, n_modules_ptr, cluster_sizes_view,
-                 cluster_prefix_sum_view](::sycl::nd_item<2> item) {
-                    // Get the current module id_x and current cell in this
-                    // module id_y
-                    auto id_x = item.get_global_id(0);
-                    auto id_y = item.get_global_id(1);
+                ndrange, [=](::sycl::nd_item<1> item) {
+                    // Get the current idx
+                    auto idx = item.get_global_linear_id();
+
+                    // Get the device vector of the cell prefix sum
+                    vecmem::device_vector<const device::prefix_sum_element_t>
+                        cells_prefix_sum(cells_prefix_sum_view);
 
                     // Ignore if id_x is out of range
-                    if (id_x >= *n_modules_ptr)
+                    if (idx >= cells_prefix_sum.size())
                         return;
+
+                    // Get the indices for the module and the cell in this
+                    // module, from the prefix sum
+                    auto module_idx = cells_prefix_sum[idx].first;
+                    auto cell_idx = cells_prefix_sum[idx].second;
 
                     // Vectors used for cluster indices found by sparse CCL
                     vecmem::jagged_device_vector<unsigned int>
                         device_sparse_ccl_indices(sparse_ccl_indices_view);
                     const auto& cluster_indices =
-                        device_sparse_ccl_indices.at(id_x);
-
-                    // Ignore if id_y is out of range (more than num of cells
-                    // for this module)
-                    if (id_y >= cluster_indices.size())
-                        return;
+                        device_sparse_ccl_indices[module_idx];
 
                     // Number of clusters that sparce_ccl found for this module
                     const unsigned int n_clusters = cluster_indices.back();
 
-                    // Get the prefix sum at this id_x to know where to write
-                    // clusters from this module to the cluster_container
+                    // Get the cluster prefix sum at this module_idx to know
+                    // where to write current clusters in the
+                    // cluster container
                     vecmem::device_vector<std::size_t>
                         device_cluster_prefix_sum(cluster_prefix_sum_view);
                     const std::size_t prefix_sum =
-                        device_cluster_prefix_sum[id_x];
+                        device_cluster_prefix_sum[module_idx];
 
                     // Vector to fill in with the sizes of each cluster
                     vecmem::device_vector<unsigned int> device_cluster_sizes(
                         cluster_sizes_view);
 
                     // Count the cluster sizes for each position
-                    unsigned int cindex = cluster_indices[id_y] - 1;
+                    unsigned int cindex = cluster_indices[cell_idx] - 1;
                     if (cindex < n_clusters) {
                         vecmem::device_atomic_ref<unsigned int>(
                             device_cluster_sizes[prefix_sum + cindex])

--- a/device/sycl/src/clusterization/clusterization_algorithm.cpp
+++ b/device/sycl/src/clusterization/clusterization_algorithm.cpp
@@ -5,17 +5,23 @@
  * Mozilla Public License Version 2.0
  */
 
-// Clusterization include(s)
+// Project include(s)
 #include "traccc/sycl/clusterization/clusterization_algorithm.hpp"
+
+#include "traccc/device/get_prefix_sum.hpp"
 
 // SYCL library include(s).
 #include "cluster_counting.hpp"
 #include "clusters_sum.hpp"
 #include "component_connection.hpp"
 #include "measurement_creation.hpp"
+#include "spacepoint_formation.hpp"
 
 // Vecmem include(s).
 #include <vecmem/utils/copy.hpp>
+
+// System include(s).
+#include <algorithm>
 
 namespace traccc::sycl {
 
@@ -23,7 +29,7 @@ clusterization_algorithm::clusterization_algorithm(vecmem::memory_resource &mr,
                                                    queue_wrapper queue)
     : m_mr(mr), m_queue(queue) {}
 
-host_measurement_container clusterization_algorithm::operator()(
+host_spacepoint_container clusterization_algorithm::operator()(
     const cell_container_types::host &cells_per_event) const {
 
     // Number of modules
@@ -32,20 +38,24 @@ host_measurement_container clusterization_algorithm::operator()(
     // Vecmem copy object for moving the data between host and device
     vecmem::copy copy;
 
-    // Get the sizes of the cells in each module (+1 is an extra space for
-    // storing the n_clusters at the end of the indices vector) and the maximum
-    // size of cells in module
-    std::size_t cells_max = 0;
-    std::vector<std::size_t> cell_sizes(num_modules, 0);
-    for (std::size_t j = 0; j < num_modules; ++j) {
-        cell_sizes[j] = cells_per_event.get_items().at(j).size() + 1;
-        if (cell_sizes[j] - 1 > cells_max)
-            cells_max = cell_sizes[j] - 1;
-    }
+    // Get the view of the cells container
+    auto cells_data = get_data(cells_per_event, &m_mr.get());
+    cell_container_types::const_view cells_view(cells_data);
+
+    // Get the sizes of the cells in each module
+    auto cell_sizes = copy.get_sizes(cells_view.items);
+
+    // Get the cell sizes with +1 in each entry for sparse ccl indices buffer
+    // The +1 is needed to store the number of found clusters at the end of
+    // the vector in each module
+    std::vector<std::size_t> cell_sizes_plus(num_modules);
+    std::transform(cell_sizes.begin(), cell_sizes.end(),
+                   cell_sizes_plus.begin(),
+                   [](std::size_t x) { return x + 1; });
 
     // Helper container for sparse CCL calculations
     vecmem::data::jagged_vector_buffer<unsigned int> sparse_ccl_indices(
-        cell_sizes, m_mr.get());
+        cell_sizes_plus, m_mr.get());
     copy.setup(sparse_ccl_indices);
 
     // Vector buffer for prefix sums for proper indexing, used only on device.
@@ -62,16 +72,23 @@ host_measurement_container clusterization_algorithm::operator()(
     // will be found (and also computes the prefix sums and clusters per module)
     auto total_clusters = vecmem::make_unique_alloc<unsigned int>(m_mr.get());
     *total_clusters = 0;
-    traccc::sycl::clusters_sum(cells_per_event, sparse_ccl_indices,
-                               *total_clusters, cluster_prefix_sum,
-                               clusters_per_module, m_mr.get(), m_queue);
 
-    // Vector of the exact cluster sizes, will be filled in cluster_counting
-    // kernel
+    // Clusters sum kernel
+    traccc::sycl::clusters_sum(cells_view, sparse_ccl_indices, *total_clusters,
+                               cluster_prefix_sum, clusters_per_module,
+                               m_queue);
+
+    // Get the prefix sum of the cells
+    const device::prefix_sum_t cells_prefix_sum =
+        device::get_prefix_sum(cell_sizes, m_mr.get());
+
+    // Vector of the exact cluster sizes, will be filled in cluster counting
     vecmem::vector<unsigned int> cluster_sizes(*total_clusters, 0, &m_mr.get());
+
+    // Cluster counting kernel
     traccc::sycl::cluster_counting(
-        num_modules, sparse_ccl_indices, vecmem::get_data(cluster_sizes),
-        cluster_prefix_sum, cells_max, m_mr.get(), m_queue);
+        sparse_ccl_indices, vecmem::get_data(cluster_sizes), cluster_prefix_sum,
+        vecmem::get_data(cells_prefix_sum), m_queue);
 
     // Cluster container buffer for the clusters and headers (cluster ids)
     cluster_container_types::buffer clusters_buffer{
@@ -79,43 +96,54 @@ host_measurement_container clusterization_algorithm::operator()(
         {std::vector<std::size_t>(*total_clusters, 0),
          std::vector<std::size_t>(cluster_sizes.begin(), cluster_sizes.end()),
          m_mr.get()}};
-
     copy.setup(clusters_buffer.headers);
     copy.setup(clusters_buffer.items);
 
     // Component connection kernel
-    traccc::sycl::component_connection(clusters_buffer, cells_per_event,
-                                       sparse_ccl_indices, cluster_prefix_sum,
-                                       cells_max, m_mr.get(), m_queue);
+    traccc::sycl::component_connection(
+        clusters_buffer, cells_view, sparse_ccl_indices, cluster_prefix_sum,
+        vecmem::get_data(cells_prefix_sum), m_queue);
 
     // Copy the sizes of clusters per each module to the std vector for
-    // measurement buffer initialization
+    // initialization of measurements buffer
     std::vector<std::size_t> clusters_per_module_host;
     copy(clusters_per_module, clusters_per_module_host);
 
     // Resizable buffer for the measurements
-    measurement_container_buffer measurement_buffer{
+    measurement_container_buffer measurements_buffer{
         {num_modules, m_mr.get()},
         {std::vector<std::size_t>(num_modules, 0), clusters_per_module_host,
          m_mr.get()}};
-    copy.setup(measurement_buffer.items);
+    copy.setup(measurements_buffer.headers);
+    copy.setup(measurements_buffer.items);
 
     // Measurement creation kernel
-    traccc::sycl::measurement_creation(measurement_buffer, clusters_buffer,
-                                       m_queue);
+    traccc::sycl::measurement_creation(measurements_buffer, clusters_buffer,
+                                       cells_view, m_queue);
+
+    // Spacepoint container buffer to fill in spacepoint formation
+    spacepoint_container_buffer spacepoints_buffer{
+        {num_modules, m_mr.get()},
+        {std::vector<std::size_t>(num_modules, 0), clusters_per_module_host,
+         m_mr.get()}};
+    copy.setup(spacepoints_buffer.headers);
+    copy.setup(spacepoints_buffer.items);
+
+    // Get the prefix sum of the measurements.
+    const device::prefix_sum_t measurements_prefix_sum = device::get_prefix_sum(
+        copy.get_sizes(measurements_buffer.items), m_mr.get());
+
+    // Spacepoint formation kernel
+    traccc::sycl::spacepoint_formation(
+        spacepoints_buffer, measurements_buffer,
+        vecmem::get_data(measurements_prefix_sum), m_queue);
 
     // Copy the results back to the host
-    host_measurement_container measurements(&m_mr.get());
-    copy(measurement_buffer.items, measurements.get_items());
+    host_spacepoint_container spacepoints_per_event(&m_mr.get());
+    copy(spacepoints_buffer.headers, spacepoints_per_event.get_headers());
+    copy(spacepoints_buffer.items, spacepoints_per_event.get_items());
 
-    // Fill the headers of measurements with cell modules
-    assert(cells_per_event.get_headers().size() ==
-           measurements.get_items().size());
-    for (const cell_module &cm : cells_per_event.get_headers()) {
-        measurements.get_headers().push_back(cm);
-    }
-
-    return measurements;
+    return spacepoints_per_event;
 }
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/clusterization/clusters_sum.hpp
+++ b/device/sycl/src/clusterization/clusters_sum.hpp
@@ -13,19 +13,18 @@
 
 // Vecmem include(s).
 #include <vecmem/containers/data/jagged_vector_view.hpp>
-#include <vecmem/memory/memory_resource.hpp>
-#include <vecmem/memory/unique_ptr.hpp>
+#include <vecmem/containers/data/vector_view.hpp>
 
 namespace traccc::sycl {
 
 /// Forward declaration of clusters sum function
 ///
 void clusters_sum(
-    const cell_container_types::host& cells_per_event,
+    const cell_container_types::const_view& cells_view,
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
     unsigned int& total_clusters,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
     vecmem::data::vector_view<std::size_t> clusters_per_module_view,
-    vecmem::memory_resource& resource, queue_wrapper queue);
+    queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/clusterization/clusters_sum.sycl
+++ b/device/sycl/src/clusterization/clusters_sum.sycl
@@ -17,15 +17,15 @@
 namespace traccc::sycl {
 
 void clusters_sum(
-    const cell_container_types::host& cells_per_event,
+    const cell_container_types::const_view& cells_view,
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
     unsigned int& total_clusters,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
     vecmem::data::vector_view<std::size_t> clusters_per_module_view,
-    vecmem::memory_resource& resource, queue_wrapper queue) {
+    queue_wrapper queue) {
 
-    // Execution size of the algorithm
-    std::size_t n_modules = cells_per_event.size();
+    // The execution range of the kernel
+    auto n_modules = cells_view.headers.size();
 
     // Calculate the execution NDrange for the kernel
     auto wGroupSize = 64;
@@ -33,67 +33,60 @@ void clusters_sum(
     auto ndrange = ::sycl::nd_range<1>{::sycl::range<1>(num * wGroupSize),
                                        ::sycl::range<1>(wGroupSize)};
 
-    // Get the view of the cells container
-    auto cells_data = get_data(cells_per_event, &resource);
-    cell_container_types::const_view cells_view(cells_data);
-
     details::get_queue(queue)
         .submit([&ndrange, &cells_view, &sparse_ccl_indices_view,
                  &total_clusters, &cluster_prefix_sum_view,
                  &clusters_per_module_view](::sycl::handler& h) {
-            h.parallel_for<class ClusterSum>(
-                ndrange,
-                [cells_view, sparse_ccl_indices_view,
-                 total_clusters = &total_clusters, cluster_prefix_sum_view,
-                 clusters_per_module_view](::sycl::nd_item<1> item) {
-                    // Get the global index
-                    auto idx = item.get_global_linear_id();
+            h.parallel_for<class ClusterSum>(ndrange, [=, total_clusters =
+                                                              &total_clusters](
+                                                          ::sycl::nd_item<1>
+                                                              item) {
+                // Get the current index
+                auto idx = item.get_global_linear_id();
 
-                    // Initialize the data on the device
-                    cell_container_types::const_device cells_device(cells_view);
+                // Initialize the data on the device
+                cell_container_types::const_device cells_device(cells_view);
 
-                    // Ignore if idx is out of range
-                    if (idx < cells_device.size()) {
+                // Ignore if idx is out of range
+                if (idx >= cells_device.size())
+                    return;
 
-                        // Get the cells from the current module
-                        const auto& cells = cells_device.at(idx).items;
+                // Get the cells for the current module
+                const auto& cells = cells_device.at(idx).items;
 
-                        // Number of clusters that sparce_ccl will find for this
-                        // module
-                        unsigned int n_clusters = 0;
+                // Number of clusters that sparce CCL will find for this
+                // module
+                unsigned int n_clusters = 0;
 
-                        // Vectors used for cluster indices found by sparse CCL
-                        vecmem::jagged_device_vector<unsigned int>
-                            device_sparse_ccl_indices(sparse_ccl_indices_view);
-                        auto cluster_indices =
-                            device_sparse_ccl_indices.at(idx);
+                // Vectors used for cluster indices found by sparse CCL
+                vecmem::jagged_device_vector<unsigned int>
+                    device_sparse_ccl_indices(sparse_ccl_indices_view);
+                auto cluster_indices = device_sparse_ccl_indices.at(idx);
 
-                        // Run the sparse_ccl algorithm
-                        detail::sparse_ccl(cells, cluster_indices, n_clusters);
+                // Run the sparse CCL algorithm
+                detail::sparse_ccl(cells, cluster_indices, n_clusters);
 
-                        // Save the number of clusters found in this module at
-                        // the last, extra place in the indices vectors
-                        cluster_indices.back() = n_clusters;
+                // Save the number of clusters found in this module at
+                // the last, extra place in the indices vectors
+                cluster_indices.back() = n_clusters;
 
-                        auto prefix_sum =
-                            vecmem::device_atomic_ref<unsigned int>(
-                                *total_clusters)
-                                .fetch_add(n_clusters);
+                // Calculate the cluster prefix sum for this module idx
+                auto prefix_sum =
+                    vecmem::device_atomic_ref<unsigned int>(*total_clusters)
+                        .fetch_add(n_clusters);
 
-                        // Save the current prefix sum at a correct index in a
-                        // vector
-                        vecmem::device_vector<std::size_t>
-                            device_cluster_prefix_sum(cluster_prefix_sum_view);
-                        device_cluster_prefix_sum[idx] = prefix_sum;
+                // Save the current prefix sum at the current idx in a
+                // vector
+                vecmem::device_vector<std::size_t> device_cluster_prefix_sum(
+                    cluster_prefix_sum_view);
+                device_cluster_prefix_sum[idx] = prefix_sum;
 
-                        // At last, fill also the "number of clusters per
-                        // module" for measurement creation buffer
-                        vecmem::device_vector<std::size_t>
-                            device_clusters_per_module(
-                                clusters_per_module_view);
-                        device_clusters_per_module[idx] = n_clusters;
-                    }
-                });
+                // At last, fill also the "number of clusters per
+                // module" for measurement creation buffer
+                vecmem::device_vector<std::size_t> device_clusters_per_module(
+                    clusters_per_module_view);
+                device_clusters_per_module[idx] = n_clusters;
+            });
         })
         .wait_and_throw();
 }

--- a/device/sycl/src/clusterization/component_connection.sycl
+++ b/device/sycl/src/clusterization/component_connection.sycl
@@ -18,83 +18,85 @@ namespace traccc::sycl {
 
 void component_connection(
     cluster_container_types::view clusters_view,
-    const cell_container_types::host& cells_per_event,
+    const cell_container_types::const_view& cells_view,
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
-    std::size_t cells_max, vecmem::memory_resource& resource,
+    vecmem::data::vector_view<const device::prefix_sum_element_t>
+        cells_prefix_sum_view,
     queue_wrapper queue) {
 
-    // Execution size of the algorithm
-    std::size_t n_modules = cells_per_event.size();
+    // The execution range of the kernel
+    auto n_cells = cells_prefix_sum_view.size();
 
-    // Calculate the 2-dim NDrange for the kernel
-    auto wGroupSize = 16;
-    auto numGroupsX = (n_modules + wGroupSize - 1) / wGroupSize;
-    auto numGroupsY = (cells_max + wGroupSize - 1) / wGroupSize;
-    auto ndrange = ::sycl::nd_range<2>{
-        ::sycl::range<2>(numGroupsX * wGroupSize, numGroupsY * wGroupSize),
-        ::sycl::range<2>(wGroupSize, wGroupSize)};
-
-    // Get the view of the cells container
-    auto cells_data = get_data(cells_per_event, &resource);
-    cell_container_types::const_view cells_view(cells_data);
+    // Calculate the execution NDrange for the kernel
+    auto wGroupSize = 64;
+    auto num = (n_cells + wGroupSize - 1) / wGroupSize;
+    auto ndrange = ::sycl::nd_range<1>{::sycl::range<1>(num * wGroupSize),
+                                       ::sycl::range<1>(wGroupSize)};
 
     details::get_queue(queue)
-        .parallel_for<class ComponentConnection>(
-            ndrange,
-            [cells_view, cluster_prefix_sum_view, clusters_view,
-             sparse_ccl_indices_view](::sycl::nd_item<2> item) {
-                // Get the current module id_x and current cell in this module
-                // id_y
-                auto id_x = item.get_global_id(0);
-                auto id_y = item.get_global_id(1);
+        .submit([&ndrange, &cells_view, &cluster_prefix_sum_view,
+                 &clusters_view, &sparse_ccl_indices_view,
+                 &cells_prefix_sum_view](::sycl::handler& h) {
+            h.parallel_for<class ComponentConnection>(
+                ndrange, [=](::sycl::nd_item<1> item) {
+                    // Get the current idx
+                    auto idx = item.get_global_linear_id();
 
-                // Initialize the data on the device
-                cell_container_types::const_device cells_device(cells_view);
-                cluster_container_types::device clusters_device(clusters_view);
+                    // Get device vector of the cells prefix sum
+                    vecmem::device_vector<const device::prefix_sum_element_t>
+                        cells_prefix_sum(cells_prefix_sum_view);
 
-                // Ignore if id_x is out of range
-                if (id_x >= cells_device.size())
-                    return;
+                    if (idx >= cells_prefix_sum.size())
+                        return;
 
-                // Get the cells from the current module
-                const auto& cells = cells_device.at(id_x).items;
-                const auto module = cells_device.at(id_x).header;
+                    // Get the indices for the module idx and the cell idx
+                    auto module_idx = cells_prefix_sum[idx].first;
+                    auto cell_idx = cells_prefix_sum[idx].second;
 
-                // Ignore if id_y is out of range
-                if (id_y >= cells.size())
-                    return;
+                    // Initialize the device containers for cells and clusters
+                    cell_container_types::const_device cells_device(cells_view);
+                    cluster_container_types::device clusters_device(
+                        clusters_view);
 
-                // Vectors used for cluster indices found by sparse CCL
-                vecmem::jagged_device_vector<unsigned int>
-                    device_sparse_ccl_indices(sparse_ccl_indices_view);
-                const auto& cluster_indices =
-                    device_sparse_ccl_indices.at(id_x);
+                    // Get the cells for the current module idx
+                    const auto& cells = cells_device.at(module_idx).items;
+                    const auto module = cells_device.at(module_idx).header;
 
-                // Number of clusters found for this module
-                const auto num_clusters = cluster_indices.back();
+                    // Vectors used for cluster indices found by sparse CCL
+                    vecmem::jagged_device_vector<unsigned int>
+                        device_sparse_ccl_indices(sparse_ccl_indices_view);
+                    const auto& cluster_indices =
+                        device_sparse_ccl_indices.at(module_idx);
 
-                // Get the prefix sum for this id_x
-                vecmem::device_vector<std::size_t> device_cluster_prefix_sum(
-                    cluster_prefix_sum_view);
-                const auto prefix_sum = device_cluster_prefix_sum[id_x];
+                    // Number of clusters found for this module
+                    const auto num_clusters = cluster_indices.back();
 
-                // Push back the cells to the correct item vector
-                unsigned int cindex = cluster_indices[id_y] - 1;
-                if (cindex < num_clusters) {
-                    // Create cluster id - same for all clusters in this module
-                    cluster_id cl_id{};
-                    cl_id.module = module.module;
-                    cl_id.placement = module.placement;
-                    cl_id.module_idx = id_x;
-                    cl_id.pixel = module.pixel;
+                    // Get the cluster prefix sum for this module idx
+                    vecmem::device_vector<std::size_t>
+                        device_cluster_prefix_sum(cluster_prefix_sum_view);
+                    const auto prefix_sum =
+                        device_cluster_prefix_sum[module_idx];
 
-                    // Push back the header and items
-                    clusters_device[prefix_sum + cindex].header = cl_id;
-                    clusters_device[prefix_sum + cindex].items.push_back(
-                        cells[id_y]);
-                }
-            })
+                    // Push back the cells to the correct item vector indicated
+                    // by the cluster prefix sum
+                    unsigned int cindex = cluster_indices[cell_idx] - 1;
+                    if (cindex < num_clusters) {
+                        // Create cluster id - same for all clusters in this
+                        // module
+                        cluster_id cl_id{};
+                        cl_id.module = module.module;
+                        cl_id.placement = module.placement;
+                        cl_id.module_idx = module_idx;
+                        cl_id.pixel = module.pixel;
+
+                        // Push back the header and items
+                        clusters_device[prefix_sum + cindex].header = cl_id;
+                        clusters_device[prefix_sum + cindex].items.push_back(
+                            cells[cell_idx]);
+                    }
+                });
+        })
         .wait_and_throw();
 }
 

--- a/device/sycl/src/clusterization/measurement_creation.hpp
+++ b/device/sycl/src/clusterization/measurement_creation.hpp
@@ -18,6 +18,7 @@ namespace traccc::sycl {
 ///
 void measurement_creation(measurement_container_view measurements_view,
                           cluster_container_types::const_view clusters_view,
+                          const cell_container_types::const_view& cells_view,
                           queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -18,77 +18,87 @@ namespace traccc::sycl {
 
 void measurement_creation(measurement_container_view measurements_view,
                           cluster_container_types::const_view clusters_view,
+                          const cell_container_types::const_view& cells_view,
                           queue_wrapper queue) {
 
-    // The kernel execution range
+    // The execution range of the kernel
     auto n_clusters = clusters_view.headers.size();
 
     // Calculate the execution NDrange for the kernel
-    auto workGroupSize = 64;
-    auto num = (n_clusters + workGroupSize - 1) / workGroupSize;
-    auto ndrange = ::sycl::nd_range<1>{::sycl::range<1>(num * workGroupSize),
-                                       ::sycl::range<1>(workGroupSize)};
-    // Run the kernel
+    auto wGroupSize = 64;
+    auto num = (n_clusters + wGroupSize - 1) / wGroupSize;
+    auto ndrange = ::sycl::nd_range<1>{::sycl::range<1>(num * wGroupSize),
+                                       ::sycl::range<1>(wGroupSize)};
+
     details::get_queue(queue)
-        .parallel_for<class MeasurementCreation>(
-            ndrange,
-            [clusters_view, measurements_view](::sycl::nd_item<1> item) {
-                // Get the global index
-                auto idx = item.get_global_linear_id();
+        .submit([&ndrange, &clusters_view, &measurements_view,
+                 &cells_view](::sycl::handler& h) {
+            h.parallel_for<class MeasurementCreation>(
+                ndrange, [=](::sycl::nd_item<1> item) {
+                    // Get the current index
+                    auto idx = item.get_global_linear_id();
 
-                // Initialize device vectors
-                const cluster_container_types::const_device clusters_device(
-                    clusters_view);
-                device_measurement_container measurement_device(
-                    measurements_view);
+                    // Initialize device vectors
+                    const cluster_container_types::const_device clusters_device(
+                        clusters_view);
+                    device_measurement_container measurements_device(
+                        measurements_view);
+                    cell_container_types::const_device cells_device(cells_view);
 
-                // Ignore if idx is out of range
-                if (idx >= clusters_device.size())
-                    return;
+                    // Ignore if idx is out of range
+                    if (idx >= clusters_device.size())
+                        return;
 
-                // items: cluster of cells at current idx
-                // header: cluster_id object with the information about the cell
-                // module
-                const auto& cluster = clusters_device.get_items().at(idx);
-                const cluster_id& cl_id = clusters_device.get_headers().at(idx);
+                    // items: cluster of cells at current idx
+                    // header: cluster_id object with the information about the
+                    // cell module
+                    const auto& cluster = clusters_device[idx].items;
+                    const cluster_id& cl_id = clusters_device[idx].header;
 
-                const vector2 pitch = detail::get_pitch(cl_id);
-                const auto module_idx = cl_id.module_idx;
+                    const vector2 pitch = detail::get_pitch(cl_id);
+                    const auto module_idx = cl_id.module_idx;
 
-                scalar totalWeight = 0.;
+                    scalar totalWeight = 0.;
 
-                // To calculate the mean and variance with high numerical
-                // stability we use a weighted variant of Welford's algorithm.
-                // This is a single-pass online algorithm that works well for
-                // large numbers of samples, as well as samples with very high
-                // values.
-                //
-                // To learn more about this algorithm please refer to:
-                // [1] https://doi.org/10.1080/00401706.1962.10490022
-                // [2] The Art of Computer Programming, Donald E. Knuth, second
-                //     edition, chapter 4.2.2.
-                point2 mean = {0., 0.}, var = {0., 0.};
+                    // Get the cell module for this module idx
+                    const auto& module = cells_device[module_idx].header;
 
-                // Should not happen
-                assert(cluster.empty() == false);
+                    // To calculate the mean and variance with high numerical
+                    // stability we use a weighted variant of Welford's
+                    // algorithm. This is a single-pass online algorithm that
+                    // works well for large numbers of samples, as well as
+                    // samples with very high values.
+                    //
+                    // To learn more about this algorithm please refer to:
+                    // [1] https://doi.org/10.1080/00401706.1962.10490022
+                    // [2] The Art of Computer Programming, Donald E. Knuth,
+                    // second
+                    //     edition, chapter 4.2.2.
+                    point2 mean = {0., 0.}, var = {0., 0.};
 
-                detail::calc_cluster_properties(cluster, cl_id, mean, var,
-                                                totalWeight);
+                    // Should not happen
+                    assert(cluster.empty() == false);
 
-                if (totalWeight > 0.) {
-                    measurement m;
-                    // normalize the cell position
-                    m.local = mean;
-                    // normalize the variance
-                    m.variance[0] = var[0] / totalWeight;
-                    m.variance[1] = var[1] / totalWeight;
-                    // plus pitch^2 / 12
-                    m.variance = m.variance + point2{pitch[0] * pitch[0] / 12,
-                                                     pitch[1] * pitch[1] / 12};
-                    // @todo add variance estimation
-                    measurement_device.get_items().at(module_idx).push_back(m);
-                }
-            })
+                    detail::calc_cluster_properties(cluster, cl_id, mean, var,
+                                                    totalWeight);
+
+                    if (totalWeight > 0.) {
+                        measurement m;
+                        // normalize the cell position
+                        m.local = mean;
+                        // normalize the variance
+                        m.variance[0] = var[0] / totalWeight;
+                        m.variance[1] = var[1] / totalWeight;
+                        // plus pitch^2 / 12
+                        m.variance =
+                            m.variance + point2{pitch[0] * pitch[0] / 12,
+                                                pitch[1] * pitch[1] / 12};
+                        // @todo add variance estimation
+                        measurements_device[module_idx].header = module;
+                        measurements_device[module_idx].items.push_back(m);
+                    }
+                });
+        })
         .wait_and_throw();
 }
 

--- a/device/sycl/src/clusterization/spacepoint_formation.hpp
+++ b/device/sycl/src/clusterization/spacepoint_formation.hpp
@@ -10,23 +10,22 @@
 // Project include(s).
 #include "traccc/device/get_prefix_sum.hpp"
 #include "traccc/edm/cell.hpp"
-#include "traccc/edm/cluster.hpp"
+#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/spacepoint.hpp"
 
 // Vecmem include(s).
-#include <vecmem/containers/data/jagged_vector_view.hpp>
 #include <vecmem/containers/data/vector_view.hpp>
+#include <vecmem/memory/memory_resource.hpp>
 
 namespace traccc::sycl {
 
-/// Forward declaration of component connection function
+/// Forward decleration of spacepoint formation kernel
 ///
-void component_connection(
-    cluster_container_types::view clusters_view,
-    const cell_container_types::const_view& cells_view,
-    vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
-    vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
+void spacepoint_formation(
+    spacepoint_container_view spacepoints_view,
+    measurement_container_view measurements_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
-        cells_prefix_sum_view,
+        measurements_prefix_sum_view,
     queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/clusterization/spacepoint_formation.sycl
+++ b/device/sycl/src/clusterization/spacepoint_formation.sycl
@@ -1,0 +1,81 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL library include(s).
+#include "../utils/get_queue.hpp"
+
+// Spacepoint formation include(s).
+#include "spacepoint_formation.hpp"
+
+// SYCL include(s)
+#include <CL/sycl.hpp>
+
+namespace traccc::sycl {
+
+void spacepoint_formation(
+    spacepoint_container_view spacepoints_view,
+    measurement_container_view measurements_view,
+    vecmem::data::vector_view<const device::prefix_sum_element_t>
+        measurements_prefix_sum_view,
+    queue_wrapper queue) {
+
+    // The execution range of the kernel
+    auto n_measurements = measurements_prefix_sum_view.size();
+
+    // Calculate the execution NDrange for the kernel
+    auto wGroupSize = 64;
+    auto num = (n_measurements + wGroupSize - 1) / wGroupSize;
+    auto ndrange = ::sycl::nd_range<1>{::sycl::range<1>(num * wGroupSize),
+                                       ::sycl::range<1>(wGroupSize)};
+
+    details::get_queue(queue)
+        .submit([&ndrange, &spacepoints_view, &measurements_view,
+                 &measurements_prefix_sum_view](::sycl::handler& h) {
+            h.parallel_for<class SpacepointFormation>(
+                ndrange, [=](::sycl::nd_item<1> item) {
+                    // Get the global idx
+                    auto idx = item.get_global_linear_id();
+
+                    // Initialize device containers
+                    device_measurement_container measurements_device(
+                        measurements_view);
+                    device_spacepoint_container spacepoints_device(
+                        spacepoints_view);
+                    vecmem::device_vector<const device::prefix_sum_element_t>
+                        measurements_prefix_sum(measurements_prefix_sum_view);
+
+                    // Ignore if idx is out of range
+                    if (idx >= measurements_prefix_sum.size())
+                        return;
+
+                    // Get the indices from the prefix sum vector
+                    const auto module_idx = measurements_prefix_sum[idx].first;
+                    const auto measurement_idx =
+                        measurements_prefix_sum[idx].second;
+
+                    // Get the measurement for this idx
+                    const auto& m = measurements_device[module_idx].items.at(
+                        measurement_idx);
+
+                    // Get the current cell module
+                    const auto& module = measurements_device[module_idx].header;
+
+                    // Form a spacepoint based on this measurement
+                    point3 local_3d = {m.local[0], m.local[1], 0.};
+                    point3 global = module.placement.point_to_global(local_3d);
+                    spacepoint s({global, m});
+
+                    // Push the speacpoint into the container at the appropriate
+                    // module idx
+                    spacepoints_device[module_idx].header = module.module;
+                    spacepoints_device[module_idx].items.push_back(s);
+                });
+        })
+        .wait_and_throw();
+}
+
+}  // namespace traccc::sycl

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -66,8 +66,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     uint64_t n_modules = 0;
     // uint64_t n_clusters = 0;
     uint64_t n_measurements = 0;
-    uint64_t n_measurements_sycl = 0;
     uint64_t n_spacepoints = 0;
+    uint64_t n_spacepoints_sycl = 0;
     uint64_t n_seeds = 0;
     uint64_t n_seeds_sycl = 0;
 
@@ -128,23 +128,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         /*time*/ file_reading_cpu += time_file_reading_cpu.count();
 
         /*-----------------------------
-            Clusterization algorithm
+            Clusterization algorithm (CPU)
           -----------------------------*/
-
-        // SYCL
-
-        /*time*/ auto start_clusterization_sycl =
-            std::chrono::system_clock::now();
-
-        auto measurements_per_event_sycl = ca_sycl(cells_per_event);
-
-        /*time*/ auto end_clusterization_sycl =
-            std::chrono::system_clock::now();
-        /*time*/ std::chrono::duration<double> time_clusterization_sycl =
-            end_clusterization_sycl - start_clusterization_sycl;
-        /*time*/ clusterization_sycl += time_clusterization_sycl.count();
-
-        // CPU
 
         /*time*/ auto start_clusterization_cpu =
             std::chrono::system_clock::now();
@@ -157,7 +142,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         /*time*/ clusterization_cpu += time_clusterization_cpu.count();
 
         /*---------------------------------
-               Spacepoint formation (cpu)
+               Spacepoint formation (CPU)
           ---------------------------------*/
 
         /*time*/ auto start_sp_formation_cpu = std::chrono::system_clock::now();
@@ -169,8 +154,20 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
             end_sp_formation_cpu - start_sp_formation_cpu;
         /*time*/ sp_formation_cpu += time_sp_formation_cpu.count();
 
-        // Spacepoint formation for SYCL algorithms
-        auto spacepoints_per_event_sycl = sf(measurements_per_event_sycl);
+        /*---------------------------------------------------
+               Clusterization & Spacepoint formation (SYCL)
+          ---------------------------------------------------*/
+
+        /*time*/ auto start_clusterization_sycl =
+            std::chrono::system_clock::now();
+
+        auto spacepoints_per_event_sycl = ca_sycl(cells_per_event);
+
+        /*time*/ auto end_clusterization_sycl =
+            std::chrono::system_clock::now();
+        /*time*/ std::chrono::duration<double> time_clusterization_sycl =
+            end_clusterization_sycl - start_clusterization_sycl;
+        /*time*/ clusterization_sycl += time_clusterization_sycl.count();
 
         /*----------------------------
              Seeding algorithm
@@ -247,30 +244,43 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
             std::cout << " number of seeds (sycl): " << seeds_sycl.size()
                       << std::endl;
 
-            // measurement matching rate
-            int n_measurements_match = 0;
-            for (uint64_t i = 0; i < measurements_per_event.size(); ++i) {
-                for (auto& m : measurements_per_event.get_items().at(i)) {
-
-                    if (std::find(
-                            measurements_per_event_sycl.get_items()
-                                .at(i)
-                                .begin(),
-                            measurements_per_event_sycl.get_items().at(i).end(),
-                            m) !=
-                        measurements_per_event_sycl.get_items().at(i).end()) {
-                        n_measurements_match++;
+            // measurements & spacepoint matching rate
+            int n_m_match = 0;
+            int n_match = 0;
+            assert(spacepoints_per_event.size() ==
+                   spacepoints_per_event_sycl.size());
+            for (std::size_t i = 0; i < spacepoints_per_event.size(); ++i) {
+                assert(spacepoints_per_event[i].items.size() ==
+                       spacepoints_per_event_sycl[i].items.size());
+                for (auto& sp : spacepoints_per_event[i].items) {
+                    auto found_sp = std::find(
+                        spacepoints_per_event_sycl[i].items.begin(),
+                        spacepoints_per_event_sycl[i].items.end(), sp);
+                    auto found_m = std::find_if(
+                        spacepoints_per_event_sycl[i].items.begin(),
+                        spacepoints_per_event_sycl[i].items.end(),
+                        [&sp](auto& sp_sycl) {
+                            return sp.meas == sp_sycl.meas;
+                        });
+                    if (found_m != spacepoints_per_event_sycl[i].items.end()) {
+                        n_m_match++;
+                    }
+                    if (found_sp != spacepoints_per_event_sycl[i].items.end()) {
+                        n_match++;
                     }
                 }
             }
-            float matching_rate = float(n_measurements_match) /
-                                  measurements_per_event.total_size();
-            std::cout << " measurements matching rate: " << matching_rate
+            float m_matching_rate =
+                float(n_m_match) / spacepoints_per_event.total_size();
+            std::cout << " measurements matching rate: " << m_matching_rate
+                      << std::endl;
+            float matching_rate =
+                float(n_match) / spacepoints_per_event.total_size();
+            std::cout << " spacepoint matching rate: " << matching_rate
                       << std::endl;
 
             // seeding matching rate
-            int n_match = 0;
-
+            n_match = 0;
             std::vector<std::array<traccc::spacepoint, 3>> sp3_vector =
                 traccc::get_spacepoint_vector(seeds, spacepoints_per_event);
 
@@ -307,8 +317,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         n_modules += cells_per_event.size();
         n_cells += cells_per_event.total_size();
         n_measurements += measurements_per_event.total_size();
-        n_measurements_sycl += measurements_per_event_sycl.total_size();
         n_spacepoints += spacepoints_per_event.total_size();
+        n_spacepoints_sycl += spacepoints_per_event_sycl.total_size();
         n_seeds_sycl += seeds_sycl.size();
         n_seeds += seeds.size();
 
@@ -321,7 +331,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                                       i_cfg.hit_directory,
                                       i_cfg.particle_directory, host_mr);
             sd_performance_writer.write("SYCL", seeds_sycl,
-                                        spacepoints_per_event, evt_map);
+                                        spacepoints_per_event_sycl, evt_map);
 
             if (run_cpu) {
                 sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
@@ -345,10 +355,10 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
               << std::endl;
     std::cout << "- created        " << n_measurements << " meaurements     "
               << std::endl;
-    std::cout << "- created (sycl) " << n_measurements_sycl
-              << " measurements     " << std::endl;
     std::cout << "- created        " << n_spacepoints << " spacepoints     "
               << std::endl;
+    std::cout << "- created (sycl) " << n_spacepoints_sycl
+              << " spacepoints     " << std::endl;
 
     std::cout << "- created (cpu)  " << n_seeds << " seeds" << std::endl;
     std::cout << "- created (sycl) " << n_seeds_sycl << " seeds" << std::endl;


### PR DESCRIPTION
This PR adds the Spacepoint formation in SYCL. With this in place we will have all the pieces to  start playing with using just device memory all the way from cells to seeding :metal:  :cowboy_hat_face: 

I didn't separate this implementation from the clusterization algorithm (similarly to the CPU version) because there was some information needed from the "clusterization chain", to construct the buffers for the spacepoints. 

I also rewrote the current SYCL clusterization algorithm to make use of the code that constructs [prefix sums](https://github.com/acts-project/traccc/blob/main/device/common/include/traccc/device/get_prefix_sum.hpp) out of our 2-dimensional containers that @krasznaa  recently added. Getting rid of 2-dim kernels as a result. This logic is also implemented for the spacepoint formation.

#### Some benchmarks:
- Intel UHD Graphics 630
```
clusterization_time (cpu) 0.00602939
spacepoint_formation_time (cpu) 0.0152623 
clusterization_time (sycl) 0.370286  
```
NVIDIA RTX 2060 (shared_mr), CPU (host_mr)
```
clusterization_time (cpu) 0.00562569
spacepoint_formation_time (cpu) 0.0138134 
clusterization_time (sycl) 0.0251253 
```
Keep in mind that sycl clusterization here means clusterization + spacepoint formation