### PR TITLE
Make Clusterization Result Correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ cmake --build <build_directory> <options>
 ### cpu reconstruction chain
 
 ```sh
-<build_directory>/bin/traccc_seq_example --detector_file=tml_detector/trackml-detector.csv --cell_directory=tml_pixels/ --events=10 
+<build_directory>/bin/traccc_seq_example --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --cell_directory=tml_pixels/ --events=10 
 ```
 
 ### cuda reconstruction chain
@@ -219,7 +219,7 @@ cmake --build <build_directory> <options>
 - Users can generate cuda examples by adding `-DTRACCC_BUILD_CUDA=ON` to cmake options
 
 ```sh
-<build_directory>/bin/traccc_seq_example_cuda --detector_file=tml_detector/trackml-detector.csv --cell_directory=tml_pixels/ --events=10 --run_cpu=1
+<build_directory>/bin/traccc_seq_example_cuda --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --cell_directory=tml_pixels/ --events=10 --run_cpu=1
 ```
 
 ## Troubleshooting

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -69,4 +69,4 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/seeding/spacepoint_binning.hpp"
   "src/seeding/spacepoint_binning.cpp" )
 target_link_libraries( traccc_core
-  PUBLIC Eigen3::Eigen vecmem::core detray::core ActsCore traccc::algebra )
+  PUBLIC Eigen3::Eigen vecmem::core detray::core ActsCore ActsPluginJson traccc::algebra )

--- a/core/include/traccc/edm/cell.hpp
+++ b/core/include/traccc/edm/cell.hpp
@@ -69,9 +69,15 @@ struct cell_module {
     channel_id range0[2] = {std::numeric_limits<channel_id>::max(), 0};
     channel_id range1[2] = {std::numeric_limits<channel_id>::max(), 0};
 
-    pixel_data pixel{-8.425, -36.025, 0.05, 0.05};
+    pixel_data pixel;
 
 };  // struct cell_module
+
+/// Equality operator for cell module
+TRACCC_HOST_DEVICE
+inline bool operator==(const cell_module& lhs, const cell_module& rhs) {
+    return lhs.module == rhs.module;
+}
 
 /// Declare all cell collection types
 using cell_collection_types = collection_types<cell>;

