### PR TITLE
Upgrade vecmem to version 0.17.0

### DIFF
--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.16.0.tar.gz;URL_MD5;32ecea8471026080c65b14808175ddfa"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.17.0.tar.gz;URL_MD5;4911795b54045159ac0428688f900210"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
This commit updates the version of vecmem to 0.17.0, which fixes a critical issue in the buddy allocator which was breaking some of the examples.