### PR TITLE
Add support for the Futhark programming language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ endif()
 option( TRACCC_BUILD_CUDA "Build the CUDA sources included in traccc"
    ${TRACCC_BUILD_CUDA_DEFAULT} )
 option( TRACCC_BUILD_SYCL "Build the SYCL sources included in traccc" FALSE )
+option( TRACCC_BUILD_FUTHARK "Build the Futhark sources included in traccc" FALSE)
 option( TRACCC_BUILD_TESTING "Build the (unit) tests of traccc" TRUE )
 option( TRACCC_BUILD_EXAMPLES "Build the examples of traccc" TRUE )
 
@@ -182,4 +183,8 @@ endif()
 include( CTest )
 if( BUILD_TESTING AND TRACCC_BUILD_TESTING )
    add_subdirectory( tests )
+endif()
+
+if(TRACCC_BUILD_FUTHARK)
+   add_subdirectory(device/futhark)
 endif()

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ Demonstrator tracking chain for accelerators.
 
 ## Features
 
-| Category           | Algorithms             | CPU | CUDA | SYCL |
-| ------------------ | ---------------------- | --- | ---- | ---- |
-| **Clusterization** | CCL                    | ✅  | 🟡   | 🟡   |
-|                    | Measurement creation   | ✅  | 🟡   | 🟡   |
-|                    | Spacepoint formation   | ✅  | 🟡   | 🟡   |
-| **Track finding**  | Spacepoint binning     | ✅  | ✅   | ✅   |
-|                    | Seed finding           | ✅  | ✅   | ✅   |
-|                    | Track param estimation | ✅  | ✅   | ✅   |
-|                    | Combinatorial KF       | ⚪  | ⚪   | ⚪   |
-| **Track fitting**  | KF                     | 🟡  | 🟡   | ⚪   |
+| Category           | Algorithms             | CPU | CUDA | SYCL | Futhark |
+| ------------------ | ---------------------- | --- | ---- | ---- | ------- |
+| **Clusterization** | CCL                    | ✅  | 🟡   | 🟡   | ⚪      |
+|                    | Measurement creation   | ✅  | 🟡   | 🟡   | ⚪      |
+|                    | Spacepoint formation   | ✅  | 🟡   | 🟡   | ⚪      |
+| **Track finding**  | Spacepoint binning     | ✅  | ✅   | ✅   | ⚪      |
+|                    | Seed finding           | ✅  | ✅   | ✅   | ⚪      |
+|                    | Track param estimation | ✅  | ✅   | ✅   | ⚪      |
+|                    | Combinatorial KF       | ⚪  | ⚪   | ⚪   | ⚪      |
+| **Track fitting**  | KF                     | 🟡  | 🟡   | ⚪   | ⚪      |
 
 ✅: exists, 🟡: work started, ⚪: work not started yet
 

