### PR TITLE
VecMem Update, main branch (2022.06.03.)

### DIFF
--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.14.0.tar.gz;URL_MD5;12bf988c5d49d35ae785022fa3bb4f72"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.15.0.tar.gz;URL_MD5;714c7557ca79a7749d8b161cad8783b0"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Updated the project to [VecMem v0.15.0](https://github.com/acts-project/vecmem/releases/tag/v0.15.0).

The relevant updates are:
  - Added a virtual destructor to `vecmem::copy` to make it possible to manage "copy objects" in memory through their base pointer;
    * This is required for #201 to progress;
  - Updated `vecmem::copy` to coalesce jagged vectors in host memory before doing H->D or D->H copies, minimising the number of H->D and D->H copies on the expense of extra H->H copies (and an additional host memory allocation).
    * This will allow for some optimisations in how copies are made in this project. Hopefully...