### PR TITLE
Update Acts dependency to version 20.1.0

### DIFF
--- a/extern/acts/CMakeLists.txt
+++ b/extern/acts/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Acts as part of the TRACCC project" )
 
 # Declare where to get Acts from.
 set( TRACCC_ACTS_SOURCE
-   "URL;https://github.com/krasznaa/acts/archive/refs/tags/v10.0.1.tar.gz;URL_MD5;fcd2f2f7b5810e34b8faa12634043be3"
+   "URL;https://github.com/acts-project/acts/archive/refs/tags/v20.1.0.tar.gz;URL_MD5;ada5b638e944cde1650a537a3efe0bd0"
    CACHE STRING "Source for Acts, when built as part of this project" )
 mark_as_advanced( TRACCC_ACTS_SOURCE )
 FetchContent_Declare( Acts ${TRACCC_ACTS_SOURCE} )


### PR DESCRIPTION
We're currently using a very, very old version of Acts, namely v10. It is also a modified version from Attila's repository. I think it's important that we update the version of Acts so we can get the latest utilities, and keep up with the latest developments in algorithms.