--- a/cmake/FindFuthark.cmake
+++ b/cmake/FindFuthark.cmake
@@ -1,0 +1,154 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Necessary CMake includes
+include(FindPackageHandleStandardArgs)
+include(CheckLanguage)
+
+# The C language is not enabled in our project by default, but we need it to
+# compile Futhark's code.
+check_language(C)
+if(CMAKE_C_COMPILER)
+    enable_language(C)
+endif()
+
+# Try to find our dependencies, which are of course Futhark itself (required)
+# and the CUDA toolkit for compiling CUDA projects. Also notify the user of
+# what we find.
+find_program(Futhark_EXECUTABLE futhark)
+mark_as_advanced(Futhark_EXECUTABLE)
+find_package(CUDAToolkit)
+
+# Report the status of loading Futhark to the user.
+find_package_handle_standard_args(
+    Futhark
+    REQUIRED_VARS
+    Futhark_EXECUTABLE
+    CMAKE_C_COMPILER
+)
+
+# This function describes how to add a Futhark source to a CMake library. The
+# function adds sources generated from a source file `_SOURCE_NAME` to a target
+# called `TARGET_NAME`. The Futhark target platform (CUDA or C) is given
+# (case-insensitively) by `_LANGUAGE_TARGET`
+function(add_futhark_to_library TARGET_NAME _LANGUAGE_TARGET _SOURCE_NAME)
+    # Parse the arguments that we get.
+    cmake_parse_arguments(
+        ARGS
+        ""
+        ""
+        "DEPENDENCIES"
+        ${ARGN}
+    )
+
+    # Set a few useful variables.
+    set(FUTHARK_LANGUAGES c cuda)
+    set(SOURCE_NAME "${CMAKE_CURRENT_SOURCE_DIR}/${_SOURCE_NAME}")
+    string(TOLOWER ${_LANGUAGE_TARGET} LANGUAGE_TARGET)
+    string(TOUPPER ${_LANGUAGE_TARGET} LANGUAGE_TARGET_FANCY)
+
+    # Notify the user of what we are doing.
+    message(
+        STATUS
+        "Adding ${LANGUAGE_TARGET_FANCY} sources generated from Futhark source ${SOURCE_NAME} to ${TARGET_NAME}."
+    )
+
+    # Make sure that the source file actually exists.
+    if(NOT EXISTS ${SOURCE_NAME})
+        message(
+            FATAL_ERROR
+            "File ${SOURCE_NAME} does not exist!"
+        )
+    endif()
+
+    # Ensure that the requested language is actually a supported one, namely C
+    # or CUDA.
+    list(FIND FUTHARK_LANGUAGES ${LANGUAGE_TARGET} index)
+    if(index EQUAL -1)
+        message(
+            FATAL_ERROR
+            "Futhark language must be one of ${FUTHARK_LANGUAGES}, not ${LANGUAGE_TARGET}."
+        )
+    endif()
+
+    # Define some needed directory and file names.
+    get_filename_component(FILE_ROOT "${SOURCE_NAME}" NAME_WE)
+    set(FUTHARK_OUTPUT_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/src")
+    set(FUTHARK_OUTPUT_HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/include/traccc/futhark")
+    set(FUTHARK_OUTPUT_SOURCE "${FUTHARK_OUTPUT_SOURCE_DIR}/${FILE_ROOT}.c")
+    set(FUTHARK_OUTPUT_HEADER "${FUTHARK_OUTPUT_HEADER_DIR}/${FILE_ROOT}.h")
+
+    # Create the destination directories.
+    file(MAKE_DIRECTORY "${FUTHARK_OUTPUT_SOURCE_DIR}")
+    file(MAKE_DIRECTORY "${FUTHARK_OUTPUT_HEADER_DIR}")
+
+    # Define the custom command for generating .c and .h files from .fut files.
+    add_custom_command(
+        # Generate two files, a source file and a header file.
+        OUTPUT "${FUTHARK_OUTPUT_SOURCE}" "${FUTHARK_OUTPUT_HEADER}"
+
+        # Invoke the Futhark compiler in library mode.
+        COMMAND ${Futhark_EXECUTABLE}
+        ARGS ${LANGUAGE_TARGET} --library -o "${FILE_ROOT}" "${SOURCE_NAME}"
+
+        # Move the generated source and header file to their destinations.
+        COMMAND "${CMAKE_COMMAND}" -E copy "${FILE_ROOT}.c" "${FUTHARK_OUTPUT_SOURCE}"
+        COMMAND "${CMAKE_COMMAND}" -E copy "${FILE_ROOT}.h" "${FUTHARK_OUTPUT_HEADER}"
+
+        # Register the generated JSON interface file as a byproduct.
+        BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${FILE_ROOT}.json"
+
+        # Mark the Futhark file as the main dependency.
+        MAIN_DEPENDENCY "${SOURCE_NAME}"
+
+        # Mark the auxiliary Futhark files as dependencies.
+        DEPENDS ${ARGS_DEPENDENCIES}
+
+        # Execute this from the binary directory, to ensure that no dirty files
+        # are generated in the user's work directory.
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}"
+
+        # Notify the user that we are generating code from this Futhark file.
+        COMMENT "Generating ${LANGUAGE_TARGET_FANCY} file ${FILE_ROOT}.c from ${SOURCE_NAME}"
+        VERBATIM
+    )
+
+    # With the output source now generated, we can add it to the target
+    # library.
+    target_sources(
+        ${TARGET_NAME}
+        PRIVATE
+        "${FUTHARK_OUTPUT_SOURCE}"
+    )
+
+    # If we are genering a CUDA target, we will need to link against the CUDA
+    # runtime to get the right headers.
+    if(${LANGUAGE_TARGET} STREQUAL "cuda")
+        if(NOT CUDAToolkit_FOUND)
+            message(
+                FATAL_ERROR
+                "CUDA compilation of Futhark sources ${SOURCE_NAME} for ${TARGET_NAME} requested, but CUDA toolkit is not available!"
+            )
+        endif()
+
+        target_link_libraries(
+            ${TARGET_NAME}
+            PUBLIC
+            CUDA::cudart
+            PRIVATE
+            CUDA::cuda_driver
+            CUDA::nvrtc
+        )
+    endif()
+
+    # Add the newly generated header file as an include directory of our newly
+    # generated target.
+    target_include_directories(
+        ${TARGET_NAME}
+        PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/include/"
+    )
+endfunction()

--- a/device/futhark/CMakeLists.txt
+++ b/device/futhark/CMakeLists.txt
@@ -1,0 +1,37 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+find_package(Futhark REQUIRED)
+
+# Create a new traccc library which is built from the CCA CUDA core, plus some
+# extra code.
+traccc_add_library(
+    traccc_futhark
+    futhark
+    TYPE SHARED
+    "src/context.cpp"
+)
+
+# Link the new outward-facing library against our code librar(y|ies)
+target_link_libraries(
+    traccc_futhark
+    PUBLIC
+    traccc::core
+    PRIVATE
+    vecmem::core
+)
+
+# Add the Futhark sources to our traccc library.
+add_futhark_to_library(
+    traccc_futhark
+    CUDA
+    src/entry.fut
+    DEPENDENCIES
+    src/linear.fut
+    src/edm.fut
+    src/maybe.fut
+    src/zip.fut
+)

--- a/device/futhark/include/traccc/futhark/context.hpp
+++ b/device/futhark/include/traccc/futhark/context.hpp
@@ -1,0 +1,14 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <traccc/futhark/entry.h>
+
+namespace traccc::futhark {
+struct futhark_context& get_context();
+}  // namespace traccc::futhark

--- a/device/futhark/include/traccc/futhark/utils.hpp
+++ b/device/futhark/include/traccc/futhark/utils.hpp
@@ -1,0 +1,30 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <sstream>
+#include <stdexcept>
+
+#define FUTHARK_ERROR_CHECK(ans) futharkAssert((ans), __FILE__, __LINE__);
+
+inline void futharkAssert(int code, const char *file, int line,
+                          bool abort = true) {
+    if (code == 2) {
+        throw std::runtime_error(
+            "Futhark program exited due to a programming error.");
+    } else if (code == 3) {
+        throw std::runtime_error(
+            "Futhark program exited due to lack of allocatable memory.");
+    } else if (code != 0) {
+        std::stringstream ss;
+        ss << "Futhark program exited with unknown non-zero return code "
+           << code << ".";
+
+        throw std::runtime_error(ss.str());
+    }
+}

--- a/device/futhark/include/traccc/futhark/wrapper.hpp
+++ b/device/futhark/include/traccc/futhark/wrapper.hpp
@@ -1,0 +1,91 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <traccc/futhark/entry.h>
+
+#include <cstring>
+#include <numeric>
+#include <traccc/futhark/context.hpp>
+#include <tuple>
+#include <vector>
+
+namespace traccc::futhark {
+template <typename, typename, typename>
+struct wrapper {};
+
+template <typename T, typename... IArgs, typename... OArgs>
+struct wrapper<T, std::tuple<IArgs...>, std::tuple<OArgs...>> {
+    using output_t = std::tuple<std::vector<typename OArgs::cpp_t>...>;
+
+    template <std::size_t... IIdxs, std::size_t... OIdxs>
+    static output_t run_helper(struct futhark_context &ctx,
+                               std::vector<typename IArgs::cpp_t> &&... args,
+                               std::index_sequence<IIdxs...>,
+                               std::index_sequence<OIdxs...>) {
+        std::tuple<typename IArgs::futhark_t *...> futhark_inputs = {
+            IArgs::alloc_f(&ctx, args.data(), args.size())...};
+        std::tuple<typename OArgs::futhark_t *...> futhark_outputs;
+
+        /*
+         * Make the call to the Futhark entry point.
+         */
+        T::entry_f(&ctx, (&std::get<OIdxs>(futhark_outputs))...,
+                   std::get<IIdxs>(futhark_inputs)...);
+
+        /*
+         * Free the inputs, which are no longer needed.
+         */
+        (IArgs::free_f(&ctx, std::get<IIdxs>(futhark_inputs)), ...);
+
+        /*
+         * Retrieve the shapes of output vectors.
+         */
+        std::tuple<std::array<int64_t, OArgs::rank_v>...> output_ranks;
+        std::array<const int64_t *, sizeof...(OArgs)> output_rank_ptrs;
+        ((std::get<OIdxs>(output_rank_ptrs) =
+              OArgs::shape_f(&ctx, std::get<OIdxs>(futhark_outputs))),
+         ...);
+        ((std::memcpy(std::get<OIdxs>(output_ranks).data(),
+                      std::get<OIdxs>(output_rank_ptrs),
+                      OArgs::rank_v * sizeof(int64_t))),
+         ...);
+
+        /*
+         * Create the output vectors.
+         */
+        std::tuple<std::vector<typename OArgs::cpp_t>...> out(
+            std::accumulate(std::get<OIdxs>(output_ranks).begin(),
+                            std::get<OIdxs>(output_ranks).end(), 1,
+                            std::multiplies<int64_t>())...);
+
+        /*
+         * Copy the values from the Futhark output vectors.
+         */
+        (OArgs::values_f(&ctx, std::get<OIdxs>(futhark_outputs),
+                         std::get<OIdxs>(out).data()),
+         ...);
+
+        /*
+         * Free the Futhark output vectors.
+         */
+        (OArgs::free_f(&ctx, std::get<OIdxs>(futhark_outputs)), ...);
+
+        return out;
+    }
+
+    static std::tuple<std::vector<typename OArgs::cpp_t>...> run(
+        std::vector<typename IArgs::cpp_t> &&... args) {
+        return run_helper(
+            get_context(),
+            std::forward<std::vector<typename IArgs::cpp_t>>(args)...,
+            std::index_sequence_for<IArgs...>{},
+            std::index_sequence_for<OArgs...>{});
+    }
+};
+}  // namespace traccc::futhark

--- a/device/futhark/src/context.cpp
+++ b/device/futhark/src/context.cpp
@@ -1,0 +1,25 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <traccc/futhark/entry.h>
+
+namespace traccc::futhark {
+static struct futhark_context_config* __global_futhark_config = nullptr;
+static struct futhark_context* __global_futhark_context = nullptr;
+
+struct futhark_context& get_context() {
+    if (!__global_futhark_config) {
+        __global_futhark_config = futhark_context_config_new();
+    }
+
+    if (!__global_futhark_context) {
+        __global_futhark_context = futhark_context_new(__global_futhark_config);
+    }
+
+    return *__global_futhark_context;
+}
+}  // namespace traccc::futhark

--- a/device/futhark/src/edm.fut
+++ b/device/futhark/src/edm.fut
@@ -1,0 +1,33 @@
+-- TRACCC library, part of the ACTS project (R&D line)
+--
+-- (c) 2022 CERN for the benefit of the ACTS project
+--
+-- Mozilla Public License Version 2.0
+
+import "linear"
+
+type Cell = {
+    event: u64,
+    geometry: u64,
+    position: (i64, i64),
+    activation: f32
+}
+
+type Measurement = {
+    event: u64,
+    geometry: u64,
+    position: Point2,
+    variance: Point2
+}
+
+type Spacepoint = {
+    event: u64,
+    position: Point3
+}
+
+type Seed = {
+    event: u64,
+    lo: Point3,
+    mi: Point3,
+    hi: Point3
+}

--- a/device/futhark/src/entry.fut
+++ b/device/futhark/src/entry.fut
@@ -1,0 +1,9 @@
+-- TRACCC library, part of the ACTS project (R&D line)
+--
+-- (c) 2022 CERN for the benefit of the ACTS project
+--
+-- Mozilla Public License Version 2.0
+
+import "linear"
+import "edm"
+import "zip"

--- a/device/futhark/src/linear.fut
+++ b/device/futhark/src/linear.fut
@@ -1,0 +1,17 @@
+-- TRACCC library, part of the ACTS project (R&D line)
+--
+-- (c) 2022 CERN for the benefit of the ACTS project
+--
+-- Mozilla Public License Version 2.0
+
+type Point2 = (f32, f32)
+
+type Point3 = (f32, f32, f32)
+
+type Affine3 = [4][4]f32
+
+def transform (t: Affine3) ((x, y): Point2): Point3 = (
+    x * t[0, 0] + y * t[0, 1] + t[0, 3],
+    x * t[1, 0] + y * t[1, 1] + t[1, 3],
+    x * t[2, 0] + y * t[2, 1] + t[2, 3]
+)

--- a/device/futhark/src/maybe.fut
+++ b/device/futhark/src/maybe.fut
@@ -1,0 +1,15 @@
+-- TRACCC library, part of the ACTS project (R&D line)
+--
+-- (c) 2022 CERN for the benefit of the ACTS project
+--
+-- Mozilla Public License Version 2.0
+
+type Maybe 'a = #Just a | #Nothing
+
+def fmap 'a 'b (f: a -> b) (v: Maybe a): Maybe b = match v
+    case #Just x -> #Just (f x)
+    case #Nothing -> #Nothing
+
+def maybe 'a (d: a) (v: Maybe a): a = match v
+    case #Just x -> x
+    case #Nothing -> d

--- a/device/futhark/src/zip.fut
+++ b/device/futhark/src/zip.fut
@@ -1,0 +1,23 @@
+-- TRACCC library, part of the ACTS project (R&D line)
+--
+-- (c) 2022 CERN for the benefit of the ACTS project
+--
+-- Mozilla Public License Version 2.0
+
+def unzip6 [n] 'a 'b 'c 'd 'e 'f
+    (xs: [n](a, b, c, d, e, f)):
+    ([n]a, [n]b, [n]c, [n]d, [n]e, [n]f) =
+    let (as, bs, cs, ds, des) = unzip5
+        (map (\(a, b, c, d, e, f) -> (a, b, c, d, (e, f))) xs)
+    let (es, fs) = unzip des
+    in (as, bs, cs, ds, es, fs)
+
+def unzip10 [n] 'a 'b 'c 'd 'e 'f 'g 'h 'i 'j
+    (xs: [n](a, b, c, d, e, f, g, h, i, j)):
+    ([n]a, [n]b, [n]c, [n]d, [n]e, [n]f, [n]g, [n]h, [n]i, [n]j) =
+    let (lhs, rhs) = unzip
+        (map (\(a, b, c, d, e, f, g, h, i, j) ->
+               ((a, b, c, d, e), (f, g, h, i, j))) xs)
+    let (as, bs, cs, ds, es) = unzip5 lhs
+    let (fs, gs, hs, js, is) = unzip5 rhs in
+    (as, bs, cs, ds, es, fs, gs, hs, js, is)


### PR DESCRIPTION
This commit provides some of the necessary utilities for adding support for Futhark to the traccc code base. It contains useful wrappers for Futhark C interfaces, as well as the necessary CMake functions to make this work.