### PR TITLE
Changed get_prefix_sum to device kernel

### DIFF
--- a/device/common/CMakeLists.txt
+++ b/device/common/CMakeLists.txt
@@ -12,7 +12,11 @@ traccc_add_library( traccc_device_common device_common TYPE SHARED
    # General function(s).
    "include/traccc/device/get_prefix_sum.hpp"
    "include/traccc/device/impl/get_prefix_sum.ipp"
+   "include/traccc/device/fill_prefix_sum.hpp"
+   "include/traccc/device/impl/fill_prefix_sum.ipp"
    "src/get_prefix_sum.cpp"
+   "include/traccc/device/make_prefix_sum_buffer.hpp"
+   "src/make_prefix_sum_buffer.cpp"
    # EDM class(es).
    "include/traccc/edm/device/doublet_counter.hpp"
    "include/traccc/edm/device/triplet_counter.hpp"

--- a/device/common/include/traccc/device/fill_prefix_sum.hpp
+++ b/device/common/include/traccc/device/fill_prefix_sum.hpp
@@ -1,0 +1,43 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/device/get_prefix_sum.hpp"
+#include "traccc/edm/container.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/utils/copy.hpp>
+
+namespace traccc::device {
+
+using prefix_sum_size_t = vecmem::data::vector_view<int>::size_type;
+
+/// Function filling the prefix sum for a "size vector"
+///
+/// This simple function is just meant to translate the received "size vector"
+/// into a "prefix sum". I.e. into a list of index pairs that would allow
+/// visiting all elements of the jagged vector described by this "size vector".
+///
+/// @param[in] globalIndex The index of the current thread
+/// @param[in] sizes_view View on the sizes of the "inner vectors" of a jagged
+/// vector
+/// @param[out] ps_view   View on the result vector of index pairs
+///
+TRACCC_HOST_DEVICE
+void fill_prefix_sum(
+    std::size_t globalIndex,
+    const vecmem::data::vector_view<const prefix_sum_size_t>& sizes_view,
+    vecmem::data::vector_view<prefix_sum_element_t> ps_view);
+
+}  // namespace traccc::device
+
+// Include the implementation.
+#include "traccc/device/impl/fill_prefix_sum.ipp"

--- a/device/common/include/traccc/device/impl/fill_prefix_sum.ipp
+++ b/device/common/include/traccc/device/impl/fill_prefix_sum.ipp
@@ -1,0 +1,33 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::device {
+
+TRACCC_HOST_DEVICE
+void fill_prefix_sum(
+    const std::size_t globalIndex,
+    const vecmem::data::vector_view<const prefix_sum_size_t>& sizes_view,
+    vecmem::data::vector_view<prefix_sum_element_t> ps_view) {
+
+    const vecmem::device_vector<const prefix_sum_size_t> sizes(sizes_view);
+    vecmem::device_vector<prefix_sum_element_t> result(ps_view);
+
+    if (globalIndex >= sizes.size()) {
+        return;
+    }
+
+    const prefix_sum_size_t previous =
+        (globalIndex == 0) ? 0 : sizes[globalIndex - 1];
+    const prefix_sum_size_t current = sizes[globalIndex];
+    for (prefix_sum_size_t i = 0; i < current - previous; ++i) {
+        result.at(previous + i) = {globalIndex, i};
+    }
+}
+
+}  // namespace traccc::device

--- a/device/common/include/traccc/device/make_prefix_sum_buffer.hpp
+++ b/device/common/include/traccc/device/make_prefix_sum_buffer.hpp
@@ -1,0 +1,57 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/device/fill_prefix_sum.hpp"
+#include "traccc/device/get_prefix_sum.hpp"
+#include "traccc/utils/memory_resource.hpp"
+
+// VecMem include(s).
+#include <vecmem/utils/copy.hpp>
+
+// System include(s).
+#include <variant>
+
+namespace traccc::device {
+
+/** @struct make_result_t
+ * @brief Helper class for return type of make_sum_buffer function
+ * @param view View on the result vector
+ * @param variant Object posessing memory of the result vector
+ * @param totalSize Last member of result vector
+ */
+struct prefix_sum_buffer {
+    vecmem::data::vector_view<prefix_sum_size_t> view;
+    std::variant<vecmem::vector<prefix_sum_size_t>,
+                 vecmem::data::vector_buffer<prefix_sum_size_t>>
+        variant;
+    prefix_sum_size_t totalSize;
+};  // struct prefix_sum_buffer
+
+using prefix_sum_buffer_t = prefix_sum_buffer;
+
+/// Function providing the prefix sum for a "size vector"
+///
+/// This simple function is just meant to translate the received "size vector"
+/// into its prefix sum. I.e. Each element of the output vector equals the
+/// summation of all the elements up to that point of the input vector
+///
+/// @param sizes The sizes of the "inner vectors" of a jagged vector
+/// @param copy A "copy object" capable of dealing with the view
+/// @param mr    The memory resource to use of the result
+/// @return A class containing the prefix sum view, a memory posessing object on
+/// the view elements, and the total summation of the size vector
+///
+TRACCC_HOST
+prefix_sum_buffer_t make_prefix_sum_buffer(
+    const std::vector<prefix_sum_size_t>& sizes, vecmem::copy& copy,
+    const traccc::memory_resource& mr);
+
+}  // namespace traccc::device

--- a/device/common/src/make_prefix_sum_buffer.cpp
+++ b/device/common/src/make_prefix_sum_buffer.cpp
@@ -1,0 +1,51 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "traccc/device/make_prefix_sum_buffer.hpp"
+
+// System include(s).
+#include <algorithm>
+
+namespace traccc::device {
+
+TRACCC_HOST
+prefix_sum_buffer_t make_prefix_sum_buffer(
+    const std::vector<prefix_sum_size_t>& sizes, vecmem::copy& copy,
+    const traccc::memory_resource& mr) {
+
+    if (sizes.size() == 0) {
+        return {{}, {}, 0};
+    }
+
+    // Create vector with summation of sizes
+    vecmem::vector<prefix_sum_size_t> sizes_sum(sizes.size(),
+                                                mr.host ? mr.host : &(mr.main));
+    std::partial_sum(sizes.begin(), sizes.end(), sizes_sum.begin(),
+                     std::plus<prefix_sum_size_t>());
+    const prefix_sum_size_t totalSize = sizes_sum.back();
+
+    if (mr.host != nullptr) {
+        // Create buffer and view objects
+        vecmem::data::vector_buffer<prefix_sum_size_t> sizes_sum_buff(
+            sizes_sum.size(), mr.main);
+        copy.setup(sizes_sum_buff);
+        (copy)(vecmem::get_data(sizes_sum), sizes_sum_buff);
+        vecmem::data::vector_view<prefix_sum_size_t> sizes_sum_view(
+            sizes_sum_buff);
+
+        return {sizes_sum_view, std::move(sizes_sum_buff), totalSize};
+    } else {
+        // Create view object
+        vecmem::data::vector_view<prefix_sum_size_t> sizes_sum_view =
+            vecmem::get_data(sizes_sum);
+
+        return {sizes_sum_view, std::move(sizes_sum), totalSize};
+    }
+}
+
+}  // namespace traccc::device

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// System include(s).
+#include <algorithm>
+
 // SYCL library include(s).
 #include "traccc/sycl/seeding/seed_finding.hpp"
 
@@ -13,7 +16,9 @@
 #include "traccc/sycl/utils/calculate1DimNdRange.hpp"
 
 // Project include(s).
+#include "traccc/device/fill_prefix_sum.hpp"
 #include "traccc/device/get_prefix_sum.hpp"
+#include "traccc/device/make_prefix_sum_buffer.hpp"
 #include "traccc/edm/device/doublet_counter.hpp"
 #include "traccc/seeding/detail/doublet.hpp"
 #include "traccc/seeding/detail/triplet.hpp"
@@ -53,7 +58,42 @@ class update_triplet_weights;
 /// Class identifying the kernel running @c traccc::device::select_seeds
 class select_seeds;
 
+/// Class identifying the kernel running @c traccc::device::fill_prefix_sum
+class fill_prefix_sum;
+
 }  // namespace kernels