--- a/core/src/clusterization/component_connection.cpp
+++ b/core/src/clusterization/component_connection.cpp
@@ -40,6 +40,7 @@ component_connection::output_type component_connection::operator()(
     for (auto& cl_id : result.get_headers()) {
         cl_id.module = module.module;
         cl_id.placement = module.placement;
+        cl_id.pixel = module.pixel;
     }
 
     auto& cluster_items = result.get_items();

--- a/examples/options/include/traccc/options/full_tracking_input_options.hpp
+++ b/examples/options/include/traccc/options/full_tracking_input_options.hpp
@@ -15,6 +15,7 @@ namespace po = boost::program_options;
 struct full_tracking_input_config {
     std::string detector_file;
     std::string cell_directory;
+    std::string digitization_config_file;
     std::string hit_directory;
     std::string particle_directory;
     bool check_seeding_performance;

--- a/examples/options/src/options/full_tracking_input_options.cpp
+++ b/examples/options/src/options/full_tracking_input_options.cpp
@@ -15,6 +15,9 @@ traccc::full_tracking_input_config::full_tracking_input_config(
                        "specify detector file");
     desc.add_options()("cell_directory", po::value<std::string>()->required(),
                        "specify the directory of cell files");
+    desc.add_options()("digitization_config_file",
+                       po::value<std::string>()->required(),
+                       "specify the digitization configuration file");
     desc.add_options()(
         "hit_directory", po::value<std::string>()->default_value(""),
         "specify the directory of hit files used for performance writer");
@@ -26,6 +29,7 @@ traccc::full_tracking_input_config::full_tracking_input_config(
 void traccc::full_tracking_input_config::read(const po::variables_map& vm) {
     detector_file = vm["detector_file"].as<std::string>();
     cell_directory = vm["cell_directory"].as<std::string>();
+    digitization_config_file = vm["digitization_config_file"].as<std::string>();
     hit_directory = vm["hit_directory"].as<std::string>();
     particle_directory = vm["particle_directory"].as<std::string>();
     check_seeding_performance =

--- a/examples/performance/include/traccc/event/event_map.hpp
+++ b/examples/performance/include/traccc/event/event_map.hpp
@@ -16,13 +16,14 @@ struct event_map {
     event_map() = delete;
 
     event_map(std::size_t event, const std::string& detector_file,
-              const std::string& cell_dir, const std::string& hit_dir,
-              const std::string particle_dir,
+              const std::string& digi_config_file, const std::string& cell_dir,
+              const std::string& hit_dir, const std::string particle_dir,
               vecmem::memory_resource& resource) {
 
         ptc_map = generate_particle_map(event, particle_dir);
         meas_ptc_map = generate_measurement_particle_map(
-            event, detector_file, cell_dir, hit_dir, particle_dir, resource);
+            event, detector_file, digi_config_file, cell_dir, hit_dir,
+            particle_dir, resource);
     }
 
     event_map(std::size_t event, const std::string& detector_file,

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -37,6 +37,10 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
 
+    // Read the digitization configuration file
+    auto digi_cfg =
+        traccc::read_digitization_config(i_cfg.digitization_config_file);
+
     // Output stats
     uint64_t n_cells = 0;
     uint64_t n_modules = 0;
@@ -63,9 +67,9 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         // Read the cells from the relevant event file
         traccc::cell_container_types::host cells_per_event =
-            traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          common_opts.input_data_format,
-                                          surface_transforms, host_mr);
+            traccc::read_cells_from_event(
+                event, i_cfg.cell_directory, common_opts.input_data_format,
+                surface_transforms, digi_cfg, host_mr);
 
         /*-------------------
             Clusterization
@@ -107,6 +111,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         if (i_cfg.check_seeding_performance) {
             traccc::event_map evt_map(event, i_cfg.detector_file,
+                                      i_cfg.digitization_config_file,
                                       i_cfg.cell_directory, i_cfg.hit_directory,
                                       i_cfg.particle_directory, host_mr);
 

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -45,6 +45,10 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
 
+    // Read the digitization configuration file
+    auto digi_cfg =
+        traccc::read_digitization_config(i_cfg.digitization_config_file);
+
     // Output stats
     uint64_t n_cells = 0;
     uint64_t n_modules = 0;
@@ -93,9 +97,9 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         // Read the cells from the relevant event file
         traccc::cell_container_types::host cells_per_event =
-            traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          common_opts.input_data_format,
-                                          surface_transforms, host_mr);
+            traccc::read_cells_from_event(
+                event, i_cfg.cell_directory, common_opts.input_data_format,
+                surface_transforms, digi_cfg, host_mr);
 
         /*time*/ auto end_file_reading_cpu = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_file_reading_cpu =
@@ -251,7 +255,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         if (i_cfg.check_seeding_performance) {
             traccc::event_map evt_map(event, i_cfg.detector_file,
-                                      i_cfg.hit_directory,
+                                      i_cfg.digitization_config_file,
+                                      i_cfg.cell_directory, i_cfg.hit_directory,
                                       i_cfg.particle_directory, host_mr);
             sd_performance_writer.write("CUDA", seeds_cuda,
                                         spacepoints_per_event, evt_map);

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -62,6 +62,10 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
 
+    // Read the digitization configuration file
+    auto digi_cfg =
+        traccc::read_digitization_config(i_cfg.digitization_config_file);
+
     // Output stats
     uint64_t n_cells = 0;
     uint64_t n_modules = 0;
@@ -119,9 +123,9 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         // Read the cells from the relevant event file for CPU algorithm
         traccc::cell_container_types::host cells_per_event =
-            traccc::read_cells_from_event(event, i_cfg.cell_directory,
-                                          common_opts.input_data_format,
-                                          surface_transforms, shared_mr);
+            traccc::read_cells_from_event(
+                event, i_cfg.cell_directory, common_opts.input_data_format,
+                surface_transforms, digi_cfg, shared_mr);
 
         /*time*/ auto end_file_reading_cpu = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_file_reading_cpu =
@@ -338,7 +342,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         if (i_cfg.check_seeding_performance) {
             traccc::event_map evt_map(event, i_cfg.detector_file,
-                                      i_cfg.hit_directory,
+                                      i_cfg.digitization_config_file,
+                                      i_cfg.cell_directory, i_cfg.hit_directory,
                                       i_cfg.particle_directory, host_mr);
             sd_performance_writer.write("SYCL", seeds_sycl,
                                         spacepoints_per_event_sycl, evt_map);

--- a/extern/acts/CMakeLists.txt
+++ b/extern/acts/CMakeLists.txt
@@ -21,6 +21,8 @@ FetchContent_Declare( Acts ${TRACCC_ACTS_SOURCE} )
 # Options used in the build of Acts.
 set( ACTS_SETUP_EIGEN3 FALSE CACHE BOOL
    "Do not set up Eigen in the Acts code, we do it in this project" )
+set( ACTS_BUILD_PLUGIN_JSON TRUE CACHE BOOL
+   "Build JSON plugin in Acts" )
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( Acts )

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 # Set up the "build" of the traccc::io library.
 traccc_add_library( traccc_io io TYPE INTERFACE
+  "include/traccc/detail/json_digitization_config.hpp"
   "include/traccc/io/binary.hpp"
   "include/traccc/io/csv.hpp"
   "include/traccc/io/data_format.hpp"
@@ -15,4 +16,4 @@ traccc_add_library( traccc_io io TYPE INTERFACE
   "include/traccc/io/utils.hpp"
   "include/traccc/io/reader.hpp" )
 target_link_libraries( traccc_io
-  INTERFACE dfelibs::dfelibs vecmem::core traccc::core )
+  INTERFACE dfelibs::dfelibs vecmem::core traccc::core ActsPluginJson ActsCore)

--- a/io/include/traccc/io/detail/json_digitization_config.hpp
+++ b/io/include/traccc/io/detail/json_digitization_config.hpp
@@ -1,0 +1,28 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Acts include(s)
+#include "Acts/Plugins/Json/ActsJson.hpp"
+#include "Acts/Plugins/Json/UtilitiesJsonConverter.hpp"
+#include "Acts/Utilities/BinUtility.hpp"
+
+namespace traccc {
+
+struct digitization_config {
+    Acts::BinUtility segmentation;
+};
+
+inline void from_json(const nlohmann::json& j, digitization_config& geo_cfg) {
+    if (j.find("geometric") != j.end()) {
+        nlohmann::json jgdc = j["geometric"];
+        from_json(jgdc["segmentation"], geo_cfg.segmentation);
+    }
+}
+
+}  // namespace traccc

--- a/io/include/traccc/io/mapper.hpp
+++ b/io/include/traccc/io/mapper.hpp
@@ -104,13 +104,30 @@ hit_map generate_hit_map(size_t event, const std::string& hits_dir) {
 
     csv_fatras_hit iohit;
 
+    // Read the hits from the relevant event file
+    std::string io_meas_hit_id_file =
+        data_directory() + hits_dir +
+        get_event_filename(event, "-measurement-simhit-map.csv");
+
+    meas_hit_id_reader mhid_reader(io_meas_hit_id_file,
+                                   {"measurement_id", "hit_id"});
+
+    csv_meas_hit_id mh_id;
+
+    std::map<uint64_t, uint64_t> mh_id_map;
+
+    while (mhid_reader.read(mh_id)) {
+        mh_id_map[mh_id.hit_id] = mh_id.measurement_id;
+    }
+
     hit_id hid = 0;
     while (hreader.read(iohit)) {
 
         spacepoint sp;
         sp.global = {iohit.tx, iohit.ty, iohit.tz};
 
-        result[hid] = sp;
+        // result[hid] = sp;
+        result[mh_id_map[hid]] = sp;
 
         hid++;
     }
@@ -166,7 +183,8 @@ cell_particle_map generate_cell_particle_map(size_t event,
 
 measurement_cell_map generate_measurement_cell_map(
     size_t event, const std::string& detector_file,
-    const std::string& cells_dir, vecmem::memory_resource& resource) {
+    const std::string& digi_config_file, const std::string& cells_dir,
+    vecmem::memory_resource& resource) {
 
     measurement_cell_map result;
 
@@ -177,10 +195,13 @@ measurement_cell_map generate_measurement_cell_map(
     // Read the surface transforms
     auto surface_transforms = read_geometry(detector_file);
 
+    // Read the digitization configuration file
+    auto digi_cfg = traccc::read_digitization_config(digi_config_file);
+
     // Read the cells from the relevant event file
     cell_container_types::host cells_per_event =
         read_cells_from_event(event, cells_dir, traccc::data_format::csv,
-                              surface_transforms, resource);
+                              surface_transforms, digi_cfg, resource);
 
     for (std::size_t i = 0; i < cells_per_event.size(); ++i) {
         auto module = cells_per_event.at(i).header;
@@ -208,8 +229,9 @@ measurement_cell_map generate_measurement_cell_map(
 
 measurement_particle_map generate_measurement_particle_map(
     size_t event, const std::string& detector_file,
-    const std::string& cells_dir, const std::string& hits_dir,
-    const std::string& particle_dir, vecmem::memory_resource& resource) {
+    const std::string& digi_config_file, const std::string& cells_dir,
+    const std::string& hits_dir, const std::string& particle_dir,
+    vecmem::memory_resource& resource) {
 
     measurement_particle_map result;
 
@@ -218,8 +240,8 @@ measurement_particle_map generate_measurement_particle_map(
         generate_cell_particle_map(event, cells_dir, hits_dir, particle_dir);
 
     // generate measurement cell map
-    auto m_c_map = generate_measurement_cell_map(event, detector_file,
-                                                 cells_dir, resource);
+    auto m_c_map = generate_measurement_cell_map(
+        event, detector_file, digi_config_file, cells_dir, resource);
 
     for (auto const& [meas, cells] : m_c_map) {
         for (const auto& c : cells) {

--- a/tests/common/tests/cca_test.hpp
+++ b/tests/common/tests/cca_test.hpp
@@ -107,7 +107,7 @@ class ConnectedComponentAnalysisTests
                 result.at(io_truth.geometry_id);
 
             traccc::scalar tol = std::max(
-                0.01, 0.0001 * std::max(io_truth.channel0, io_truth.channel1));
+                0.1, 0.0001 * std::max(io_truth.channel0, io_truth.channel1));
 
             auto match = std::find_if(
                 meas.begin(), meas.end(),

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -7,5 +7,6 @@
 # Declare the cpu algorithm test(s).
 traccc_add_test( cpu "compare_with_acts_seeding.cpp"
    "seq_single_module.cpp" "test_component_connection.cpp" "test_cca.cpp"
+   "test_clusterization_resolution.cpp"
    LINK_LIBRARIES GTest::gtest_main vecmem::core traccc_tests_common
                   traccc::core traccc::io )

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -39,9 +39,6 @@
 // GTest include(s).
 #include <gtest/gtest.h>
 
-// System include(s).
-#include <iostream>
-
 inline bool operator==(const SpacePoint* acts_sp,
                        const traccc::spacepoint& traccc_sp) {
     if (abs(acts_sp->x() - traccc_sp.global[0]) < traccc::float_epsilon &&

--- a/tests/cpu/test_clusterization_resolution.cpp
+++ b/tests/cpu/test_clusterization_resolution.cpp
@@ -1,0 +1,125 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/clusterization/clusterization_algorithm.hpp"
+#include "traccc/clusterization/spacepoint_formation.hpp"
+#include "traccc/io/reader.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+class SurfaceBinningTests
+    : public ::testing::TestWithParam<
+          std::tuple<std::string, std::string, std::string, unsigned int>> {};
+
+// This defines the local frame test suite
+TEST_P(SurfaceBinningTests, Run) {
+
+    std::string detector_file = std::get<0>(GetParam());
+    std::string digi_config_file = std::get<1>(GetParam());
+    std::string data_dir = std::get<2>(GetParam());
+    unsigned int event = std::get<3>(GetParam());
+
+    // Read the surface transforms
+    auto surface_transforms = traccc::read_geometry(detector_file);
+
+    // Read the digitization configuration file
+    auto digi_cfg = traccc::read_digitization_config(digi_config_file);
+
+    // Memory resource used by the EDM.
+    vecmem::host_memory_resource host_mr;
+
+    // Algorithms
+    traccc::clusterization_algorithm ca(host_mr);
+    traccc::spacepoint_formation sf(host_mr);
+
+    // Read the cells from the relevant event file
+    traccc::cell_container_types::host cells_truth =
+        traccc::read_cells_from_event(event, data_dir, traccc::data_format::csv,
+                                      surface_transforms, digi_cfg, host_mr);
+
+    // Get Reconstructed Spacepoints
+    auto measurements_recon = ca(cells_truth);
+    auto spacepoints_recon = sf(measurements_recon);
+
+    // Read the hits from the relevant event file
+    traccc::spacepoint_container_types::host spacepoints_truth =
+        traccc::read_spacepoints_from_event(event, data_dir,
+                                            traccc::data_format::csv,
+                                            surface_transforms, host_mr);
+
+    // Check the size of spacepoints
+    EXPECT_TRUE(spacepoints_recon.size() > 0);
+    EXPECT_EQ(spacepoints_recon.size(), spacepoints_truth.size());
+    EXPECT_TRUE(spacepoints_recon.total_size() > 0);
+    EXPECT_EQ(spacepoints_recon.total_size(), spacepoints_truth.total_size());
+
+    for (std::size_t i = 0; i < spacepoints_recon.size(); i++) {
+        EXPECT_EQ(spacepoints_recon.at(i).header,
+                  spacepoints_truth.at(i).header);
+
+        // Get the spacepoint vectors
+        traccc::spacepoint_collection_types::host& sp_collection_recon =
+            spacepoints_recon[i].items;
+
+        traccc::spacepoint_collection_types::host& sp_collection_truth =
+            spacepoints_truth[i].items;
+
+        EXPECT_EQ(sp_collection_recon.size(), sp_collection_truth.size());
+
+        // Iterate over each spacepoint
+        for (std::size_t j = 0; j < sp_collection_recon.size(); j++) {
+            const auto& sp_recon = sp_collection_recon[j];
+            const auto& sp_truth = sp_collection_truth[j];
+
+            // Make sure that the difference in spacepoint position is less than
+            // 1%
+            EXPECT_TRUE(
+                traccc::getter::norm(sp_recon.global - sp_truth.global) /
+                    traccc::getter::norm(sp_recon.global) <
+                0.01);
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SurfaceBinningValidation, SurfaceBinningTests,
+    ::testing::Values(
+        std::make_tuple("tml_detector/trackml-detector.csv",
+                        "tml_detector/default-geometric-config-generic.json",
+                        "tml_full/single_muon/", 0),
+        std::make_tuple("tml_detector/trackml-detector.csv",
+                        "tml_detector/default-geometric-config-generic.json",
+                        "tml_full/single_muon/", 1),
+        std::make_tuple("tml_detector/trackml-detector.csv",
+                        "tml_detector/default-geometric-config-generic.json",
+                        "tml_full/single_muon/", 2),
+        std::make_tuple("tml_detector/trackml-detector.csv",
+                        "tml_detector/default-geometric-config-generic.json",
+                        "tml_full/single_muon/", 3),
+        std::make_tuple("tml_detector/trackml-detector.csv",
+                        "tml_detector/default-geometric-config-generic.json",
+                        "tml_full/single_muon/", 4),
+        std::make_tuple("tml_detector/trackml-detector.csv",
+                        "tml_detector/default-geometric-config-generic.json",
+                        "tml_full/single_muon/", 5),
+        std::make_tuple("tml_detector/trackml-detector.csv",
+                        "tml_detector/default-geometric-config-generic.json",
+                        "tml_full/single_muon/", 6),
+        std::make_tuple("tml_detector/trackml-detector.csv",
+                        "tml_detector/default-geometric-config-generic.json",
+                        "tml_full/single_muon/", 7),
+        std::make_tuple("tml_detector/trackml-detector.csv",
+                        "tml_detector/default-geometric-config-generic.json",
+                        "tml_full/single_muon/", 8),
+        std::make_tuple("tml_detector/trackml-detector.csv",
+                        "tml_detector/default-geometric-config-generic.json",
+                        "tml_full/single_muon/", 9)));

--- a/tests/io/mock_data/event000000000-measurement-simhit-map.csv
+++ b/tests/io/mock_data/event000000000-measurement-simhit-map.csv
@@ -1,0 +1,4 @@
+measurement_id,hit_id
+0,0
+1,1
+2,2

--- a/tests/io/test_binary.cpp
+++ b/tests/io/test_binary.cpp
@@ -33,11 +33,15 @@ TEST(io_binary, cell) {
     auto surface_transforms =
         traccc::read_geometry("tml_detector/trackml-detector.csv");
 
+    // Read the digitization configuration file
+    auto digi_cfg = traccc::read_digitization_config(
+        "tml_detector/default-geometric-config-generic.json");
+
     // Read csv file
     traccc::cell_container_types::host cells_csv =
         traccc::read_cells_from_event(event, cells_directory,
                                       traccc::data_format::csv,
-                                      surface_transforms, host_mr);
+                                      surface_transforms, digi_cfg, host_mr);
 
     // Write binary file
     traccc::write_cells(event, cells_directory, traccc::data_format::binary,
@@ -47,7 +51,7 @@ TEST(io_binary, cell) {
     traccc::cell_container_types::host cells_binary =
         traccc::read_cells_from_event(event, cells_directory,
                                       traccc::data_format::binary,
-                                      surface_transforms, host_mr);
+                                      surface_transforms, digi_cfg, host_mr);
 
     // Delete binary file
     std::string io_cells_file = traccc::data_directory() + cells_directory +

--- a/tests/io/test_csv.cpp
+++ b/tests/io/test_csv.cpp
@@ -81,7 +81,7 @@ TEST_F(io, csv_read_tml_transforms) {
                "rot_zu", "rot_zv", "rot_zw"});
     auto tml_barrel_transforms = traccc::read_surfaces(sreader);
 
-    ASSERT_EQ(tml_barrel_transforms.size(), 18751u);
+    ASSERT_EQ(tml_barrel_transforms.size(), 18791u);
 }
 
 // This reads in the tml pixel barrel first event

--- a/tests/io/test_mapper.cpp
+++ b/tests/io/test_mapper.cpp
@@ -17,6 +17,8 @@
 std::size_t event = 0;
 
 std::string detector_file = "/tml_detector/trackml-detector.csv";
+std::string digi_config_file =
+    "/tml_detector/default-geometric-config-generic.json";
 std::string hits_dir = "../tests/io/mock_data/";
 std::string cells_dir = "../tests/io/mock_data/";
 std::string particles_dir = "../tests/io/mock_data/";
@@ -175,8 +177,8 @@ TEST(mappper, measurement_cell_map) {
 
     vecmem::host_memory_resource resource;
 
-    auto m_c_map = traccc::generate_measurement_cell_map(event, detector_file,
-                                                         cells_dir, resource);
+    auto m_c_map = traccc::generate_measurement_cell_map(
+        event, detector_file, digi_config_file, cells_dir, resource);
 
     vecmem::vector<traccc::cell> cells0;
     cells0.push_back({1, 0, 0.0041470062, 0});
@@ -222,7 +224,8 @@ TEST(mappper, measurement_particle_map_with_clusterization) {
     vecmem::host_memory_resource mr;
 
     auto m_p_map = traccc::generate_measurement_particle_map(
-        event, detector_file, cells_dir, hits_dir, particles_dir, mr);
+        event, detector_file, digi_config_file, cells_dir, hits_dir,
+        particles_dir, mr);
 
     // There are two measurements (or clusters)
     EXPECT_EQ(m_p_map.size(), 2);


### PR DESCRIPTION
The clusterization result has been wrong which makes the seeding efficiency of `seq_example` drop to nearly zero. 
And I am glad that I finally fixed the problems (as far as I can detect)

There are ~~two~~ three bugs that I fixed:

#### Bug 1. Wrong binning setup for clusterization
The data files that I updated in `traccc-data` were generated from the digitization configuration file (`acts/Examples/Algorithms/Digitization/share/default-geometric-config-generic.json`), which sets different binning for each module. 

Meanwhile, the traccc `cell_module` always have the same binning scheme: 
```c++
// in cell.hpp
pixel_data pixel{-8.425, -36.025, 0.05, 0.05};
```
Thus, I took out binning information using `Acts::GeometryHierarchyMap` and apply to `pixel_data` in `csv.hpp`

#### Bug 2. Cell module was shifted during reading in `csv.hpp`
There was still a mismatch between header and item of `cell_container`. It was because the cell module information of the next cell group was recorded for the current cell group. It could be fixed by replacing `geometry_id` to `reference_id` in `read_cells` function.

```c++
// in csv.hpp
    while (creader.read(iocell)) {

        if (first_line_read and iocell.geometry_id != reference_id) {
            if (tfmap != nullptr) {
               // reference_id should be used instead of geometry_id
                if (tfmap->contains(iocell.geometry_id)) { 
                    module.placement = (*tfmap)[iocell.geometry_id];
                }
            }
            ...
```
#### Bug 3. Use measurement-simhit-map for correct indexing
See https://github.com/acts-project/traccc/pull/197#issuecomment-1136478051

### Physics performance after fix

I will compare two cases:

1) `seq_example` with ttbar<140> cell file (clusterization+seeding)
<img src="https://user-images.githubusercontent.com/63090140/169700429-b12cfb42-face-4ac6-ba70-9c6f3668167f.png" width="300">

2) `seeding_example` with ttbar<140> hit file (seeding)
<img src="https://user-images.githubusercontent.com/63090140/169700468-aa0568fe-e11c-4ce4-825f-3bc86a25bf94.png" width="300">