### PR TITLE
Single Precision Fixes, main branch (2022.06.28.)

### DIFF
--- a/core/include/traccc/seeding/track_params_estimation_helper.hpp
+++ b/core/include/traccc/seeding/track_params_estimation_helper.hpp
@@ -7,9 +7,13 @@
 
 #pragma once
 
+// Library include(s).
 #include "traccc/edm/seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/edm/track_parameters.hpp"
+
+// System include(s).
+#include <cmath>
 
 namespace traccc {
 
@@ -78,12 +82,13 @@ inline TRACCC_HOST_DEVICE bound_vector seed_to_bound_vector(
     scalar B = uv2[1] - A * uv2[0];
 
     // Curvature (with a sign) estimate
-    scalar rho = -2.0 * B / getter::perp(vector2{1., A});
+    scalar rho = -2.0f * B / getter::perp(vector2{1., A});
     // The projection of the top space point on the transverse plane of
     // the new frame
     scalar rn = local2[0] * local2[0] + local2[1] * local2[1];
     // The (1/tanTheta) of momentum in the new frame,
-    scalar invTanTheta = local2[2] * std::sqrt(1. / rn) / (1. + rho * rho * rn);
+    scalar invTanTheta =
+        local2[2] * std::sqrt(1.f / rn) / (1.f + rho * rho * rn);
 
     // The momentum direction in the new frame (the center of the circle
     // has the coordinate (-1.*A/(2*B), 1./(2*B)))
@@ -104,16 +109,16 @@ inline TRACCC_HOST_DEVICE bound_vector seed_to_bound_vector(
 
     // The estimated q/pt in [GeV/c]^-1 (note that the pt is the
     // projection of momentum on the transverse plane of the new frame)
-    scalar qOverPt =
-        rho * (Acts::UnitConstants::m) / (0.3 * getter::norm(bfield));
+    scalar qOverPt = rho * (static_cast<scalar>(Acts::UnitConstants::m)) /
+                     (0.3f * getter::norm(bfield));
     // The estimated q/p in [GeV/c]^-1
     params[e_bound_qoverp] = qOverPt / getter::perp(vector2{1., invTanTheta});
 
     // The estimated momentum, and its projection along the magnetic
     // field diretion
-    scalar pInGeV = std::abs(1.0 / params[e_bound_qoverp]);
-    scalar pzInGeV = 1.0 / std::abs(qOverPt) * invTanTheta;
-    scalar massInGeV = mass / Acts::UnitConstants::GeV;
+    scalar pInGeV = std::abs(1.0f / params[e_bound_qoverp]);
+    scalar pzInGeV = 1.0f / std::abs(qOverPt) * invTanTheta;
+    scalar massInGeV = mass / static_cast<scalar>(Acts::UnitConstants::GeV);
 
     // The estimated velocity, and its projection along the magnetic
     // field diretion

--- a/device/sycl/src/seeding/seed_selecting.sycl
+++ b/device/sycl/src/seeding/seed_selecting.sycl
@@ -202,10 +202,15 @@ class SeedSelect {
                     const auto& spB2 = spacepoints_device.at(ispB2.m_link);
                     const auto& spT2 = spacepoints_device.at(ispT2.m_link);
 
-                    seed1_sum += pow(spB1.y(), 2) + pow(spB1.z(), 2);
-                    seed1_sum += pow(spT1.y(), 2) + pow(spT1.z(), 2);
-                    seed2_sum += pow(spB2.y(), 2) + pow(spB2.z(), 2);
-                    seed2_sum += pow(spT2.y(), 2) + pow(spT2.z(), 2);
+                    constexpr scalar exp = 2;
+                    seed1_sum +=
+                        ::sycl::pow(spB1.y(), exp) + ::sycl::pow(spB1.z(), exp);
+                    seed1_sum +=
+                        ::sycl::pow(spT1.y(), exp) + ::sycl::pow(spT1.z(), exp);
+                    seed2_sum +=
+                        ::sycl::pow(spB2.y(), exp) + ::sycl::pow(spB2.z(), exp);
+                    seed2_sum +=
+                        ::sycl::pow(spT2.y(), exp) + ::sycl::pow(spT2.z(), exp);
 
                     return seed1_sum > seed2_sum;
                 }


### PR DESCRIPTION
Eliminated some double-precision calculations when `scalar` is set to `float`.

In order to allow using these code pieces on hardware that does not support double-precision calculations, we need to be very explicit about the types that we would use in certain places. On my shiny new laptop, with its Intel Xe GPU, I was running into runtime errors like:

```
...
error: double type is not supported on this platform
in file: track_params_estimation_helper.hpp:95

in kernel: 'typeinfo name for traccc::sycl::TrackParamsEstimation'
error: backend compiler failed build.
 -11 (PI_ERROR_BUILD_PROGRAM_FAILURE)
Aborted (core dumped)
```

(The line number is not too meaningful in the example. It came from an "intermediate" state of the code while I was trying things out.)

With these changes I am able to run `traccc_seq_example_sycl` (once again) on hardware that dislikes double-precision calculations. (My laptop...)