+
+vecmem::data::vector_buffer<device::prefix_sum_element_t> make_prefix_sum_buff(
+    const std::vector<device::prefix_sum_size_t>& sizes, vecmem::copy& copy,
+    const traccc::memory_resource& mr, ::sycl::queue& queue) {
+
+    const device::prefix_sum_buffer_t make_sum_result =
+        device::make_prefix_sum_buffer(sizes, copy, mr);
+    const vecmem::data::vector_view<const device::prefix_sum_size_t>
+        sizes_sum_view = make_sum_result.view;
+    const unsigned int totalSize = make_sum_result.totalSize;
+
+    // Create buffer and view objects for prefix sum vector
+    vecmem::data::vector_buffer<device::prefix_sum_element_t> prefix_sum_buff(
+        totalSize, mr.main);
+    copy.setup(prefix_sum_buff);
+    vecmem::data::vector_view<device::prefix_sum_element_t> prefix_sum_view =
+        prefix_sum_buff;
+
+    // Fill the prefix sum vector
+    queue
+        .submit([&](::sycl::handler& h) {
+            h.parallel_for<kernels::fill_prefix_sum>(
+                ::sycl::nd_range<1>(((sizes_sum_view.size() / 32) + 1) * 32,
+                                    32),
+                [sizes_sum_view, prefix_sum_view](::sycl::id<1> idx) {
+                    fill_prefix_sum(idx, sizes_sum_view, prefix_sum_view);
+                });
+        })
+        .wait_and_throw();
+
+    return prefix_sum_buff;
+}
 
 seed_finding::seed_finding(const seedfinder_config& config,
                            const traccc::memory_resource& mr,
@@ -91,27 +131,21 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     const sp_grid_const_view& g2_view,
     const std::vector<unsigned int>& grid_sizes) const {
 
-    // Get the prefix sum for the spacepoint grid using buffer.
-    const device::prefix_sum_t sp_grid_prefix_sum = device::get_prefix_sum(
-        grid_sizes, (m_mr.host ? *(m_mr.host) : m_mr.main));
+    // Create prefix sum buffer and its view
+    vecmem::data::vector_buffer sp_grid_prefix_sum_buff = make_prefix_sum_buff(
+        grid_sizes, *m_copy, m_mr, details::get_queue(m_queue));
+    vecmem::data::vector_view<device::prefix_sum_element_t>
+        sp_grid_prefix_sum_view = sp_grid_prefix_sum_buff;
 
     // Set up the doublet counter buffer.
     device::doublet_counter_container_types::buffer doublet_counter_buffer =
         device::make_doublet_counter_buffer(grid_sizes, *m_copy, m_mr.main,
                                             m_mr.host);
 
-    // Set up the buffer of the prefix sum and its view
-    vecmem::data::vector_buffer<device::prefix_sum_element_t>
-        sp_grid_prefix_sum_buff(sp_grid_prefix_sum.size(), m_mr.main);
-    m_copy->setup(sp_grid_prefix_sum_buff);
-    (*m_copy)(vecmem::get_data(sp_grid_prefix_sum), sp_grid_prefix_sum_buff);
-    vecmem::data::vector_view<device::prefix_sum_element_t>
-        sp_grid_prefix_sum_view = sp_grid_prefix_sum_buff;
-
     // Calculate the range to run the doublet counting for.
     static constexpr unsigned int doubletCountLocalSize = 32 * 2;
     auto doubletCountRange = traccc::sycl::calculate1DimNdRange(
-        sp_grid_prefix_sum.size(), doubletCountLocalSize);
+        sp_grid_prefix_sum_view.size(), doubletCountLocalSize);
 
     // Count the number of doublets that we need to produce.
     device::doublet_counter_container_types::view doublet_counter_view =
