### PR TITLE
Spacepoint EDM Update, main branch (2022.05.18.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -53,15 +53,20 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/seeding/detail/bin_finder.hpp"
   "include/traccc/seeding/seed_selecting_helper.hpp"
   "include/traccc/seeding/seed_filtering.hpp"
+  "src/seeding/seed_filtering.cpp"
   "include/traccc/seeding/seeding_algorithm.hpp"
+  "src/seeding/seeding_algorithm.cpp"
   "include/traccc/seeding/track_params_estimation_helper.hpp"
   "include/traccc/seeding/doublet_finding_helper.hpp"
   "include/traccc/seeding/spacepoint_binning_helper.hpp"
   "include/traccc/seeding/track_params_estimation.hpp"
+  "src/seeding/track_params_estimation.cpp"
   "include/traccc/seeding/triplet_finding_helper.hpp"
   "include/traccc/seeding/doublet_finding.hpp"
   "include/traccc/seeding/triplet_finding.hpp"
   "include/traccc/seeding/seed_finding.hpp"
-  "include/traccc/seeding/spacepoint_binning.hpp" )
+  "src/seeding/seed_finding.cpp"
+  "include/traccc/seeding/spacepoint_binning.hpp"
+  "src/seeding/spacepoint_binning.cpp" )
 target_link_libraries( traccc_core
   PUBLIC Eigen3::Eigen vecmem::core detray::core ActsCore traccc::algebra )

