### PR TITLE
CUDA Seedfinding Fix, main branch (2022.05.24.)

### DIFF
--- a/device/cuda/src/seeding/seed_selecting.cu
+++ b/device/cuda/src/seeding/seed_selecting.cu
@@ -51,7 +51,7 @@ void seed_selecting(
 
     unsigned int nbins = internal_sp_view._data_view.m_size;
 
-    spacepoint_container_types::const_view spacepoints_view =
+    spacepoint_container_types::const_data spacepoints_view =
         get_data(spacepoints, &resource);
 
     // The thread-block is desinged to make each thread investigate the

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -28,7 +28,7 @@ track_params_estimation::output_type track_params_estimation::operator()(
 
     output_type params(seeds.size(), &m_mr.get());
 
-    spacepoint_container_types::const_view spacepoints_view =
+    spacepoint_container_types::const_data spacepoints_view =
         get_data(spacepoints, &m_mr.get());
     auto seeds_view = vecmem::get_data(seeds);
     auto params_view = vecmem::get_data(params);


### PR DESCRIPTION
After looking at the issue reported by @beomki-yeo in #196 a little more, I finally found what the issue was.

I moved away from using `auto` as the return type of the `get_data(...)` calls in the CUDA code. I wanted to make the code a little more readable with that. But I managed to replace `auto` with incorrect types in 2 places. :frowning:

This was as sneaky as it was because while the translation from `vecmem::jagged_vector_data<traccc::spacepoint>` to `vecmem::jagged_vector_view<traccc::spacepoint>` explicitly freed the global memory in which the data that `compute-sanitizer` was complaining about lived, that data was not actually cleared from the global memory. The addresses used by the code for reading from global memory were still valid. But only because nothing else was in need of memory between these `get_data(...)` calls and the kernel launches.

Long story short, with these bugfixes the errors are gone.

```
[bash][Legolas]:build > compute-sanitizer ./bin/traccc_seeding_example_cuda --detector_file=tml_detector/trackml-detector.csv --hit_directory=tml_full/ttbar_mu40/ --events=1 --run_cpu=1
========= COMPUTE-SANITIZER
Running /data/ssd-1tb/projects/traccc/build/./bin/traccc_seeding_example_cuda tml_detector/trackml-detector.csv tml_full/ttbar_mu40/ 1
Module libc not found.
event 0
 seed matching rate: 0.991749
 track parameters matching rate: 0.993612
==> Statistics ... 
- read    24066 spacepoints from 0 modules
- created (cpu)  3757 seeds
- created (cuda) 3757 seeds
==> Elpased time ... 
wall time           3.82421   
hit reading (cpu)   0.898047  
seeding_time (cpu)  0.096489  
seeding_time (cuda) 1.08806   
tr_par_esti_time (cpu)    0.0228567 
tr_par_esti_time (cuda)   0.0341193 
========= ERROR SUMMARY: 0 errors
[bash][Legolas]:build >
```

(This is still in full Debug mode, hence the terrible device execution time. :wink:)