@@ -138,23 +172,16 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     device::doublet_buffer_pair doublet_buffers = device::make_doublet_buffers(
         doublet_counter_buffer, *m_copy, m_mr.main, m_mr.host);
 
-    // Get the prefix sum for the doublet counter buffer.
-    const device::prefix_sum_t doublet_prefix_sum =
-        device::get_prefix_sum(doublet_counter_buffer.items,
-                               (m_mr.host ? *(m_mr.host) : m_mr.main), *m_copy);
-
-    // Set up the buffer of the prefix sum and its view
-    vecmem::data::vector_buffer<device::prefix_sum_element_t>
-        doublet_prefix_sum_buff(doublet_prefix_sum.size(), m_mr.main);
-    m_copy->setup(doublet_prefix_sum_buff);
-    (*m_copy)(vecmem::get_data(doublet_prefix_sum), doublet_prefix_sum_buff);
-    vecmem::data::vector_view<device::prefix_sum_element_t>
-        doublet_prefix_sum_view = doublet_prefix_sum_buff;
+    // Create prefix sum buffer and its view
+    vecmem::data::vector_buffer doublet_prefix_sum_buff =
+        make_prefix_sum_buff(m_copy->get_sizes(doublet_counter_buffer.items),
+                             *m_copy, m_mr, details::get_queue(m_queue));
+    vecmem::data::vector_view doublet_prefix_sum_view = doublet_prefix_sum_buff;
 
     // Calculate the range to run the doublet finding for.
     static constexpr unsigned int doubletFindLocalSize = 32 * 2;
     auto doubletFindRange = traccc::sycl::calculate1DimNdRange(
-        doublet_prefix_sum.size(), doubletFindLocalSize);
+        doublet_prefix_sum_view.size(), doubletFindLocalSize);
 
     // Find all of the spacepoint doublets.
     doublet_container_view mb_view = doublet_buffers.middleBottom;
