### PR TITLE
Changed prefix sum element type and creation of prefix sum vector function

### DIFF
--- a/core/include/traccc/edm/internal_spacepoint.hpp
+++ b/core/include/traccc/edm/internal_spacepoint.hpp
@@ -48,7 +48,7 @@ struct internal_spacepoint {
         const spacepoint_container_t& sp_container, const link_type& sp_link,
         const vector2& offsetXY)
         : m_link(std::move(sp_link)) {
-        const spacepoint_t& sp = sp_container.at({sp_idx.first, sp_idx.second});
+        const spacepoint_t& sp = sp_container.at({sp_link.first, sp_link.second});
         m_x = sp.global[0] - offsetXY[0];
         m_y = sp.global[1] - offsetXY[1];
         m_z = sp.global[2];

--- a/core/include/traccc/edm/internal_spacepoint.hpp
+++ b/core/include/traccc/edm/internal_spacepoint.hpp
@@ -48,7 +48,7 @@ struct internal_spacepoint {
         const spacepoint_container_t& sp_container, const link_type& sp_link,
         const vector2& offsetXY)
         : m_link(std::move(sp_link)) {
-        const spacepoint_t& sp = sp_container.at(sp_link);
+        const spacepoint_t& sp = sp_container.at({sp_idx.first, sp_idx.second});
         m_x = sp.global[0] - offsetXY[0];
         m_y = sp.global[1] - offsetXY[1];
         m_z = sp.global[2];

--- a/core/include/traccc/edm/internal_spacepoint.hpp
+++ b/core/include/traccc/edm/internal_spacepoint.hpp
@@ -48,7 +48,8 @@ struct internal_spacepoint {
         const spacepoint_container_t& sp_container, const link_type& sp_link,
         const vector2& offsetXY)
         : m_link(std::move(sp_link)) {
-        const spacepoint_t& sp = sp_container.at({sp_link.first, sp_link.second});
+        const spacepoint_t& sp =
+            sp_container.at({sp_link.first, sp_link.second});
         m_x = sp.global[0] - offsetXY[0];
         m_y = sp.global[1] - offsetXY[1];
         m_z = sp.global[2];

--- a/device/common/include/traccc/device/get_prefix_sum.hpp
+++ b/device/common/include/traccc/device/get_prefix_sum.hpp
@@ -21,8 +21,16 @@
 
 namespace traccc::device {
 
-/// Convenience type definition for the elements of the prefix sums
-typedef std::pair<std::size_t, std::size_t> prefix_sum_element_t;
+struct prefix_sum_element {
+    // Bin id
+    std::size_t first;
+
+    // Local id
+    std::size_t second;
+};
+
+typedef prefix_sum_element prefix_sum_element_t;
+
 /// Convenience type definition for the return value of the helper function
 typedef vecmem::vector<prefix_sum_element_t> prefix_sum_t;
 

--- a/device/common/include/traccc/seeding/device/impl/count_grid_capacities.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_grid_capacities.ipp
@@ -35,14 +35,14 @@ void count_grid_capacities(
     const prefix_sum_element_t sp_idx = sp_prefix_sum[globalIndex];
     const spacepoint_container_types::const_device spacepoints(
         spacepoints_view);
-    const spacepoint sp = spacepoints.at(sp_idx);
+    const spacepoint sp = spacepoints.at({sp_idx.first, sp_idx.second});
 
     /// Check out if the spacepoint can be used for seeding.
     if (is_valid_sp(config, sp) != detray::invalid_value<size_t>()) {
 
         // Find the grid bin that the spacepoint belongs to.
-        const internal_spacepoint<spacepoint> isp(spacepoints, sp_idx,
-                                                  config.beamPos);
+        const internal_spacepoint<spacepoint> isp(
+            spacepoints, {sp_idx.first, sp_idx.second}, config.beamPos);
         const std::size_t bin_index =
             phi_axis.bin(isp.phi()) + phi_axis.bins() * z_axis.bin(isp.z());
 

--- a/device/common/include/traccc/seeding/device/impl/populate_grid.ipp
+++ b/device/common/include/traccc/seeding/device/impl/populate_grid.ipp
@@ -31,7 +31,7 @@ void populate_grid(
     const prefix_sum_element_t sp_idx = sp_prefix_sum[globalIndex];
     const spacepoint_container_types::const_device spacepoints(
         spacepoints_view);
-    const spacepoint sp = spacepoints.at(sp_idx);
+    const spacepoint sp = spacepoints.at({sp_idx.first, sp_idx.second});
 
     /// Check out if the spacepoint can be used for seeding.
     if (is_valid_sp(config, sp) != detray::invalid_value<size_t>()) {
@@ -42,8 +42,8 @@ void populate_grid(
         const sp_grid_device::axis_p1_type& z_axis = grid.axis_p1();
 
         // Find the grid bin that the spacepoint belongs to.
-        const internal_spacepoint<spacepoint> isp(spacepoints, sp_idx,
-                                                  config.beamPos);
+        const internal_spacepoint<spacepoint> isp(
+            spacepoints, {sp_idx.first, sp_idx.second}, config.beamPos);
         const std::size_t bin_index =
             phi_axis.bin(isp.phi()) + phi_axis.bins() * z_axis.bin(isp.z());
 

--- a/device/common/src/get_prefix_sum.cpp
+++ b/device/common/src/get_prefix_sum.cpp
@@ -10,6 +10,7 @@
 
 // System include(s).
 #include <algorithm>
+#include <cassert>
 
 namespace traccc::device {
 
@@ -19,15 +20,15 @@ prefix_sum_t get_prefix_sum(
     vecmem::memory_resource& mr) {
 
     // Create the result object.
-    prefix_sum_t result(&mr);
     const std::size_t nelements = static_cast<std::size_t>(
         std::accumulate(sizes.begin(), sizes.end(), 0));
-    result.reserve(nelements);
+    prefix_sum_t result(nelements, &mr);
 
     // Fill the result object.
-    for (std::size_t i = 0; i < sizes.size(); ++i) {
-        for (std::size_t j = 0; j < sizes[i]; ++j) {
-            result.push_back({i, j});
+    for (std::size_t i = 0, k = 0; i < sizes.size(); ++i) {
+        for (std::size_t j = 0; j < sizes[i]; ++j, ++k) {
+            assert(k < result.size());
+            result[k] = {i, j};
         }
     }
 


### PR DESCRIPTION
@krasznaa 

Performance improvement on get_prefix_sum function.


Sample output in same conditions old / new:

**Old:**
wall time           120.212   
file reading (cpu)        63.9631   
clusterization_time (cpu) 0.65169   
spacepoint_formation_time (cpu) 0.129127  
clusterization and sp formation (cuda) 0.241384  
seeding_time (cpu)        2.79764   
seeding_time (cuda)       0.128792  
tr_par_esti_time (cpu)    0.311556  
tr_par_esti_time (cuda)   0.00514919

**New:**
wall time           119.376   
file reading (cpu)        63.3151   
clusterization_time (cpu) 0.65213   
spacepoint_formation_time (cpu) 0.129153  
clusterization and sp formation (cuda) 0.147325  
seeding_time (cpu)        2.80033   
seeding_time (cuda)       0.0913527 
tr_par_esti_time (cpu)    0.312316  
tr_par_esti_time (cuda)   0.00516295
