### PR TITLE
VecMem Update, main branch (2022.07.13.)

### DIFF
--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.15.0.tar.gz;URL_MD5;714c7557ca79a7749d8b161cad8783b0"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.16.0.tar.gz;URL_MD5;32ecea8471026080c65b14808175ddfa"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Updated the project to [VecMem 0.16.0](https://github.com/acts-project/vecmem/releases/tag/v0.16.0). This is mainly to help with the performance issues observed by @Chamodya-ka in https://github.com/acts-project/vecmem/issues/182.

Plus it fixes some platform specific issues that could lead to build errors and warnings under some circumstances.