@@ -179,11 +206,6 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
         doublet_counts.begin(), doublet_counts.end(), mb_buffer_sizes.begin(),
         [](const device::doublet_counter_header& dc) { return dc.m_nMidBot; });
 
-    // Get the prefix sum for the midBot doublets using buffer.
-    const device::prefix_sum_t mb_prefix_sum =
-        device::get_prefix_sum(doublet_buffers.middleBottom.items,
-                               (m_mr.host ? *(m_mr.host) : m_mr.main), *m_copy);
-
     // Set up the triplet counter buffer and its view
     device::triplet_counter_container_types::buffer triplet_counter_buffer =
         device::make_triplet_counter_buffer(mb_buffer_sizes, *m_copy, m_mr.main,
@@ -192,18 +214,16 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     device::triplet_counter_container_types::view triplet_counter_view =
         triplet_counter_buffer;
 
-    // Set up the buffer of the prefix sum and its view
-    vecmem::data::vector_buffer<device::prefix_sum_element_t>
-        mb_prefix_sum_buff(mb_prefix_sum.size(), m_mr.main);
-    m_copy->setup(mb_prefix_sum_buff);
-    (*m_copy)(vecmem::get_data(mb_prefix_sum), mb_prefix_sum_buff);
-    vecmem::data::vector_view<device::prefix_sum_element_t> mb_prefix_sum_view =
-        mb_prefix_sum_buff;
+    // Create prefix sum buffer and its view
+    vecmem::data::vector_buffer mb_prefix_sum_buff = make_prefix_sum_buff(
+        m_copy->get_sizes(doublet_buffers.middleBottom.items), *m_copy, m_mr,
+        details::get_queue(m_queue));
+    vecmem::data::vector_view mb_prefix_sum_view = mb_prefix_sum_buff;
 
     // Calculate the range to run the triplet counting for.
     static constexpr unsigned int tripletCountLocalSize = 32 * 2;
     auto tripletCountRange = traccc::sycl::calculate1DimNdRange(
-        mb_prefix_sum.size(), tripletCountLocalSize);
+        mb_prefix_sum_view.size(), tripletCountLocalSize);
 
     // Count the number of triplets that we need to produce.
     details::get_queue(m_queue)
@@ -226,25 +246,17 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
         triplet_counter_buffer, *m_copy, m_mr.main, m_mr.host);
     triplet_container_view triplet_view = triplet_buffer;
 
