### PR TITLE
Measurement EDM Update, main branch (2022.05.17.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -40,6 +40,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/clusterization/clusterization_algorithm.hpp"
   "src/clusterization/clusterization_algorithm.cpp"
   "include/traccc/clusterization/spacepoint_formation.hpp"
+  "src/clusterization/spacepoint_formation.cpp"
   "include/traccc/clusterization/measurement_creation.hpp"
   "src/clusterization/measurement_creation.cpp"
   # Seed finding algorithmic code.

--- a/core/include/traccc/clusterization/clusterization_algorithm.hpp
+++ b/core/include/traccc/clusterization/clusterization_algorithm.hpp
@@ -27,8 +27,9 @@ namespace traccc {
 /// This algorithm creates local/2D measurements separately for each detector
 /// module from the cells of the modules.
 ///
-class clusterization_algorithm : public algorithm<host_measurement_container(
-                                     const cell_container_types::host&)> {
+class clusterization_algorithm
+    : public algorithm<measurement_container_types::host(
+          const cell_container_types::host&)> {
 
     public:
     /// Clusterization algorithm constructor

--- a/core/include/traccc/clusterization/measurement_creation.hpp
+++ b/core/include/traccc/clusterization/measurement_creation.hpp
@@ -28,7 +28,7 @@ namespace traccc {
 /// module.
 ///
 class measurement_creation
-    : public algorithm<host_measurement_collection(
+    : public algorithm<measurement_collection_types::host(
           const cluster_container_types::host &, const cell_module &)> {
 
     public:

--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -10,69 +10,51 @@
 // Project include(s).
 #include "traccc/definitions/common.hpp"
 #include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/container.hpp"
 
 // System include(s).
-#include <vector>
+#include <cmath>
 
 namespace traccc {
 
-/// A measurement definition:
-/// fix to two-dimensional here
+/// Measurement expressed in local coordinates
+///
+/// It describes the 2D position and the uncertainty of that position
+/// of a measurement on a detector element.
+///
 struct measurement {
-    point2 local = {0., 0.};
-    variance2 variance = {0., 0.};
-
-    TRACCC_HOST_DEVICE
-    static inline measurement invalid_value() {
-        return measurement({{0., 0.}, {0., 0.}});
-    }
+    /// Local 2D coordinates for a measurement on a detector module
+    point2 local{0., 0.};
+    /// Variance on the 2D coordinates of the measurement
+    variance2 variance{0., 0.};
 };
 
+/// Comparison / ordering operator for measurements
+TRACCC_HOST_DEVICE
 inline bool operator<(const measurement& lhs, const measurement& rhs) {
-    if (lhs.local[0] < rhs.local[0]) {
-        return true;
+
+    if (std::abs(lhs.local[0] - rhs.local[0]) > float_epsilon) {
+        return (lhs.local[0] < rhs.local[0]);
+    } else {
+        return (lhs.local[1] < rhs.local[1]);
     }
-    return false;
 }
 
+/// Equality operator for measurements
+TRACCC_HOST_DEVICE
 inline bool operator==(const measurement& lhs, const measurement& rhs) {
-    return (std::abs(lhs.local[0] - rhs.local[0]) < float_epsilon &&
-            std::abs(lhs.local[1] - rhs.local[1]) < float_epsilon &&
-            std::abs(lhs.variance[0] - rhs.variance[0]) < float_epsilon &&
-            std::abs(lhs.variance[1] - rhs.variance[1]) < float_epsilon);
+
+    return ((std::abs(lhs.local[0] - rhs.local[0]) < float_epsilon) &&
+            (std::abs(lhs.local[1] - rhs.local[1]) < float_epsilon) &&
+            (std::abs(lhs.variance[0] - rhs.variance[0]) < float_epsilon) &&
+            (std::abs(lhs.variance[1] - rhs.variance[1]) < float_epsilon));
 }
 
-/// Container of measurements belonging to one detector module
-template <template <typename> class vector_t>
-using measurement_collection = vector_t<measurement>;
-
-/// Convenience declaration for the measurement collection type to use in host
-/// code
-using host_measurement_collection = measurement_collection<vecmem::vector>;
-/// Convenience declaration for the measurement collection type to use in device
-/// code
-using device_measurement_collection =
-    measurement_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the measurement container type to use in host
-/// code
-using host_measurement_container = host_container<cell_module, measurement>;
-
-/// Convenience declaration for the measurement container type to use in device
-/// code
-using device_measurement_container = device_container<cell_module, measurement>;
-/// Convenience declaration for the measurement container data type to use in
-/// host code
-using measurement_container_data = container_data<cell_module, measurement>;
-
-/// Convenience declaration for the measurement container buffer type to use in
-/// host code
-using measurement_container_buffer = container_buffer<cell_module, measurement>;
-
-/// Convenience declaration for the measurement container view type to use in
-/// host code
-using measurement_container_view = container_view<cell_module, measurement>;
+/// Declare all measurement collection types
+using measurement_collection_types = collection_types<measurement>;
+/// Declare all measurement container types
+using measurement_container_types = container_types<cell_module, measurement>;
 
 }  // namespace traccc

--- a/core/include/traccc/edm/spacepoint.hpp
+++ b/core/include/traccc/edm/spacepoint.hpp
@@ -25,12 +25,6 @@ struct spacepoint {
     measurement meas;
 
     TRACCC_HOST_DEVICE
-    static inline spacepoint invalid_value() {
-        measurement ms = measurement::invalid_value();
-        return spacepoint({{0., 0., 0.}, ms});
-    }
-
-    TRACCC_HOST_DEVICE
     const scalar& x() const { return global[0]; }
     TRACCC_HOST_DEVICE
     const scalar& y() const { return global[1]; }

--- a/core/src/clusterization/clusterization_algorithm.cpp
+++ b/core/src/clusterization/clusterization_algorithm.cpp
@@ -29,12 +29,11 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
             cells_per_module = cells.at(i).items;
 
         // Reconstruct all measurements for the current module.
-        traccc::cluster_container_types::host clusters =
-            m_cc(cells_per_module, module);
+        cluster_container_types::host clusters = m_cc(cells_per_module, module);
         for (cluster_id& cl_id : clusters.get_headers()) {
             cl_id.pixel = module.pixel;
         }
-        traccc::host_measurement_collection measurements =
+        measurement_collection_types::host measurements =
             m_mc(clusters, module);
 
         // Save the measurements into the event-wide container.

--- a/core/src/clusterization/spacepoint_formation.cpp
+++ b/core/src/clusterization/spacepoint_formation.cpp
@@ -1,0 +1,47 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/clusterization/spacepoint_formation.hpp"
+
+namespace traccc {
+
+spacepoint_formation::spacepoint_formation(vecmem::memory_resource& mr)
+    : m_mr(mr) {}
+
+spacepoint_formation::output_type spacepoint_formation::operator()(
+    const measurement_container_types::host& measurements) const {
+
+    // Create the result container, with the correct "outer size".
+    output_type result(measurements.size(), &(m_mr.get()));
+
+    // Iterate over the modules.
+    for (std::size_t i = 0; i < measurements.size(); ++i) {
+
+        // Access the measurements of the current module.
+        const cell_module& module = measurements.get_headers()[i];
+        const measurement_collection_types::host& measurements_per_module =
+            measurements.get_items()[i];
+
+        // Access the spacepoint collection for the module.
+        host_spacepoint_collection& spacepoints_per_module = result[i].items;
+        spacepoints_per_module.reserve(measurements_per_module.size());
+
+        // Construct the spacepoints.
+        for (const measurement& m : measurements_per_module) {
+
+            point3 local_3d = {m.local[0], m.local[1], 0.};
+            point3 global = module.placement.point_to_global(local_3d);
+            spacepoints_per_module.push_back({global, m});
+        }
+    }
+
+    // Return the created container.
+    return result;
+}
+
+}  // namespace traccc

--- a/device/cuda/include/traccc/cuda/cca/component_connection.hpp
+++ b/device/cuda/include/traccc/cuda/cca/component_connection.hpp
@@ -13,9 +13,8 @@
 #include "traccc/utils/algorithm.hpp"
 
 namespace traccc::cuda {
-struct component_connection : algorithm<host_measurement_container(
+struct component_connection : algorithm<measurement_container_types::host(
                                   const cell_container_types::host& cells)> {
-    host_measurement_container operator()(
-        const cell_container_types::host& cells) const;
+    output_type operator()(const cell_container_types::host& cells) const;
 };
 }  // namespace traccc::cuda

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -561,7 +561,7 @@ vecmem::vector<details::ccl_partition> partition(
 }
 }  // namespace details
 
-host_measurement_container component_connection::operator()(
+component_connection::output_type component_connection::operator()(
     const cell_container_types::host& data) const {
     vecmem::cuda::managed_memory_resource upstream;
     vecmem::binary_page_memory_resource mem(upstream);
@@ -654,7 +654,7 @@ host_measurement_container component_connection::operator()(
     /*
      * Copy back the data from our flattened data structure into the traccc EDM.
      */
-    host_measurement_container out;
+    output_type out;
 
     for (std::size_t i = 0; i < data.size(); ++i) {
         vecmem::vector<measurement> v(&mem);

--- a/device/sycl/src/clusterization/clusterization_algorithm.cpp
+++ b/device/sycl/src/clusterization/clusterization_algorithm.cpp
@@ -110,7 +110,7 @@ host_spacepoint_container clusterization_algorithm::operator()(
     copy(clusters_per_module, clusters_per_module_host);
 
     // Resizable buffer for the measurements
-    measurement_container_buffer measurements_buffer{
+    measurement_container_types::buffer measurements_buffer{
         {num_modules, m_mr.get()},
         {std::vector<std::size_t>(num_modules, 0), clusters_per_module_host,
          m_mr.get()}};

--- a/device/sycl/src/clusterization/measurement_creation.hpp
+++ b/device/sycl/src/clusterization/measurement_creation.hpp
@@ -16,7 +16,7 @@ namespace traccc::sycl {
 
 /// Forward decleration of measurement creation kernel
 ///
-void measurement_creation(measurement_container_view measurements_view,
+void measurement_creation(measurement_container_types::view measurements_view,
                           cluster_container_types::const_view clusters_view,
                           const cell_container_types::const_view& cells_view,
                           queue_wrapper queue);

--- a/device/sycl/src/clusterization/measurement_creation.sycl
+++ b/device/sycl/src/clusterization/measurement_creation.sycl
@@ -16,7 +16,7 @@
 
 namespace traccc::sycl {
 
-void measurement_creation(measurement_container_view measurements_view,
+void measurement_creation(measurement_container_types::view measurements_view,
                           cluster_container_types::const_view clusters_view,
                           const cell_container_types::const_view& cells_view,
                           queue_wrapper queue) {
@@ -41,7 +41,7 @@ void measurement_creation(measurement_container_view measurements_view,
                     // Initialize device vectors
                     const cluster_container_types::const_device clusters_device(
                         clusters_view);
-                    device_measurement_container measurements_device(
+                    measurement_container_types::device measurements_device(
                         measurements_view);
                     cell_container_types::const_device cells_device(cells_view);
 

--- a/device/sycl/src/clusterization/spacepoint_formation.hpp
+++ b/device/sycl/src/clusterization/spacepoint_formation.hpp
@@ -23,7 +23,7 @@ namespace traccc::sycl {
 ///
 void spacepoint_formation(
     spacepoint_container_view spacepoints_view,
-    measurement_container_view measurements_view,
+    measurement_container_types::const_view measurements_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         measurements_prefix_sum_view,
     queue_wrapper queue);

--- a/device/sycl/src/clusterization/spacepoint_formation.sycl
+++ b/device/sycl/src/clusterization/spacepoint_formation.sycl
@@ -18,7 +18,7 @@ namespace traccc::sycl {
 
 void spacepoint_formation(
     spacepoint_container_view spacepoints_view,
-    measurement_container_view measurements_view,
+    measurement_container_types::const_view measurements_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         measurements_prefix_sum_view,
     queue_wrapper queue) {
@@ -41,8 +41,8 @@ void spacepoint_formation(
                     auto idx = item.get_global_linear_id();
 
                     // Initialize device containers
-                    device_measurement_container measurements_device(
-                        measurements_view);
+                    measurement_container_types::const_device
+                        measurements_device(measurements_view);
                     device_spacepoint_container spacepoints_device(
                         spacepoints_view);
                     vecmem::device_vector<const device::prefix_sum_element_t>

--- a/io/include/traccc/io/csv.hpp
+++ b/io/include/traccc/io/csv.hpp
@@ -335,20 +335,20 @@ inline std::vector<cluster_container_types::host> read_truth_clusters(
 ///
 /// @param hreader The measurement reader type
 /// @param resource The memory resource to use for the return value
-inline host_measurement_container read_measurements(
+inline measurement_container_types::host read_measurements(
     measurement_reader& mreader, vecmem::memory_resource& resource,
     const std::map<geometry_id, transform3>& tfmap = {},
     unsigned int max_measurements = std::numeric_limits<unsigned int>::max()) {
 
     uint64_t reference_id = 0;
-    host_measurement_container result = {
-        host_measurement_container::header_vector(&resource),
-        host_measurement_container::item_vector(&resource)};
+    measurement_container_types::host result = {
+        measurement_container_types::host::header_vector(&resource),
+        measurement_container_types::host::item_vector(&resource)};
 
     bool first_line_read = false;
     unsigned int read_measurements = 0;
     csv_measurement iomeasurement;
-    host_measurement_collection measurements(&resource);
+    measurement_collection_types::host measurements(&resource);
     cell_module module;
     while (mreader.read(iomeasurement)) {
         if (first_line_read and iomeasurement.geometry_id != reference_id) {
@@ -363,7 +363,7 @@ inline host_measurement_container read_measurements(
             result.push_back(std::move(module), std::move(measurements));
 
             // Clear for next round
-            measurements = host_measurement_collection(&resource);
+            measurements.clear();
             module = cell_module();
         }
         first_line_read = true;

--- a/io/include/traccc/io/demonstrator_edm.hpp
+++ b/io/include/traccc/io/demonstrator_edm.hpp
@@ -13,10 +13,10 @@
 
 namespace traccc {
 struct result {
-    traccc::host_measurement_container measurements;
+    measurement_container_types::host measurements;
     traccc::host_spacepoint_container spacepoints;
 };
 
 using demonstrator_input = vecmem::vector<cell_container_types::host>;
-using demonstrator_result = vecmem::vector<traccc::result>;
+using demonstrator_result = vecmem::vector<result>;
 }  // namespace traccc

--- a/io/include/traccc/io/mapper.hpp
+++ b/io/include/traccc/io/mapper.hpp
@@ -192,7 +192,7 @@ measurement_cell_map generate_measurement_cell_map(
             cl_id.pixel = module.pixel;
         }
 
-        host_measurement_collection measurements_per_module =
+        measurement_collection_types::host measurements_per_module =
             mt(clusters, module);
 
         for (std::size_t j = 0; j < clusters.size(); j++) {

--- a/tests/cpu/seq_single_module.cpp
+++ b/tests/cpu/seq_single_module.cpp
@@ -45,7 +45,7 @@ TEST(algorithms, seq_single_module) {
 
     traccc::cluster_container_types::host clusters(&resource);
 
-    traccc::host_measurement_collection measurements;
+    traccc::measurement_collection_types::host measurements;
 
     traccc::host_spacepoint_collection spacepoints;
 

--- a/tests/cpu/test_cca.cpp
+++ b/tests/cpu/test_cca.cpp
@@ -30,20 +30,22 @@ traccc::component_connection cc(resource);
 traccc::measurement_creation mc(resource);
 traccc::cell_module module;
 
-std::function<traccc::host_measurement_collection(
+std::function<traccc::measurement_collection_types::host(
     const traccc::cell_collection_types::host &)>
-    fp = traccc::compose(std::function<traccc::cluster_container_types::host(
-                             const traccc::cell_collection_types::host &)>(
-                             std::bind(cc, std::placeholders::_1, module)),
-                         std::function<traccc::host_measurement_collection(
-                             const traccc::cluster_container_types::host &)>(
-                             std::bind(mc, std::placeholders::_1, module)));
+    fp = traccc::compose(
+        std::function<traccc::cluster_container_types::host(
+            const traccc::cell_collection_types::host &)>(
+            std::bind(cc, std::placeholders::_1, module)),
+        std::function<traccc::measurement_collection_types::host(
+            const traccc::cluster_container_types::host &)>(
+            std::bind(mc, std::placeholders::_1, module)));
 
 cca_function_t f = [](const traccc::cell_container_types::host &data) {
     std::map<traccc::geometry_id, std::vector<traccc::measurement>> result;
 
     for (std::size_t i = 0; i < data.size(); ++i) {
-        traccc::host_measurement_collection measurements = fp(data.at(i).items);
+        traccc::measurement_collection_types::host measurements =
+            fp(data.at(i).items);
         std::vector<traccc::measurement> out(measurements.begin(),
                                              measurements.end());
         result.emplace(data.at(i).header.module, std::move(out));

--- a/tests/cuda/test_cca.cpp
+++ b/tests/cuda/test_cca.cpp
@@ -18,7 +18,7 @@ traccc::cuda::component_connection cc;
 cca_function_t f = [](const traccc::cell_container_types::host &data) {
     std::map<traccc::geometry_id, std::vector<traccc::measurement>> result;
 
-    traccc::host_measurement_container mss = cc(data);
+    traccc::measurement_container_types::host mss = cc(data);
 
     for (std::size_t i = 0; i < mss.size(); ++i) {
         std::vector<traccc::measurement> msv;


### PR DESCRIPTION
Updated the measurement containers to the "new declaration style", following in the footsteps of #188, #189 and #190.

Updated all of the code to use the new type names, and moved the implementation of `traccc::spacepoint_formation` into a `.cpp` file.

The only not-completely-trivial update is that I removed the `traccc::measurement::invalid_value()` and `traccc::spacepoint::invalid_value()` functions. These were just ill-defined, and we never used them anywhere luckily.