### PR TITLE
Cuda clusterization using common kernels

### DIFF
--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -37,6 +37,9 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/seeding/triplet_finding.cu"
   "src/seeding/seeding_algorithm.cpp"
   "src/cca/component_connection.cu"
+  # Clusterization
+  "include/traccc/cuda/clusterization/clusterization_algorithm.hpp"
+  "src/clusterization/clusterization_algorithm.cu"
 )
 target_compile_options( traccc_cuda
   PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr> )

--- a/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
@@ -18,8 +18,8 @@
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/utils/copy.hpp>
 
-// Traccc library include(s).
-#include "traccc/utils/memory_resource.hpp"
+//// Traccc library include(s).
+//#include "traccc/utils/memory_resource.hpp"
 
 namespace traccc::cuda {
 

--- a/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-
 // Project include(s).
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/cluster.hpp"

--- a/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
@@ -1,0 +1,50 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+
+// Project include(s).
+#include "traccc/edm/cell.hpp"
+#include "traccc/edm/cluster.hpp"
+#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/spacepoint.hpp"
+#include "traccc/utils/algorithm.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/utils/copy.hpp>
+
+// Traccc library include(s).
+#include "traccc/utils/memory_resource.hpp"
+
+namespace traccc::cuda {
+
+class clusterization_algorithm
+    : public algorithm<spacepoint_container_types::buffer(
+          const cell_container_types::host&)> {
+
+    public:
+    /// Constructor for clusterization algorithm
+    ///
+    /// @param mr is a memory resource (device)
+    clusterization_algorithm(vecmem::memory_resource& mr);
+
+    /// Callable operator for clusterization algorithm
+    ///
+    /// @param cells_per_event is a container with cell modules as headers
+    /// and cells as the items
+    /// @return a spacepoint container (buffer) - jagged vector of spacepoints
+    /// per module.
+    output_type operator()(
+        const cell_container_types::host& cells_per_event) const override;
+
+    private:
+    std::reference_wrapper<vecmem::memory_resource> m_mr;
+};
+
+}  // namespace traccc::cuda

--- a/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
@@ -26,7 +26,7 @@ namespace traccc::cuda {
 /// Seed finding for cuda
 class seed_finding
     : public algorithm<host_seed_collection(
-          const spacepoint_container_types::host&, const sp_grid_const_view&)> {
+          const spacepoint_container_types::view&, const sp_grid_const_view&)> {
 
     public:
     /// Constructor for the cuda seed finding
@@ -39,7 +39,7 @@ class seed_finding
     /// Callable operator for the seed finding
     ///
     /// @return seed_collection is the vector of seeds per event
-    output_type operator()(const spacepoint_container_types::host& spacepoints,
+    output_type operator()(const spacepoint_container_types::view& spacepoints,
                            const sp_grid_const_view& g2_view) const override;
 
     private:

--- a/device/cuda/include/traccc/cuda/seeding/seed_selecting.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_selecting.hpp
@@ -33,7 +33,7 @@ namespace cuda {
 void seed_selecting(
     const seedfilter_config& filter_config,
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
-    const spacepoint_container_types::host& spacepoints,
+    const spacepoint_container_types::view& spacepoints,
     sp_grid_const_view internal_sp_view,
     device::doublet_counter_container_types::const_view dcc_view,
     triplet_counter_container_view tcc_view, triplet_container_view tc_view,

--- a/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
@@ -23,7 +23,7 @@ namespace traccc::cuda {
 
 /// Main algorithm for performing the track seeding on an NVIDIA GPU
 class seeding_algorithm : public algorithm<host_seed_collection(
-                              const spacepoint_container_types::host&)> {
+                              const spacepoint_container_types::view&)> {
 
     public:
     /// Constructor for the seed finding algorithm
@@ -38,7 +38,7 @@ class seeding_algorithm : public algorithm<host_seed_collection(
     /// @return The track seeds reconstructed from the spacepoints
     ///
     output_type operator()(
-        const spacepoint_container_types::host& spacepoints) const override;
+        const spacepoint_container_types::view& spacepoints) const override;
 
     private:
     /// Sub-algorithm performing the spacepoint binning

--- a/device/cuda/include/traccc/cuda/seeding/spacepoint_binning.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/spacepoint_binning.hpp
@@ -24,7 +24,7 @@ namespace traccc::cuda {
 
 /// Spacepoing binning executed on a CUDA device
 class spacepoint_binning : public algorithm<sp_grid_buffer(
-                               const spacepoint_container_types::host&)> {
+                               const spacepoint_container_types::view&)> {
 
     public:
     /// Constructor for the algorithm
@@ -34,7 +34,7 @@ class spacepoint_binning : public algorithm<sp_grid_buffer(
 
     /// Function executing the algorithm
     sp_grid_buffer operator()(
-        const spacepoint_container_types::host& spacepoints) const override;
+        const spacepoint_container_types::view& sp_data) const override;
 
     private:
     seedfinder_config m_config;

--- a/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
@@ -28,8 +28,9 @@ struct track_params_estimation
     /// @param input_type is the seed container
     ///
     /// @return vector of bound track parameters
-    output_type operator()(const spacepoint_container_types::view& spacepoints_view,
-                           host_seed_collection&& seeds) const override;
+    output_type operator()(
+        const spacepoint_container_types::view& spacepoints_view,
+        host_seed_collection&& seeds) const override;
 
     private:
     std::reference_wrapper<vecmem::memory_resource> m_mr;

--- a/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
@@ -16,7 +16,7 @@ namespace cuda {
 /// track parameter estimation for cuda
 struct track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
-          const spacepoint_container_types::host&, host_seed_collection&&)> {
+          const spacepoint_container_types::view&, host_seed_collection&&)> {
     public:
     /// Constructor for track_params_estimation
     ///
@@ -28,7 +28,7 @@ struct track_params_estimation
     /// @param input_type is the seed container
     ///
     /// @return vector of bound track parameters
-    output_type operator()(const spacepoint_container_types::host& spacepoints,
+    output_type operator()(const spacepoint_container_types::view& spacepoints_view,
                            host_seed_collection&& seeds) const override;
 
     private:

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -211,11 +211,11 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     // Calclating grid size for cluster counting kernel (block size 64)
     blocksPerGrid =
         (cells_prefix_sum_view.size() + threadsPerBlock - 1) / threadsPerBlock;
-    // Invoke cluster counting will call count clusters kernel
+    // Invoke cluster counting will call count cluster cells kernel
     kernels::invoke_cluster_counting<<<blocksPerGrid, threadsPerBlock>>>(
         sparse_ccl_indices_view, cl_per_module_prefix_view,
         cells_prefix_sum_view, cluster_sizes_view);
-    // Wait here for the cluster_counting kernel to finish
+    // Wait for the cluster_counting kernel to finish
     CUDA_ERROR_CHECK(cudaGetLastError());
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
@@ -293,12 +293,12 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     spacepoint_container_types::view spacepoints_view = spacepoints_buffer;
 
     // Using the same grid size as before
-    // Invoke measurements creation will call create measurements kernel
+    // Invoke spacepoint formation will call form_spacepoints kernel
     kernels::invoke_spacepoint_formation<<<blocksPerGrid, threadsPerBlock>>>(
         measurements_view, meas_prefix_sum_view, spacepoints_view);
     CUDA_ERROR_CHECK(cudaGetLastError());
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
-
+    // Wait for the spacepoint formation kernel to finish
     return spacepoints_buffer;
 }
 

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -216,7 +216,8 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     kernels::count_cluster_cells<<<blocksPerGrid, threadsPerBlock>>>(
         sparse_ccl_indices_view, cl_per_module_prefix_view,
         cells_prefix_sum_view, cluster_sizes_view);
-    // Check for kernel launch errors and Wait for the cluster_counting kernel to finish
+    // Check for kernel launch errors and Wait for the cluster_counting kernel
+    // to finish
     CUDA_ERROR_CHECK(cudaGetLastError());
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
@@ -275,7 +276,8 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     kernels::create_measurements<<<blocksPerGrid, threadsPerBlock>>>(
         cells_view, clusters_view, measurements_view);
 
-    // Check for kernel launch errors and Wait here for the measurements creation kernel to finish
+    // Check for kernel launch errors and Wait here for the measurements
+    // creation kernel to finish
     CUDA_ERROR_CHECK(cudaGetLastError());
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
@@ -297,7 +299,8 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     // Invoke spacepoint formation will call form_spacepoints kernel
     kernels::form_spacepoints<<<blocksPerGrid, threadsPerBlock>>>(
         measurements_view, meas_prefix_sum_view, spacepoints_view);
-    // Check for kernel launch errors and Wait for the spacepoint formation kernel to finish
+    // Check for kernel launch errors and Wait for the spacepoint formation
+    // kernel to finish
     CUDA_ERROR_CHECK(cudaGetLastError());
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
     return spacepoints_buffer;

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -1,0 +1,308 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/cuda/clusterization/clusterization_algorithm.hpp"
+
+
+// Project include(s)
+#include "traccc/clusterization/device/connect_components.hpp"
+#include "traccc/clusterization/device/count_cluster_cells.hpp"
+#include "traccc/clusterization/device/create_measurements.hpp"
+#include "traccc/clusterization/device/find_clusters.hpp"
+#include "traccc/clusterization/device/form_spacepoints.hpp"
+#include "traccc/device/get_prefix_sum.hpp"
+
+// Vecmem include(s).
+#include <vecmem/utils/copy.hpp>
+
+// System include(s).
+#include <algorithm>
+
+// Local include(s)
+#include "traccc/cuda/utils/definitions.hpp"
+
+namespace traccc::cuda {
+namespace kernels{
+
+__global__ void invoke_find_clusters_kernel(
+    const cell_container_types::const_view cells_view,
+    vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
+    vecmem::data::vector_view<std::size_t> clusters_per_module_view) {
+
+        device::find_clusters(
+            threadIdx.x + blockIdx.x * blockDim.x, 
+            cells_view, sparse_ccl_indices_view, clusters_per_module_view);
+
+}
+
+__global__ void invoke_cluster_counting(vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
+    vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
+    vecmem::data::vector_view<const device::prefix_sum_element_t>
+        cells_prefix_sum_view,
+    vecmem::data::vector_view<unsigned int> cluster_sizes_view){
+
+        device::count_cluster_cells(threadIdx.x + blockIdx.x * blockDim.x,
+        sparse_ccl_indices_view,cluster_prefix_sum_view,cells_prefix_sum_view,cluster_sizes_view);
+
+}
+
+__global__ void invoke_connect_components(const cell_container_types::const_view cells_view,
+    vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
+    vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,
+    vecmem::data::vector_view<const device::prefix_sum_element_t>
+        cells_prefix_sum_view,
+    cluster_container_types::view clusters_view){
+
+        device::connect_components(threadIdx.x + blockIdx.x * blockDim.x, 
+        cells_view,sparse_ccl_indices_view,cluster_prefix_sum_view,cells_prefix_sum_view,clusters_view);
+
+
+    }
+__global__ void invoke_measurements_creation(const cell_container_types::const_view cells_view,
+                         cluster_container_types::const_view clusters_view,
+                         measurement_container_types::view measurements_view){
+
+        device::create_measurements(threadIdx.x + blockIdx.x * blockDim.x, clusters_view, cells_view,measurements_view);
+
+}
+
+__global__ void invoke_spacepoint_formation(measurement_container_types::const_view measurements_view,
+    vecmem::data::vector_view<const device::prefix_sum_element_t>
+        measurements_prefix_sum_view,
+    spacepoint_container_types::view spacepoints_view){
+
+        device::form_spacepoints(threadIdx.x + blockIdx.x * blockDim.x, measurements_view, measurements_prefix_sum_view, spacepoints_view);
+
+    }
+
+
+}// namespace kernels
+
+clusterization_algorithm::clusterization_algorithm(
+    vecmem::memory_resource &mr)
+    : m_mr(mr) {
+}
+
+clusterization_algorithm::output_type clusterization_algorithm::operator()(
+    const cell_container_types::host& cells_per_event) const {
+    
+    // Vecmem copy object for moving the data between host and device
+    vecmem::copy copy;
+
+    // Number of modules
+    unsigned int num_modules = cells_per_event.size();
+
+    // Work block size for kernel execution
+    std::size_t threadsPerBlock = 64;
+
+    // Get the view of the cells container
+    auto cells_data =
+        get_data(cells_per_event, &m_mr.get());
+
+    // Get the sizes of the cells in each module
+    auto cell_sizes = copy.get_sizes(cells_data.items);
+
+    /*
+     * Helper container for sparse CCL calculations.
+     * Each inner vector corresponds to 1 module.
+     * The indices in a particular inner vector will be filled by sparse ccl
+     * and will indicate to which cluster, a particular cell in the module
+     * belongs to.
+     */
+    vecmem::data::jagged_vector_buffer<unsigned int> sparse_ccl_indices_buff(
+        std::vector<std::size_t>(cell_sizes.begin(), cell_sizes.end()),
+        m_mr.get());
+    copy.setup(sparse_ccl_indices_buff);
+
+    /*
+     * cl_per_module_prefix_buff is a vector buffer with numbers of found
+     * clusters in each module. Later it will be transformed into prefix sum
+     * vector (hence the name). The logic is the following. After
+     * cluster_finding_kernel, the buffer will contain cluster sizes e.i.
+     *
+     * cluster sizes: | 1 | 12 | 5 | 102 | 42 | ... - cl_per_module_prefix_buff
+     * module index:  | 0 |  1 | 2 |  3  |  4 | ...
+     *
+     * Now, we copy those cluster sizes to the host and make a duplicate vector
+     * of them. So, we are left with cl_per_module_prefix_host, and
+     * clusters_per_module_host - which are the same. Now, we procede to
+     * modifying the cl_per_module_prefix_host to actually resemble its name
+     * i.e.
+     *
+     * We do std::inclusive_scan on it, which will result in a prefix sum
+     * vector:
+     *
+     * cl_per_module_prefix_host: | 1 | 13 | 18 | 120 | 162 | ...
+     *
+     * Then, we copy this vector into the previous cl_per_module_prefix_buff.
+     * In this way, we don't need to allocate the memory on the device twice.
+     *
+     * Now, the monotonic prefix sum buffer - cl_per_module_prefix_buff, will
+     * allow us to insert the clusters at the correct position inside the
+     * kernel. The remaining host vector - clusters_per_module_host, will be
+     * needed to allocate memory for other buffers later in the code.
+     */
+    vecmem::data::vector_buffer<std::size_t> cl_per_module_prefix_buff(
+        num_modules, m_mr.get());
+    copy.setup(cl_per_module_prefix_buff);
+
+    // Create views to pass to cluster finding kernel
+    const cell_container_types::const_view cells_view(cells_data);
+    vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view =
+        sparse_ccl_indices_buff;
+    vecmem::data::vector_view<std::size_t> cl_per_module_prefix_view =
+        cl_per_module_prefix_buff;
+
+    // Calculating grid size for cluster finding kernel
+    std::size_t blocksPerGrid = (num_modules+threadsPerBlock-1)/threadsPerBlock; 
+
+    // Invoke find clusters that will call cluster finding kernel
+    kernels::invoke_find_clusters_kernel<<<blocksPerGrid,threadsPerBlock>>>(cells_view, sparse_ccl_indices_view,cl_per_module_prefix_view);
+
+
+
+    // Get the prefix sum of the cells and copy it to the device buffer
+    const device::prefix_sum_t cells_prefix_sum = device::get_prefix_sum(
+        cell_sizes, m_mr.get());
+    vecmem::data::vector_buffer<device::prefix_sum_element_t>
+        cells_prefix_sum_buff(cells_prefix_sum.size(), m_mr.get());
+    copy.setup(cells_prefix_sum_buff);
+    copy(vecmem::get_data(cells_prefix_sum), cells_prefix_sum_buff,
+              vecmem::copy::type::copy_type::host_to_device);
+
+    // Wait here for the cluster_finding kernel to finish
+    CUDA_ERROR_CHECK(cudaGetLastError());
+    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+
+    // Copy the sizes of clusters per module to the host
+    // and create a copy of "clusters per module" vector
+    vecmem::vector<std::size_t> cl_per_module_prefix_host(
+        &m_mr.get());
+    copy(cl_per_module_prefix_buff, cl_per_module_prefix_host,
+              vecmem::copy::type::copy_type::device_to_host);
+    std::vector<std::size_t> clusters_per_module_host(
+        cl_per_module_prefix_host.begin(), cl_per_module_prefix_host.end());
+
+    // Perform the inclusive scan operation
+    std::inclusive_scan(cl_per_module_prefix_host.begin(),
+                        cl_per_module_prefix_host.end(),
+                        cl_per_module_prefix_host.begin());
+
+    unsigned int total_clusters = cl_per_module_prefix_host.back();
+
+    // Copy the prefix sum back to its device container
+    copy(vecmem::get_data(cl_per_module_prefix_host),
+              cl_per_module_prefix_buff,
+              vecmem::copy::type::copy_type::host_to_device);
+
+    // Vector of the exact cluster sizes, will be filled in cluster counting
+    vecmem::data::vector_buffer<unsigned int> cluster_sizes_buffer(
+        total_clusters, m_mr.get());
+    copy.setup(cluster_sizes_buffer);
+    copy.memset(cluster_sizes_buffer, 0);
+
+    // Create views to pass to cluster counting kernel
+    vecmem::data::vector_view<const device::prefix_sum_element_t>
+        cells_prefix_sum_view = cells_prefix_sum_buff;
+    vecmem::data::vector_view<unsigned int> cluster_sizes_view =
+        cluster_sizes_buffer;
+
+    // Calclating grid size for cluster counting kernel (block size 64)
+    blocksPerGrid = (cells_prefix_sum_view.size()+threadsPerBlock-1) / threadsPerBlock;
+    // Invoke cluster counting will call count clusters kernel
+    kernels::invoke_cluster_counting<<<blocksPerGrid,threadsPerBlock>>>(sparse_ccl_indices_view, cl_per_module_prefix_view
+                                    , cells_prefix_sum_view, cluster_sizes_view);
+    // Wait here for the cluster_counting kernel to finish
+    CUDA_ERROR_CHECK(cudaGetLastError());
+    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+
+
+    // Copy cluster sizes back to the host
+    std::vector<unsigned int> cluster_sizes;
+    copy(cluster_sizes_buffer, cluster_sizes,
+              vecmem::copy::type::copy_type::device_to_host);
+
+    // Cluster container buffer for the clusters and headers (cluster ids)
+    cluster_container_types::buffer clusters_buffer{
+        {total_clusters, m_mr.get()},
+        {std::vector<std::size_t>(total_clusters, 0),
+         std::vector<std::size_t>(cluster_sizes.begin(), cluster_sizes.end()),
+         m_mr.get()}};
+    copy.setup(clusters_buffer.headers);
+    copy.setup(clusters_buffer.items);
+
+    // Create views to pass to component connection kernel
+    cluster_container_types::view clusters_view = clusters_buffer;
+
+    // Using previous block size and thread size (64) 
+    // Invoke connect components will call connect components kernel
+    kernels::invoke_connect_components<<<blocksPerGrid,threadsPerBlock>>>(cells_view,sparse_ccl_indices_view
+                            , cl_per_module_prefix_view, cells_prefix_sum_view, clusters_view);  
+
+    // Resizable buffer for the measurements
+    measurement_container_types::buffer measurements_buffer{
+        {num_modules, m_mr.get()},
+        {std::vector<std::size_t>(num_modules, 0), clusters_per_module_host,
+         m_mr.get()}};
+    copy.setup(measurements_buffer.headers);
+    copy.setup(measurements_buffer.items);
+
+    // Spacepoint container buffer to fill inside the spacepoint formation
+    // kernel
+    spacepoint_container_types::buffer spacepoints_buffer{
+        {num_modules, m_mr.get()},
+        {std::vector<std::size_t>(num_modules, 0), clusters_per_module_host,
+         m_mr.get()}};
+    copy.setup(spacepoints_buffer.headers);
+    copy.setup(spacepoints_buffer.items);
+
+    // Wait here for the component connection kernel to finish
+    CUDA_ERROR_CHECK(cudaGetLastError());
+    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+
+    // Create views to pass to measurement creation kernel
+    measurement_container_types::view measurements_view = measurements_buffer;
+
+    // Calculating grid size for measurements creation kernel (block size 64)
+    blocksPerGrid = (clusters_view.headers.size() -1 + threadsPerBlock) / threadsPerBlock;
+
+    // Invoke measurements creation will call create measurements kernel
+    kernels::invoke_measurements_creation<<<blocksPerGrid,threadsPerBlock>>>(cells_view,
+                clusters_view, measurements_view);
+
+    // Wait here for the measurements creation kernel to finish            
+    CUDA_ERROR_CHECK(cudaGetLastError());
+    CUDA_ERROR_CHECK(cudaDeviceSynchronize());    
+
+    // Get the prefix sum of the measurements and copy it to the device buffer
+    const device::prefix_sum_t meas_prefix_sum =
+        device::get_prefix_sum(copy.get_sizes(measurements_buffer.items),
+                               m_mr.get());
+    vecmem::data::vector_buffer<device::prefix_sum_element_t>
+        meas_prefix_sum_buff(meas_prefix_sum.size(), m_mr.get());
+    copy.setup(meas_prefix_sum_buff);
+    copy(vecmem::get_data(meas_prefix_sum), meas_prefix_sum_buff,
+              vecmem::copy::type::copy_type::host_to_device);
+
+    // Create views to run spacepoint formation
+    vecmem::data::vector_view<const device::prefix_sum_element_t>
+        meas_prefix_sum_view = meas_prefix_sum_buff;
+    spacepoint_container_types::view spacepoints_view = spacepoints_buffer;
+
+    // Using the same grid size as before
+    // Invoke measurements creation will call create measurements kernel
+    kernels::invoke_spacepoint_formation<<<blocksPerGrid,threadsPerBlock>>>(
+        measurements_view, meas_prefix_sum_view, spacepoints_view
+    );
+    CUDA_ERROR_CHECK(cudaGetLastError());
+    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+
+    return spacepoints_buffer;
+}
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -63,7 +63,7 @@ seed_finding::seed_finding(const seedfinder_config& config,
     : m_seedfinder_config(config), m_mr(mr) {}
 
 seed_finding::output_type seed_finding::operator()(
-    const spacepoint_container_types::host& spacepoints,
+    const spacepoint_container_types::view& spacepoints,
     const sp_grid_const_view& g2_view) const {
 
     // Helper object for the data management.

--- a/device/cuda/src/seeding/seed_selecting.cu
+++ b/device/cuda/src/seeding/seed_selecting.cu
@@ -42,7 +42,7 @@ __global__ void seed_selecting_kernel(
 void seed_selecting(
     const seedfilter_config& filter_config,
     const vecmem::vector<device::doublet_counter_header>& dcc_headers,
-    const spacepoint_container_types::host& spacepoints,
+    const spacepoint_container_types::view& spacepoints_view,
     sp_grid_const_view internal_sp_view,
     device::doublet_counter_container_types::const_view dcc_view,
     triplet_counter_container_view tcc_view, triplet_container_view tc_view,
@@ -50,9 +50,6 @@ void seed_selecting(
     vecmem::memory_resource& resource) {
 
     unsigned int nbins = internal_sp_view._data_view.m_size;
-
-    spacepoint_container_types::const_data spacepoints_view =
-        get_data(spacepoints, &resource);
 
     // The thread-block is desinged to make each thread investigate the
     // compatible middle spacepoint

--- a/device/cuda/src/seeding/seeding_algorithm.cpp
+++ b/device/cuda/src/seeding/seeding_algorithm.cpp
@@ -60,7 +60,7 @@ seeding_algorithm::seeding_algorithm(vecmem::memory_resource& mr)
       m_seed_finding(default_seedfinder_config(), mr) {}
 
 seeding_algorithm::output_type seeding_algorithm::operator()(
-    const spacepoint_container_types::host& spacepoints) const {
+    const spacepoint_container_types::view& spacepoints) const {
 
     return m_seed_finding(spacepoints, m_spacepoint_binning(spacepoints));
 }

--- a/device/cuda/src/seeding/spacepoint_binning.cu
+++ b/device/cuda/src/seeding/spacepoint_binning.cu
@@ -52,14 +52,10 @@ spacepoint_binning::spacepoint_binning(
     : m_config(config), m_axes(get_axes(grid_config, mr)), m_mr(mr) {}
 
 sp_grid_buffer spacepoint_binning::operator()(
-    const spacepoint_container_types::host& spacepoints) const {
+    const spacepoint_container_types::view& sp_data) const {
 
     // Helper object for the data management.
     vecmem::copy copy;
-
-    // Get the data/view for the spacepoints.
-    const spacepoint_container_types::const_data sp_data =
-        traccc::get_data(spacepoints);
 
     // Get the prefix sum for the spacepoints.
     const device::prefix_sum_t sp_prefix_sum =

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -23,13 +23,11 @@ __global__ void track_params_estimating_kernel(
     vecmem::data::vector_view<bound_track_parameters> params_view);
 
 track_params_estimation::output_type track_params_estimation::operator()(
-    const spacepoint_container_types::host& spacepoints,
+    const spacepoint_container_types::view& spacepoints_view,
     host_seed_collection&& seeds) const {
 
     output_type params(seeds.size(), &m_mr.get());
 
-    spacepoint_container_types::const_data spacepoints_view =
-        get_data(spacepoints, &m_mr.get());
     auto seeds_view = vecmem::get_data(seeds);
     auto params_view = vecmem::get_data(params);
 

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -95,9 +95,11 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
             end_hit_reading_cpu - start_hit_reading_cpu;
         /*time*/ hit_reading_cpu += time_hit_reading_cpu.count();
 
-        // Get spacepoint container view. 
-        // This is required as seeding cuda now expected a spacepoint container view 
-        traccc::spacepoint_container_types::view sp_view_per_event = get_data(spacepoints_per_event,&mng_mr);
+        // Get spacepoint container view.
+        // This is required as seeding cuda now expected a spacepoint container
+        // view
+        traccc::spacepoint_container_types::view sp_view_per_event =
+            get_data(spacepoints_per_event, &mng_mr);
 
         /*----------------------------
              Seeding algorithm

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -95,6 +95,10 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
             end_hit_reading_cpu - start_hit_reading_cpu;
         /*time*/ hit_reading_cpu += time_hit_reading_cpu.count();
 
+        // Get spacepoint container view. 
+        // This is required as seeding cuda now expected a spacepoint container view 
+        traccc::spacepoint_container_types::view sp_view_per_event = get_data(spacepoints_per_event,&mng_mr);
+
         /*----------------------------
              Seeding algorithm
           ----------------------------*/
@@ -103,7 +107,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
 
         /*time*/ auto start_seeding_cuda = std::chrono::system_clock::now();
 
-        auto seeds_cuda = sa_cuda(std::move(spacepoints_per_event));
+        auto seeds_cuda = sa_cuda(std::move(sp_view_per_event));
 
         /*time*/ auto end_seeding_cuda = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_seeding_cuda =
@@ -135,7 +139,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
             std::chrono::system_clock::now();
 
         auto params_cuda =
-            tp_cuda(std::move(spacepoints_per_event), std::move(seeds_cuda));
+            tp_cuda(std::move(sp_view_per_event), std::move(seeds_cuda));
 
         /*time*/ auto end_tp_estimating_cuda = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_cuda =

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -16,6 +16,7 @@
 #include "traccc/clusterization/spacepoint_formation.hpp"
 #include "traccc/cuda/seeding/seeding_algorithm.hpp"
 #include "traccc/cuda/seeding/track_params_estimation.hpp"
+#include "traccc/cuda/clusterization/clusterization_algorithm.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
 
@@ -64,7 +65,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     float clusterization_cpu(0);
     float sp_formation_cpu(0);
     float seeding_cpu(0);
-    // float clusterization_cuda(0);
+    float clusterization_cuda(0);
     float seeding_cuda(0);
     float tp_estimating_cpu(0);
     float tp_estimating_cuda(0);
@@ -80,6 +81,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
     traccc::cuda::seeding_algorithm sa_cuda(mng_mr);
     traccc::cuda::track_params_estimation tp_cuda(mng_mr);
+    traccc::cuda::clusterization_algorithm ca_cuda(mng_mr);
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
@@ -132,6 +134,12 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         /*time*/ std::chrono::duration<double> time_sp_formation_cpu =
             end_sp_formation_cpu - start_sp_formation_cpu;
         /*time*/ sp_formation_cpu += time_sp_formation_cpu.count();
+
+        /*-----------------------------
+              Clusterization and Spacepoint Creation (cuda)
+          -----------------------------*/
+
+        auto spacepoints_cuda = ca_cuda(cells_per_event);
 
         /*----------------------------
              Seeding algorithm

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -42,6 +42,7 @@ namespace po = boost::program_options;
 
 int seq_run(const traccc::full_tracking_input_config& i_cfg,
             const traccc::common_options& common_opts, bool run_cpu) {
+
     // Read the surface transforms
     auto surface_transforms = traccc::read_geometry(i_cfg.detector_file);
 


### PR DESCRIPTION
This PR succeeds PR #206 . CUDA kernels are sharing the code from common and follows the same structure as in PR #205.
Moreover changes are made to seeding algorithm interfaces to take spacepoint container view input in order to prevent device to host copy of spacepoints jagged vector.

```
$ build/bin/traccc_seq_example_cuda --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --cell_directory=tml_full/ttbar_mu200/ --events=5 --run_cpu=1 --input-binary
Running build/bin/traccc_seq_example_cuda tml_detector/trackml-detector.csv tml_full/ttbar_mu200/ 5
event 0
 number of seeds (cpu): 15424
 number of seeds (cuda): 15424
 seed matching rate: 0.940871
 track parameters matching rate: 0.988849
event 1
 number of seeds (cpu): 17811
 number of seeds (cuda): 17810
 seed matching rate: 0.943855
 track parameters matching rate: 0.991073
event 2
 number of seeds (cpu): 14055
 number of seeds (cuda): 14055
 seed matching rate: 0.934329
 track parameters matching rate: 0.990466
event 3
 number of seeds (cpu): 14257
 number of seeds (cuda): 14257
 seed matching rate: 0.937645
 track parameters matching rate: 0.991022
event 4
 number of seeds (cpu): 16510
 number of seeds (cuda): 16510
 seed matching rate: 0.943065
 track parameters matching rate: 0.992247
==> Statistics ... 
- read    475088 spacepoints from 67736 modules
- created        1657976 cells           
- created        475088 meaurements     
- created        475088 spacepoints     
- created (cpu)  78057 seeds
- created (cuda) 78056 seeds
==> Elpased time ... 
wall time           10.9656   
file reading (cpu)        0.345571  
clusterization_time (cpu) 0.0848409 
spacepoint_formation_time (cpu) 0.00617293
clusterization and sp formation (cuda) 0.497775  
seeding_time (cpu)        0.927675  
seeding_time (cuda)       0.192998  
tr_par_esti_time (cpu)    0.021466  
tr_par_esti_time (cuda)   0.0101964 

```