-    // Get the prefix sum for the triplet counter buffer
-    const device::prefix_sum_t triplet_counter_prefix_sum =
-        device::get_prefix_sum(triplet_counter_buffer.items,
-                               (m_mr.host ? *(m_mr.host) : m_mr.main), *m_copy);
-
-    // Set up the buffer of the prefix sum and its view
-    vecmem::data::vector_buffer<device::prefix_sum_element_t>
-        triplet_counter_prefix_sum_buff(triplet_counter_prefix_sum.size(),
-                                        m_mr.main);
-    m_copy->setup(triplet_counter_prefix_sum_buff);
-    (*m_copy)(vecmem::get_data(triplet_counter_prefix_sum),
-              triplet_counter_prefix_sum_buff);
-    vecmem::data::vector_view<device::prefix_sum_element_t>
-        triplet_counter_prefix_sum_view = triplet_counter_prefix_sum_buff;
+    // Create prefix sum buffer and its view
+    vecmem::data::vector_buffer triplet_counter_prefix_sum_buff =
+        make_prefix_sum_buff(m_copy->get_sizes(triplet_counter_buffer.items),
+                             *m_copy, m_mr, details::get_queue(m_queue));
+    vecmem::data::vector_view triplet_counter_prefix_sum_view =
+        triplet_counter_prefix_sum_buff;
 
     // Calculate the range to run the triplet finding for
     static constexpr unsigned int tripletFindLocalSize = 32 * 2;
     auto tripletFindRange = traccc::sycl::calculate1DimNdRange(
-        triplet_counter_prefix_sum.size(), tripletFindLocalSize);
+        triplet_counter_prefix_sum_view.size(), tripletFindLocalSize);
 
     // Find all of the spacepoint triplets.
     details::get_queue(m_queue)
@@ -265,21 +277,16 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
         })
         .wait_and_throw();
 
-    const device::prefix_sum_t triplet_prefix_sum = device::get_prefix_sum(
-        triplet_buffer.items, (m_mr.host ? *(m_mr.host) : m_mr.main), *m_copy);
-
-    // Set up the buffer of the prefix sum and its view
-    vecmem::data::vector_buffer<device::prefix_sum_element_t>
-        triplet_prefix_sum_buff(triplet_prefix_sum.size(), m_mr.main);
-    m_copy->setup(triplet_prefix_sum_buff);
-    (*m_copy)(vecmem::get_data(triplet_prefix_sum), triplet_prefix_sum_buff);
-    vecmem::data::vector_view<device::prefix_sum_element_t>
-        triplet_prefix_sum_view = triplet_prefix_sum_buff;
+    // Create prefix sum buffer and its view
+    vecmem::data::vector_buffer triplet_prefix_sum_buff =
+        make_prefix_sum_buff(m_copy->get_sizes(triplet_buffer.items), *m_copy,
+                             m_mr, details::get_queue(m_queue));
+    vecmem::data::vector_view triplet_prefix_sum_view = triplet_prefix_sum_buff;
 
     // Calculate the range to run the weight updating for
     static constexpr unsigned int weightUpdatingLocalSize = 32 * 2;
     auto weightUpdatingRange = traccc::sycl::calculate1DimNdRange(
-        triplet_prefix_sum.size(), weightUpdatingLocalSize);
+        triplet_prefix_sum_view.size(), weightUpdatingLocalSize);
 
     // Check if device is capable of allocating sufficient local memory
     assert(sizeof(scalar) * m_seedfilter_config.compatSeedLimit *
@@ -334,7 +341,7 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // Calculate the range to run the seed selecting for
     static constexpr unsigned int seedSelectingLocalSize = 32 * 2;
     auto seedSelectingRange = traccc::sycl::calculate1DimNdRange(
-        doublet_prefix_sum.size(), seedSelectingLocalSize);
+        doublet_prefix_sum_view.size(), seedSelectingLocalSize);
 
     // Check if device is capable of allocating sufficient local memory
     assert(sizeof(triplet) * m_seedfilter_config.max_triplets_per_spM *


### PR DESCRIPTION
This PR depends on #219 #220 #221 , ~~yet to be merged~~

Following the poor performance observed in the get_prefix_sum function (see #217 #218), this function was changed to run in parallel on the device rather than the cpu.  

