### PR TITLE
Comment cuda cca fast sv 2

### DIFF
--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -472,7 +472,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK) void sparse_ccl_kernel(
     __syncthreads();
 
     /*
-     * Count the number of clusters by checking how many nodes have
+     * Count the number of clusters by checking how many cells have
      * themself assigned as a parent.
      */
     for (index_t tst = 0, tid;

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -719,7 +719,7 @@ component_connection::output_type component_connection::operator()(
     /*
      * Copy back the data from our flattened data structure into the traccc EDM.
      */
-    host_measurement_container out;
+    output_type out;
 
     for (std::size_t i = 0; i < data.size(); ++i) {
         vecmem::vector<measurement> v(&mem);

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -152,7 +152,7 @@ __device__ void fast_sv_1(index_t* f, index_t* f_next, unsigned char adjc[],
     do {
         /*
          * Reset the end-parameter to false, so we can set it to true if we
-         * make a change to our arrays.
+         * make a change to the f array.
          */
         f_changed = false;
 

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -315,8 +315,7 @@ __device__ void fast_sv_2(index_t* f, index_t* f_next, unsigned char adjc[],
         __syncthreads();
 
         /*
-         * Update the array for the next generation, keeping track of any
-         * changes we make.
+         * Update the array for the next generation.
          */
         for (index_t tst = 0, tid;
              (tid = tst * blockDim.x + threadIdx.x) < size; ++tst) {

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -516,7 +516,7 @@ __device__ void aggregate_clusters(const cell_container& cells,
     }
 }
 
-__global__ __launch_bounds__(THREADS_PER_BLOCK) void sparse_ccl_kernel(
+__global__ __launch_bounds__(THREADS_PER_BLOCK) void ccl_kernel(
     const cell_container container, const ccl_partition* partitions,
     measurement_container& _out_ctnr) {
     const ccl_partition& partition = partitions[blockIdx.x];
@@ -812,7 +812,7 @@ component_connection::output_type component_connection::operator()(
      *
      * This step includes the measurement (hit) creation for each cluster.
      */
-    sparse_ccl_kernel<<<partitions.size(), THREADS_PER_BLOCK>>>(
+    ccl_kernel<<<partitions.size(), THREADS_PER_BLOCK>>>(
         container, partitions.data(), *mctnr);
 
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -260,11 +260,11 @@ __device__ void fast_sv_2(index_t* f, index_t* f_next, unsigned char adjc[],
         for (index_t tst = 0, tid;
              (tid = tst * blockDim.x + threadIdx.x) < size; ++tst) {
             for (unsigned char k = 0; k < adjc[tst]; ++k) {
-                index_t q = adjv[tst][k];
+                index_t q = f[f[adjv[tst][k]]];
 
-                if (f[f[q]] < f_next[f[tid]]) {
+                if (q < f_next[f[tid]]) {
                     // hook to grandparent of adjacent cell
-                    f_next[f[tid]] = f[f[q]];
+                    f_next[f[tid]] = q;
                     f_next_changed = true;
                 }
             }

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -140,7 +140,7 @@ __device__ void reduce_problem_cell(cell_container& cells, index_t tid,
  * f      = array holding the parent cell ID for the current iteration.
  * f_next = buffer array holding updated information for the next iteration.
  */
-__device__ void fast_sv_1(index_t* f, index_t* gf, unsigned char adjc[],
+__device__ void fast_sv_1(index_t* f, index_t* f_next, unsigned char adjc[],
                           index_t adjv[][8], unsigned int size) {
     /*
      * The algorithm finishes if an iteration leaves the arrays unchanged.

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -398,6 +398,9 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK) void sparse_ccl_kernel(
      * hit the thread is processing. This number is never larger than
      * the max number of activations per module divided by the threads per
      * block.
+     *
+     * adjc = adjecency count
+     * adjv = adjecency vector
      */
     index_t adjv[MAX_CELLS_PER_PARTITION / THREADS_PER_BLOCK][8];
     unsigned char adjc[MAX_CELLS_PER_PARTITION / THREADS_PER_BLOCK];

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -147,7 +147,7 @@ __device__ void fast_sv_1(index_t* f, index_t* gf, unsigned char adjc[],
      * This varible will be set if a change is made, and dictates if another
      * loop is necessary.
      */
-    bool gfc;
+    bool f_changed;
 
     do {
         /*

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -434,16 +434,16 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK) void sparse_ccl_kernel(
      * memory is limited. These could always be moved to global memory, but
      * the algorithm would be decidedly slower in that case.
      */
-    __shared__ index_t f[MAX_CELLS_PER_PARTITION], gf[MAX_CELLS_PER_PARTITION];
+    __shared__ index_t f[MAX_CELLS_PER_PARTITION], f_next[MAX_CELLS_PER_PARTITION];
 
     for (index_t tst = 0, tid;
          (tid = tst * blockDim.x + threadIdx.x) < cells.size; ++tst) {
         /*
-         * At the start, the values of f and gf should be equal to the ID of
+         * At the start, the values of f and f_next should be equal to the ID of
          * the cell.
          */
         f[tid] = tid;
-        gf[tid] = tid;
+        f_next[tid] = tid;
     }
 
     /*
@@ -452,7 +452,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK) void sparse_ccl_kernel(
      */
     __syncthreads();
 
-    fast_sv_1(f, gf, adjc, adjv, cells.size);
+    fast_sv_1(f, f_next, adjc, adjv, cells.size);
 
     /*
      * This variable will be used to write to the output later.

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -175,8 +175,8 @@ __device__ void fast_sv_1(index_t* f, index_t* f_next, unsigned char adjc[],
                      * but it does not matter, since the algorithm converges
                      * eventually.
                      */
-                    f_next[f_next[tid]] = f[q];
-                    f_next[tid] = f[q]; // a form of short-cutting
+                    f_next[f_next[tid]] = f[q]; // update parent of current cell's parent
+                    f_next[tid] = f[q]; // update parent of current cell
                 }
             }
         }

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -170,13 +170,8 @@ __device__ void fast_sv_1(index_t* f, index_t* f_next, unsigned char adjc[],
                 index_t q = adjv[tst][k];
 
                 if (f[tid] > f[q]) {
-                    /*
-                     * The following updates have possible concurrent accesses,
-                     * but it does not matter, since the algorithm converges
-                     * eventually.
-                     */
-                    f_next[f_next[tid]] = f[q]; // update parent of current cell's parent
-                    f_next[tid] = f[q]; // update parent of current cell
+                    f_next[f_next[tid]] = f[q]; // update grandparent of current cell
+                    f_next[tid] = f[q]; // update parent of current cell, kind of shortcutting
                 }
             }
         }

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -162,11 +162,11 @@ __device__ void fast_sv_1(index_t* f, index_t* gf, unsigned char adjc[],
             __builtin_assume(adjc[tst] <= 8);
 
             for (unsigned char k = 0; k < adjc[tst]; ++k) {
-                index_t q = gf[adjv[tst][k]];
+                index_t q = adjv[tst][k];
 
-                if (gf[tid] > q) {
-                    f[f[tid]] = q;
-                    f[tid] = q;
+                if (gf[tid] > gf[q]) {
+                    f[f[tid]] = gf[q];
+                    f[tid] = gf[q];
                 }
             }
         }

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -34,7 +34,7 @@ struct ccl_partition {
 };
 
 /*
- * Convenience structure to work with flattened data arrays instead of 
+ * Convenience structure to work with flattened data arrays instead of
  * an array/vector of cells.
  */
 struct cell_container {
@@ -47,7 +47,7 @@ struct cell_container {
 };
 
 /*
- * Convenience structure to work with flattened data arrays instead of 
+ * Convenience structure to work with flattened data arrays instead of
  * an array/vector of measures.
  */
 struct measurement_container {
@@ -570,18 +570,18 @@ vecmem::vector<details::ccl_partition> partition(
      */
     for (std::size_t i = 0; i < data.size(); ++i) {
         /*
-         * We start at 0 since this is the origin of the local coordinate 
+         * We start at 0 since this is the origin of the local coordinate
          * system within a cell module.
          */
         channel_id last_mid = 0;
 
         for (const cell& c : data.at(i).items) {
             /*
-             * Create a new partition if an "empty" row is detected. A row 
-             * is considered "empty" if the channel1 value between two 
+             * Create a new partition if an "empty" row is detected. A row
+             * is considered "empty" if the channel1 value between two
              * consecutive cells have a difference > 1.
              * To prevent creating many small partitions, the current partition
-             * must have at least twice the size of threads per block. This 
+             * must have at least twice the size of threads per block. This
              * guarantees that each thread handles later at least two cells.
              */
             if (c.channel1 > last_mid + 1 && size >= 2 * THREADS_PER_BLOCK) {
@@ -613,7 +613,7 @@ vecmem::vector<details::ccl_partition> partition(
     }
 
     /*
-     * Create the very last partition after having iterated over all cell 
+     * Create the very last partition after having iterated over all cell
      * modules and cells.
      */
     if (size > 0) {
@@ -638,7 +638,7 @@ component_connection::output_type component_connection::operator()(
 
     /*
      * Flatten the data to handle memory access (fetch and cache)
-     * more efficiently. This removes the hierarchy level that 
+     * more efficiently. This removes the hierarchy level that
      * references to the cell module.
      */
     vecmem::vector<channel_id> channel0(&mem);
@@ -675,8 +675,8 @@ component_connection::output_type component_connection::operator()(
 
     /*
      * Separate the problem into various subproblems (partitions).
-     * We know that the input data is sorted primarily on channel1 (y-axis), 
-     * and secondarily on channel0 (x-axis). This allows the cheap creation 
+     * We know that the input data is sorted primarily on channel1 (y-axis),
+     * and secondarily on channel0 (x-axis). This allows the cheap creation
      * of partitions based on the distance of the y-value between two
      * consecutive cells. If this distance is above a threshold, we have the
      * guarantee that the two cells belong not to the same cluster.
@@ -685,7 +685,7 @@ component_connection::output_type component_connection::operator()(
         details::partition(data, mem);
 
     /*
-     * Reserve space for the result of the algorithm. Currently, there is 
+     * Reserve space for the result of the algorithm. Currently, there is
      * enough space allocated that (in theory) each cell could be a single
      * cluster, but this should not be the case with real experiment data.
      */
@@ -707,7 +707,7 @@ component_connection::output_type component_connection::operator()(
 
     /*
      * Run the connected component labeling algorithm to retrieve the clusters.
-     * 
+     *
      * This step includes the measurement (hit) creation for each cluster.
      */
     sparse_ccl_kernel<<<partitions.size(), THREADS_PER_BLOCK>>>(

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -168,13 +168,13 @@ __device__ void fast_sv_1(index_t* f, index_t* f_next, unsigned char adjc[],
             __builtin_assume(adjc[tst] <= 8);
 
             for (unsigned char k = 0; k < adjc[tst]; ++k) {
-                index_t q = adjv[tst][k];
+                index_t q = f[adjv[tst][k]];
 
-                if (f[tid] > f[q]) {
+                if (f[tid] > q) {
                     // update grandparent of current cell
-                    f_next[f_next[tid]] = f[q];
+                    f_next[f_next[tid]] = q;
                     // update parent of current cell, kind of shortcutting
-                    f_next[tid] = f[q];
+                    f_next[tid] = q;
                 }
             }
         }

--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -282,10 +282,10 @@ __device__ void fast_sv_2(index_t* f, index_t* f_next, unsigned char adjc[],
         for (index_t tst = 0, tid;
              (tid = tst * blockDim.x + threadIdx.x) < size; ++tst) {
             for (unsigned char k = 0; k < adjc[tst]; ++k) {
-                index_t q = adjv[tst][k];
+                index_t q = f[f[adjv[tst][k]]];
 
-                if (f[f[q]] < f_next[tid]) {
-                    f_next[tid] = f[f[q]];
+                if (q < f_next[tid]) {
+                    f_next[tid] = q;
                     f_next_changed = true;
                 }
             }


### PR DESCRIPTION
This PR adds comments to the two fast_sv algorithms and the variables `adjc` and `adjv` are mentioned to be abbreviations for `adjecency count` respectively `adjecency vector`. 

Further, the variables `f` and `f_next` are introduced to be more coherent with the vocabulary of [the paper describing the Fast SV algorithm](https://epubs.siam.org/doi/pdf/10.1137/1.9781611976137.5). 
Concretely:
* in fast_sv_1: `f` (<-`gf`) and `f_next` (<-`f`)
* in fast_sv_2: `f` (<-`f`) and `f_next` (<-`gf`)
