### PR TITLE
Eigen Build Tweak, main branch (2022.07.12.)

### DIFF
--- a/extern/eigen3/CMakeLists.txt
+++ b/extern/eigen3/CMakeLists.txt
@@ -18,11 +18,15 @@ set( TRACCC_EIGEN_SOURCE
 mark_as_advanced( TRACCC_EIGEN_SOURCE )
 FetchContent_Declare( Eigen3 ${TRACCC_EIGEN_SOURCE} )
 
-# Turn off the unit tests for Eigen3.
+# Configure the Eigen build.
 if( DEFINED CACHE{BUILD_TESTING} )
    set( _buildTestingValue ${BUILD_TESTING} )
 endif()
 set( BUILD_TESTING FALSE CACHE INTERNAL "Forceful setting of BUILD_TESTING" )
+set( EIGEN_BUILD_DOC FALSE CACHE BOOL
+   "Turn off the Eigen documentation build" )
+set( EIGEN_TEST_NOQT TRUE CACHE BOOL
+   "Don't set up Qt based Eigen tests/demos" )
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( Eigen3 )


### PR DESCRIPTION
Turned off the setup of the Qt(4) based targets in Eigen. This is in order to avoid warnings about Eigen's Qt usage when that library is available.

Since right now, if Qt4 is available for the build, you would see these warnings during the CMake configuration of the project:

```
...
-- Check for working Fortran compiler: /cvmfs/sft.cern.ch/lcg/releases/gcc/11.2.0-8a51a/x86_64-centos7/bin/gfortran - skipped
-- Checking whether /cvmfs/sft.cern.ch/lcg/releases/gcc/11.2.0-8a51a/x86_64-centos7/bin/gfortran supports Fortran 90
-- Checking whether /cvmfs/sft.cern.ch/lcg/releases/gcc/11.2.0-8a51a/x86_64-centos7/bin/gfortran supports Fortran 90 - yes
CMake Deprecation Warning at /cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/x86_64/Cmake/3.21.3/Linux-x86_64/share/cmake-3.21/Modules/Qt4Macros.cmake:372 (message):
  The qt4_automoc macro is obsolete.  Use the CMAKE_AUTOMOC feature instead.
Call Stack (most recent call first):
  /afs/cern.ch/user/k/krasznaa/work/traccc/build/_deps/eigen3-src/demos/mandelbrot/CMakeLists.txt:16 (qt4_automoc)


CMake Warning (dev) at /cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/x86_64/Cmake/3.21.3/Linux-x86_64/share/cmake-3.21/Modules/FindOpenGL.cmake:315 (message):                                                     
  Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when                                    
  available.  Run "cmake --help-policy CMP0072" for policy details.  Use the                             
  cmake_policy command to set the policy and suppress this warning.                                      

  FindOpenGL found both a legacy GL library:                                                             

    OPENGL_gl_LIBRARY: /usr/lib64/libGL.so                                                               

  and GLVND libraries for OpenGL and GLX:                                                                

    OPENGL_opengl_LIBRARY: /usr/lib64/libOpenGL.so                                                       
    OPENGL_glx_LIBRARY: /usr/lib64/libGLX.so                                                             

  OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for                                   
  compatibility with CMake 3.10 and below the legacy GL library will be used.                            
Call Stack (most recent call first):                                                                     
  /afs/cern.ch/user/k/krasznaa/work/traccc/build/_deps/eigen3-src/demos/opengl/CMakeLists.txt:2 (find_package)                                                                                                    
This warning is for project developers.  Use -Wno-dev to suppress it.                                    

-- Found OpenGL: /usr/lib64/libOpenGL.so   
CMake Deprecation Warning at /cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/x86_64/Cmake/3.21.3/Linux-x86_64/share/cmake-3.21/Modules/Qt4Macros.cmake:372 (message):
  The qt4_automoc macro is obsolete.  Use the CMAKE_AUTOMOC feature instead.
Call Stack (most recent call first):
  /afs/cern.ch/user/k/krasznaa/work/traccc/build/_deps/eigen3-src/demos/opengl/CMakeLists.txt:15 (qt4_automoc)


-- Could NOT find CHOLMOD (missing: CHOLMOD_INCLUDES CHOLMOD_LIBRARIES)
...
```

The OpenGL based warning, if we actually wanted to use OpenGL, could be handled with the suggested [OpenGL_GL_PREFERENCE](https://cmake.org/cmake/help/latest/module/FindOpenGL.html#linux-specific) variable as well. But we don't actually want to build any of that code anyway.

While at it, I noticed that the Eigen documentation should also be turned off in the build.