### PR TITLE
Rewrote SYCL algorithms to accept view objects

### DIFF
--- a/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
@@ -16,6 +16,7 @@
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/containers/data/vector_buffer.hpp>
 
 // System include(s).
 #include <functional>

--- a/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
@@ -15,8 +15,8 @@
 #include "traccc/utils/algorithm.hpp"
 
 // VecMem include(s).
-#include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/containers/data/vector_buffer.hpp>
+#include <vecmem/memory/memory_resource.hpp>
 
 // System include(s).
 #include <functional>

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -22,7 +22,7 @@
 
 namespace traccc::sycl {
 
-class clusterization_algorithm : public algorithm<host_spacepoint_container(
+class clusterization_algorithm : public algorithm<spacepoint_container_buffer(
                                      const cell_container_types::host&)> {
 
     public:

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -36,7 +36,8 @@ class clusterization_algorithm : public algorithm<spacepoint_container_buffer(
     ///
     /// @param cells_per_event is a container with cell modules as headers
     /// and cells as the items
-    /// @return a measurement collection - vector of measurements
+    /// @return a spacepoint container (buffer) - jagged vector of spacepoints
+    /// per module.
     output_type operator()(
         const cell_container_types::host& cells_per_event) const override;
 

--- a/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
@@ -27,8 +27,8 @@ namespace traccc::sycl {
 
 // Sycl seeding function object
 class seed_finding
-    : public algorithm<vecmem::data::vector_buffer<seed>(const spacepoint_container_const_view&,
-                                            const sp_grid_const_view&)> {
+    : public algorithm<vecmem::data::vector_buffer<seed>(
+          const spacepoint_container_const_view&, const sp_grid_const_view&)> {
 
     public:
     /// Constructor for the sycl seed finding
@@ -44,8 +44,9 @@ class seed_finding
     /// Callable operator for the seed finding
     ///
     /// @return seed_collection is the vector of seeds per event
-    output_type operator()(const spacepoint_container_const_view& spacepoints_view,
-                           const sp_grid_const_view& g2_view) const override;
+    output_type operator()(
+        const spacepoint_container_const_view& spacepoints_view,
+        const sp_grid_const_view& g2_view) const override;
 
     private:
     seedfinder_config m_seedfinder_config;

--- a/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
@@ -27,7 +27,7 @@ namespace traccc::sycl {
 
 // Sycl seeding function object
 class seed_finding
-    : public algorithm<host_seed_collection(const host_spacepoint_container&,
+    : public algorithm<vecmem::data::vector_buffer<seed>(const spacepoint_container_const_view&,
                                             const sp_grid_const_view&)> {
 
     public:
@@ -44,7 +44,7 @@ class seed_finding
     /// Callable operator for the seed finding
     ///
     /// @return seed_collection is the vector of seeds per event
-    output_type operator()(const host_spacepoint_container& spacepoints,
+    output_type operator()(const spacepoint_container_const_view& spacepoints_view,
                            const sp_grid_const_view& g2_view) const override;
 
     private:

--- a/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
@@ -14,8 +14,8 @@
 #include "traccc/utils/algorithm.hpp"
 
 // VecMem include(s).
-#include <vecmem/utils/copy.hpp>
 #include <vecmem/containers/data/vector_buffer.hpp>
+#include <vecmem/utils/copy.hpp>
 
 // System include(s).
 #include <memory>
@@ -23,8 +23,8 @@
 namespace traccc {
 namespace sycl {
 
-class seeding_algorithm
-    : public algorithm<vecmem::data::vector_buffer<seed>(const spacepoint_container_const_view&)> {
+class seeding_algorithm : public algorithm<vecmem::data::vector_buffer<seed>(
+                              const spacepoint_container_const_view&)> {
 
     public:
     seeding_algorithm(vecmem::memory_resource& mr, ::sycl::queue* q = nullptr)
@@ -57,8 +57,8 @@ class seeding_algorithm
             traccc::sycl::seed_finding(m_config, mr, q));
     }
 
-    output_type operator()(
-        const spacepoint_container_const_view& spacepoints_view) const override {
+    output_type operator()(const spacepoint_container_const_view&
+                               spacepoints_view) const override {
         sp_grid_buffer internal_sp_g2 = (*sb)(spacepoints_view);
         output_type seeds = (*sf)(spacepoints_view, internal_sp_g2);
         return seeds;

--- a/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
@@ -15,6 +15,7 @@
 
 // VecMem include(s).
 #include <vecmem/utils/copy.hpp>
+#include <vecmem/containers/data/vector_buffer.hpp>
 
 // System include(s).
 #include <memory>
@@ -23,7 +24,7 @@ namespace traccc {
 namespace sycl {
 
 class seeding_algorithm
-    : public algorithm<host_seed_collection(const host_spacepoint_container&)> {
+    : public algorithm<vecmem::data::vector_buffer<seed>(const spacepoint_container_const_view&)> {
 
     public:
     seeding_algorithm(vecmem::memory_resource& mr, ::sycl::queue* q = nullptr)
@@ -57,10 +58,9 @@ class seeding_algorithm
     }
 
     output_type operator()(
-        const host_spacepoint_container& spacepoints) const override {
-        output_type seeds(&m_mr.get());
-        sp_grid_buffer internal_sp_g2 = (*sb)(spacepoints);
-        seeds = (*sf)(spacepoints, internal_sp_g2);
+        const spacepoint_container_const_view& spacepoints_view) const override {
+        sp_grid_buffer internal_sp_g2 = (*sb)(spacepoints_view);
+        output_type seeds = (*sf)(spacepoints_view, internal_sp_g2);
         return seeds;
     }
 

--- a/device/sycl/include/traccc/sycl/seeding/spacepoint_binning.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/spacepoint_binning.hpp
@@ -27,7 +27,7 @@ namespace traccc::sycl {
 
 /// Spacepoing binning executed on a SYCL device
 class spacepoint_binning
-    : public algorithm<sp_grid_buffer(const host_spacepoint_container&)> {
+    : public algorithm<sp_grid_buffer(const spacepoint_container_const_view&)> {
 
     public:
     /// Constructor for the algorithm
@@ -37,7 +37,7 @@ class spacepoint_binning
 
     /// Function executing the algorithm
     sp_grid_buffer operator()(
-        const host_spacepoint_container& spacepoints) const override;
+        const spacepoint_container_const_view& spacepoints_view) const override;
 
     private:
     seedfinder_config m_config;

--- a/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
@@ -27,7 +27,7 @@ namespace traccc::sycl {
 /// track parameter estimation for sycl
 struct track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
-          host_spacepoint_container&&, host_seed_collection&&)> {
+          const spacepoint_container_const_view&, const vecmem::data::vector_view<const seed>&)> {
     public:
     /// Constructor for track_params_estimation
     ///
@@ -40,8 +40,8 @@ struct track_params_estimation
     /// @param input_type is the seed container
     ///
     /// @return vector of bound track parameters
-    output_type operator()(host_spacepoint_container&& spacepoints,
-                           host_seed_collection&& seeds) const override;
+    output_type operator()(const spacepoint_container_const_view& spacepoints_view,
+                           const vecmem::data::vector_view<const seed>& seeds_view) const override;
 
     private:
     std::reference_wrapper<vecmem::memory_resource> m_mr;

--- a/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
@@ -27,7 +27,8 @@ namespace traccc::sycl {
 /// track parameter estimation for sycl
 struct track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
-          const spacepoint_container_const_view&, const vecmem::data::vector_view<const seed>&)> {
+          const spacepoint_container_const_view&,
+          const vecmem::data::vector_view<const seed>&)> {
     public:
     /// Constructor for track_params_estimation
     ///
@@ -40,8 +41,9 @@ struct track_params_estimation
     /// @param input_type is the seed container
     ///
     /// @return vector of bound track parameters
-    output_type operator()(const spacepoint_container_const_view& spacepoints_view,
-                           const vecmem::data::vector_view<const seed>& seeds_view) const override;
+    output_type operator()(
+        const spacepoint_container_const_view& spacepoints_view,
+        const vecmem::data::vector_view<const seed>& seeds_view) const override;
 
     private:
     std::reference_wrapper<vecmem::memory_resource> m_mr;

--- a/device/sycl/src/clusterization/cluster_counting.hpp
+++ b/device/sycl/src/clusterization/cluster_counting.hpp
@@ -21,7 +21,7 @@ namespace traccc::sycl {
 ///
 void cluster_counting(
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
-    vecmem::data::vector_view<std::size_t> cluster_sizes_view,
+    vecmem::data::vector_view<unsigned int> cluster_sizes_view,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         cells_prefix_sum_view,

--- a/device/sycl/src/clusterization/cluster_counting.hpp
+++ b/device/sycl/src/clusterization/cluster_counting.hpp
@@ -21,7 +21,7 @@ namespace traccc::sycl {
 ///
 void cluster_counting(
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
-    vecmem::data::vector_view<unsigned int> cluster_sizes_view,
+    vecmem::data::vector_view<std::size_t> cluster_sizes_view,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         cells_prefix_sum_view,

--- a/device/sycl/src/clusterization/cluster_counting.sycl
+++ b/device/sycl/src/clusterization/cluster_counting.sycl
@@ -34,18 +34,22 @@ void cluster_counting(
                                        ::sycl::range<1>(wGroupSize)};
 
     // Set zero kernel
-    details::get_queue(queue).submit([&ndrange, &cluster_sizes_view](::sycl::handler& h){
-        h.parallel_for<class SetZeroClusterCounting>(ndrange, [=](::sycl::nd_item<1> item){
-            auto idx = item.get_global_linear_id();
+    details::get_queue(queue)
+        .submit([&ndrange, &cluster_sizes_view](::sycl::handler& h) {
+            h.parallel_for<class SetZeroClusterCounting>(
+                ndrange, [=](::sycl::nd_item<1> item) {
+                    auto idx = item.get_global_linear_id();
 
-            vecmem::device_vector<std::size_t> device_cluster_sizes(cluster_sizes_view);
+                    vecmem::device_vector<std::size_t> device_cluster_sizes(
+                        cluster_sizes_view);
 
-            if (idx >= device_cluster_sizes.size())
-                return;
-            
-            device_cluster_sizes[idx] = 0;
-        });
-    }).wait_and_throw();
+                    if (idx >= device_cluster_sizes.size())
+                        return;
+
+                    device_cluster_sizes[idx] = 0;
+                });
+        })
+        .wait_and_throw();
 
     // Cluster Counting kernel
     details::get_queue(queue)

--- a/device/sycl/src/clusterization/cluster_counting.sycl
+++ b/device/sycl/src/clusterization/cluster_counting.sycl
@@ -18,7 +18,7 @@ namespace traccc::sycl {
 
 void cluster_counting(
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
-    vecmem::data::vector_view<std::size_t> cluster_sizes_view,
+    vecmem::data::vector_view<unsigned int> cluster_sizes_view,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         cells_prefix_sum_view,
@@ -40,7 +40,7 @@ void cluster_counting(
                 ndrange, [=](::sycl::nd_item<1> item) {
                     auto idx = item.get_global_linear_id();
 
-                    vecmem::device_vector<std::size_t> device_cluster_sizes(
+                    vecmem::device_vector<unsigned int> device_cluster_sizes(
                         cluster_sizes_view);
 
                     if (idx >= device_cluster_sizes.size())
@@ -92,13 +92,13 @@ void cluster_counting(
                         device_cluster_prefix_sum[module_idx];
 
                     // Vector to fill in with the sizes of each cluster
-                    vecmem::device_vector<std::size_t> device_cluster_sizes(
+                    vecmem::device_vector<unsigned int> device_cluster_sizes(
                         cluster_sizes_view);
 
                     // Count the cluster sizes for each position
                     unsigned int cindex = cluster_indices[cell_idx] - 1;
                     if (cindex < n_clusters) {
-                        vecmem::device_atomic_ref<std::size_t>(
+                        vecmem::device_atomic_ref<unsigned int>(
                             device_cluster_sizes[prefix_sum + cindex])
                             .fetch_add(1);
                     }

--- a/device/sycl/src/clusterization/cluster_counting.sycl
+++ b/device/sycl/src/clusterization/cluster_counting.sycl
@@ -18,7 +18,7 @@ namespace traccc::sycl {
 
 void cluster_counting(
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
-    vecmem::data::vector_view<unsigned int> cluster_sizes_view,
+    vecmem::data::vector_view<std::size_t> cluster_sizes_view,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         cells_prefix_sum_view,
@@ -33,6 +33,21 @@ void cluster_counting(
     auto ndrange = ::sycl::nd_range<1>{::sycl::range<1>(num * wGroupSize),
                                        ::sycl::range<1>(wGroupSize)};
 
+    // Set zero kernel
+    details::get_queue(queue).submit([&ndrange, &cluster_sizes_view](::sycl::handler& h){
+        h.parallel_for<class SetZeroClusterCounting>(ndrange, [=](::sycl::nd_item<1> item){
+            auto idx = item.get_global_linear_id();
+
+            vecmem::device_vector<std::size_t> device_cluster_sizes(cluster_sizes_view);
+
+            if (idx >= device_cluster_sizes.size())
+                return;
+            
+            device_cluster_sizes[idx] = 0;
+        });
+    }).wait_and_throw();
+
+    // Cluster Counting kernel
     details::get_queue(queue)
         .submit([&ndrange, &sparse_ccl_indices_view, &cluster_sizes_view,
                  &cluster_prefix_sum_view,
@@ -73,13 +88,13 @@ void cluster_counting(
                         device_cluster_prefix_sum[module_idx];
 
                     // Vector to fill in with the sizes of each cluster
-                    vecmem::device_vector<unsigned int> device_cluster_sizes(
+                    vecmem::device_vector<std::size_t> device_cluster_sizes(
                         cluster_sizes_view);
 
                     // Count the cluster sizes for each position
                     unsigned int cindex = cluster_indices[cell_idx] - 1;
                     if (cindex < n_clusters) {
-                        vecmem::device_atomic_ref<unsigned int>(
+                        vecmem::device_atomic_ref<std::size_t>(
                             device_cluster_sizes[prefix_sum + cindex])
                             .fetch_add(1);
                     }

--- a/device/sycl/src/clusterization/clusterization_algorithm.cpp
+++ b/device/sycl/src/clusterization/clusterization_algorithm.cpp
@@ -83,7 +83,7 @@ spacepoint_container_buffer clusterization_algorithm::operator()(
                                m_queue);
 
     // Vector of the exact cluster sizes, will be filled in cluster counting
-    vecmem::data::vector_buffer<std::size_t> cluster_sizes_buffer(
+    vecmem::data::vector_buffer<unsigned int> cluster_sizes_buffer(
         *total_clusters, m_mr.get());
     copy.setup(cluster_sizes_buffer);
 
@@ -92,13 +92,14 @@ spacepoint_container_buffer clusterization_algorithm::operator()(
                                    cluster_prefix_sum,
                                    vecmem::get_data(cells_prefix_sum), m_queue);
 
-    std::vector<std::size_t> cluster_sizes;
+    std::vector<unsigned int> cluster_sizes;
     copy(cluster_sizes_buffer, cluster_sizes);
 
     // Cluster container buffer for the clusters and headers (cluster ids)
     cluster_container_types::buffer clusters_buffer{
         {*total_clusters, m_mr.get()},
-        {std::vector<std::size_t>(*total_clusters, 0), cluster_sizes,
+        {std::vector<std::size_t>(*total_clusters, 0),
+         std::vector<std::size_t>(cluster_sizes.begin(), cluster_sizes.end()),
          m_mr.get()}};
     copy.setup(clusters_buffer.headers);
     copy.setup(clusters_buffer.items);
@@ -141,11 +142,6 @@ spacepoint_container_buffer clusterization_algorithm::operator()(
     traccc::sycl::spacepoint_formation(
         spacepoints_buffer, measurements_buffer,
         vecmem::get_data(measurements_prefix_sum), m_queue);
-
-    // Copy the results back to the host
-    // host_spacepoint_container spacepoints_per_event(&m_mr.get());
-    // copy(spacepoints_buffer.headers, spacepoints_per_event.get_headers());
-    // copy(spacepoints_buffer.items, spacepoints_per_event.get_items());
 
     return spacepoints_buffer;
 }

--- a/device/sycl/src/clusterization/clusterization_algorithm.cpp
+++ b/device/sycl/src/clusterization/clusterization_algorithm.cpp
@@ -83,22 +83,22 @@ spacepoint_container_buffer clusterization_algorithm::operator()(
                                m_queue);
 
     // Vector of the exact cluster sizes, will be filled in cluster counting
-    vecmem::data::vector_buffer<std::size_t> cluster_sizes_buffer(*total_clusters, m_mr.get());
+    vecmem::data::vector_buffer<std::size_t> cluster_sizes_buffer(
+        *total_clusters, m_mr.get());
     copy.setup(cluster_sizes_buffer);
 
     // Cluster counting kernel
-    traccc::sycl::cluster_counting(
-        sparse_ccl_indices, cluster_sizes_buffer, cluster_prefix_sum,
-        vecmem::get_data(cells_prefix_sum), m_queue);
-    
+    traccc::sycl::cluster_counting(sparse_ccl_indices, cluster_sizes_buffer,
+                                   cluster_prefix_sum,
+                                   vecmem::get_data(cells_prefix_sum), m_queue);
+
     std::vector<std::size_t> cluster_sizes;
     copy(cluster_sizes_buffer, cluster_sizes);
 
     // Cluster container buffer for the clusters and headers (cluster ids)
     cluster_container_types::buffer clusters_buffer{
         {*total_clusters, m_mr.get()},
-        {std::vector<std::size_t>(*total_clusters, 0),
-        cluster_sizes,
+        {std::vector<std::size_t>(*total_clusters, 0), cluster_sizes,
          m_mr.get()}};
     copy.setup(clusters_buffer.headers);
     copy.setup(clusters_buffer.items);

--- a/device/sycl/src/clusterization/clusterization_algorithm.cpp
+++ b/device/sycl/src/clusterization/clusterization_algorithm.cpp
@@ -29,7 +29,7 @@ clusterization_algorithm::clusterization_algorithm(vecmem::memory_resource &mr,
                                                    queue_wrapper queue)
     : m_mr(mr), m_queue(queue) {}
 
-host_spacepoint_container clusterization_algorithm::operator()(
+spacepoint_container_buffer clusterization_algorithm::operator()(
     const cell_container_types::host &cells_per_event) const {
 
     // Number of modules
@@ -139,11 +139,11 @@ host_spacepoint_container clusterization_algorithm::operator()(
         vecmem::get_data(measurements_prefix_sum), m_queue);
 
     // Copy the results back to the host
-    host_spacepoint_container spacepoints_per_event(&m_mr.get());
-    copy(spacepoints_buffer.headers, spacepoints_per_event.get_headers());
-    copy(spacepoints_buffer.items, spacepoints_per_event.get_items());
+    // host_spacepoint_container spacepoints_per_event(&m_mr.get());
+    // copy(spacepoints_buffer.headers, spacepoints_per_event.get_headers());
+    // copy(spacepoints_buffer.items, spacepoints_per_event.get_items());
 
-    return spacepoints_per_event;
+    return spacepoints_buffer;
 }
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -126,7 +126,7 @@ seed_finding::output_type seed_finding::operator()(
         .wait_and_throw();
 
     // The number of bins.
-    const std::size_t nbins = g2_view._data_view.m_size;
+    unsigned int nbins = g2_view._data_view.m_size;
 
     vecmem::vector<doublet_per_bin> mb_headers(&m_mr.get());
     copy(doublet_buffers.middleBottom.headers, mb_headers);
@@ -137,48 +137,60 @@ seed_finding::output_type seed_finding::operator()(
         [](const device::doublet_counter_header& dc) { return dc.m_nMidBot; });
 
     // create the triplet_counter container with the number of doublets
-    host_triplet_counter_container triplet_counter_container(nbins,
-                                                             &m_mr.get());
-    for (std::size_t i = 0; i < nbins; ++i) {
-        triplet_counter_container.get_headers()[i].zeros();
-        triplet_counter_container.get_items()[i].resize(mb_buffer_sizes[i]);
-    }
+    triplet_counter_container_buffer tcc_buffer{{nbins, m_mr.get()}, 
+                                                {mb_buffer_sizes, m_mr.get()}};
+    copy.setup(tcc_buffer.headers);
+    copy.setup(tcc_buffer.items);
 
     // triplet counting
     triplet_counting(m_seedfinder_config, mb_headers, g2_view,
                      doublet_counter_view, mb_view, mt_view,
-                     triplet_counter_container, m_mr.get(), m_queue);
+                     tcc_buffer, m_queue);
 
-    // create the triplet container with the number of triplets
-    host_triplet_container triplet_container(nbins, &m_mr.get());
-    for (size_t i = 0; i < nbins; ++i) {
-        triplet_container.get_headers()[i].zeros();
-        triplet_container.get_items()[i].resize(
-            triplet_counter_container.get_headers()[i].n_triplets);
+    // Take header of the triplet counter container buffer into host
+    vecmem::vector<triplet_counter_per_bin> tcc_headers(&m_mr.get());
+    copy(tcc_buffer.headers, tcc_headers);
+
+    // Fill the size vector for triplet container
+    std::vector<size_t> n_triplets_per_bin;
+    n_triplets_per_bin.reserve(nbins);
+    for (const auto& h : tcc_headers) {
+        n_triplets_per_bin.push_back(h.n_triplets);
     }
 
+    // Create triplet container buffer
+    triplet_container_buffer tc_buffer{{nbins, m_mr.get()},
+                                       {n_triplets_per_bin, m_mr.get()}};
+    copy.setup(tc_buffer.headers);
+    copy.setup(tc_buffer.items);
+
     // triplet finding
-    triplet_finding(m_seedfinder_config, m_seedfilter_config, g2_view,
+    triplet_finding(m_seedfinder_config, m_seedfilter_config, tcc_headers, g2_view,
                     doublet_counter_view, mb_view, mt_view,
-                    triplet_counter_container, triplet_container, m_mr.get(),
+                    tcc_buffer, tc_buffer,
                     m_queue);
 
+    // Take header of the triplet container buffer into host
+    vecmem::vector<triplet_per_bin> tc_headers(&m_mr.get());
+    copy(tc_buffer.headers, tc_headers);
+
     // weight updating
-    weight_updating(m_seedfilter_config, g2_view, triplet_counter_container,
-                    triplet_container, m_mr.get(), m_queue);
+    weight_updating(m_seedfilter_config, tc_headers, g2_view, tcc_buffer,
+                    tc_buffer, m_queue);
+
+    // Get the number of seeds (triplets)
+    auto n_triplets = std::accumulate(n_triplets_per_bin.begin(),
+                                      n_triplets_per_bin.end(), 0);
 
     vecmem::data::vector_buffer<seed> seed_buffer(
-        triplet_container.total_size(), 0, m_mr.get());
+        n_triplets, 0, m_mr.get());
     copy.setup(seed_buffer);
 
     // seed selecting
     seed_selecting(m_seedfilter_config, doublet_counts,
                    spacepoints_view, g2_view,
-                   doublet_counter_view, triplet_counter_container,
-                   triplet_container, seed_buffer, m_mr.get(), m_queue);
-
-    // host_seed_collection seed_collection(&m_mr.get());
-    // copy(seed_buffer, seed_collection);
+                   doublet_counter_view, tcc_buffer,
+                   tc_buffer, seed_buffer, m_queue);
 
     return seed_buffer;
 }

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -44,7 +44,7 @@ seed_finding::seed_finding(const seedfinder_config& config,
     : m_seedfinder_config(config), m_mr(mr), m_queue(queue) {}
 
 seed_finding::output_type seed_finding::operator()(
-    const host_spacepoint_container& spacepoints,
+    const spacepoint_container_const_view& spacepoints_view,
     const sp_grid_const_view& g2_view) const {
 
     // Helper object for the data management.
@@ -173,14 +173,14 @@ seed_finding::output_type seed_finding::operator()(
 
     // seed selecting
     seed_selecting(m_seedfilter_config, doublet_counts,
-                   const_cast<host_spacepoint_container&>(spacepoints), g2_view,
+                   spacepoints_view, g2_view,
                    doublet_counter_view, triplet_counter_container,
                    triplet_container, seed_buffer, m_mr.get(), m_queue);
 
-    host_seed_collection seed_collection(&m_mr.get());
-    copy(seed_buffer, seed_collection);
+    // host_seed_collection seed_collection(&m_mr.get());
+    // copy(seed_buffer, seed_collection);
 
-    return seed_collection;
+    return seed_buffer;
 }
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -137,15 +137,15 @@ seed_finding::output_type seed_finding::operator()(
         [](const device::doublet_counter_header& dc) { return dc.m_nMidBot; });
 
     // create the triplet_counter container with the number of doublets
-    triplet_counter_container_buffer tcc_buffer{{nbins, m_mr.get()}, 
+    triplet_counter_container_buffer tcc_buffer{{nbins, m_mr.get()},
                                                 {mb_buffer_sizes, m_mr.get()}};
     copy.setup(tcc_buffer.headers);
     copy.setup(tcc_buffer.items);
 
     // triplet counting
     triplet_counting(m_seedfinder_config, mb_headers, g2_view,
-                     doublet_counter_view, mb_view, mt_view,
-                     tcc_buffer, m_queue);
+                     doublet_counter_view, mb_view, mt_view, tcc_buffer,
+                     m_queue);
 
     // Take header of the triplet counter container buffer into host
     vecmem::vector<triplet_counter_per_bin> tcc_headers(&m_mr.get());
@@ -165,10 +165,9 @@ seed_finding::output_type seed_finding::operator()(
     copy.setup(tc_buffer.items);
 
     // triplet finding
-    triplet_finding(m_seedfinder_config, m_seedfilter_config, tcc_headers, g2_view,
-                    doublet_counter_view, mb_view, mt_view,
-                    tcc_buffer, tc_buffer,
-                    m_queue);
+    triplet_finding(m_seedfinder_config, m_seedfilter_config, tcc_headers,
+                    g2_view, doublet_counter_view, mb_view, mt_view, tcc_buffer,
+                    tc_buffer, m_queue);
 
     // Take header of the triplet container buffer into host
     vecmem::vector<triplet_per_bin> tc_headers(&m_mr.get());
@@ -182,15 +181,13 @@ seed_finding::output_type seed_finding::operator()(
     auto n_triplets = std::accumulate(n_triplets_per_bin.begin(),
                                       n_triplets_per_bin.end(), 0);
 
-    vecmem::data::vector_buffer<seed> seed_buffer(
-        n_triplets, 0, m_mr.get());
+    vecmem::data::vector_buffer<seed> seed_buffer(n_triplets, 0, m_mr.get());
     copy.setup(seed_buffer);
 
     // seed selecting
-    seed_selecting(m_seedfilter_config, doublet_counts,
-                   spacepoints_view, g2_view,
-                   doublet_counter_view, tcc_buffer,
-                   tc_buffer, seed_buffer, m_queue);
+    seed_selecting(m_seedfilter_config, doublet_counts, spacepoints_view,
+                   g2_view, doublet_counter_view, tcc_buffer, tc_buffer,
+                   seed_buffer, m_queue);
 
     return seed_buffer;
 }

--- a/device/sycl/src/seeding/seed_selecting.hpp
+++ b/device/sycl/src/seeding/seed_selecting.hpp
@@ -42,9 +42,7 @@ void seed_selecting(
     const sp_grid_const_view& internal_sp,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,
-    triplet_counter_container_view tcc_view,
-    triplet_container_view tc_view,
-    vecmem::data::vector_buffer<seed>& seed_buffer,
-    queue_wrapper queue);
+    triplet_counter_container_view tcc_view, triplet_container_view tc_view,
+    vecmem::data::vector_buffer<seed>& seed_buffer, queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/seeding/seed_selecting.hpp
+++ b/device/sycl/src/seeding/seed_selecting.hpp
@@ -42,9 +42,9 @@ void seed_selecting(
     const sp_grid_const_view& internal_sp,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,
-    host_triplet_counter_container& triplet_counter_container,
-    host_triplet_container& triplet_container,
+    triplet_counter_container_view tcc_view,
+    triplet_container_view tc_view,
     vecmem::data::vector_buffer<seed>& seed_buffer,
-    vecmem::memory_resource& resource, queue_wrapper queue);
+    queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/seeding/seed_selecting.hpp
+++ b/device/sycl/src/seeding/seed_selecting.hpp
@@ -38,7 +38,7 @@ namespace traccc::sycl {
 void seed_selecting(
     const seedfilter_config& filter_config,
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
-    host_spacepoint_container& spacepoints,
+    const spacepoint_container_const_view& spacepoints_view,
     const sp_grid_const_view& internal_sp,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,

--- a/device/sycl/src/seeding/seed_selecting.sycl
+++ b/device/sycl/src/seeding/seed_selecting.sycl
@@ -56,7 +56,7 @@ static int min_elem(const local_accessor<triplet>& arr, const int& begin_idx,
 class SeedSelect {
     public:
     SeedSelect(const seedfilter_config filter_config,
-               spacepoint_container_view spacepoints_view,
+               spacepoint_container_const_view spacepoints_view,
                sp_grid_const_view internal_sp_view,
                device::doublet_counter_container_types::const_view
                    doublet_counter_view,
@@ -79,7 +79,7 @@ class SeedSelect {
         auto workItemIdx = item.get_local_id(0);
 
         // Get device container for input parameters
-        device_spacepoint_container spacepoints_device(m_spacepoints_view);
+        device_spacepoint_const_container spacepoints_device(m_spacepoints_view);
 
         const_sp_grid_device internal_sp_device(m_internal_sp_view);
 
@@ -243,7 +243,7 @@ class SeedSelect {
 
     private:
     const seedfilter_config m_filter_config;
-    spacepoint_container_view m_spacepoints_view;
+    spacepoint_container_const_view m_spacepoints_view;
     sp_grid_const_view m_internal_sp_view;
     device::doublet_counter_container_types::const_view m_doublet_counter_view;
     triplet_counter_container_view m_triplet_counter_view;
@@ -255,7 +255,7 @@ class SeedSelect {
 void seed_selecting(
     const seedfilter_config& filter_config,
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
-    host_spacepoint_container& spacepoints,
+    const spacepoint_container_const_view& spacepoints_view,
     const sp_grid_const_view& internal_sp,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,
@@ -264,7 +264,6 @@ void seed_selecting(
     vecmem::data::vector_buffer<seed>& seed_buffer,
     vecmem::memory_resource& resource, queue_wrapper queue) {
 
-    auto spacepoints_view = get_data(spacepoints, &resource);
     auto triplet_counter_container_view =
         get_data(triplet_counter_container, &resource);
     auto triplet_container_view = get_data(triplet_container, &resource);

--- a/device/sycl/src/seeding/seed_selecting.sycl
+++ b/device/sycl/src/seeding/seed_selecting.sycl
@@ -79,7 +79,8 @@ class SeedSelect {
         auto workItemIdx = item.get_local_id(0);
 
         // Get device container for input parameters
-        device_spacepoint_const_container spacepoints_device(m_spacepoints_view);
+        device_spacepoint_const_container spacepoints_device(
+            m_spacepoints_view);
 
         const_sp_grid_device internal_sp_device(m_internal_sp_view);
 
@@ -259,10 +260,8 @@ void seed_selecting(
     const sp_grid_const_view& internal_sp,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,
-    triplet_counter_container_view tcc_view,
-    triplet_container_view tc_view,
-    vecmem::data::vector_buffer<seed>& seed_buffer,
-    queue_wrapper queue) {
+    triplet_counter_container_view tcc_view, triplet_container_view tc_view,
+    vecmem::data::vector_buffer<seed>& seed_buffer, queue_wrapper queue) {
 
     // The thread-block is desinged to make each thread find triplets per
     // compatible middle-bot doublet
@@ -290,9 +289,8 @@ void seed_selecting(
                 h);
 
             SeedSelect kernel(filter_config, spacepoints_view, internal_sp,
-                              doublet_counter_container,
-                              tcc_view,
-                              tc_view, seed_buffer, localMem);
+                              doublet_counter_container, tcc_view, tc_view,
+                              seed_buffer, localMem);
 
             h.parallel_for<SeedSelect>(seedSelectNdRange, kernel);
         })

--- a/device/sycl/src/seeding/seed_selecting.sycl
+++ b/device/sycl/src/seeding/seed_selecting.sycl
@@ -259,14 +259,10 @@ void seed_selecting(
     const sp_grid_const_view& internal_sp,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,
-    host_triplet_counter_container& triplet_counter_container,
-    host_triplet_container& triplet_container,
+    triplet_counter_container_view tcc_view,
+    triplet_container_view tc_view,
     vecmem::data::vector_buffer<seed>& seed_buffer,
-    vecmem::memory_resource& resource, queue_wrapper queue) {
-
-    auto triplet_counter_container_view =
-        get_data(triplet_counter_container, &resource);
-    auto triplet_container_view = get_data(triplet_container, &resource);
+    queue_wrapper queue) {
 
     // The thread-block is desinged to make each thread find triplets per
     // compatible middle-bot doublet
@@ -295,8 +291,8 @@ void seed_selecting(
 
             SeedSelect kernel(filter_config, spacepoints_view, internal_sp,
                               doublet_counter_container,
-                              triplet_counter_container_view,
-                              triplet_container_view, seed_buffer, localMem);
+                              tcc_view,
+                              tc_view, seed_buffer, localMem);
 
             h.parallel_for<SeedSelect>(seedSelectNdRange, kernel);
         })

--- a/device/sycl/src/seeding/spacepoint_binning.sycl
+++ b/device/sycl/src/seeding/spacepoint_binning.sycl
@@ -43,18 +43,14 @@ spacepoint_binning::spacepoint_binning(
       m_queue(queue) {}
 
 sp_grid_buffer spacepoint_binning::operator()(
-    const host_spacepoint_container& spacepoints) const {
+    const spacepoint_container_const_view& spacepoints_view) const {
 
     // Helper object for the data management.
     vecmem::copy copy;
 
-    // Get the data/view for the spacepoints.
-    const spacepoint_container_const_data sp_data =
-        traccc::get_data(spacepoints);
-
     // Get the prefix sum for the spacepoints.
     const device::prefix_sum_t sp_prefix_sum =
-        device::get_prefix_sum(sp_data.items, m_mr.get(), copy);
+        device::get_prefix_sum(spacepoints_view.items, m_mr.get(), copy);
     auto sp_prefix_sum_view = vecmem::get_data(sp_prefix_sum);
 
     // Set up the container that will be filled with the required capacities for
@@ -69,9 +65,6 @@ sp_grid_buffer spacepoint_binning::operator()(
     ::sycl::nd_range<1> range(globalSize, localSize);
 
     // Fill the grid capacity container.
-    spacepoint_container_const_data spacepoints_data =
-        traccc::get_data(spacepoints);
-    spacepoint_container_const_view spacepoints_view = spacepoints_data;
     details::get_queue(m_queue)
         .submit([&](::sycl::handler& h) {
             h.parallel_for<kernels::count_grid_capacities>(

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -37,7 +37,8 @@ class TrackParamsEstimation {
         auto workItemIdx = item.get_local_id(0);
 
         // Get device container for input parameters
-        device_spacepoint_const_container spacepoints_device(m_spacepoints_view);
+        device_spacepoint_const_container spacepoints_device(
+            m_spacepoints_view);
         vecmem::device_vector<const seed> seeds_device(m_seeds_view);
         device_bound_track_parameters_collection params_device(m_params_view);
 

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -20,8 +20,8 @@ namespace traccc::sycl {
 class TrackParamsEstimation {
     public:
     TrackParamsEstimation(
-        spacepoint_container_view spacepoints_view,
-        vecmem::data::vector_view<seed> seeds_view,
+        spacepoint_container_const_view spacepoints_view,
+        vecmem::data::vector_view<const seed> seeds_view,
         vecmem::data::vector_view<bound_track_parameters> params_view)
         : m_spacepoints_view(spacepoints_view),
           m_seeds_view(seeds_view),
@@ -37,8 +37,8 @@ class TrackParamsEstimation {
         auto workItemIdx = item.get_local_id(0);
 
         // Get device container for input parameters
-        device_spacepoint_container spacepoints_device(m_spacepoints_view);
-        device_seed_collection seeds_device(m_seeds_view);
+        device_spacepoint_const_container spacepoints_device(m_spacepoints_view);
+        vecmem::device_vector<const seed> seeds_device(m_seeds_view);
         device_bound_track_parameters_collection params_device(m_params_view);
 
         // vector index for threads
@@ -61,8 +61,8 @@ class TrackParamsEstimation {
     }
 
     private:
-    spacepoint_container_view m_spacepoints_view;
-    vecmem::data::vector_view<seed> m_seeds_view;
+    spacepoint_container_const_view m_spacepoints_view;
+    vecmem::data::vector_view<const seed> m_seeds_view;
     vecmem::data::vector_view<bound_track_parameters> m_params_view;
 };
 
@@ -71,18 +71,16 @@ track_params_estimation::track_params_estimation(vecmem::memory_resource& mr,
     : m_mr(mr), m_queue(queue) {}
 
 track_params_estimation::output_type track_params_estimation::operator()(
-    host_spacepoint_container&& spacepoints,
-    host_seed_collection&& seeds) const {
+    const spacepoint_container_const_view& spacepoints_view,
+    const vecmem::data::vector_view<const seed>& seeds_view) const {
 
-    output_type params(seeds.size(), &m_mr.get());
+    output_type params(seeds_view.size(), &m_mr.get());
 
     // Check if anything needs to be done.
-    if (seeds.size() == 0) {
+    if (seeds_view.size() == 0) {
         return params;
     }
 
-    auto spacepoints_view = get_data(spacepoints, &m_mr.get());
-    auto seeds_view = vecmem::get_data(seeds);
     auto params_view = vecmem::get_data(params);
 
     // -- localSize
@@ -92,7 +90,7 @@ track_params_estimation::output_type track_params_estimation::operator()(
 
     // -- Num groups
     // The dimension of grid is number_of_seeds / localSize + 1
-    unsigned int num_groups = (seeds.size() + localSize - 1) / localSize;
+    unsigned int num_groups = (seeds_view.size() + localSize - 1) / localSize;
 
     unsigned int globalSize = localSize * num_groups;
     // 1 dim ND Range for the kernel

--- a/device/sycl/src/seeding/triplet_counting.hpp
+++ b/device/sycl/src/seeding/triplet_counting.hpp
@@ -41,7 +41,7 @@ void triplet_counting(const seedfinder_config& config,
                           doublet_counter_container,
                       doublet_container_view mid_bot_doublet_container,
                       doublet_container_view mid_top_doublet_container,
-                      host_triplet_counter_container& triplet_counter_container,
-                      vecmem::memory_resource& resource, queue_wrapper queue);
+                      triplet_counter_container_view tcc_view,
+                      queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/seeding/triplet_counting.sycl
+++ b/device/sycl/src/seeding/triplet_counting.sycl
@@ -214,25 +214,27 @@ void triplet_counting(const seedfinder_config& config,
     auto tripletCountNdRange = ::sycl::nd_range<1>{globalSize, localSize};
 
     // Set zero kernel
-    details::get_queue(queue).submit([&](::sycl::handler& h){
-        h.parallel_for<class SetZeroTripletCount>(tripletCountNdRange, [tcc_view](::sycl::nd_item<1> item){
-            auto idx = item.get_global_linear_id();
-            
-            device_triplet_counter_container tcc_device(tcc_view);
-            if (idx >= tcc_device.size())
-                return;
+    details::get_queue(queue)
+        .submit([&](::sycl::handler& h) {
+            h.parallel_for<class SetZeroTripletCount>(
+                tripletCountNdRange, [tcc_view](::sycl::nd_item<1> item) {
+                    auto idx = item.get_global_linear_id();
 
-            tcc_device.get_headers().at(idx).zeros();
-        });
-    }).wait_and_throw();
+                    device_triplet_counter_container tcc_device(tcc_view);
+                    if (idx >= tcc_device.size())
+                        return;
+
+                    tcc_device.get_headers().at(idx).zeros();
+                });
+        })
+        .wait_and_throw();
 
     // triplet counting kernel
     details::get_queue(queue)
         .submit([&](::sycl::handler& h) {
             TripletCount kernel(config, internal_sp, doublet_counter_container,
                                 mid_bot_doublet_container,
-                                mid_top_doublet_container,
-                                tcc_view);
+                                mid_top_doublet_container, tcc_view);
             h.parallel_for<TripletCount>(tripletCountNdRange, kernel);
         })
         .wait_and_throw();

--- a/device/sycl/src/seeding/triplet_counting.sycl
+++ b/device/sycl/src/seeding/triplet_counting.sycl
@@ -192,11 +192,8 @@ void triplet_counting(const seedfinder_config& config,
                           doublet_counter_container,
                       doublet_container_view mid_bot_doublet_container,
                       doublet_container_view mid_top_doublet_container,
-                      host_triplet_counter_container& triplet_counter_container,
-                      vecmem::memory_resource& resource, queue_wrapper queue) {
-
-    auto triplet_counter_container_view =
-        get_data(triplet_counter_container, &resource);
+                      triplet_counter_container_view tcc_view,
+                      queue_wrapper queue) {
 
     // The thread-block is desinged to make each thread count triplets per
     // middle-bot doublet
@@ -216,12 +213,26 @@ void triplet_counting(const seedfinder_config& config,
     // 1 dim ND Range for the kernel
     auto tripletCountNdRange = ::sycl::nd_range<1>{globalSize, localSize};
 
+    // Set zero kernel
+    details::get_queue(queue).submit([&](::sycl::handler& h){
+        h.parallel_for<class SetZeroTripletCount>(tripletCountNdRange, [tcc_view](::sycl::nd_item<1> item){
+            auto idx = item.get_global_linear_id();
+            
+            device_triplet_counter_container tcc_device(tcc_view);
+            if (idx >= tcc_device.size())
+                return;
+
+            tcc_device.get_headers().at(idx).zeros();
+        });
+    }).wait_and_throw();
+
+    // triplet counting kernel
     details::get_queue(queue)
         .submit([&](::sycl::handler& h) {
             TripletCount kernel(config, internal_sp, doublet_counter_container,
                                 mid_bot_doublet_container,
                                 mid_top_doublet_container,
-                                triplet_counter_container_view);
+                                tcc_view);
             h.parallel_for<TripletCount>(tripletCountNdRange, kernel);
         })
         .wait_and_throw();

--- a/device/sycl/src/seeding/triplet_finding.hpp
+++ b/device/sycl/src/seeding/triplet_finding.hpp
@@ -38,13 +38,14 @@ namespace traccc::sycl {
 /// @param q sycl queue for kernel scheduling
 void triplet_finding(const seedfinder_config& config,
                      const seedfilter_config& filter_config,
+                     const vecmem::vector<triplet_counter_per_bin>& tcc_headers,
                      const sp_grid_const_view& internal_sp,
                      const device::doublet_counter_container_types::const_view&
                          doublet_counter_container,
                      doublet_container_view mid_bot_doublet_container,
                      doublet_container_view mid_top_doublet_container,
-                     host_triplet_counter_container& triplet_counter_container,
-                     host_triplet_container& triplet_container,
-                     vecmem::memory_resource& resource, queue_wrapper queue);
+                     triplet_counter_container_view tcc_view,
+                     triplet_container_view tc_view,
+                     queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/seeding/triplet_finding.hpp
+++ b/device/sycl/src/seeding/triplet_finding.hpp
@@ -45,7 +45,6 @@ void triplet_finding(const seedfinder_config& config,
                      doublet_container_view mid_bot_doublet_container,
                      doublet_container_view mid_top_doublet_container,
                      triplet_counter_container_view tcc_view,
-                     triplet_container_view tc_view,
-                     queue_wrapper queue);
+                     triplet_container_view tc_view, queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/seeding/triplet_finding.sycl
+++ b/device/sycl/src/seeding/triplet_finding.sycl
@@ -261,36 +261,49 @@ class TripletFind {
 
 void triplet_finding(const seedfinder_config& config,
                      const seedfilter_config& filter_config,
+                     const vecmem::vector<triplet_counter_per_bin>& tcc_headers,
                      const sp_grid_const_view& internal_sp,
                      const device::doublet_counter_container_types::const_view&
                          doublet_counter_container,
                      doublet_container_view mid_bot_doublet_container,
                      doublet_container_view mid_top_doublet_container,
-                     host_triplet_counter_container& triplet_counter_container,
-                     host_triplet_container& triplet_container,
-                     vecmem::memory_resource& resource, queue_wrapper queue) {
-
-    auto triplet_counter_view = get_data(triplet_counter_container, &resource);
-    auto triplet_view = get_data(triplet_container, &resource);
+                     triplet_counter_container_view tcc_view,
+                     triplet_container_view tc_view,
+                     queue_wrapper queue) {
 
     // The thread-block is desinged to make each thread find triplets per
     // compatible middle-bot doublet
 
+    unsigned int nbins = internal_sp._data_view.m_size;
     // -- localSize
     // The dimension of workGroup (block) is the integer multiple of WARP_SIZE
     // (=32)
     unsigned int localSize = 64;
     // Calculate the global number of threads to run in kernel
     unsigned int num_groups = 0;
-    for (unsigned int i = 0; i < internal_sp._data_view.m_size; ++i) {
+    for (unsigned int i = 0; i < nbins; ++i) {
         num_groups +=
-            triplet_counter_container.get_headers()[i].n_mid_bot / localSize +
+            tcc_headers[i].n_mid_bot / localSize +
             1;
     }
     unsigned int globalSize = localSize * num_groups;
 
     // 1 dim ND Range for the kernel
     auto tripletFindNdRange = ::sycl::nd_range<1>{globalSize, localSize};
+
+    // Set zero kernel
+    details::get_queue(queue).submit([&](::sycl::handler& h){
+        h.parallel_for<class SetZeroTripletFind>(tripletFindNdRange, [tc_view](::sycl::nd_item<1> item){
+            auto idx = item.get_global_linear_id();
+            
+            device_triplet_container tc_device(tc_view);
+            if (idx >= tc_device.size())
+                return;
+
+            tc_device.get_headers().at(idx).zeros();
+        });
+    }).wait_and_throw();
+
     details::get_queue(queue)
         .submit([&](::sycl::handler& h) {
             // local memory initialization (equivalent to shared memory in CUDA)
@@ -299,7 +312,7 @@ void triplet_finding(const seedfinder_config& config,
             TripletFind kernel(
                 config, filter_config, internal_sp, doublet_counter_container,
                 mid_bot_doublet_container, mid_top_doublet_container,
-                triplet_counter_view, triplet_view, localMem);
+                tcc_view, tc_view, localMem);
 
             h.parallel_for<TripletFind>(tripletFindNdRange, kernel);
         })

--- a/device/sycl/src/seeding/triplet_finding.sycl
+++ b/device/sycl/src/seeding/triplet_finding.sycl
@@ -268,8 +268,7 @@ void triplet_finding(const seedfinder_config& config,
                      doublet_container_view mid_bot_doublet_container,
                      doublet_container_view mid_top_doublet_container,
                      triplet_counter_container_view tcc_view,
-                     triplet_container_view tc_view,
-                     queue_wrapper queue) {
+                     triplet_container_view tc_view, queue_wrapper queue) {
 
     // The thread-block is desinged to make each thread find triplets per
     // compatible middle-bot doublet
@@ -282,9 +281,7 @@ void triplet_finding(const seedfinder_config& config,
     // Calculate the global number of threads to run in kernel
     unsigned int num_groups = 0;
     for (unsigned int i = 0; i < nbins; ++i) {
-        num_groups +=
-            tcc_headers[i].n_mid_bot / localSize +
-            1;
+        num_groups += tcc_headers[i].n_mid_bot / localSize + 1;
     }
     unsigned int globalSize = localSize * num_groups;
 
@@ -292,17 +289,20 @@ void triplet_finding(const seedfinder_config& config,
     auto tripletFindNdRange = ::sycl::nd_range<1>{globalSize, localSize};
 
     // Set zero kernel
-    details::get_queue(queue).submit([&](::sycl::handler& h){
-        h.parallel_for<class SetZeroTripletFind>(tripletFindNdRange, [tc_view](::sycl::nd_item<1> item){
-            auto idx = item.get_global_linear_id();
-            
-            device_triplet_container tc_device(tc_view);
-            if (idx >= tc_device.size())
-                return;
+    details::get_queue(queue)
+        .submit([&](::sycl::handler& h) {
+            h.parallel_for<class SetZeroTripletFind>(
+                tripletFindNdRange, [tc_view](::sycl::nd_item<1> item) {
+                    auto idx = item.get_global_linear_id();
 
-            tc_device.get_headers().at(idx).zeros();
-        });
-    }).wait_and_throw();
+                    device_triplet_container tc_device(tc_view);
+                    if (idx >= tc_device.size())
+                        return;
+
+                    tc_device.get_headers().at(idx).zeros();
+                });
+        })
+        .wait_and_throw();
 
     details::get_queue(queue)
         .submit([&](::sycl::handler& h) {
@@ -311,8 +311,8 @@ void triplet_finding(const seedfinder_config& config,
 
             TripletFind kernel(
                 config, filter_config, internal_sp, doublet_counter_container,
-                mid_bot_doublet_container, mid_top_doublet_container,
-                tcc_view, tc_view, localMem);
+                mid_bot_doublet_container, mid_top_doublet_container, tcc_view,
+                tc_view, localMem);
 
             h.parallel_for<TripletFind>(tripletFindNdRange, kernel);
         })

--- a/device/sycl/src/seeding/weight_updating.hpp
+++ b/device/sycl/src/seeding/weight_updating.hpp
@@ -32,9 +32,10 @@ namespace traccc::sycl {
 /// @param resource vecmem memory resource
 /// @param q sycl queue for kernel scheduling
 void weight_updating(const seedfilter_config& filter_config,
+                     const vecmem::vector<triplet_per_bin>& tc_headers,
                      const sp_grid_const_view& internal_sp,
-                     host_triplet_counter_container& triplet_counter_container,
-                     host_triplet_container& triplet_container,
-                     vecmem::memory_resource& resource, queue_wrapper queue);
+                     triplet_counter_container_view tcc_view, 
+                     triplet_container_view tc_view,
+                     queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/seeding/weight_updating.hpp
+++ b/device/sycl/src/seeding/weight_updating.hpp
@@ -34,8 +34,7 @@ namespace traccc::sycl {
 void weight_updating(const seedfilter_config& filter_config,
                      const vecmem::vector<triplet_per_bin>& tc_headers,
                      const sp_grid_const_view& internal_sp,
-                     triplet_counter_container_view tcc_view, 
-                     triplet_container_view tc_view,
-                     queue_wrapper queue);
+                     triplet_counter_container_view tcc_view,
+                     triplet_container_view tc_view, queue_wrapper queue);
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/seeding/weight_updating.sycl
+++ b/device/sycl/src/seeding/weight_updating.sycl
@@ -174,16 +174,16 @@ class WeightUpdate {
 };
 
 void weight_updating(const seedfilter_config& filter_config,
-                     const sp_grid_const_view& internal_sp,
-                     host_triplet_counter_container& triplet_counter_container,
-                     host_triplet_container& triplet_container,
-                     vecmem::memory_resource& resource, queue_wrapper queue) {
-
-    auto triplet_counter_view = get_data(triplet_counter_container, &resource);
-    auto triplet_view = get_data(triplet_container, &resource);
+                     const vecmem::vector<triplet_per_bin>& tc_headers,
+                     const sp_grid_const_view& internal_sp_view,
+                     triplet_counter_container_view tcc_view, 
+                     triplet_container_view tc_view,
+                     queue_wrapper queue) {
 
     // The thread-block is desinged to make each thread find triplets per
     // compatible middle-bot doublet
+
+    unsigned int nbins = internal_sp_view._data_view.m_size;
 
     // -- localSize
     // The dimension of workGroup (block) is the integer multiple of WARP_SIZE
@@ -191,9 +191,9 @@ void weight_updating(const seedfilter_config& filter_config,
     unsigned int localSize = 64;
     // Calculate the global number of threads to run in kernel
     unsigned int num_groups = 0;
-    for (unsigned int i = 0; i < internal_sp._data_view.m_size; ++i) {
+    for (unsigned int i = 0; i < nbins; ++i) {
         num_groups +=
-            triplet_container.get_headers()[i].n_triplets / localSize + 1;
+            tc_headers[i].n_triplets / localSize + 1;
     }
     unsigned int globalSize = localSize * num_groups;
     // 1 dim ND Range for the kernel
@@ -205,8 +205,8 @@ void weight_updating(const seedfilter_config& filter_config,
             auto localMem = local_accessor<scalar>(
                 ::sycl::range<1>(filter_config.compatSeedLimit), h);
 
-            WeightUpdate kernel(filter_config, internal_sp,
-                                triplet_counter_view, triplet_view, localMem);
+            WeightUpdate kernel(filter_config, internal_sp_view,
+                                tcc_view, tc_view, localMem);
 
             h.parallel_for<WeightUpdate>(weightUpdateNdRange, kernel);
         })

--- a/device/sycl/src/seeding/weight_updating.sycl
+++ b/device/sycl/src/seeding/weight_updating.sycl
@@ -176,9 +176,8 @@ class WeightUpdate {
 void weight_updating(const seedfilter_config& filter_config,
                      const vecmem::vector<triplet_per_bin>& tc_headers,
                      const sp_grid_const_view& internal_sp_view,
-                     triplet_counter_container_view tcc_view, 
-                     triplet_container_view tc_view,
-                     queue_wrapper queue) {
+                     triplet_counter_container_view tcc_view,
+                     triplet_container_view tc_view, queue_wrapper queue) {
 
     // The thread-block is desinged to make each thread find triplets per
     // compatible middle-bot doublet
@@ -192,8 +191,7 @@ void weight_updating(const seedfilter_config& filter_config,
     // Calculate the global number of threads to run in kernel
     unsigned int num_groups = 0;
     for (unsigned int i = 0; i < nbins; ++i) {
-        num_groups +=
-            tc_headers[i].n_triplets / localSize + 1;
+        num_groups += tc_headers[i].n_triplets / localSize + 1;
     }
     unsigned int globalSize = localSize * num_groups;
     // 1 dim ND Range for the kernel
@@ -205,8 +203,8 @@ void weight_updating(const seedfilter_config& filter_config,
             auto localMem = local_accessor<scalar>(
                 ::sycl::range<1>(filter_config.compatSeedLimit), h);
 
-            WeightUpdate kernel(filter_config, internal_sp_view,
-                                tcc_view, tc_view, localMem);
+            WeightUpdate kernel(filter_config, internal_sp_view, tcc_view,
+                                tc_view, localMem);
 
             h.parallel_for<WeightUpdate>(weightUpdateNdRange, kernel);
         })

--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -15,11 +15,11 @@ traccc_add_executable( traccc_sycl_language_example
    "sycl_language_example.sycl" )
 
 # SYCL seeding executable(s).
-traccc_add_executable( seeding_example_sycl "seeding_example_sycl.sycl"
-   LINK_LIBRARIES traccc::options vecmem::core vecmem::sycl traccc::io
-                  traccc::core traccc::sycl traccc::performance)
+# traccc_add_executable( seeding_example_sycl "seeding_example_sycl.sycl"
+#    LINK_LIBRARIES traccc::options vecmem::core vecmem::sycl traccc::io
+#                   traccc::core traccc::sycl traccc::performance)
 
-target_compile_definitions( traccc_seeding_example_sycl PRIVATE EIGEN_NO_CUDA )
+# target_compile_definitions( traccc_seeding_example_sycl PRIVATE EIGEN_NO_CUDA )
 
 traccc_add_executable( seq_example_sycl "seq_example_sycl.sycl"
    LINK_LIBRARIES traccc::options vecmem::core vecmem::sycl traccc::io

--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -15,11 +15,11 @@ traccc_add_executable( traccc_sycl_language_example
    "sycl_language_example.sycl" )
 
 # SYCL seeding executable(s).
-# traccc_add_executable( seeding_example_sycl "seeding_example_sycl.sycl"
-#    LINK_LIBRARIES traccc::options vecmem::core vecmem::sycl traccc::io
-#                   traccc::core traccc::sycl traccc::performance)
+traccc_add_executable( seeding_example_sycl "seeding_example_sycl.sycl"
+   LINK_LIBRARIES traccc::options vecmem::core vecmem::sycl traccc::io
+                  traccc::core traccc::sycl traccc::performance)
 
-# target_compile_definitions( traccc_seeding_example_sycl PRIVATE EIGEN_NO_CUDA )
+target_compile_definitions( traccc_seeding_example_sycl PRIVATE EIGEN_NO_CUDA )
 
 traccc_add_executable( seq_example_sycl "seq_example_sycl.sycl"
    LINK_LIBRARIES traccc::options vecmem::core vecmem::sycl traccc::io

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -5,289 +5,295 @@
  * Mozilla Public License Version 2.0
  */
 
-// // SYCL include(s)
-// #include <CL/sycl.hpp>
-
-// // algorithms
-// #include "traccc/seeding/seeding_algorithm.hpp"
-// #include "traccc/seeding/track_params_estimation.hpp"
-// #include "traccc/sycl/seeding/seeding_algorithm.hpp"
-// #include "traccc/sycl/seeding/track_params_estimation.hpp"
+// SYCL include(s)
+#include <CL/sycl.hpp>
+
+// algorithms
+#include "traccc/seeding/seeding_algorithm.hpp"
+#include "traccc/seeding/track_params_estimation.hpp"
+#include "traccc/sycl/seeding/seeding_algorithm.hpp"
+#include "traccc/sycl/seeding/track_params_estimation.hpp"
+
+// io
+#include "traccc/io/csv.hpp"
+#include "traccc/io/reader.hpp"
+#include "traccc/io/writer.hpp"
+
+// performance
+#include "traccc/efficiency/seeding_performance_writer.hpp"
 
-// // io
-// #include "traccc/io/csv.hpp"
-// #include "traccc/io/reader.hpp"
-// #include "traccc/io/writer.hpp"
-
-// // performance
-// #include "traccc/efficiency/seeding_performance_writer.hpp"
+// options
+#include "traccc/options/common_options.hpp"
+#include "traccc/options/handle_argument_errors.hpp"
+#include "traccc/options/seeding_input_options.hpp"
 
-// // options
-// #include "traccc/options/common_options.hpp"
-// #include "traccc/options/handle_argument_errors.hpp"
-// #include "traccc/options/seeding_input_options.hpp"
+// Vecmem include(s)
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/memory/sycl/shared_memory_resource.hpp>
+#include <vecmem/utils/copy.hpp>
 
-// // Vecmem include(s)
-// #include <vecmem/memory/host_memory_resource.hpp>
-// #include <vecmem/memory/sycl/shared_memory_resource.hpp>
+// System include(s).
+#include <chrono>
+#include <exception>
+#include <iomanip>
+#include <iostream>
 
-// // System include(s).
-// #include <chrono>
-// #include <exception>
-// #include <iomanip>
-// #include <iostream>
+namespace po = boost::program_options;
 
-// namespace po = boost::program_options;
+int seq_run(const traccc::seeding_input_config& i_cfg,
+            const traccc::common_options& common_opts, bool run_cpu) {
 
-// int seq_run(const traccc::seeding_input_config& i_cfg,
-//             const traccc::common_options& common_opts, bool run_cpu) {
+    // Read the surface transforms
+    auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
 
-//     // Read the surface transforms
-//     auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
+    // Output stats
+    uint64_t n_modules = 0;
+    uint64_t n_spacepoints = 0;
+    uint64_t n_seeds = 0;
+    uint64_t n_seeds_sycl = 0;
 
-//     // Output stats
-//     uint64_t n_modules = 0;
-//     uint64_t n_spacepoints = 0;
-//     uint64_t n_seeds = 0;
-//     uint64_t n_seeds_sycl = 0;
+    // Memory resource used by the EDM.
+    vecmem::host_memory_resource host_mr;
 
-//     // Memory resource used by the EDM.
-//     vecmem::host_memory_resource host_mr;
+    // Creating sycl queue object
+    ::sycl::queue q(::sycl::gpu_selector{});
+    std::cout << "Running on device: "
+              << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
-//     // Creating sycl queue object
-//     ::sycl::queue q(::sycl::gpu_selector{});
-//     std::cout << "Running on device: "
-//               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
+    // Memory resource used by the EDM.
+    vecmem::sycl::shared_memory_resource shared_mr(&q);
 
-//     // Memory resource used by the EDM.
-//     vecmem::sycl::shared_memory_resource shared_mr(&q);
+    // Elapsed time
+    float wall_time(0);
+    float hit_reading_cpu(0);
+    float seeding_cpu(0);
+    float seeding_sycl(0);
+    float tp_estimating_cpu(0);
+    float tp_estimating_sycl(0);
 
-//     // Elapsed time
-//     float wall_time(0);
-//     float hit_reading_cpu(0);
-//     float seeding_cpu(0);
-//     float seeding_sycl(0);
-//     float tp_estimating_cpu(0);
-//     float tp_estimating_sycl(0);
+    traccc::seeding_algorithm sa(host_mr);
+    traccc::track_params_estimation tp(host_mr);
 
-//     traccc::seeding_algorithm sa(host_mr);
-//     traccc::track_params_estimation tp(host_mr);
+    traccc::sycl::seeding_algorithm sa_sycl(shared_mr, &q);
+    traccc::sycl::track_params_estimation tp_sycl(shared_mr, &q);
 
-//     traccc::sycl::seeding_algorithm sa_sycl(shared_mr, &q);
-//     traccc::sycl::track_params_estimation tp_sycl(shared_mr, &q);
+    // performance writer
+    traccc::seeding_performance_writer sd_performance_writer(
+        traccc::seeding_performance_writer::config{});
+    sd_performance_writer.add_cache("CPU");
+    sd_performance_writer.add_cache("SYCL");
 
-//     // performance writer
-//     traccc::seeding_performance_writer sd_performance_writer(
-//         traccc::seeding_performance_writer::config{});
-//     sd_performance_writer.add_cache("CPU");
-//     sd_performance_writer.add_cache("SYCL");
+    /*time*/ auto start_wall_time = std::chrono::system_clock::now();
 
-//     /*time*/ auto start_wall_time = std::chrono::system_clock::now();
+    // Loop over events
+    for (unsigned int event = common_opts.skip;
+         event < common_opts.events + common_opts.skip; ++event) {
 
-//     // Loop over events
-//     for (unsigned int event = common_opts.skip;
-//          event < common_opts.events + common_opts.skip; ++event) {
+        /*-----------------
+          hit file reading
+          -----------------*/
 
-//         /*-----------------
-//           hit file reading
-//           -----------------*/
+        /*time*/ auto start_hit_reading_cpu = std::chrono::system_clock::now();
 
-//         /*time*/ auto start_hit_reading_cpu = std::chrono::system_clock::now();
+        // Read the hits from the relevant event file
+        traccc::host_spacepoint_container spacepoints_per_event =
+            traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
+                                                common_opts.input_data_format,
+                                                surface_transforms, shared_mr);
 
-//         // Read the hits from the relevant event file
-//         traccc::host_spacepoint_container spacepoints_per_event =
-//             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
-//                                                 common_opts.input_data_format,
-//                                                 surface_transforms, shared_mr);
+        /*time*/ auto end_hit_reading_cpu = std::chrono::system_clock::now();
+        /*time*/ std::chrono::duration<double> time_hit_reading_cpu =
+            end_hit_reading_cpu - start_hit_reading_cpu;
+        /*time*/ hit_reading_cpu += time_hit_reading_cpu.count();
 
-//         /*time*/ auto end_hit_reading_cpu = std::chrono::system_clock::now();
-//         /*time*/ std::chrono::duration<double> time_hit_reading_cpu =
-//             end_hit_reading_cpu - start_hit_reading_cpu;
-//         /*time*/ hit_reading_cpu += time_hit_reading_cpu.count();
-
-//         /*----------------------------
-//              Seeding algorithm
-//           ----------------------------*/
+        /*----------------------------
+             Seeding algorithm
+          ----------------------------*/
 
-//         /// SYCL
+        /// SYCL
 
-//         /*time*/ auto start_seeding_sycl = std::chrono::system_clock::now();
+        /*time*/ auto start_seeding_sycl = std::chrono::system_clock::now();
 
-//         auto seeds_sycl = sa_sycl(std::move(spacepoints_per_event));
+        auto seeds_sycl_buffer = sa_sycl(traccc::get_data(spacepoints_per_event, &shared_mr));
 
-//         /*time*/ auto end_seeding_sycl = std::chrono::system_clock::now();
-//         /*time*/ std::chrono::duration<double> time_seeding_sycl =
-//             end_seeding_sycl - start_seeding_sycl;
-//         /*time*/ seeding_sycl += time_seeding_sycl.count();
+        /*time*/ auto end_seeding_sycl = std::chrono::system_clock::now();
+        /*time*/ std::chrono::duration<double> time_seeding_sycl =
+            end_seeding_sycl - start_seeding_sycl;
+        /*time*/ seeding_sycl += time_seeding_sycl.count();
 
-//         // CPU
+        // CPU
 
-//         /*time*/ auto start_seeding_cpu = std::chrono::system_clock::now();
-
-//         traccc::seeding_algorithm::output_type seeds;
-
-//         if (run_cpu) {
-//             seeds = sa(spacepoints_per_event);
-//         }
-
-//         /*time*/ auto end_seeding_cpu = std::chrono::system_clock::now();
-//         /*time*/ std::chrono::duration<double> time_seeding_cpu =
-//             end_seeding_cpu - start_seeding_cpu;
-//         /*time*/ seeding_cpu += time_seeding_cpu.count();
-
-//         /*----------------------------
-//           Track params estimation
-//           ----------------------------*/
-
-//         // SYCL
-
-//         /*time*/ auto start_tp_estimating_sycl =
-//             std::chrono::system_clock::now();
-
-//         auto params_sycl =
-//             tp_sycl(std::move(spacepoints_per_event), std::move(seeds_sycl));
-
-//         /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
-//         /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =
-//             end_tp_estimating_sycl - start_tp_estimating_sycl;
-//         /*time*/ tp_estimating_sycl += time_tp_estimating_sycl.count();
-
-//         // CPU
-
-//         /*time*/ auto start_tp_estimating_cpu =
-//             std::chrono::system_clock::now();
-
-//         traccc::track_params_estimation::output_type params;
-//         if (run_cpu) {
-//             params = tp(std::move(spacepoints_per_event), seeds);
-//         }
-
-//         /*time*/ auto end_tp_estimating_cpu = std::chrono::system_clock::now();
-//         /*time*/ std::chrono::duration<double> time_tp_estimating_cpu =
-//             end_tp_estimating_cpu - start_tp_estimating_cpu;
-//         /*time*/ tp_estimating_cpu += time_tp_estimating_cpu.count();
-
-//         /*----------------------------------
-//           compare seeds from cpu and sycl
-//           ----------------------------------*/
-
-//         if (run_cpu) {
-//             // seeding
-//             int n_match = 0;
-
-//             std::vector<std::array<traccc::spacepoint, 3>> sp3_vector =
-//                 traccc::get_spacepoint_vector(seeds, spacepoints_per_event);
-
-//             std::vector<std::array<traccc::spacepoint, 3>> sp3_vector_sycl =
-//                 traccc::get_spacepoint_vector(seeds_sycl,
-//                                               spacepoints_per_event);
-
-//             for (const auto& sp3 : sp3_vector) {
-//                 if (std::find(sp3_vector_sycl.cbegin(), sp3_vector_sycl.cend(),
-//                               sp3) != sp3_vector_sycl.cend()) {
-//                     n_match++;
-//                 }
-//             }
-
-//             float matching_rate = float(n_match) / seeds.size();
-//             std::cout << "event " << std::to_string(event) << std::endl;
-//             std::cout << " seed matching rate: " << matching_rate << std::endl;
-
-//             // track parameter estimation
-//             n_match = 0;
-//             for (auto& param : params) {
-//                 if (std::find(params_sycl.begin(), params_sycl.end(), param) !=
-//                     params_sycl.end()) {
-//                     n_match++;
-//                 }
-//             }
-//             matching_rate = float(n_match) / params.size();
-//             std::cout << " track parameters matching rate: " << matching_rate
-//                       << std::endl;
-//         }
-
-//         /*----------------
-//              Statistics
-//           ---------------*/
-
-//         n_spacepoints += spacepoints_per_event.total_size();
-//         n_seeds_sycl += seeds_sycl.size();
-//         n_seeds += seeds.size();
-
-//         /*------------
-//           Writer
-//           ------------*/
-
-//         if (i_cfg.check_seeding_performance) {
-//             traccc::event_map evt_map(event, i_cfg.detector_file,
-//                                       i_cfg.hit_directory,
-//                                       i_cfg.particle_directory, host_mr);
-//             sd_performance_writer.write("SYCL", seeds_sycl,
-//                                         spacepoints_per_event, evt_map);
-//             if (run_cpu) {
-//                 sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
-//                                             evt_map);
-//             }
-//         }
-//     }
-
-//     /*time*/ auto end_wall_time = std::chrono::system_clock::now();
-//     /*time*/ std::chrono::duration<double> time_wall_time =
-//         end_wall_time - start_wall_time;
-
-//     /*time*/ wall_time += time_wall_time.count();
-
-//     sd_performance_writer.finalize();
-
-//     std::cout << "==> Statistics ... " << std::endl;
-//     std::cout << "- read    " << n_spacepoints << " spacepoints from "
-//               << n_modules << " modules" << std::endl;
-//     std::cout << "- created (cpu)  " << n_seeds << " seeds" << std::endl;
-//     std::cout << "- created (sycl) " << n_seeds_sycl << " seeds" << std::endl;
-//     std::cout << "==> Elpased time ... " << std::endl;
-//     std::cout << "wall time           " << std::setw(10) << std::left
-//               << wall_time << std::endl;
-//     std::cout << "hit reading (cpu)   " << std::setw(10) << std::left
-//               << hit_reading_cpu << std::endl;
-//     std::cout << "seeding_time (cpu)  " << std::setw(10) << std::left
-//               << seeding_cpu << std::endl;
-//     std::cout << "seeding_time (sycl) " << std::setw(10) << std::left
-//               << seeding_sycl << std::endl;
-//     std::cout << "tr_par_esti_time (cpu)    " << std::setw(10) << std::left
-//               << tp_estimating_cpu << std::endl;
-//     std::cout << "tr_par_esti_time (sycl)   " << std::setw(10) << std::left
-//               << tp_estimating_sycl << std::endl;
-
-//     return 0;
-// }
-
-// // The main routine
-// //
-// int main(int argc, char* argv[]) {
-//     // Set up the program options
-//     po::options_description desc("Allowed options");
-
-//     // Add options
-//     desc.add_options()("help,h", "Give some help with the program's options");
-//     traccc::common_options common_opts(desc);
-//     traccc::seeding_input_config seeding_input_cfg(desc);
-//     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
-//                        "run cpu tracking as well");
-
-//     po::variables_map vm;
-//     po::store(po::parse_command_line(argc, argv, desc), vm);
-
-//     // Check errors
-//     traccc::handle_argument_errors(vm, desc);
-
-//     // Read options
-//     common_opts.read(vm);
-//     seeding_input_cfg.read(vm);
-//     auto run_cpu = vm["run_cpu"].as<bool>();
-
-//     std::cout << "Running " << argv[0] << " " << seeding_input_cfg.detector_file
-//               << " " << seeding_input_cfg.hit_directory << " "
-//               << common_opts.events << std::endl;
-
-//     return seq_run(seeding_input_cfg, common_opts, run_cpu);
-// }
+        /*time*/ auto start_seeding_cpu = std::chrono::system_clock::now();
+
+        traccc::seeding_algorithm::output_type seeds;
+
+        if (run_cpu) {
+            seeds = sa(spacepoints_per_event);
+        }
+
+        /*time*/ auto end_seeding_cpu = std::chrono::system_clock::now();
+        /*time*/ std::chrono::duration<double> time_seeding_cpu =
+            end_seeding_cpu - start_seeding_cpu;
+        /*time*/ seeding_cpu += time_seeding_cpu.count();
+
+        /*----------------------------
+          Track params estimation
+          ----------------------------*/
+
+        // SYCL
+
+        /*time*/ auto start_tp_estimating_sycl =
+            std::chrono::system_clock::now();
+
+        auto params_sycl =
+            tp_sycl(traccc::get_data(spacepoints_per_event, &shared_mr), seeds_sycl_buffer);
+
+        /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
+        /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =
+            end_tp_estimating_sycl - start_tp_estimating_sycl;
+        /*time*/ tp_estimating_sycl += time_tp_estimating_sycl.count();
+
+        // CPU
+
+        /*time*/ auto start_tp_estimating_cpu =
+            std::chrono::system_clock::now();
+
+        traccc::track_params_estimation::output_type params;
+        if (run_cpu) {
+            params = tp(std::move(spacepoints_per_event), seeds);
+        }
+
+        /*time*/ auto end_tp_estimating_cpu = std::chrono::system_clock::now();
+        /*time*/ std::chrono::duration<double> time_tp_estimating_cpu =
+            end_tp_estimating_cpu - start_tp_estimating_cpu;
+        /*time*/ tp_estimating_cpu += time_tp_estimating_cpu.count();
+
+        /*----------------------------------
+          compare seeds from cpu and sycl
+          ----------------------------------*/
+
+        // Copy the seeds to the host for comparisons
+        vecmem::copy copy;
+        traccc::host_seed_collection seeds_sycl;
+        copy(seeds_sycl_buffer, seeds_sycl);
+
+        if (run_cpu) {
+            // seeding
+            int n_match = 0;
+
+            std::vector<std::array<traccc::spacepoint, 3>> sp3_vector =
+                traccc::get_spacepoint_vector(seeds, spacepoints_per_event);
+
+            std::vector<std::array<traccc::spacepoint, 3>> sp3_vector_sycl =
+                traccc::get_spacepoint_vector(seeds_sycl,
+                                              spacepoints_per_event);
+
+            for (const auto& sp3 : sp3_vector) {
+                if (std::find(sp3_vector_sycl.cbegin(), sp3_vector_sycl.cend(),
+                              sp3) != sp3_vector_sycl.cend()) {
+                    n_match++;
+                }
+            }
+
+            float matching_rate = float(n_match) / seeds.size();
+            std::cout << "event " << std::to_string(event) << std::endl;
+            std::cout << " seed matching rate: " << matching_rate << std::endl;
+
+            // track parameter estimation
+            n_match = 0;
+            for (auto& param : params) {
+                if (std::find(params_sycl.begin(), params_sycl.end(), param) !=
+                    params_sycl.end()) {
+                    n_match++;
+                }
+            }
+            matching_rate = float(n_match) / params.size();
+            std::cout << " track parameters matching rate: " << matching_rate
+                      << std::endl;
+        }
+
+        /*----------------
+             Statistics
+          ---------------*/
+
+        n_spacepoints += spacepoints_per_event.total_size();
+        n_seeds_sycl += seeds_sycl.size();
+        n_seeds += seeds.size();
+
+        /*------------
+          Writer
+          ------------*/
+
+        if (i_cfg.check_seeding_performance) {
+            traccc::event_map evt_map(event, i_cfg.detector_file,
+                                      i_cfg.hit_directory,
+                                      i_cfg.particle_directory, host_mr);
+            sd_performance_writer.write("SYCL", seeds_sycl,
+                                        spacepoints_per_event, evt_map);
+            if (run_cpu) {
+                sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
+                                            evt_map);
+            }
+        }
+    }
+
+    /*time*/ auto end_wall_time = std::chrono::system_clock::now();
+    /*time*/ std::chrono::duration<double> time_wall_time =
+        end_wall_time - start_wall_time;
+
+    /*time*/ wall_time += time_wall_time.count();
+
+    sd_performance_writer.finalize();
+
+    std::cout << "==> Statistics ... " << std::endl;
+    std::cout << "- read    " << n_spacepoints << " spacepoints from "
+              << n_modules << " modules" << std::endl;
+    std::cout << "- created (cpu)  " << n_seeds << " seeds" << std::endl;
+    std::cout << "- created (sycl) " << n_seeds_sycl << " seeds" << std::endl;
+    std::cout << "==> Elpased time ... " << std::endl;
+    std::cout << "wall time           " << std::setw(10) << std::left
+              << wall_time << std::endl;
+    std::cout << "hit reading (cpu)   " << std::setw(10) << std::left
+              << hit_reading_cpu << std::endl;
+    std::cout << "seeding_time (cpu)  " << std::setw(10) << std::left
+              << seeding_cpu << std::endl;
+    std::cout << "seeding_time (sycl) " << std::setw(10) << std::left
+              << seeding_sycl << std::endl;
+    std::cout << "tr_par_esti_time (cpu)    " << std::setw(10) << std::left
+              << tp_estimating_cpu << std::endl;
+    std::cout << "tr_par_esti_time (sycl)   " << std::setw(10) << std::left
+              << tp_estimating_sycl << std::endl;
+
+    return 0;
+}
+
+// The main routine
+//
+int main(int argc, char* argv[]) {
+    // Set up the program options
+    po::options_description desc("Allowed options");
+
+    // Add options
+    desc.add_options()("help,h", "Give some help with the program's options");
+    traccc::common_options common_opts(desc);
+    traccc::seeding_input_config seeding_input_cfg(desc);
+    desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
+                       "run cpu tracking as well");
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+
+    // Check errors
+    traccc::handle_argument_errors(vm, desc);
+
+    // Read options
+    common_opts.read(vm);
+    seeding_input_cfg.read(vm);
+    auto run_cpu = vm["run_cpu"].as<bool>();
+
+    std::cout << "Running " << argv[0] << " " << seeding_input_cfg.detector_file
+              << " " << seeding_input_cfg.hit_directory << " "
+              << common_opts.events << std::endl;
+
+    return seq_run(seeding_input_cfg, common_opts, run_cpu);
+}

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -114,7 +114,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
 
         /*time*/ auto start_seeding_sycl = std::chrono::system_clock::now();
 
-        auto seeds_sycl_buffer = sa_sycl(traccc::get_data(spacepoints_per_event, &shared_mr));
+        auto seeds_sycl_buffer =
+            sa_sycl(traccc::get_data(spacepoints_per_event, &shared_mr));
 
         /*time*/ auto end_seeding_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_seeding_sycl =
@@ -146,7 +147,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
             std::chrono::system_clock::now();
 
         auto params_sycl =
-            tp_sycl(traccc::get_data(spacepoints_per_event, &shared_mr), seeds_sycl_buffer);
+            tp_sycl(traccc::get_data(spacepoints_per_event, &shared_mr),
+                    seeds_sycl_buffer);
 
         /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -5,289 +5,289 @@
  * Mozilla Public License Version 2.0
  */
 
-// SYCL include(s)
-#include <CL/sycl.hpp>
-
-// algorithms
-#include "traccc/seeding/seeding_algorithm.hpp"
-#include "traccc/seeding/track_params_estimation.hpp"
-#include "traccc/sycl/seeding/seeding_algorithm.hpp"
-#include "traccc/sycl/seeding/track_params_estimation.hpp"
+// // SYCL include(s)
+// #include <CL/sycl.hpp>
+
+// // algorithms
+// #include "traccc/seeding/seeding_algorithm.hpp"
+// #include "traccc/seeding/track_params_estimation.hpp"
+// #include "traccc/sycl/seeding/seeding_algorithm.hpp"
+// #include "traccc/sycl/seeding/track_params_estimation.hpp"
 
-// io
-#include "traccc/io/csv.hpp"
-#include "traccc/io/reader.hpp"
-#include "traccc/io/writer.hpp"
-
-// performance
-#include "traccc/efficiency/seeding_performance_writer.hpp"
+// // io
+// #include "traccc/io/csv.hpp"
+// #include "traccc/io/reader.hpp"
+// #include "traccc/io/writer.hpp"
+
+// // performance
+// #include "traccc/efficiency/seeding_performance_writer.hpp"
 
-// options
-#include "traccc/options/common_options.hpp"
-#include "traccc/options/handle_argument_errors.hpp"
-#include "traccc/options/seeding_input_options.hpp"
+// // options
+// #include "traccc/options/common_options.hpp"
+// #include "traccc/options/handle_argument_errors.hpp"
+// #include "traccc/options/seeding_input_options.hpp"
 
-// Vecmem include(s)
-#include <vecmem/memory/host_memory_resource.hpp>
-#include <vecmem/memory/sycl/shared_memory_resource.hpp>
+// // Vecmem include(s)
+// #include <vecmem/memory/host_memory_resource.hpp>
+// #include <vecmem/memory/sycl/shared_memory_resource.hpp>
 
-// System include(s).
-#include <chrono>
-#include <exception>
-#include <iomanip>
-#include <iostream>
+// // System include(s).
+// #include <chrono>
+// #include <exception>
+// #include <iomanip>
+// #include <iostream>
 
-namespace po = boost::program_options;
+// namespace po = boost::program_options;
 
-int seq_run(const traccc::seeding_input_config& i_cfg,
-            const traccc::common_options& common_opts, bool run_cpu) {
+// int seq_run(const traccc::seeding_input_config& i_cfg,
+//             const traccc::common_options& common_opts, bool run_cpu) {
 
-    // Read the surface transforms
-    auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
+//     // Read the surface transforms
+//     auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
 
-    // Output stats
-    uint64_t n_modules = 0;
-    uint64_t n_spacepoints = 0;
-    uint64_t n_seeds = 0;
-    uint64_t n_seeds_sycl = 0;
+//     // Output stats
+//     uint64_t n_modules = 0;
+//     uint64_t n_spacepoints = 0;
+//     uint64_t n_seeds = 0;
+//     uint64_t n_seeds_sycl = 0;
 
-    // Memory resource used by the EDM.
-    vecmem::host_memory_resource host_mr;
+//     // Memory resource used by the EDM.
+//     vecmem::host_memory_resource host_mr;
 
-    // Creating sycl queue object
-    ::sycl::queue q(::sycl::gpu_selector{});
-    std::cout << "Running on device: "
-              << q.get_device().get_info<::sycl::info::device::name>() << "\n";
+//     // Creating sycl queue object
+//     ::sycl::queue q(::sycl::gpu_selector{});
+//     std::cout << "Running on device: "
+//               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
-    // Memory resource used by the EDM.
-    vecmem::sycl::shared_memory_resource shared_mr(&q);
+//     // Memory resource used by the EDM.
+//     vecmem::sycl::shared_memory_resource shared_mr(&q);
 
-    // Elapsed time
-    float wall_time(0);
-    float hit_reading_cpu(0);
-    float seeding_cpu(0);
-    float seeding_sycl(0);
-    float tp_estimating_cpu(0);
-    float tp_estimating_sycl(0);
+//     // Elapsed time
+//     float wall_time(0);
+//     float hit_reading_cpu(0);
+//     float seeding_cpu(0);
+//     float seeding_sycl(0);
+//     float tp_estimating_cpu(0);
+//     float tp_estimating_sycl(0);
 
-    traccc::seeding_algorithm sa(host_mr);
-    traccc::track_params_estimation tp(host_mr);
+//     traccc::seeding_algorithm sa(host_mr);
+//     traccc::track_params_estimation tp(host_mr);
 
-    traccc::sycl::seeding_algorithm sa_sycl(shared_mr, &q);
-    traccc::sycl::track_params_estimation tp_sycl(shared_mr, &q);
+//     traccc::sycl::seeding_algorithm sa_sycl(shared_mr, &q);
+//     traccc::sycl::track_params_estimation tp_sycl(shared_mr, &q);
 
-    // performance writer
-    traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{});
-    sd_performance_writer.add_cache("CPU");
-    sd_performance_writer.add_cache("SYCL");
+//     // performance writer
+//     traccc::seeding_performance_writer sd_performance_writer(
+//         traccc::seeding_performance_writer::config{});
+//     sd_performance_writer.add_cache("CPU");
+//     sd_performance_writer.add_cache("SYCL");
 
-    /*time*/ auto start_wall_time = std::chrono::system_clock::now();
+//     /*time*/ auto start_wall_time = std::chrono::system_clock::now();
 
-    // Loop over events
-    for (unsigned int event = common_opts.skip;
-         event < common_opts.events + common_opts.skip; ++event) {
+//     // Loop over events
+//     for (unsigned int event = common_opts.skip;
+//          event < common_opts.events + common_opts.skip; ++event) {
 
-        /*-----------------
-          hit file reading
-          -----------------*/
+//         /*-----------------
+//           hit file reading
+//           -----------------*/
 
-        /*time*/ auto start_hit_reading_cpu = std::chrono::system_clock::now();
+//         /*time*/ auto start_hit_reading_cpu = std::chrono::system_clock::now();
 
-        // Read the hits from the relevant event file
-        traccc::host_spacepoint_container spacepoints_per_event =
-            traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
-                                                common_opts.input_data_format,
-                                                surface_transforms, shared_mr);
+//         // Read the hits from the relevant event file
+//         traccc::host_spacepoint_container spacepoints_per_event =
+//             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
+//                                                 common_opts.input_data_format,
+//                                                 surface_transforms, shared_mr);
 
-        /*time*/ auto end_hit_reading_cpu = std::chrono::system_clock::now();
-        /*time*/ std::chrono::duration<double> time_hit_reading_cpu =
-            end_hit_reading_cpu - start_hit_reading_cpu;
-        /*time*/ hit_reading_cpu += time_hit_reading_cpu.count();
-
-        /*----------------------------
-             Seeding algorithm
-          ----------------------------*/
+//         /*time*/ auto end_hit_reading_cpu = std::chrono::system_clock::now();
+//         /*time*/ std::chrono::duration<double> time_hit_reading_cpu =
+//             end_hit_reading_cpu - start_hit_reading_cpu;
+//         /*time*/ hit_reading_cpu += time_hit_reading_cpu.count();
+
+//         /*----------------------------
+//              Seeding algorithm
+//           ----------------------------*/
 
-        /// SYCL
+//         /// SYCL
 
-        /*time*/ auto start_seeding_sycl = std::chrono::system_clock::now();
+//         /*time*/ auto start_seeding_sycl = std::chrono::system_clock::now();
 
-        auto seeds_sycl = sa_sycl(std::move(spacepoints_per_event));
+//         auto seeds_sycl = sa_sycl(std::move(spacepoints_per_event));
 
-        /*time*/ auto end_seeding_sycl = std::chrono::system_clock::now();
-        /*time*/ std::chrono::duration<double> time_seeding_sycl =
-            end_seeding_sycl - start_seeding_sycl;
-        /*time*/ seeding_sycl += time_seeding_sycl.count();
+//         /*time*/ auto end_seeding_sycl = std::chrono::system_clock::now();
+//         /*time*/ std::chrono::duration<double> time_seeding_sycl =
+//             end_seeding_sycl - start_seeding_sycl;
+//         /*time*/ seeding_sycl += time_seeding_sycl.count();
 
-        // CPU
+//         // CPU
 
-        /*time*/ auto start_seeding_cpu = std::chrono::system_clock::now();
-
-        traccc::seeding_algorithm::output_type seeds;
-
-        if (run_cpu) {
-            seeds = sa(spacepoints_per_event);
-        }
-
-        /*time*/ auto end_seeding_cpu = std::chrono::system_clock::now();
-        /*time*/ std::chrono::duration<double> time_seeding_cpu =
-            end_seeding_cpu - start_seeding_cpu;
-        /*time*/ seeding_cpu += time_seeding_cpu.count();
-
-        /*----------------------------
-          Track params estimation
-          ----------------------------*/
-
-        // SYCL
-
-        /*time*/ auto start_tp_estimating_sycl =
-            std::chrono::system_clock::now();
-
-        auto params_sycl =
-            tp_sycl(std::move(spacepoints_per_event), std::move(seeds_sycl));
-
-        /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
-        /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =
-            end_tp_estimating_sycl - start_tp_estimating_sycl;
-        /*time*/ tp_estimating_sycl += time_tp_estimating_sycl.count();
-
-        // CPU
-
-        /*time*/ auto start_tp_estimating_cpu =
-            std::chrono::system_clock::now();
-
-        traccc::track_params_estimation::output_type params;
-        if (run_cpu) {
-            params = tp(std::move(spacepoints_per_event), seeds);
-        }
-
-        /*time*/ auto end_tp_estimating_cpu = std::chrono::system_clock::now();
-        /*time*/ std::chrono::duration<double> time_tp_estimating_cpu =
-            end_tp_estimating_cpu - start_tp_estimating_cpu;
-        /*time*/ tp_estimating_cpu += time_tp_estimating_cpu.count();
-
-        /*----------------------------------
-          compare seeds from cpu and sycl
-          ----------------------------------*/
-
-        if (run_cpu) {
-            // seeding
-            int n_match = 0;
-
-            std::vector<std::array<traccc::spacepoint, 3>> sp3_vector =
-                traccc::get_spacepoint_vector(seeds, spacepoints_per_event);
-
-            std::vector<std::array<traccc::spacepoint, 3>> sp3_vector_sycl =
-                traccc::get_spacepoint_vector(seeds_sycl,
-                                              spacepoints_per_event);
-
-            for (const auto& sp3 : sp3_vector) {
-                if (std::find(sp3_vector_sycl.cbegin(), sp3_vector_sycl.cend(),
-                              sp3) != sp3_vector_sycl.cend()) {
-                    n_match++;
-                }
-            }
-
-            float matching_rate = float(n_match) / seeds.size();
-            std::cout << "event " << std::to_string(event) << std::endl;
-            std::cout << " seed matching rate: " << matching_rate << std::endl;
-
-            // track parameter estimation
-            n_match = 0;
-            for (auto& param : params) {
-                if (std::find(params_sycl.begin(), params_sycl.end(), param) !=
-                    params_sycl.end()) {
-                    n_match++;
-                }
-            }
-            matching_rate = float(n_match) / params.size();
-            std::cout << " track parameters matching rate: " << matching_rate
-                      << std::endl;
-        }
-
-        /*----------------
-             Statistics
-          ---------------*/
-
-        n_spacepoints += spacepoints_per_event.total_size();
-        n_seeds_sycl += seeds_sycl.size();
-        n_seeds += seeds.size();
-
-        /*------------
-          Writer
-          ------------*/
-
-        if (i_cfg.check_seeding_performance) {
-            traccc::event_map evt_map(event, i_cfg.detector_file,
-                                      i_cfg.hit_directory,
-                                      i_cfg.particle_directory, host_mr);
-            sd_performance_writer.write("SYCL", seeds_sycl,
-                                        spacepoints_per_event, evt_map);
-            if (run_cpu) {
-                sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
-                                            evt_map);
-            }
-        }
-    }
-
-    /*time*/ auto end_wall_time = std::chrono::system_clock::now();
-    /*time*/ std::chrono::duration<double> time_wall_time =
-        end_wall_time - start_wall_time;
-
-    /*time*/ wall_time += time_wall_time.count();
-
-    sd_performance_writer.finalize();
-
-    std::cout << "==> Statistics ... " << std::endl;
-    std::cout << "- read    " << n_spacepoints << " spacepoints from "
-              << n_modules << " modules" << std::endl;
-    std::cout << "- created (cpu)  " << n_seeds << " seeds" << std::endl;
-    std::cout << "- created (sycl) " << n_seeds_sycl << " seeds" << std::endl;
-    std::cout << "==> Elpased time ... " << std::endl;
-    std::cout << "wall time           " << std::setw(10) << std::left
-              << wall_time << std::endl;
-    std::cout << "hit reading (cpu)   " << std::setw(10) << std::left
-              << hit_reading_cpu << std::endl;
-    std::cout << "seeding_time (cpu)  " << std::setw(10) << std::left
-              << seeding_cpu << std::endl;
-    std::cout << "seeding_time (sycl) " << std::setw(10) << std::left
-              << seeding_sycl << std::endl;
-    std::cout << "tr_par_esti_time (cpu)    " << std::setw(10) << std::left
-              << tp_estimating_cpu << std::endl;
-    std::cout << "tr_par_esti_time (sycl)   " << std::setw(10) << std::left
-              << tp_estimating_sycl << std::endl;
-
-    return 0;
-}
-
-// The main routine
-//
-int main(int argc, char* argv[]) {
-    // Set up the program options
-    po::options_description desc("Allowed options");
-
-    // Add options
-    desc.add_options()("help,h", "Give some help with the program's options");
-    traccc::common_options common_opts(desc);
-    traccc::seeding_input_config seeding_input_cfg(desc);
-    desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
-                       "run cpu tracking as well");
-
-    po::variables_map vm;
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-
-    // Check errors
-    traccc::handle_argument_errors(vm, desc);
-
-    // Read options
-    common_opts.read(vm);
-    seeding_input_cfg.read(vm);
-    auto run_cpu = vm["run_cpu"].as<bool>();
-
-    std::cout << "Running " << argv[0] << " " << seeding_input_cfg.detector_file
-              << " " << seeding_input_cfg.hit_directory << " "
-              << common_opts.events << std::endl;
-
-    return seq_run(seeding_input_cfg, common_opts, run_cpu);
-}
+//         /*time*/ auto start_seeding_cpu = std::chrono::system_clock::now();
+
+//         traccc::seeding_algorithm::output_type seeds;
+
+//         if (run_cpu) {
+//             seeds = sa(spacepoints_per_event);
+//         }
+
+//         /*time*/ auto end_seeding_cpu = std::chrono::system_clock::now();
+//         /*time*/ std::chrono::duration<double> time_seeding_cpu =
+//             end_seeding_cpu - start_seeding_cpu;
+//         /*time*/ seeding_cpu += time_seeding_cpu.count();
+
+//         /*----------------------------
+//           Track params estimation
+//           ----------------------------*/
+
+//         // SYCL
+
+//         /*time*/ auto start_tp_estimating_sycl =
+//             std::chrono::system_clock::now();
+
+//         auto params_sycl =
+//             tp_sycl(std::move(spacepoints_per_event), std::move(seeds_sycl));
+
+//         /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
+//         /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =
+//             end_tp_estimating_sycl - start_tp_estimating_sycl;
+//         /*time*/ tp_estimating_sycl += time_tp_estimating_sycl.count();
+
+//         // CPU
+
+//         /*time*/ auto start_tp_estimating_cpu =
+//             std::chrono::system_clock::now();
+
+//         traccc::track_params_estimation::output_type params;
+//         if (run_cpu) {
+//             params = tp(std::move(spacepoints_per_event), seeds);
+//         }
+
+//         /*time*/ auto end_tp_estimating_cpu = std::chrono::system_clock::now();
+//         /*time*/ std::chrono::duration<double> time_tp_estimating_cpu =
+//             end_tp_estimating_cpu - start_tp_estimating_cpu;
+//         /*time*/ tp_estimating_cpu += time_tp_estimating_cpu.count();
+
+//         /*----------------------------------
+//           compare seeds from cpu and sycl
+//           ----------------------------------*/
+
+//         if (run_cpu) {
+//             // seeding
+//             int n_match = 0;
+
+//             std::vector<std::array<traccc::spacepoint, 3>> sp3_vector =
+//                 traccc::get_spacepoint_vector(seeds, spacepoints_per_event);
+
+//             std::vector<std::array<traccc::spacepoint, 3>> sp3_vector_sycl =
+//                 traccc::get_spacepoint_vector(seeds_sycl,
+//                                               spacepoints_per_event);
+
+//             for (const auto& sp3 : sp3_vector) {
+//                 if (std::find(sp3_vector_sycl.cbegin(), sp3_vector_sycl.cend(),
+//                               sp3) != sp3_vector_sycl.cend()) {
+//                     n_match++;
+//                 }
+//             }
+
+//             float matching_rate = float(n_match) / seeds.size();
+//             std::cout << "event " << std::to_string(event) << std::endl;
+//             std::cout << " seed matching rate: " << matching_rate << std::endl;
+
+//             // track parameter estimation
+//             n_match = 0;
+//             for (auto& param : params) {
+//                 if (std::find(params_sycl.begin(), params_sycl.end(), param) !=
+//                     params_sycl.end()) {
+//                     n_match++;
+//                 }
+//             }
+//             matching_rate = float(n_match) / params.size();
+//             std::cout << " track parameters matching rate: " << matching_rate
+//                       << std::endl;
+//         }
+
+//         /*----------------
+//              Statistics
+//           ---------------*/
+
+//         n_spacepoints += spacepoints_per_event.total_size();
+//         n_seeds_sycl += seeds_sycl.size();
+//         n_seeds += seeds.size();
+
+//         /*------------
+//           Writer
+//           ------------*/
+
+//         if (i_cfg.check_seeding_performance) {
+//             traccc::event_map evt_map(event, i_cfg.detector_file,
+//                                       i_cfg.hit_directory,
+//                                       i_cfg.particle_directory, host_mr);
+//             sd_performance_writer.write("SYCL", seeds_sycl,
+//                                         spacepoints_per_event, evt_map);
+//             if (run_cpu) {
+//                 sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
+//                                             evt_map);
+//             }
+//         }
+//     }
+
+//     /*time*/ auto end_wall_time = std::chrono::system_clock::now();
+//     /*time*/ std::chrono::duration<double> time_wall_time =
+//         end_wall_time - start_wall_time;
+
+//     /*time*/ wall_time += time_wall_time.count();
+
+//     sd_performance_writer.finalize();
+
+//     std::cout << "==> Statistics ... " << std::endl;
+//     std::cout << "- read    " << n_spacepoints << " spacepoints from "
+//               << n_modules << " modules" << std::endl;
+//     std::cout << "- created (cpu)  " << n_seeds << " seeds" << std::endl;
+//     std::cout << "- created (sycl) " << n_seeds_sycl << " seeds" << std::endl;
+//     std::cout << "==> Elpased time ... " << std::endl;
+//     std::cout << "wall time           " << std::setw(10) << std::left
+//               << wall_time << std::endl;
+//     std::cout << "hit reading (cpu)   " << std::setw(10) << std::left
+//               << hit_reading_cpu << std::endl;
+//     std::cout << "seeding_time (cpu)  " << std::setw(10) << std::left
+//               << seeding_cpu << std::endl;
+//     std::cout << "seeding_time (sycl) " << std::setw(10) << std::left
+//               << seeding_sycl << std::endl;
+//     std::cout << "tr_par_esti_time (cpu)    " << std::setw(10) << std::left
+//               << tp_estimating_cpu << std::endl;
+//     std::cout << "tr_par_esti_time (sycl)   " << std::setw(10) << std::left
+//               << tp_estimating_sycl << std::endl;
+
+//     return 0;
+// }
+
+// // The main routine
+// //
+// int main(int argc, char* argv[]) {
+//     // Set up the program options
+//     po::options_description desc("Allowed options");
+
+//     // Add options
+//     desc.add_options()("help,h", "Give some help with the program's options");
+//     traccc::common_options common_opts(desc);
+//     traccc::seeding_input_config seeding_input_cfg(desc);
+//     desc.add_options()("run_cpu", po::value<bool>()->default_value(false),
+//                        "run cpu tracking as well");
+
+//     po::variables_map vm;
+//     po::store(po::parse_command_line(argc, argv, desc), vm);
+
+//     // Check errors
+//     traccc::handle_argument_errors(vm, desc);
+
+//     // Read options
+//     common_opts.read(vm);
+//     seeding_input_cfg.read(vm);
+//     auto run_cpu = vm["run_cpu"].as<bool>();
+
+//     std::cout << "Running " << argv[0] << " " << seeding_input_cfg.detector_file
+//               << " " << seeding_input_cfg.hit_directory << " "
+//               << common_opts.events << std::endl;
+
+//     return seq_run(seeding_input_cfg, common_opts, run_cpu);
+// }

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -34,6 +34,7 @@
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
 #include <vecmem/memory/sycl/shared_memory_resource.hpp>
+#include <vecmem/utils/copy.hpp>
 
 // System include(s).
 #include <chrono>
@@ -161,7 +162,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         /*time*/ auto start_clusterization_sycl =
             std::chrono::system_clock::now();
 
-        auto spacepoints_per_event_sycl = ca_sycl(cells_per_event);
+        auto spacepoints_sycl_buffer = ca_sycl(cells_per_event);
 
         /*time*/ auto end_clusterization_sycl =
             std::chrono::system_clock::now();
@@ -177,7 +178,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         /*time*/ auto start_seeding_sycl = std::chrono::system_clock::now();
 
-        auto seeds_sycl = sa_sycl(spacepoints_per_event_sycl);
+        auto seeds_sycl_buffer = sa_sycl(spacepoints_sycl_buffer);
 
         /*time*/ auto end_seeding_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_seeding_sycl =
@@ -208,8 +209,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         /*time*/ auto start_tp_estimating_sycl =
             std::chrono::system_clock::now();
 
-        auto params_sycl = tp_sycl(std::move(spacepoints_per_event_sycl),
-                                   std::move(seeds_sycl));
+        auto params_sycl = tp_sycl(spacepoints_sycl_buffer,
+                                   seeds_sycl_buffer);
 
         /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =
@@ -231,11 +232,20 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
             end_tp_estimating_cpu - start_tp_estimating_cpu;
         /*time*/ tp_estimating_cpu += time_tp_estimating_cpu.count();
 
+        // Copy the seeds and spacepoints to the host for comparisons
+        vecmem::copy copy;
+        traccc::host_spacepoint_container spacepoints_per_event_sycl;
+        copy(spacepoints_sycl_buffer.headers, spacepoints_per_event_sycl.get_headers());
+        copy(spacepoints_sycl_buffer.items, spacepoints_per_event_sycl.get_items());
+        traccc::host_seed_collection seeds_sycl;
+        copy(seeds_sycl_buffer, seeds_sycl);
+
         /*----------------------------------
           compare cpu and sycl result
           ----------------------------------*/
 
         if (run_cpu) {
+
 
             // Initial information about number of seeds found
             std::cout << "event " << std::to_string(event) << std::endl;

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -209,8 +209,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         /*time*/ auto start_tp_estimating_sycl =
             std::chrono::system_clock::now();
 
-        auto params_sycl = tp_sycl(spacepoints_sycl_buffer,
-                                   seeds_sycl_buffer);
+        auto params_sycl = tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer);
 
         /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =
@@ -235,8 +234,10 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         // Copy the seeds and spacepoints to the host for comparisons
         vecmem::copy copy;
         traccc::host_spacepoint_container spacepoints_per_event_sycl;
-        copy(spacepoints_sycl_buffer.headers, spacepoints_per_event_sycl.get_headers());
-        copy(spacepoints_sycl_buffer.items, spacepoints_per_event_sycl.get_items());
+        copy(spacepoints_sycl_buffer.headers,
+             spacepoints_per_event_sycl.get_headers());
+        copy(spacepoints_sycl_buffer.items,
+             spacepoints_per_event_sycl.get_items());
         traccc::host_seed_collection seeds_sycl;
         copy(seeds_sycl_buffer, seeds_sycl);
 
@@ -245,7 +246,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
           ----------------------------------*/
 
         if (run_cpu) {
-
 
             // Initial information about number of seeds found
             std::cout << "event " << std::to_string(event) << std::endl;


### PR DESCRIPTION
In the current implementation, there are good amounts of memory copies between launching the algorithms (e.i. clusterization -> seed finding -> track param estimation). This is because at the end of each algorithmic execution, we copy the results back to the host and return a host object. 

In many cases, this is not really necessary and the data can stay on the device for the next algorithm to use. To do that, I changed the SYCL algorithms to receive view objects and return buffers. 

I also included in this PR some updates to the SYCL seedfinding that @beomki-yeo made some time ago in #160 to the CUDA version.

P. S. @krasznaa let me know if we want to split this PR in the end :wink: 