--- a/core/include/traccc/clusterization/spacepoint_formation.hpp
+++ b/core/include/traccc/clusterization/spacepoint_formation.hpp
@@ -25,7 +25,7 @@ namespace traccc {
 /// This algorithm performs the local-to-global transformation of the 2D
 /// measurements made on every detector module, into 3D spacepoint coordinates.
 ///
-class spacepoint_formation : public algorithm<host_spacepoint_container(
+class spacepoint_formation : public algorithm<spacepoint_container_types::host(
                                  const measurement_container_types::host&)> {
 
     public:

--- a/core/include/traccc/edm/seed.hpp
+++ b/core/include/traccc/edm/seed.hpp
@@ -12,12 +12,10 @@
 
 namespace traccc {
 
-/// Header: unsigned int for number of seeds
-
 /// Item: seed consisting of three spacepoints, z origin and weight
 struct seed {
 
-    using link_type = typename host_spacepoint_container::link_type;
+    using link_type = typename spacepoint_container_types::host::link_type;
 
     link_type spB_link;
     link_type spM_link;
@@ -46,16 +44,20 @@ struct seed {
         return *this;
     }
 
-    TRACCC_HOST
+    TRACCC_HOST_DEVICE
     std::array<measurement, 3> get_measurements(
-        const host_spacepoint_container& spacepoints) const {
+        const spacepoint_container_types::const_view& spacepoints_view) const {
+        const spacepoint_container_types::const_device spacepoints(
+            spacepoints_view);
         return {spacepoints.at(spB_link).meas, spacepoints.at(spM_link).meas,
                 spacepoints.at(spT_link).meas};
     }
 
-    TRACCC_HOST
+    TRACCC_HOST_DEVICE
     std::array<spacepoint, 3> get_spacepoints(
-        const host_spacepoint_container& spacepoints) const {
+        const spacepoint_container_types::const_view& spacepoints_view) const {
+        const spacepoint_container_types::const_device spacepoints(
+            spacepoints_view);
         return {spacepoints.at(spB_link), spacepoints.at(spM_link),
                 spacepoints.at(spT_link)};
     }
@@ -68,9 +70,10 @@ TRACCC_HOST std::vector<std::array<spacepoint, 3>> get_spacepoint_vector(
     std::vector<std::array<spacepoint, 3>> result;
     result.reserve(seeds.size());
 
-    std::transform(
-        seeds.cbegin(), seeds.cend(), std::back_inserter(result),
-        [&](const seed& value) { return value.get_spacepoints(container); });
+    std::transform(seeds.cbegin(), seeds.cend(), std::back_inserter(result),
+                   [&](const seed& value) {
+                       return value.get_spacepoints(get_data(container));
+                   });
 
     return result;
 }

--- a/core/include/traccc/edm/spacepoint.hpp
+++ b/core/include/traccc/edm/spacepoint.hpp
@@ -15,13 +15,20 @@
 #include "traccc/edm/measurement.hpp"
 
 // System include(s).
-#include <vector>
+#include <cmath>
 
 namespace traccc {
 
-/// A spacepoint definition: global position and errors
+/// A spacepoint expressed in global coordinates
+///
+/// It describes the 3D position of the spacepoint, and the 2D measurement that
+/// the spacepoint was created from.
+///
 struct spacepoint {
-    point3 global = {0., 0., 0.};
+
+    /// The global position of the spacepoint in 3D space
+    point3 global{0., 0., 0.};
+    /// The local measurement of the spacepoint on the detector surface
     measurement meas;
 
     TRACCC_HOST_DEVICE
@@ -36,77 +43,32 @@ struct spacepoint {
     }
 };
 
+/// Comparison / ordering operator for spacepoints
+TRACCC_HOST_DEVICE
 inline bool operator<(const spacepoint& lhs, const spacepoint& rhs) {
-    if (lhs.global[0] < rhs.global[0]) {
-        return true;
+
+    if (std::abs(lhs.x() - rhs.x()) > float_epsilon) {
+        return (lhs.x() < rhs.x());
+    } else if (std::abs(lhs.y() - rhs.y()) > float_epsilon) {
+        return (lhs.y() < rhs.y());
+    } else {
+        return (lhs.z() < rhs.z());
     }
-    return false;
 }
 
+/// Equality operator for spacepoints
+TRACCC_HOST_DEVICE
 inline bool operator==(const spacepoint& lhs, const spacepoint& rhs) {
-    if (std::abs(lhs.global[0] - rhs.global[0]) < float_epsilon &&
-        std::abs(lhs.global[1] - rhs.global[1]) < float_epsilon &&
-        std::abs(lhs.global[2] - rhs.global[2]) < float_epsilon) {
-        return true;
-    }
-    return false;
+
+    return ((std::abs(lhs.x() - rhs.x()) < float_epsilon) &&
+            (std::abs(lhs.y() - rhs.y()) < float_epsilon) &&
+            (std::abs(lhs.z() - rhs.z()) < float_epsilon) &&
+            (lhs.meas == rhs.meas));
 }
 
-/// (Non-const) Container of spacepoints belonging to one detector module
-template <template <typename> class vector_t>
-using spacepoint_collection = vector_t<spacepoint>;
-
-/// (Const) Container of spacepoints belonging to one detector module
-template <template <typename> class vector_t>
-using spacepoint_const_collection = vector_t<const spacepoint>;
-
-/// Convenience declaration for the spacepoint collection type to use in host
-/// code
-using host_spacepoint_collection = spacepoint_collection<vecmem::vector>;
-
-/// Convenience declaration for the spacepoint collection type to use in device
-/// code (non-const)
-using device_spacepoint_collection =
-    spacepoint_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the spacepoint collection type to use in device
-/// code (const)
-using device_spacepoint_const_collection =
-    spacepoint_const_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the spacepoint container type to use in host
-/// code
-using host_spacepoint_container = host_container<geometry_id, spacepoint>;
-
-/// Convenience declaration for the spacepoint container type to use in device
-/// code (non-const)
-using device_spacepoint_container = device_container<geometry_id, spacepoint>;
-
-/// Convenience declaration for the spacepoint container type to use in device
-/// code (const)
-using device_spacepoint_const_container =
-    device_container<const geometry_id, const spacepoint>;
-
-/// Convenience declaration for the spacepoint container data type to use in
-/// host code (non-const)
-using spacepoint_container_data = container_data<geometry_id, spacepoint>;
-
-/// Convenience declaration for the spacepoint container data type to use in
-/// host code (const)
-using spacepoint_container_const_data =
-    container_data<const geometry_id, const spacepoint>;
-
-/// Convenience declaration for the spacepoint container buffer type to use in
-/// host code
-using spacepoint_container_buffer = container_buffer<geometry_id, spacepoint>;
-
-/// Convenience declaration for the spacepoint container view type to use in
-/// host code (non-const)
-using spacepoint_container_view = container_view<geometry_id, spacepoint>;
-
-/// Convenience declaration for the spacepoint container view type to use in
-/// host code (const)
-using spacepoint_container_const_view =
-    container_view<const geometry_id, const spacepoint>;
+/// Declare all spacepoint collection types
+using spacepoint_collection_types = collection_types<spacepoint>;
+/// Declare all spacepoint container types
+using spacepoint_container_types = container_types<geometry_id, spacepoint>;
 
 }  // namespace traccc

--- a/core/include/traccc/seeding/seed_filtering.hpp
+++ b/core/include/traccc/seeding/seed_filtering.hpp
@@ -7,25 +7,21 @@
 
 #pragma once
 
+// Library include(s).
 #include "traccc/edm/seed.hpp"
+#include "traccc/edm/spacepoint.hpp"
+#include "traccc/seeding/detail/seeding_config.hpp"
+#include "traccc/seeding/detail/spacepoint_grid.hpp"
 #include "traccc/seeding/detail/triplet.hpp"
-#include "traccc/seeding/seed_selecting_helper.hpp"
-#include "traccc/utils/algorithm.hpp"
 
 namespace traccc {
 
 /// Seed filtering to filter out the bad triplets
-struct seed_filtering
-    : public algorithm<
-          std::pair<host_triplet_collection&, host_seed_collection&>(
-              const host_spacepoint_container&, const sp_grid&)> {
-    seed_filtering() {}
+class seed_filtering {
 
-    output_type operator()(const host_spacepoint_container&,
-                           const sp_grid&) const override {
-        // not used
-        __builtin_unreachable();
-    }
+    public:
+    /// Constructor with the seed filter configuration
+    seed_filtering(const seedfilter_config& config);
 
     /// Callable operator for the seed filtering
     ///
@@ -36,98 +32,14 @@ struct seed_filtering
     ///
     /// @return seeds are the vector of seeds where the new compatible seeds are
     /// added
-    void operator()(const host_spacepoint_container& sp_container,
-                    const sp_grid& g2, output_type& o) const {
-        auto& triplets = o.first;
-        auto& seeds = o.second;
-
-        host_seed_collection seeds_per_spM;
-
-        for (auto& triplet : triplets) {
-            // bottom
-            const auto& spB_idx = triplet.sp1;
-            const auto& spB = g2.bin(spB_idx.bin_idx)[spB_idx.sp_idx];
-
-            // middle
-            const auto& spM_idx = triplet.sp2;
-            const auto& spM = g2.bin(spM_idx.bin_idx)[spM_idx.sp_idx];
-
-            // top
-            const auto& spT_idx = triplet.sp3;
-            const auto& spT = g2.bin(spT_idx.bin_idx)[spT_idx.sp_idx];
-
-            seed_selecting_helper::seed_weight(m_filter_config, spM, spB, spT,
-                                               triplet.weight);
-
-            if (!seed_selecting_helper::single_seed_cut(
-                    m_filter_config, spM, spB, spT, triplet.weight)) {
-                continue;
-            }
-
-            seeds_per_spM.push_back({spB.m_link, spM.m_link, spT.m_link,
-                                     triplet.weight, triplet.z_vertex});
-        }
-
-        // sort seeds based on their weights
-        std::sort(seeds_per_spM.begin(), seeds_per_spM.end(),
-                  [&](seed& seed1, seed& seed2) {
-                      if (seed1.weight != seed2.weight) {
-                          return seed1.weight > seed2.weight;
-                      } else {
-                          scalar seed1_sum = 0;
-                          scalar seed2_sum = 0;
-                          auto& spB1 = sp_container.at(seed1.spB_link);
-                          auto& spT1 = sp_container.at(seed1.spT_link);
-                          auto& spB2 = sp_container.at(seed2.spB_link);
-                          auto& spT2 = sp_container.at(seed2.spT_link);
-
-                          seed1_sum += pow(spB1.y(), 2) + pow(spB1.z(), 2);
-                          seed1_sum += pow(spT1.y(), 2) + pow(spT1.z(), 2);
-                          seed2_sum += pow(spB2.y(), 2) + pow(spB2.z(), 2);
-                          seed2_sum += pow(spT2.y(), 2) + pow(spT2.z(), 2);
-
-                          return seed1_sum > seed2_sum;
-                      }
-                  });
-
-        host_seed_collection new_seeds;
-        if (seeds_per_spM.size() > 1) {
-            new_seeds.push_back(seeds_per_spM[0]);
-
-            size_t itLength = std::min(seeds_per_spM.size(),
-                                       m_filter_config.max_triplets_per_spM);
-            // don't cut first element
-            for (size_t i = 1; i < itLength; i++) {
-                if (seed_selecting_helper::cut_per_middle_sp(
-                        m_filter_config, sp_container, seeds_per_spM[i],
-                        seeds_per_spM[i].weight)) {
-                    new_seeds.push_back(std::move(seeds_per_spM[i]));
-                }
-            }
-            seeds_per_spM = std::move(new_seeds);
-        }
-
-        unsigned int maxSeeds = seeds_per_spM.size();
-
-        if (maxSeeds > m_filter_config.maxSeedsPerSpM) {
-            maxSeeds = m_filter_config.maxSeedsPerSpM + 1;
-        }
-
-        auto itBegin = seeds_per_spM.begin();
-        auto it = seeds_per_spM.begin();
-        // default filter removes the last seeds if maximum amount exceeded
-        // ordering by weight by filterSeeds_2SpFixed means these are the lowest
-        // weight seeds
-
-        for (; it < itBegin + maxSeeds; ++it) {
-            seeds.push_back(*it);
-        }
-    }
-
-    seedfilter_config get_seedfilter_config() { return m_filter_config; }
+    void operator()(const spacepoint_container_types::host& sp_container,
+                    const sp_grid& g2, host_triplet_collection& triplets,
+                    host_seed_collection& seeds) const;
 
     private:
+    /// Seed filter configuration
     seedfilter_config m_filter_config;
-};
+
+};  // class seed_filtering
 
 }  // namespace traccc

--- a/core/include/traccc/seeding/seed_finding.hpp
+++ b/core/include/traccc/seeding/seed_finding.hpp
@@ -8,89 +8,48 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/edm/internal_spacepoint.hpp"
 #include "traccc/edm/seed.hpp"
+#include "traccc/edm/spacepoint.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
+#include "traccc/seeding/detail/spacepoint_grid.hpp"
 #include "traccc/seeding/doublet_finding.hpp"
 #include "traccc/seeding/seed_filtering.hpp"
 #include "traccc/seeding/triplet_finding.hpp"
 #include "traccc/utils/algorithm.hpp"
 
-// System include(s).
-#include <iostream>
-
 namespace traccc {
 
 /// Seed finding
-struct seed_finding : public algorithm<host_seed_collection(
-                          const host_spacepoint_container&, const sp_grid&)> {
+class seed_finding
+    : public algorithm<host_seed_collection(
+          const spacepoint_container_types::host&, const sp_grid&)> {
 
+    public:
     /// Constructor for the seed finding
     ///
-    /// @param config is seed finder configuration parameters
-    /// @param isp_container is internal spacepoint container
-    seed_finding(const seedfinder_config& config)
-        : m_doublet_finding(config), m_triplet_finding(config) {}
+    /// @param find_config is seed finder configuration parameters
+    /// @param filter_config is the seed filter configuration
+    ///
+    seed_finding(const seedfinder_config& find_config,
+                 const seedfilter_config& filter_config);
 
     /// Callable operator for the seed finding
     ///
+    /// @param sp_container All spacepoints in the event
+    /// @param g2 The same spacepoints arranged in a 2D Phi-Z grid
     /// @return seed_collection is the vector of seeds per event
-    output_type operator()(const host_spacepoint_container& sp_container,
-                           const sp_grid& g2) const override {
-
-        // Run the algorithm
-        output_type seeds;
-
-        const bool bottom = true;
-        const bool top = false;
-
-        for (unsigned int i = 0; i < g2.nbins(); i++) {
-            auto& spM_collection = g2.bin(i);
-
-            for (unsigned int j = 0; j < spM_collection.size(); ++j) {
-
-                sp_location spM_location({i, j});
-
-                // middule-bottom doublet search
-                auto mid_bot = m_doublet_finding(g2, spM_location, bottom);
-
-                if (mid_bot.first.empty())
-                    continue;
-
-                // middule-top doublet search
-                auto mid_top = m_doublet_finding(g2, spM_location, top);
-
-                if (mid_top.first.empty())
-                    continue;
-
-                host_triplet_collection triplets_per_spM;
-
-                // triplet search from the combinations of two doublets which
-                // share middle spacepoint
-                for (unsigned int k = 0; k < mid_bot.first.size(); ++k) {
-                    auto& doublet_mb = mid_bot.first[k];
-                    auto& lb = mid_bot.second[k];
-
-                    host_triplet_collection triplets = m_triplet_finding(
-                        g2, doublet_mb, lb, mid_top.first, mid_top.second);
-
-                    triplets_per_spM.insert(std::end(triplets_per_spM),
-                                            triplets.begin(), triplets.end());
-                }
-
-                // seed filtering
-                std::pair<host_triplet_collection&, host_seed_collection&>
-                    filter_output(triplets_per_spM, seeds);
-                m_seed_filtering(sp_container, g2, filter_output);
-            }
-        }
-
-        return seeds;
-    }
+    ///
+    output_type operator()(const spacepoint_container_types::host& sp_container,
+                           const sp_grid& g2) const override;
 
     private:
+    /// Algorithm performing the doublet finding
     doublet_finding m_doublet_finding;
+    /// Algorithm performing the triplet finding
     triplet_finding m_triplet_finding;
+    /// Algorithm performing the seed selection
     seed_filtering m_seed_filtering;
-};
+
+};  // class seed_finding
+
 }  // namespace traccc

--- a/core/include/traccc/seeding/seeding_algorithm.hpp
+++ b/core/include/traccc/seeding/seeding_algorithm.hpp
@@ -7,60 +7,43 @@
 
 #pragma once
 
+// Library include(s).
+#include "traccc/edm/seed.hpp"
+#include "traccc/edm/spacepoint.hpp"
 #include "traccc/seeding/seed_finding.hpp"
 #include "traccc/seeding/spacepoint_binning.hpp"
+#include "traccc/utils/algorithm.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/memory_resource.hpp>
 
 namespace traccc {
 
-class seeding_algorithm
-    : public algorithm<host_seed_collection(const host_spacepoint_container&)> {
+/// Main algorithm for performing the track seeding on the CPU
+class seeding_algorithm : public algorithm<host_seed_collection(
+                              const spacepoint_container_types::host&)> {
+
     public:
-    seeding_algorithm(vecmem::memory_resource& mr) : m_mr(mr) {
+    /// Constructor for the seed finding algorithm
+    ///
+    /// @param mr The memory resource to use
+    ///
+    seeding_algorithm(vecmem::memory_resource& mr);
 
-        m_config.highland = 13.6 * std::sqrt(m_config.radLengthPerSeed) *
-                            (1 + 0.038 * std::log(m_config.radLengthPerSeed));
-        float maxScatteringAngle = m_config.highland / m_config.minPt;
-        m_config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
-        // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV
-        // and millimeter
-        // TODO: change using ACTS units
-        m_config.pTPerHelixRadius = 300. * m_config.bFieldInZ;
-        m_config.minHelixDiameter2 =
-            std::pow(m_config.minPt * 2 / m_config.pTPerHelixRadius, 2);
-        m_config.pT2perRadius =
-            std::pow(m_config.highland / m_config.pTPerHelixRadius, 2);
-
-        m_grid_config.bFieldInZ = m_config.bFieldInZ;
-        m_grid_config.minPt = m_config.minPt;
-        m_grid_config.rMax = m_config.rMax;
-        m_grid_config.zMax = m_config.zMax;
-        m_grid_config.zMin = m_config.zMin;
-        m_grid_config.deltaRMax = m_config.deltaRMax;
-        m_grid_config.cotThetaMax = m_config.cotThetaMax;
-
-        sb = std::make_shared<traccc::spacepoint_binning>(
-            traccc::spacepoint_binning(m_config, m_grid_config, mr));
-        sf = std::make_shared<traccc::seed_finding>(
-            traccc::seed_finding(m_config));
-    }
-
+    /// Operator executing the algorithm.
+    ///
+    /// @param spacepoint All spacepoints in the event
+    /// @return The track seeds reconstructed from the spacepoints
+    ///
     output_type operator()(
-        const host_spacepoint_container& spacepoints) const override {
-
-        auto internal_sp_g2 = sb->operator()(spacepoints);
-        output_type seeds = sf->operator()(spacepoints, internal_sp_g2);
-
-        return seeds;
-    }
-
-    seedfinder_config get_seedfinder_config() { return m_config; }
+        const spacepoint_container_types::host& spacepoints) const override;
 
     private:
-    seedfinder_config m_config;
-    spacepoint_grid_config m_grid_config;
-    std::shared_ptr<traccc::spacepoint_binning> sb;
-    std::shared_ptr<traccc::seed_finding> sf;
-    std::reference_wrapper<vecmem::memory_resource> m_mr;
-};
+    /// Sub-algorithm performing the spacepoint binning
+    spacepoint_binning m_spacepoint_binning;
+    /// Sub-algorithm performing the seed finding
+    seed_finding m_seed_finding;
+
+};  // class seeding_algorithm
 
 }  // namespace traccc

--- a/core/include/traccc/seeding/track_params_estimation.hpp
+++ b/core/include/traccc/seeding/track_params_estimation.hpp
@@ -7,49 +7,48 @@
 
 #pragma once
 
-#include "traccc/seeding/track_params_estimation_helper.hpp"
+// Library include(s).
+#include "traccc/edm/seed.hpp"
+#include "traccc/edm/spacepoint.hpp"
+#include "traccc/edm/track_parameters.hpp"
 #include "traccc/utils/algorithm.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/memory_resource.hpp>
+
+// System include(s).
+#include <functional>
 
 namespace traccc {
 
-/// track parameters estimation
-/// Originated from Acts/Seeding/EstimateTrackParamsFromSeed.hpp
-
-struct track_params_estimation
+/// Track parameter estimation algorithm
+///
+/// Transcribed from Acts/Seeding/EstimateTrackParamsFromSeed.hpp.
+///
+class track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
-          const host_spacepoint_container&, const host_seed_collection&)> {
+          const spacepoint_container_types::host&,
+          const host_seed_collection&)> {
+
     public:
     /// Constructor for track_params_estimation
     ///
     /// @param mr is the memory resource
-    track_params_estimation(vecmem::memory_resource& mr) : m_mr(mr) {}
+    track_params_estimation(vecmem::memory_resource& mr);
 
     /// Callable operator for track_params_esitmation
     ///
-    /// @param input_type is the seed container
+    /// @param spacepoints All spacepoints of the event
+    /// @param seeds The reconstructed track seeds of the event
+    /// @return A vector of bound track parameters
     ///
-    /// @return vector of bound track parameters
-    output_type operator()(const host_spacepoint_container& sp_container,
-                           const host_seed_collection& seeds) const override {
-        output_type result(&m_mr.get());
-
-        // convenient assumption on bfield and mass
-        // TODO: Make use of bfield extenstion in the future
-        vector3 bfield = {0, 0, 2};
-
-        for (const auto& seed : seeds) {
-            bound_track_parameters track_params;
-            track_params.vector() =
-                seed_to_bound_vector(sp_container, seed, bfield, PION_MASS_MEV);
-
-            result.push_back(track_params);
-        }
-
-        return result;
-    }
+    output_type operator()(const spacepoint_container_types::host& spacepoints,
+                           const host_seed_collection& seeds) const override;
 
     private:
+    /// The memory resource to use in the algorithm
     std::reference_wrapper<vecmem::memory_resource> m_mr;
-};
+
+};  // class track_params_estimation
 
 }  // namespace traccc

--- a/core/src/clusterization/spacepoint_formation.cpp
+++ b/core/src/clusterization/spacepoint_formation.cpp
@@ -27,8 +27,12 @@ spacepoint_formation::output_type spacepoint_formation::operator()(
         const measurement_collection_types::host& measurements_per_module =
             measurements.get_items()[i];
 
+        // Set the geometry ID for this collection of spacepoints.
+        result[i].header = module.module;
+
         // Access the spacepoint collection for the module.
-        host_spacepoint_collection& spacepoints_per_module = result[i].items;
+        spacepoint_collection_types::host& spacepoints_per_module =
+            result[i].items;
         spacepoints_per_module.reserve(measurements_per_module.size());
 
         // Construct the spacepoints.

--- a/core/src/seeding/seed_filtering.cpp
+++ b/core/src/seeding/seed_filtering.cpp
@@ -1,0 +1,105 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/seeding/seed_filtering.hpp"
+
+#include "traccc/seeding/seed_selecting_helper.hpp"
+
+namespace traccc {
+
+seed_filtering::seed_filtering(const seedfilter_config& config)
+    : m_filter_config(config) {}
+
+void seed_filtering::operator()(
+    const spacepoint_container_types::host& sp_container, const sp_grid& g2,
+    host_triplet_collection& triplets, host_seed_collection& seeds) const {
+
+    host_seed_collection seeds_per_spM;
+
+    for (triplet& triplet : triplets) {
+        // bottom
+        const auto& spB_idx = triplet.sp1;
+        const auto& spB = g2.bin(spB_idx.bin_idx)[spB_idx.sp_idx];
+
+        // middle
+        const auto& spM_idx = triplet.sp2;
+        const auto& spM = g2.bin(spM_idx.bin_idx)[spM_idx.sp_idx];
+
+        // top
+        const auto& spT_idx = triplet.sp3;
+        const auto& spT = g2.bin(spT_idx.bin_idx)[spT_idx.sp_idx];
+
+        seed_selecting_helper::seed_weight(m_filter_config, spM, spB, spT,
+                                           triplet.weight);
+
+        if (!seed_selecting_helper::single_seed_cut(m_filter_config, spM, spB,
+                                                    spT, triplet.weight)) {
+            continue;
+        }
+
+        seeds_per_spM.push_back({spB.m_link, spM.m_link, spT.m_link,
+                                 triplet.weight, triplet.z_vertex});
+    }
+
+    // sort seeds based on their weights
+    std::sort(seeds_per_spM.begin(), seeds_per_spM.end(),
+              [&](seed& seed1, seed& seed2) {
+                  if (seed1.weight != seed2.weight) {
+                      return seed1.weight > seed2.weight;
+                  } else {
+                      scalar seed1_sum = 0;
+                      scalar seed2_sum = 0;
+                      auto& spB1 = sp_container.at(seed1.spB_link);
+                      auto& spT1 = sp_container.at(seed1.spT_link);
+                      auto& spB2 = sp_container.at(seed2.spB_link);
+                      auto& spT2 = sp_container.at(seed2.spT_link);
+
+                      seed1_sum += pow(spB1.y(), 2) + pow(spB1.z(), 2);
+                      seed1_sum += pow(spT1.y(), 2) + pow(spT1.z(), 2);
+                      seed2_sum += pow(spB2.y(), 2) + pow(spB2.z(), 2);
+                      seed2_sum += pow(spT2.y(), 2) + pow(spT2.z(), 2);
+
+                      return seed1_sum > seed2_sum;
+                  }
+              });
+
+    host_seed_collection new_seeds;
+    if (seeds_per_spM.size() > 1) {
+        new_seeds.push_back(seeds_per_spM[0]);
+
+        size_t itLength = std::min(seeds_per_spM.size(),
+                                   m_filter_config.max_triplets_per_spM);
+        // don't cut first element
+        for (size_t i = 1; i < itLength; i++) {
+            if (seed_selecting_helper::cut_per_middle_sp(
+                    m_filter_config, sp_container, seeds_per_spM[i],
+                    seeds_per_spM[i].weight)) {
+                new_seeds.push_back(std::move(seeds_per_spM[i]));
+            }
+        }
+        seeds_per_spM = std::move(new_seeds);
+    }
+
+    unsigned int maxSeeds = seeds_per_spM.size();
+
+    if (maxSeeds > m_filter_config.maxSeedsPerSpM) {
+        maxSeeds = m_filter_config.maxSeedsPerSpM + 1;
+    }
+
+    auto itBegin = seeds_per_spM.begin();
+    auto it = seeds_per_spM.begin();
+    // default filter removes the last seeds if maximum amount exceeded
+    // ordering by weight by filterSeeds_2SpFixed means these are the lowest
+    // weight seeds
+
+    for (; it < itBegin + maxSeeds; ++it) {
+        seeds.push_back(*it);
+    }
+}
+
+}  // namespace traccc

--- a/core/src/seeding/seed_finding.cpp
+++ b/core/src/seeding/seed_finding.cpp
@@ -1,0 +1,71 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/seeding/seed_finding.hpp"
+
+namespace traccc {
+
+seed_finding::seed_finding(const seedfinder_config& finder_config,
+                           const seedfilter_config& filter_config)
+    : m_doublet_finding(finder_config),
+      m_triplet_finding(finder_config),
+      m_seed_filtering(filter_config) {}
+
+seed_finding::output_type seed_finding::operator()(
+    const spacepoint_container_types::host& sp_container,
+    const sp_grid& g2) const {
+
+    // Run the algorithm
+    output_type seeds;
+
+    const bool bottom = true;
+    const bool top = false;
+
+    for (unsigned int i = 0; i < g2.nbins(); i++) {
+        auto& spM_collection = g2.bin(i);
+
+        for (unsigned int j = 0; j < spM_collection.size(); ++j) {
+
+            sp_location spM_location({i, j});
+
+            // middule-bottom doublet search
+            auto mid_bot = m_doublet_finding(g2, spM_location, bottom);
+
+            if (mid_bot.first.empty())
+                continue;
+
+            // middule-top doublet search
+            auto mid_top = m_doublet_finding(g2, spM_location, top);
+
+            if (mid_top.first.empty())
+                continue;
+
+            host_triplet_collection triplets_per_spM;
+
+            // triplet search from the combinations of two doublets which
+            // share middle spacepoint
+            for (unsigned int k = 0; k < mid_bot.first.size(); ++k) {
+                auto& doublet_mb = mid_bot.first[k];
+                auto& lb = mid_bot.second[k];
+
+                host_triplet_collection triplets = m_triplet_finding(
+                    g2, doublet_mb, lb, mid_top.first, mid_top.second);
+
+                triplets_per_spM.insert(std::end(triplets_per_spM),
+                                        triplets.begin(), triplets.end());
+            }
+
+            // seed filtering
+            m_seed_filtering(sp_container, g2, triplets_per_spM, seeds);
+        }
+    }
+
+    return seeds;
+}
+
+}  // namespace traccc

--- a/core/src/seeding/seeding_algorithm.cpp
+++ b/core/src/seeding/seeding_algorithm.cpp
@@ -1,0 +1,67 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/seeding/seeding_algorithm.hpp"
+
+#include "traccc/seeding/detail/seeding_config.hpp"
+
+// System include(s).
+#include <cmath>
+
+namespace {
+
+/// Helper function that would produce a default seed-finder configuration
+traccc::seedfinder_config default_seedfinder_config() {
+
+    traccc::seedfinder_config config;
+    config.highland = 13.6 * std::sqrt(config.radLengthPerSeed) *
+                      (1 + 0.038 * std::log(config.radLengthPerSeed));
+    float maxScatteringAngle = config.highland / config.minPt;
+    config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
+    // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV
+    // and millimeter
+    // TODO: change using ACTS units
+    config.pTPerHelixRadius = 300. * config.bFieldInZ;
+    config.minHelixDiameter2 =
+        std::pow(config.minPt * 2 / config.pTPerHelixRadius, 2);
+    config.pT2perRadius =
+        std::pow(config.highland / config.pTPerHelixRadius, 2);
+    return config;
+}
+
+/// Helper function that would produce a default spacepoint grid configuration
+traccc::spacepoint_grid_config default_spacepoint_grid_config() {
+
+    traccc::seedfinder_config config = default_seedfinder_config();
+    traccc::spacepoint_grid_config grid_config;
+    grid_config.bFieldInZ = config.bFieldInZ;
+    grid_config.minPt = config.minPt;
+    grid_config.rMax = config.rMax;
+    grid_config.zMax = config.zMax;
+    grid_config.zMin = config.zMin;
+    grid_config.deltaRMax = config.deltaRMax;
+    grid_config.cotThetaMax = config.cotThetaMax;
+    return grid_config;
+}
+
+}  // namespace
+
+namespace traccc {
+
+seeding_algorithm::seeding_algorithm(vecmem::memory_resource& mr)
+    : m_spacepoint_binning(default_seedfinder_config(),
+                           default_spacepoint_grid_config(), mr),
+      m_seed_finding(default_seedfinder_config(), seedfilter_config()) {}
+
+seeding_algorithm::output_type seeding_algorithm::operator()(
+    const spacepoint_container_types::host& spacepoints) const {
+
+    return m_seed_finding(spacepoints, m_spacepoint_binning(spacepoints));
+}
+
+}  // namespace traccc

--- a/core/src/seeding/spacepoint_binning.cpp
+++ b/core/src/seeding/spacepoint_binning.cpp
@@ -1,0 +1,56 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/seeding/spacepoint_binning.hpp"
+
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/seeding/spacepoint_binning_helper.hpp"
+
+namespace traccc {
+
+spacepoint_binning::spacepoint_binning(
+    const seedfinder_config& config, const spacepoint_grid_config& grid_config,
+    vecmem::memory_resource& mr)
+    : m_config(config),
+      m_grid_config(grid_config),
+      m_axes(get_axes(grid_config, mr)),
+      m_mr(mr) {}
+
+spacepoint_binning::output_type spacepoint_binning::operator()(
+    const spacepoint_container_types::host& sp_container) const {
+
+    output_type g2(m_axes.first, m_axes.second, m_mr.get());
+
+    djagged_vector<sp_location> rbins(m_config.get_num_rbins());
+
+    for (unsigned int i = 0; i < sp_container.size(); i++) {
+        for (unsigned int j = 0; j < sp_container.get_items()[i].size(); j++) {
+            sp_location sp_loc{i, j};
+            fill_radius_bins<spacepoint_container_types::host, djagged_vector>(
+                m_config, sp_container, sp_loc, rbins);
+        }
+    }
+
+    // fill rbins into grid such that each grid bin is sorted in r
+    // space points with delta r < rbin size can be out of order
+    for (auto& rbin : rbins) {
+        for (auto& sp_loc : rbin) {
+
+            auto isp = internal_spacepoint<spacepoint>(
+                sp_container, {sp_loc.bin_idx, sp_loc.sp_idx},
+                m_config.beamPos);
+
+            point2 sp_position = {isp.phi(), isp.z()};
+            g2.populate(sp_position, std::move(isp));
+        }
+    }
+
+    return g2;
+}
+
+}  // namespace traccc

--- a/core/src/seeding/track_params_estimation.cpp
+++ b/core/src/seeding/track_params_estimation.cpp
@@ -1,0 +1,39 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/seeding/track_params_estimation.hpp"
+
+#include "traccc/seeding/track_params_estimation_helper.hpp"
+
+namespace traccc {
+
+track_params_estimation::track_params_estimation(vecmem::memory_resource& mr)
+    : m_mr(mr) {}
+
+track_params_estimation::output_type track_params_estimation::operator()(
+    const spacepoint_container_types::host& spacepoints,
+    const host_seed_collection& seeds) const {
+
+    output_type result(&m_mr.get());
+
+    // convenient assumption on bfield and mass
+    // TODO: Make use of bfield extenstion in the future
+    vector3 bfield = {0, 0, 2};
+
+    for (const auto& seed : seeds) {
+        bound_track_parameters track_params;
+        track_params.vector() =
+            seed_to_bound_vector(spacepoints, seed, bfield, PION_MASS_MEV);
+
+        result.push_back(track_params);
+    }
+
+    return result;
+}
+
+}  // namespace traccc

--- a/device/common/include/traccc/seeding/device/count_grid_capacities.hpp
+++ b/device/common/include/traccc/seeding/device/count_grid_capacities.hpp
@@ -44,7 +44,7 @@ TRACCC_HOST_DEVICE
 void count_grid_capacities(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid::axis_p0_type& phi_axis, const sp_grid::axis_p1_type& z_axis,
-    const spacepoint_container_const_view& spacepoints,
+    const spacepoint_container_types::const_view& spacepoints,
     const vecmem::data::vector_view<const prefix_sum_element_t>& sp_prefix_sum,
     vecmem::data::vector_view<unsigned int> grid_capacities);
 

--- a/device/common/include/traccc/seeding/device/impl/count_grid_capacities.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_grid_capacities.ipp
@@ -19,7 +19,7 @@ TRACCC_HOST_DEVICE
 void count_grid_capacities(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid::axis_p0_type& phi_axis, const sp_grid::axis_p1_type& z_axis,
-    const spacepoint_container_const_view& spacepoints_view,
+    const spacepoint_container_types::const_view& spacepoints_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         sp_prefix_sum_view,
     vecmem::data::vector_view<unsigned int> grid_capacities_view) {
@@ -33,7 +33,8 @@ void count_grid_capacities(
 
     // Get the spacepoint that we need to look at.
     const prefix_sum_element_t sp_idx = sp_prefix_sum[globalIndex];
-    device_spacepoint_const_container spacepoints(spacepoints_view);
+    const spacepoint_container_types::const_device spacepoints(
+        spacepoints_view);
     const spacepoint sp = spacepoints.at(sp_idx);
 
     /// Check out if the spacepoint can be used for seeding.

--- a/device/common/include/traccc/seeding/device/impl/populate_grid.ipp
+++ b/device/common/include/traccc/seeding/device/impl/populate_grid.ipp
@@ -13,11 +13,12 @@
 namespace traccc::device {
 
 TRACCC_DEVICE
-void populate_grid(std::size_t globalIndex, const seedfinder_config& config,
-                   const spacepoint_container_const_view& spacepoints_view,
-                   const vecmem::data::vector_view<const prefix_sum_element_t>&
-                       sp_prefix_sum_view,
-                   sp_grid_view grid_view) {
+void populate_grid(
+    std::size_t globalIndex, const seedfinder_config& config,
+    const spacepoint_container_types::const_view& spacepoints_view,
+    const vecmem::data::vector_view<const prefix_sum_element_t>&
+        sp_prefix_sum_view,
+    sp_grid_view grid_view) {
 
     // Check if anything needs to be done.
     vecmem::device_vector<const prefix_sum_element_t> sp_prefix_sum(
@@ -28,7 +29,8 @@ void populate_grid(std::size_t globalIndex, const seedfinder_config& config,
 
     // Get the spacepoint that we need to look at.
     const prefix_sum_element_t sp_idx = sp_prefix_sum[globalIndex];
-    device_spacepoint_const_container spacepoints(spacepoints_view);
+    const spacepoint_container_types::const_device spacepoints(
+        spacepoints_view);
     const spacepoint sp = spacepoints.at(sp_idx);
 
     /// Check out if the spacepoint can be used for seeding.

--- a/device/common/include/traccc/seeding/device/populate_grid.hpp
+++ b/device/common/include/traccc/seeding/device/populate_grid.hpp
@@ -33,7 +33,7 @@ namespace traccc::device {
 TRACCC_DEVICE
 void populate_grid(
     std::size_t globalIndex, const seedfinder_config& config,
-    const spacepoint_container_const_view& spacepoints,
+    const spacepoint_container_types::const_view& spacepoints,
     const vecmem::data::vector_view<const prefix_sum_element_t>& sp_prefix_sum,
     sp_grid_view grid);
 

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -35,6 +35,7 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/seeding/seed_selecting.cu"
   "src/seeding/spacepoint_binning.cu"
   "src/seeding/triplet_finding.cu"
+  "src/seeding/seeding_algorithm.cpp"
   "src/cca/component_connection.cu"
 )
 target_compile_options( traccc_cuda

--- a/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
@@ -25,8 +25,8 @@ namespace traccc::cuda {
 
 /// Seed finding for cuda
 class seed_finding
-    : public algorithm<host_seed_collection(const host_spacepoint_container&,
-                                            const sp_grid_const_view&)> {
+    : public algorithm<host_seed_collection(
+          const spacepoint_container_types::host&, const sp_grid_const_view&)> {
 
     public:
     /// Constructor for the cuda seed finding
@@ -39,7 +39,7 @@ class seed_finding
     /// Callable operator for the seed finding
     ///
     /// @return seed_collection is the vector of seeds per event
-    output_type operator()(const host_spacepoint_container& spacepoints,
+    output_type operator()(const spacepoint_container_types::host& spacepoints,
                            const sp_grid_const_view& g2_view) const override;
 
     private:

--- a/device/cuda/include/traccc/cuda/seeding/seed_selecting.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_selecting.hpp
@@ -33,7 +33,7 @@ namespace cuda {
 void seed_selecting(
     const seedfilter_config& filter_config,
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
-    const host_spacepoint_container& spacepoints,
+    const spacepoint_container_types::host& spacepoints,
     sp_grid_const_view internal_sp_view,
     device::doublet_counter_container_types::const_view dcc_view,
     triplet_counter_container_view tcc_view, triplet_container_view tc_view,

--- a/device/cuda/include/traccc/cuda/seeding/spacepoint_binning.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/spacepoint_binning.hpp
@@ -23,8 +23,8 @@
 namespace traccc::cuda {
 
 /// Spacepoing binning executed on a CUDA device
-class spacepoint_binning
-    : public algorithm<sp_grid_buffer(const host_spacepoint_container&)> {
+class spacepoint_binning : public algorithm<sp_grid_buffer(
+                               const spacepoint_container_types::host&)> {
 
     public:
     /// Constructor for the algorithm
@@ -34,7 +34,7 @@ class spacepoint_binning
 
     /// Function executing the algorithm
     sp_grid_buffer operator()(
-        const host_spacepoint_container& spacepoints) const override;
+        const spacepoint_container_types::host& spacepoints) const override;
 
     private:
     seedfinder_config m_config;

--- a/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
@@ -16,7 +16,7 @@ namespace cuda {
 /// track parameter estimation for cuda
 struct track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
-          host_spacepoint_container&&, host_seed_collection&&)> {
+          const spacepoint_container_types::host&, host_seed_collection&&)> {
     public:
     /// Constructor for track_params_estimation
     ///
@@ -28,7 +28,7 @@ struct track_params_estimation
     /// @param input_type is the seed container
     ///
     /// @return vector of bound track parameters
-    output_type operator()(host_spacepoint_container&& spacepoints,
+    output_type operator()(const spacepoint_container_types::host& spacepoints,
                            host_seed_collection&& seeds) const override;
 
     private:

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -63,7 +63,7 @@ seed_finding::seed_finding(const seedfinder_config& config,
     : m_seedfinder_config(config), m_mr(mr) {}
 
 seed_finding::output_type seed_finding::operator()(
-    const host_spacepoint_container& spacepoints,
+    const spacepoint_container_types::host& spacepoints,
     const sp_grid_const_view& g2_view) const {
 
     // Helper object for the data management.

--- a/device/cuda/src/seeding/seed_selecting.cu
+++ b/device/cuda/src/seeding/seed_selecting.cu
@@ -32,7 +32,7 @@ namespace cuda {
 /// @param seed_container vecmem container for seeds
 __global__ void seed_selecting_kernel(
     const seedfilter_config filter_config,
-    spacepoint_container_const_view spacepoints_view,
+    spacepoint_container_types::const_view spacepoints_view,
     sp_grid_const_view internal_sp_view,
     device::doublet_counter_container_types::const_view doublet_counter_view,
     triplet_counter_container_view triplet_counter_view,
@@ -42,7 +42,7 @@ __global__ void seed_selecting_kernel(
 void seed_selecting(
     const seedfilter_config& filter_config,
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
-    const host_spacepoint_container& spacepoints,
+    const spacepoint_container_types::host& spacepoints,
     sp_grid_const_view internal_sp_view,
     device::doublet_counter_container_types::const_view dcc_view,
     triplet_counter_container_view tcc_view, triplet_container_view tc_view,
@@ -51,7 +51,8 @@ void seed_selecting(
 
     unsigned int nbins = internal_sp_view._data_view.m_size;
 
-    auto spacepoints_view = get_data(spacepoints, &resource);
+    spacepoint_container_types::const_view spacepoints_view =
+        get_data(spacepoints, &resource);
 
     // The thread-block is desinged to make each thread investigate the
     // compatible middle spacepoint
@@ -86,7 +87,7 @@ void seed_selecting(
 
 __global__ void seed_selecting_kernel(
     const seedfilter_config filter_config,
-    spacepoint_container_const_view spacepoints_view,
+    spacepoint_container_types::const_view spacepoints_view,
     sp_grid_const_view internal_sp_view,
     device::doublet_counter_container_types::const_view doublet_counter_view,
     triplet_counter_container_view triplet_counter_view,
@@ -94,7 +95,8 @@ __global__ void seed_selecting_kernel(
     vecmem::data::vector_view<seed> seed_view) {
 
     // Get device container for input parameters
-    device_spacepoint_const_container spacepoints_device(spacepoints_view);
+    const spacepoint_container_types::const_device spacepoints_device(
+        spacepoints_view);
     const_sp_grid_device internal_sp_device(internal_sp_view);
 
     const device::doublet_counter_container_types::const_device

--- a/device/cuda/src/seeding/seeding_algorithm.cpp
+++ b/device/cuda/src/seeding/seeding_algorithm.cpp
@@ -1,0 +1,68 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/cuda/seeding/seeding_algorithm.hpp"
+
+// Project include(s).
+#include "traccc/seeding/detail/seeding_config.hpp"
+
+// System include(s).
+#include <cmath>
+
+namespace {
+
+/// Helper function that would produce a default seed-finder configuration
+traccc::seedfinder_config default_seedfinder_config() {
+
+    traccc::seedfinder_config config;
+    config.highland = 13.6 * std::sqrt(config.radLengthPerSeed) *
+                      (1 + 0.038 * std::log(config.radLengthPerSeed));
+    float maxScatteringAngle = config.highland / config.minPt;
+    config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
+    // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV
+    // and millimeter
+    // TODO: change using ACTS units
+    config.pTPerHelixRadius = 300. * config.bFieldInZ;
+    config.minHelixDiameter2 =
+        std::pow(config.minPt * 2 / config.pTPerHelixRadius, 2);
+    config.pT2perRadius =
+        std::pow(config.highland / config.pTPerHelixRadius, 2);
+    return config;
+}
+
+/// Helper function that would produce a default spacepoint grid configuration
+traccc::spacepoint_grid_config default_spacepoint_grid_config() {
+
+    traccc::seedfinder_config config = default_seedfinder_config();
+    traccc::spacepoint_grid_config grid_config;
+    grid_config.bFieldInZ = config.bFieldInZ;
+    grid_config.minPt = config.minPt;
+    grid_config.rMax = config.rMax;
+    grid_config.zMax = config.zMax;
+    grid_config.zMin = config.zMin;
+    grid_config.deltaRMax = config.deltaRMax;
+    grid_config.cotThetaMax = config.cotThetaMax;
+    return grid_config;
+}
+
+}  // namespace
+
+namespace traccc::cuda {
+
+seeding_algorithm::seeding_algorithm(vecmem::memory_resource& mr)
+    : m_spacepoint_binning(default_seedfinder_config(),
+                           default_spacepoint_grid_config(), mr),
+      m_seed_finding(default_seedfinder_config(), mr) {}
+
+seeding_algorithm::output_type seeding_algorithm::operator()(
+    const spacepoint_container_types::host& spacepoints) const {
+
+    return m_seed_finding(spacepoints, m_spacepoint_binning(spacepoints));
+}
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/seeding/spacepoint_binning.cu
+++ b/device/cuda/src/seeding/spacepoint_binning.cu
@@ -23,7 +23,8 @@ namespace kernels {
 /// CUDA kernel for running @c traccc::device::count_grid_capacities
 __global__ void count_grid_capacities(
     seedfinder_config config, sp_grid::axis_p0_type phi_axis,
-    sp_grid::axis_p1_type z_axis, spacepoint_container_const_view spacepoints,
+    sp_grid::axis_p1_type z_axis,
+    spacepoint_container_types::const_view spacepoints,
     vecmem::data::vector_view<const device::prefix_sum_element_t> sp_prefix_sum,
     vecmem::data::vector_view<unsigned int> grid_capacities) {
 
@@ -34,7 +35,8 @@ __global__ void count_grid_capacities(
 
 /// CUDA kernel for running @c traccc::device::populate_grid
 __global__ void populate_grid(
-    seedfinder_config config, spacepoint_container_const_view spacepoints,
+    seedfinder_config config,
+    spacepoint_container_types::const_view spacepoints,
     vecmem::data::vector_view<const device::prefix_sum_element_t> sp_prefix_sum,
     sp_grid_view grid) {
 
@@ -50,13 +52,13 @@ spacepoint_binning::spacepoint_binning(
     : m_config(config), m_axes(get_axes(grid_config, mr)), m_mr(mr) {}
 
 sp_grid_buffer spacepoint_binning::operator()(
-    const host_spacepoint_container& spacepoints) const {
+    const spacepoint_container_types::host& spacepoints) const {
 
     // Helper object for the data management.
     vecmem::copy copy;
 
     // Get the data/view for the spacepoints.
-    const spacepoint_container_const_data sp_data =
+    const spacepoint_container_types::const_data sp_data =
         traccc::get_data(spacepoints);
 
     // Get the prefix sum for the spacepoints.

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -18,17 +18,18 @@ namespace cuda {
 /// @param params_view vector of bound track parameters at the bottom
 /// spacepoints
 __global__ void track_params_estimating_kernel(
-    spacepoint_container_view spacepoints_view,
+    spacepoint_container_types::const_view spacepoints_view,
     vecmem::data::vector_view<seed> seeds_view,
     vecmem::data::vector_view<bound_track_parameters> params_view);
 
 track_params_estimation::output_type track_params_estimation::operator()(
-    host_spacepoint_container&& spacepoints,
+    const spacepoint_container_types::host& spacepoints,
     host_seed_collection&& seeds) const {
 
     output_type params(seeds.size(), &m_mr.get());
 
-    auto spacepoints_view = get_data(spacepoints, &m_mr.get());
+    spacepoint_container_types::const_view spacepoints_view =
+        get_data(spacepoints, &m_mr.get());
     auto seeds_view = vecmem::get_data(seeds);
     auto params_view = vecmem::get_data(params);
 
@@ -52,12 +53,13 @@ track_params_estimation::output_type track_params_estimation::operator()(
 }
 
 __global__ void track_params_estimating_kernel(
-    spacepoint_container_view spacepoints_view,
+    spacepoint_container_types::const_view spacepoints_view,
     vecmem::data::vector_view<seed> seeds_view,
     vecmem::data::vector_view<bound_track_parameters> params_view) {
 
     // Get device container for input parameters
-    device_spacepoint_container spacepoints_device(spacepoints_view);
+    const spacepoint_container_types::const_device spacepoints_device(
+        spacepoints_view);
     device_seed_collection seeds_device(seeds_view);
     device_bound_track_parameters_collection params_device(params_view);
 

--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -35,6 +35,7 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
   "src/seeding/seed_finding.sycl"
   "src/seeding/seed_selecting.hpp"
   "src/seeding/seed_selecting.sycl"
+  "src/seeding/seeding_algorithm.cpp"
   "src/seeding/spacepoint_binning.sycl"
   "src/seeding/sycl_helper.hpp"
   "src/seeding/track_params_estimation.sycl"
@@ -50,7 +51,7 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
   "src/utils/queue_wrapper.cpp" )
 target_link_libraries( traccc_sycl
   PUBLIC vecmem::core traccc::core
-  PRIVATE traccc::device_common vecmem::sycl )
+  PRIVATE traccc::device_common )
 
 # Prevent Eigen from getting confused when building code for a HIP backend.
 target_compile_definitions( traccc_sycl PRIVATE EIGEN_NO_CUDA )

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -22,8 +22,9 @@
 
 namespace traccc::sycl {
 
-class clusterization_algorithm : public algorithm<spacepoint_container_buffer(
-                                     const cell_container_types::host&)> {
+class clusterization_algorithm
+    : public algorithm<spacepoint_container_types::buffer(
+          const cell_container_types::host&)> {
 
     public:
     /// Constructor for clusterization algorithm

--- a/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
@@ -26,9 +26,9 @@
 namespace traccc::sycl {
 
 // Sycl seeding function object
-class seed_finding
-    : public algorithm<vecmem::data::vector_buffer<seed>(
-          const spacepoint_container_const_view&, const sp_grid_const_view&)> {
+class seed_finding : public algorithm<vecmem::data::vector_buffer<seed>(
+                         const spacepoint_container_types::const_view&,
+                         const sp_grid_const_view&)> {
 
     public:
     /// Constructor for the sycl seed finding
@@ -45,7 +45,7 @@ class seed_finding
     ///
     /// @return seed_collection is the vector of seeds per event
     output_type operator()(
-        const spacepoint_container_const_view& spacepoints_view,
+        const spacepoint_container_types::const_view& spacepoints_view,
         const sp_grid_const_view& g2_view) const override;
 
     private:

--- a/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
@@ -7,70 +7,48 @@
 
 #pragma once
 
-// Project include(s).
-#include "traccc/edm/seed.hpp"
+// Library include(s).
 #include "traccc/sycl/seeding/seed_finding.hpp"
 #include "traccc/sycl/seeding/spacepoint_binning.hpp"
+#include "traccc/sycl/utils/queue_wrapper.hpp"
+
+// Project include(s).
+#include "traccc/edm/seed.hpp"
+#include "traccc/edm/spacepoint.hpp"
 #include "traccc/utils/algorithm.hpp"
 
 // VecMem include(s).
 #include <vecmem/containers/data/vector_buffer.hpp>
-#include <vecmem/utils/copy.hpp>
+#include <vecmem/memory/memory_resource.hpp>
 
-// System include(s).
-#include <memory>
+namespace traccc::sycl {
 
-namespace traccc {
-namespace sycl {
-
+/// Main algorithm for performing the track seeding using oneAPI/SYCL
 class seeding_algorithm : public algorithm<vecmem::data::vector_buffer<seed>(
-                              const spacepoint_container_const_view&)> {
+                              const spacepoint_container_types::const_view&)> {
 
     public:
-    seeding_algorithm(vecmem::memory_resource& mr, ::sycl::queue* q = nullptr)
-        : m_mr(mr) {
+    /// Constructor for the seed finding algorithm
+    ///
+    /// @param mr The memory resource to use
+    /// @param queue The SYCL queue to work with
+    ///
+    seeding_algorithm(vecmem::memory_resource& mr, queue_wrapper queue);
 
-        m_config.highland = 13.6 * std::sqrt(m_config.radLengthPerSeed) *
-                            (1 + 0.038 * std::log(m_config.radLengthPerSeed));
-        float maxScatteringAngle = m_config.highland / m_config.minPt;
-        m_config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
-        // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV
-        // and millimeter
-        // TODO: change using ACTS units
-        m_config.pTPerHelixRadius = 300. * m_config.bFieldInZ;
-        m_config.minHelixDiameter2 =
-            std::pow(m_config.minPt * 2 / m_config.pTPerHelixRadius, 2);
-        m_config.pT2perRadius =
-            std::pow(m_config.highland / m_config.pTPerHelixRadius, 2);
-
-        m_grid_config.bFieldInZ = m_config.bFieldInZ;
-        m_grid_config.minPt = m_config.minPt;
-        m_grid_config.rMax = m_config.rMax;
-        m_grid_config.zMax = m_config.zMax;
-        m_grid_config.zMin = m_config.zMin;
-        m_grid_config.deltaRMax = m_config.deltaRMax;
-        m_grid_config.cotThetaMax = m_config.cotThetaMax;
-
-        sb = std::make_shared<traccc::sycl::spacepoint_binning>(
-            traccc::sycl::spacepoint_binning(m_config, m_grid_config, mr, q));
-        sf = std::make_shared<traccc::sycl::seed_finding>(
-            traccc::sycl::seed_finding(m_config, mr, q));
-    }
-
-    output_type operator()(const spacepoint_container_const_view&
-                               spacepoints_view) const override {
-        sp_grid_buffer internal_sp_g2 = (*sb)(spacepoints_view);
-        output_type seeds = (*sf)(spacepoints_view, internal_sp_g2);
-        return seeds;
-    }
+    /// Operator executing the algorithm.
+    ///
+    /// @param spacepoints_view A view of all spacepoints in the event
+    /// @return The track seeds reconstructed from the spacepoints
+    ///
+    output_type operator()(const spacepoint_container_types::const_view&
+                               spacepoints) const override;
 
     private:
-    seedfinder_config m_config;
-    spacepoint_grid_config m_grid_config;
-    std::reference_wrapper<vecmem::memory_resource> m_mr;
-    std::shared_ptr<traccc::sycl::spacepoint_binning> sb;
-    std::shared_ptr<traccc::sycl::seed_finding> sf;
-};
+    /// Sub-algorithm performing the spacepoint binning
+    spacepoint_binning m_spacepoint_binning;
+    /// Sub-algorithm performing the seed finding
+    seed_finding m_seed_finding;
 
-}  // namespace sycl
-}  // namespace traccc
+};  // class seeding_algorithm
+
+}  // namespace traccc::sycl

--- a/device/sycl/include/traccc/sycl/seeding/spacepoint_binning.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/spacepoint_binning.hpp
@@ -26,8 +26,8 @@
 namespace traccc::sycl {
 
 /// Spacepoing binning executed on a SYCL device
-class spacepoint_binning
-    : public algorithm<sp_grid_buffer(const spacepoint_container_const_view&)> {
+class spacepoint_binning : public algorithm<sp_grid_buffer(
+                               const spacepoint_container_types::const_view&)> {
 
     public:
     /// Constructor for the algorithm
@@ -36,8 +36,8 @@ class spacepoint_binning
                        vecmem::memory_resource& mr, const queue_wrapper& queue);
 
     /// Function executing the algorithm
-    sp_grid_buffer operator()(
-        const spacepoint_container_const_view& spacepoints_view) const override;
+    sp_grid_buffer operator()(const spacepoint_container_types::const_view&
+                                  spacepoints_view) const override;
 
     private:
     seedfinder_config m_config;

--- a/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
@@ -27,8 +27,9 @@ namespace traccc::sycl {
 /// track parameter estimation for sycl
 struct track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
-          const spacepoint_container_const_view&,
+          const spacepoint_container_types::const_view&,
           const vecmem::data::vector_view<const seed>&)> {
+
     public:
     /// Constructor for track_params_estimation
     ///
@@ -42,7 +43,7 @@ struct track_params_estimation
     ///
     /// @return vector of bound track parameters
     output_type operator()(
-        const spacepoint_container_const_view& spacepoints_view,
+        const spacepoint_container_types::const_view& spacepoints_view,
         const vecmem::data::vector_view<const seed>& seeds_view) const override;
 
     private:

--- a/device/sycl/src/clusterization/clusterization_algorithm.cpp
+++ b/device/sycl/src/clusterization/clusterization_algorithm.cpp
@@ -29,7 +29,7 @@ clusterization_algorithm::clusterization_algorithm(vecmem::memory_resource &mr,
                                                    queue_wrapper queue)
     : m_mr(mr), m_queue(queue) {}
 
-spacepoint_container_buffer clusterization_algorithm::operator()(
+clusterization_algorithm::output_type clusterization_algorithm::operator()(
     const cell_container_types::host &cells_per_event) const {
 
     // Number of modules
@@ -127,7 +127,7 @@ spacepoint_container_buffer clusterization_algorithm::operator()(
                                        cells_view, m_queue);
 
     // Spacepoint container buffer to fill in spacepoint formation
-    spacepoint_container_buffer spacepoints_buffer{
+    spacepoint_container_types::buffer spacepoints_buffer{
         {num_modules, m_mr.get()},
         {std::vector<std::size_t>(num_modules, 0), clusters_per_module_host,
          m_mr.get()}};

--- a/device/sycl/src/clusterization/spacepoint_formation.hpp
+++ b/device/sycl/src/clusterization/spacepoint_formation.hpp
@@ -22,7 +22,7 @@ namespace traccc::sycl {
 /// Forward decleration of spacepoint formation kernel
 ///
 void spacepoint_formation(
-    spacepoint_container_view spacepoints_view,
+    spacepoint_container_types::view spacepoints_view,
     measurement_container_types::const_view measurements_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         measurements_prefix_sum_view,

--- a/device/sycl/src/clusterization/spacepoint_formation.sycl
+++ b/device/sycl/src/clusterization/spacepoint_formation.sycl
@@ -17,7 +17,7 @@
 namespace traccc::sycl {
 
 void spacepoint_formation(
-    spacepoint_container_view spacepoints_view,
+    spacepoint_container_types::view spacepoints_view,
     measurement_container_types::const_view measurements_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         measurements_prefix_sum_view,
@@ -43,7 +43,7 @@ void spacepoint_formation(
                     // Initialize device containers
                     measurement_container_types::const_device
                         measurements_device(measurements_view);
-                    device_spacepoint_container spacepoints_device(
+                    spacepoint_container_types::device spacepoints_device(
                         spacepoints_view);
                     vecmem::device_vector<const device::prefix_sum_element_t>
                         measurements_prefix_sum(measurements_prefix_sum_view);

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -44,7 +44,7 @@ seed_finding::seed_finding(const seedfinder_config& config,
     : m_seedfinder_config(config), m_mr(mr), m_queue(queue) {}
 
 seed_finding::output_type seed_finding::operator()(
-    const spacepoint_container_const_view& spacepoints_view,
+    const spacepoint_container_types::const_view& spacepoints_view,
     const sp_grid_const_view& g2_view) const {
 
     // Helper object for the data management.

--- a/device/sycl/src/seeding/seed_selecting.hpp
+++ b/device/sycl/src/seeding/seed_selecting.hpp
@@ -38,7 +38,7 @@ namespace traccc::sycl {
 void seed_selecting(
     const seedfilter_config& filter_config,
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
-    const spacepoint_container_const_view& spacepoints_view,
+    const spacepoint_container_types::const_view& spacepoints_view,
     const sp_grid_const_view& internal_sp,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,

--- a/device/sycl/src/seeding/seed_selecting.sycl
+++ b/device/sycl/src/seeding/seed_selecting.sycl
@@ -56,7 +56,7 @@ static int min_elem(const local_accessor<triplet>& arr, const int& begin_idx,
 class SeedSelect {
     public:
     SeedSelect(const seedfilter_config filter_config,
-               spacepoint_container_const_view spacepoints_view,
+               spacepoint_container_types::const_view spacepoints_view,
                sp_grid_const_view internal_sp_view,
                device::doublet_counter_container_types::const_view
                    doublet_counter_view,
@@ -79,7 +79,7 @@ class SeedSelect {
         auto workItemIdx = item.get_local_id(0);
 
         // Get device container for input parameters
-        device_spacepoint_const_container spacepoints_device(
+        const spacepoint_container_types::const_device spacepoints_device(
             m_spacepoints_view);
 
         const_sp_grid_device internal_sp_device(m_internal_sp_view);
@@ -244,7 +244,7 @@ class SeedSelect {
 
     private:
     const seedfilter_config m_filter_config;
-    spacepoint_container_const_view m_spacepoints_view;
+    spacepoint_container_types::const_view m_spacepoints_view;
     sp_grid_const_view m_internal_sp_view;
     device::doublet_counter_container_types::const_view m_doublet_counter_view;
     triplet_counter_container_view m_triplet_counter_view;
@@ -256,7 +256,7 @@ class SeedSelect {
 void seed_selecting(
     const seedfilter_config& filter_config,
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
-    const spacepoint_container_const_view& spacepoints_view,
+    const spacepoint_container_types::const_view& spacepoints_view,
     const sp_grid_const_view& internal_sp,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,

--- a/device/sycl/src/seeding/seeding_algorithm.cpp
+++ b/device/sycl/src/seeding/seeding_algorithm.cpp
@@ -1,0 +1,70 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/sycl/seeding/seeding_algorithm.hpp"
+
+// Project include(s).
+#include "traccc/seeding/detail/seeding_config.hpp"
+
+// System include(s).
+#include <cmath>
+
+namespace {
+
+/// Helper function that would produce a default seed-finder configuration
+traccc::seedfinder_config default_seedfinder_config() {
+
+    traccc::seedfinder_config config;
+    config.highland = 13.6 * std::sqrt(config.radLengthPerSeed) *
+                      (1 + 0.038 * std::log(config.radLengthPerSeed));
+    float maxScatteringAngle = config.highland / config.minPt;
+    config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
+    // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV
+    // and millimeter
+    // TODO: change using ACTS units
+    config.pTPerHelixRadius = 300. * config.bFieldInZ;
+    config.minHelixDiameter2 =
+        std::pow(config.minPt * 2 / config.pTPerHelixRadius, 2);
+    config.pT2perRadius =
+        std::pow(config.highland / config.pTPerHelixRadius, 2);
+    return config;
+}
+
+/// Helper function that would produce a default spacepoint grid configuration
+traccc::spacepoint_grid_config default_spacepoint_grid_config() {
+
+    traccc::seedfinder_config config = default_seedfinder_config();
+    traccc::spacepoint_grid_config grid_config;
+    grid_config.bFieldInZ = config.bFieldInZ;
+    grid_config.minPt = config.minPt;
+    grid_config.rMax = config.rMax;
+    grid_config.zMax = config.zMax;
+    grid_config.zMin = config.zMin;
+    grid_config.deltaRMax = config.deltaRMax;
+    grid_config.cotThetaMax = config.cotThetaMax;
+    return grid_config;
+}
+
+}  // namespace
+
+namespace traccc::sycl {
+
+seeding_algorithm::seeding_algorithm(vecmem::memory_resource& mr,
+                                     queue_wrapper queue)
+    : m_spacepoint_binning(default_seedfinder_config(),
+                           default_spacepoint_grid_config(), mr, queue),
+      m_seed_finding(default_seedfinder_config(), mr, queue) {}
+
+seeding_algorithm::output_type seeding_algorithm::operator()(
+    const spacepoint_container_types::const_view& spacepoints_view) const {
+
+    return m_seed_finding(spacepoints_view,
+                          m_spacepoint_binning(spacepoints_view));
+}
+
+}  // namespace traccc::sycl

--- a/device/sycl/src/seeding/spacepoint_binning.sycl
+++ b/device/sycl/src/seeding/spacepoint_binning.sycl
@@ -43,7 +43,7 @@ spacepoint_binning::spacepoint_binning(
       m_queue(queue) {}
 
 sp_grid_buffer spacepoint_binning::operator()(
-    const spacepoint_container_const_view& spacepoints_view) const {
+    const spacepoint_container_types::const_view& spacepoints_view) const {
 
     // Helper object for the data management.
     vecmem::copy copy;

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -20,7 +20,7 @@ namespace traccc::sycl {
 class TrackParamsEstimation {
     public:
     TrackParamsEstimation(
-        spacepoint_container_const_view spacepoints_view,
+        spacepoint_container_types::const_view spacepoints_view,
         vecmem::data::vector_view<const seed> seeds_view,
         vecmem::data::vector_view<bound_track_parameters> params_view)
         : m_spacepoints_view(spacepoints_view),
@@ -37,7 +37,7 @@ class TrackParamsEstimation {
         auto workItemIdx = item.get_local_id(0);
 
         // Get device container for input parameters
-        device_spacepoint_const_container spacepoints_device(
+        const spacepoint_container_types::const_device spacepoints_device(
             m_spacepoints_view);
         vecmem::device_vector<const seed> seeds_device(m_seeds_view);
         device_bound_track_parameters_collection params_device(m_params_view);
@@ -62,7 +62,7 @@ class TrackParamsEstimation {
     }
 
     private:
-    spacepoint_container_const_view m_spacepoints_view;
+    spacepoint_container_types::const_view m_spacepoints_view;
     vecmem::data::vector_view<const seed> m_seeds_view;
     vecmem::data::vector_view<bound_track_parameters> m_params_view;
 };
@@ -72,7 +72,7 @@ track_params_estimation::track_params_estimation(vecmem::memory_resource& mr,
     : m_mr(mr), m_queue(queue) {}
 
 track_params_estimation::output_type track_params_estimation::operator()(
-    const spacepoint_container_const_view& spacepoints_view,
+    const spacepoint_container_types::const_view& spacepoints_view,
     const vecmem::data::vector_view<const seed>& seeds_view) const {
 
     output_type params(seeds_view.size(), &m_mr.get());

--- a/examples/io/create_binaries.cpp
+++ b/examples/io/create_binaries.cpp
@@ -44,7 +44,7 @@ int create_binaries(const std::string& detector_file,
         if (!hit_directory.empty()) {
 
             // Read the hits from the relevant event file
-            traccc::host_spacepoint_container spacepoints_csv =
+            traccc::spacepoint_container_types::host spacepoints_csv =
                 traccc::read_spacepoints_from_event(
                     event, hit_directory, common_opts.input_data_format,
                     surface_transforms, host_mr);

--- a/examples/performance/include/traccc/efficiency/seeding_performance_writer.hpp
+++ b/examples/performance/include/traccc/efficiency/seeding_performance_writer.hpp
@@ -76,7 +76,7 @@ class seeding_performance_writer {
     }
 
     void write(std::string name, const host_seed_collection& seeds,
-               const host_spacepoint_container& spacepoints,
+               const spacepoint_container_types::host& spacepoints,
                event_map& evt_map) {
 
         auto& p_map = evt_map.ptc_map;
@@ -87,7 +87,7 @@ class seeding_performance_writer {
         std::size_t n_matched_seeds = 0;
 
         for (const auto& sd : seeds) {
-            auto measurements = sd.get_measurements(spacepoints);
+            auto measurements = sd.get_measurements(get_data(spacepoints));
 
             std::vector<particle_hit_count> particle_hit_counts =
                 identify_contributing_particles(measurements, m_p_map);

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -53,7 +53,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Read the hits from the relevant event file
-        traccc::host_spacepoint_container spacepoints_per_event =
+        traccc::spacepoint_container_types::host spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
                                                 common_opts.input_data_format,
                                                 surface_transforms, host_mr);

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -85,7 +85,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         /*time*/ auto start_hit_reading_cpu = std::chrono::system_clock::now();
 
         // Read the hits from the relevant event file
-        traccc::host_spacepoint_container spacepoints_per_event =
+        traccc::spacepoint_container_types::host spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
                                                 common_opts.input_data_format,
                                                 surface_transforms, mng_mr);

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -96,7 +96,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         /*time*/ auto start_hit_reading_cpu = std::chrono::system_clock::now();
 
         // Read the hits from the relevant event file
-        traccc::host_spacepoint_container spacepoints_per_event =
+        traccc::spacepoint_container_types::host spacepoints_per_event =
             traccc::read_spacepoints_from_event(event, i_cfg.hit_directory,
                                                 common_opts.input_data_format,
                                                 surface_transforms, shared_mr);

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -233,7 +233,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         // Copy the seeds and spacepoints to the host for comparisons
         vecmem::copy copy;
-        traccc::host_spacepoint_container spacepoints_per_event_sycl;
+        traccc::spacepoint_container_types::host spacepoints_per_event_sycl;
         copy(spacepoints_sycl_buffer.headers,
              spacepoints_per_event_sycl.get_headers());
         copy(spacepoints_sycl_buffer.items,

--- a/io/include/traccc/io/csv.hpp
+++ b/io/include/traccc/io/csv.hpp
@@ -388,16 +388,16 @@ inline measurement_container_types::host read_measurements(
 ///
 /// @param hreader The hit reader type
 /// @param resource The memory resource to use for the return value
-inline host_spacepoint_container read_hits(
+inline spacepoint_container_types::host read_hits(
     fatras_hit_reader& hreader, vecmem::memory_resource& resource,
     const traccc::geometry* tfmap = nullptr,
     unsigned int max_hits = std::numeric_limits<unsigned int>::max()) {
-    host_spacepoint_container result(&resource);
+    spacepoint_container_types::host result(&resource);
 
     unsigned int read_hits = 0;
     csv_fatras_hit iohit;
 
-    host_spacepoint_collection spacepoints(&resource);
+    spacepoint_collection_types::host spacepoints(&resource);
 
     while (hreader.read(iohit)) {
         geometry_id geom_id = iohit.geometry_id;
@@ -408,7 +408,7 @@ inline host_spacepoint_container read_hits(
         measurement m({point2({local[0], local[1]}), variance2({0., 0.})});
         spacepoint sp({position, m});
 
-        const host_spacepoint_container::header_vector& headers =
+        const spacepoint_container_types::host::header_vector& headers =
             result.get_headers();
 
         auto it = std::find(headers.begin(), headers.end(), geom_id);

--- a/io/include/traccc/io/demonstrator_edm.hpp
+++ b/io/include/traccc/io/demonstrator_edm.hpp
@@ -14,7 +14,7 @@
 namespace traccc {
 struct result {
     measurement_container_types::host measurements;
-    traccc::host_spacepoint_container spacepoints;
+    spacepoint_container_types::host spacepoints;
 };
 
 using demonstrator_input = vecmem::vector<cell_container_types::host>;

--- a/io/include/traccc/io/mapper.hpp
+++ b/io/include/traccc/io/mapper.hpp
@@ -242,7 +242,7 @@ measurement_particle_map generate_measurement_particle_map(
     auto surface_transforms = read_geometry(detector_file);
 
     // Read the spacepoints from the relevant event file
-    host_spacepoint_container spacepoints_per_event =
+    spacepoint_container_types::host spacepoints_per_event =
         read_spacepoints_from_event(event, hits_dir, traccc::data_format::csv,
                                     surface_transforms, resource);
 

--- a/io/include/traccc/io/reader.hpp
+++ b/io/include/traccc/io/reader.hpp
@@ -80,7 +80,7 @@ inline traccc::cell_container_types::host read_cells_from_event(
 /// @param data_format is the data format (e.g. csv or binary) of output file
 /// @param surface_transforms is the input geometry data
 /// @param resource is the vecmem resource
-inline traccc::host_spacepoint_container read_spacepoints_from_event(
+inline spacepoint_container_types::host read_spacepoints_from_event(
     size_t event, const std::string &hits_directory,
     const traccc::data_format &data_format, traccc::geometry surface_transforms,
     vecmem::memory_resource &resource) {
@@ -100,7 +100,7 @@ inline traccc::host_spacepoint_container read_spacepoints_from_event(
 
         vecmem::copy copy;
 
-        return traccc::read_binary<traccc::host_spacepoint_container>(
+        return traccc::read_binary<spacepoint_container_types::host>(
             io_hits_file, copy, resource);
     } else {
         throw std::invalid_argument("Allowed data format is csv or binary");

--- a/io/include/traccc/io/writer.hpp
+++ b/io/include/traccc/io/writer.hpp
@@ -47,7 +47,7 @@ inline void write_cells(
 inline void write_spacepoints(
     size_t event, const std::string &hits_directory,
     const traccc::data_format &data_format,
-    const traccc::host_spacepoint_container &spacepoints_per_event) {
+    const spacepoint_container_types::host &spacepoints_per_event) {
 
     if (data_format == traccc::data_format::binary) {
 

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -122,14 +122,14 @@ TEST_P(CompareWithActsSeedingTests, Run) {
 
     // Declare algorithms
     traccc::spacepoint_binning sb(traccc_config, grid_config, host_mr);
-    traccc::seed_finding sf(traccc_config);
+    traccc::seed_finding sf(traccc_config, traccc::seedfilter_config());
     traccc::track_params_estimation tp(host_mr);
 
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(detector_file);
 
     // Read the hits from the relevant event file
-    traccc::host_spacepoint_container spacepoints_per_event =
+    traccc::spacepoint_container_types::host spacepoints_per_event =
         traccc::read_spacepoints_from_event(event, hits_dir,
                                             traccc::data_format::csv,
                                             surface_transforms, host_mr);

--- a/tests/cpu/seq_single_module.cpp
+++ b/tests/cpu/seq_single_module.cpp
@@ -47,7 +47,7 @@ TEST(algorithms, seq_single_module) {
 
     traccc::measurement_collection_types::host measurements;
 
-    traccc::host_spacepoint_collection spacepoints;
+    traccc::spacepoint_collection_types::host spacepoints;
 
     traccc::component_connection cc(resource);
     traccc::measurement_creation mt(resource);

--- a/tests/io/test_binary.cpp
+++ b/tests/io/test_binary.cpp
@@ -98,7 +98,7 @@ TEST(io_binary, spacepoint) {
         traccc::read_geometry("tml_detector/trackml-detector.csv");
 
     // Read csv file
-    traccc::host_spacepoint_container spacepoints_csv =
+    traccc::spacepoint_container_types::host spacepoints_csv =
         traccc::read_spacepoints_from_event(event, hits_directory,
                                             traccc::data_format::csv,
                                             surface_transforms, host_mr);
@@ -108,7 +108,7 @@ TEST(io_binary, spacepoint) {
                               traccc::data_format::binary, spacepoints_csv);
 
     // Read binary file
-    traccc::host_spacepoint_container spacepoints_binary =
+    traccc::spacepoint_container_types::host spacepoints_binary =
         traccc::read_spacepoints_from_event(event, hits_directory,
                                             traccc::data_format::binary,
                                             surface_transforms, host_mr);


### PR DESCRIPTION
Continuing with the EDM updates, this one migrates the spacepoint container/collection types to the "new type" declarations.

Similar to previous PRs, I moved the implementation of algorithms into `.cpp` files as much as I could. Since spacepoints are used in a **lot** of algorithms, this meant that I had to re-structure quite a few of them.

The most controversial of these I believe is what I did with `traccc::seed_selecting`. As I stopped it from inheriting from `traccc::algorithm` all together. Previously that inheritance was not bringing anything to the table with that class. In fact, it was only making the interface of the class more ackward.

In the long term we'll need to re-design that CPU algorithm to provide a more reasonable interface. But for now this seemed the most pragmatic thing to do.

P.S. The configuration objects used by seed finding should really be configured more centrally. For now I kept the setup where each algorithm copy-paste's the same configurations. But this is really error prone like this...

P.P.S. The code is indeed performing quite nicely now, after @konradkusiak97's latest updates. :smile:

```
[bash][Legolas]:build > ./bin/traccc_seq_example_sycl --detector_file=tml_detector/trackml-detector.csv --cell_directory=tml_full/ttbar_mu80/ --events=5 --run_cpu=1
Running ./bin/traccc_seq_example_sycl tml_detector/trackml-detector.csv tml_full/ttbar_mu80/ 5
Running Seeding on device: NVIDIA GeForce RTX 3080
Module libc not found.
event 0
 number of seeds (cpu): 913
 number of seeds (sycl): 913
 measurements matching rate: 0.99981
 spacepoint matching rate: 0.985748
 seed matching rate: 0.968237
 track parameters matching rate: 1
event 1
 number of seeds (cpu): 920
 number of seeds (sycl): 920
 measurements matching rate: 0.999976
 spacepoint matching rate: 0.9857
 seed matching rate: 0.952174
 track parameters matching rate: 1
event 2
 number of seeds (cpu): 697
 number of seeds (sycl): 697
 measurements matching rate: 0.99992
 spacepoint matching rate: 0.985837
 seed matching rate: 0.965567
 track parameters matching rate: 1
event 3
 number of seeds (cpu): 570
 number of seeds (sycl): 570
 measurements matching rate: 0.999883
 spacepoint matching rate: 0.98578
 seed matching rate: 0.947368
 track parameters matching rate: 1
event 4
 number of seeds (cpu): 583
 number of seeds (sycl): 584
 measurements matching rate: 0.999836
 spacepoint matching rate: 0.985993
 seed matching rate: 0.962264
 track parameters matching rate: 1
==> Statistics ... 
- read    191792 spacepoints from 50269 modules
- created        666653 cells           
- created        191792 meaurements     
- created        191792 spacepoints     
- created (sycl) 191792 spacepoints     
- created (cpu)  3683 seeds
- created (sycl) 3684 seeds
==> Elpased time ... 
wall time           3.73685   
file reading (cpu)        2.6687    
clusterization_time (cpu) 0.0299402 
spacepoint_formation_time (cpu) 0.174405  
clusterization_time (sycl) 0.059954  
seeding_time (cpu)        0.142356  
seeding_time (sycl)       0.027711  
tr_par_esti_time (cpu)    0.000747345
tr_par_esti_time (sycl)   0.00191853
[bash][Legolas]:build >
```