### PR TITLE
Introduce traccc::pair, main branch (2022.09.07.)

### DIFF
--- a/core/include/traccc/edm/details/container_base.hpp
+++ b/core/include/traccc/edm/details/container_base.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/details/container_element.hpp"
+#include "traccc/utils/pair.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
@@ -35,7 +36,7 @@ namespace traccc {
 template <typename header_t, typename item_t,
           template <typename> class vector_t,
           template <typename> class jagged_vector_t,
-          template <typename, typename> class pair_t = std::pair>
+          template <typename, typename> class pair_t = pair>
 class container_base {
     public:
     /// @name Type definitions

--- a/core/include/traccc/edm/details/device_container.hpp
+++ b/core/include/traccc/edm/details/device_container.hpp
@@ -17,7 +17,6 @@
 
 // System include(s).
 #include <cassert>
-#include <utility>
 
 namespace traccc {
 
@@ -25,11 +24,11 @@ namespace traccc {
 template <typename header_t, typename item_t>
 class device_container
     : public container_base<header_t, item_t, vecmem::device_vector,
-                            vecmem::jagged_device_vector, std::pair> {
+                            vecmem::jagged_device_vector> {
     public:
     /// Base class type
     using base_type = container_base<header_t, item_t, vecmem::device_vector,
-                                     vecmem::jagged_device_vector, std::pair>;
+                                     vecmem::jagged_device_vector>;
 
     /// Inherit all of the base class's constructors
     using base_type::base_type;

--- a/core/include/traccc/edm/details/host_container.hpp
+++ b/core/include/traccc/edm/details/host_container.hpp
@@ -24,11 +24,11 @@ namespace traccc {
 /// Host container describing objects in a given event
 template <typename header_t, typename item_t>
 class host_container : public container_base<header_t, item_t, vecmem::vector,
-                                             vecmem::jagged_vector, std::pair> {
+                                             vecmem::jagged_vector> {
     public:
     /// Base class type
-    using base_type = container_base<header_t, item_t, vecmem::vector,
-                                     vecmem::jagged_vector, std::pair>;
+    using base_type =
+        container_base<header_t, item_t, vecmem::vector, vecmem::jagged_vector>;
 
     /// Inherit all of the base class's constructors
     using base_type::base_type;

--- a/core/include/traccc/edm/internal_spacepoint.hpp
+++ b/core/include/traccc/edm/internal_spacepoint.hpp
@@ -57,36 +57,12 @@ struct internal_spacepoint {
     }
 
     TRACCC_HOST_DEVICE
-    internal_spacepoint(const link_type& sp_link) : m_link(std::move(sp_link)) {
+    internal_spacepoint(const link_type& sp_link) : m_link(sp_link) {
 
         m_x = 0;
         m_y = 0;
         m_z = 0;
         m_r = 0;
-    }
-
-    TRACCC_HOST_DEVICE
-    internal_spacepoint(const internal_spacepoint<spacepoint_t>& sp)
-        : m_link(std::move(sp.m_link)) {
-
-        m_x = sp.m_x;
-        m_y = sp.m_y;
-        m_z = sp.m_z;
-        m_r = sp.m_r;
-    }
-
-    TRACCC_HOST_DEVICE
-    internal_spacepoint& operator=(
-        const internal_spacepoint<spacepoint_t>& sp) {
-
-        m_link.first = sp.m_link.first;
-        m_link.second = sp.m_link.second;
-        m_x = sp.m_x;
-        m_y = sp.m_y;
-        m_z = sp.m_z;
-        m_r = sp.m_r;
-
-        return *this;
     }
 
     TRACCC_HOST_DEVICE

--- a/core/include/traccc/edm/seed.hpp
+++ b/core/include/traccc/edm/seed.hpp
@@ -24,26 +24,6 @@ struct seed {
     scalar weight;
     scalar z_vertex;
 
-    seed() = default;
-    seed(const seed&) = default;
-
-    TRACCC_HOST_DEVICE
-    seed& operator=(const seed& aSeed) {
-
-        spB_link.first = aSeed.spB_link.first;
-        spB_link.second = aSeed.spB_link.second;
-
-        spM_link.first = aSeed.spM_link.first;
-        spM_link.second = aSeed.spM_link.second;
-
-        spT_link.first = aSeed.spT_link.first;
-        spT_link.second = aSeed.spT_link.second;
-
-        weight = aSeed.weight;
-        z_vertex = aSeed.z_vertex;
-        return *this;
-    }
-
     TRACCC_HOST_DEVICE
     std::array<measurement, 3> get_measurements(
         const spacepoint_container_types::const_view& spacepoints_view) const {

--- a/core/include/traccc/utils/impl/pair.ipp
+++ b/core/include/traccc/utils/impl/pair.ipp
@@ -1,0 +1,79 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc {
+
+template <typename T1, typename T2>
+TRACCC_HOST_DEVICE pair<T1, T2>::pair() : first{}, second{} {}
+
+template <typename T1, typename T2>
+TRACCC_HOST_DEVICE pair<T1, T2>::pair(const first_type& f, const second_type& s)
+    : first(f), second(s) {}
+
+template <typename T1, typename T2>
+TRACCC_HOST_DEVICE pair<T1, T2>::pair(first_type&& f, second_type&& s)
+    : first(f), second(s) {}
+
+template <typename T1, typename T2>
+TRACCC_HOST_DEVICE pair<T1, T2>::pair(const pair& parent)
+    : first(parent.first), second(parent.second) {}
+
+template <typename T1, typename T2>
+TRACCC_HOST_DEVICE pair<T1, T2>::pair(pair&& parent)
+    : first(parent.first), second(parent.second) {}
+
+template <typename T1, typename T2>
+template <typename U1, typename U2,
+          std::enable_if_t<std::is_convertible<U1, T1>::value &&
+                               std::is_convertible<U2, T2>::value,
+                           bool> >
+TRACCC_HOST_DEVICE pair<T1, T2>::pair(const pair<U1, U2>& parent)
+    : first(parent.first), second(parent.second) {}
+
+template <typename T1, typename T2>
+template <typename U1, typename U2,
+          std::enable_if_t<std::is_convertible<U1, T1>::value &&
+                               std::is_convertible<U2, T2>::value,
+                           bool> >
+TRACCC_HOST_DEVICE pair<T1, T2>::pair(pair<U1, U2>&& parent)
+    : first(parent.first), second(parent.second) {}
+
+template <typename T1, typename T2>
+TRACCC_HOST_DEVICE pair<T1, T2>& pair<T1, T2>::operator=(const pair& rhs) {
+
+    // Prevent self-assignment.
+    if (this == &rhs) {
+        return *this;
+    }
+
+    // Assign the elements.
+    this->first = rhs.first;
+    this->second = rhs.second;
+
+    // Return a reference to the updated object.
+    return *this;
+}
+
+template <typename T1, typename T2>
+TRACCC_HOST_DEVICE pair<T1, T2>& pair<T1, T2>::operator=(pair&& rhs) {
+
+    // Prevent self-assignment.
+    if (this == &rhs) {
+        return *this;
+    }
+
+    // Assign the elements.
+    this->first = rhs.first;
+    this->second = rhs.second;
+
+    // Return a reference to the updated object.
+    return *this;
+}
+
+}  // namespace traccc

--- a/core/include/traccc/utils/pair.hpp
+++ b/core/include/traccc/utils/pair.hpp
@@ -1,0 +1,83 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+
+// System include(s).
+#include <type_traits>
+
+namespace traccc {
+
+/// Trivial class mimicking @c std::pair
+///
+/// The purpose of this class is to make an @c std::pair type that is fully
+/// functional in "device code". Unfortunately some parts of @c std::pair are
+/// not at the moment of writing.
+///
+/// @tparam T1 The type of the first element of the pair
+/// @tparam T2 The type of the second element of the pair
+///
+template <typename T1, typename T2>
+struct pair {
+
+    /// The type of the first element
+    using first_type = T1;
+    /// The type of the second element
+    using second_type = T2;
+
+    /// Default constructor
+    TRACCC_HOST_DEVICE
+    pair();
+
+    /// Constructor copying existing elements
+    TRACCC_HOST_DEVICE
+    pair(const first_type& f, const second_type& s);
+    /// Constructor moving existing elements
+    TRACCC_HOST_DEVICE
+    pair(first_type&& f, second_type&& s);
+
+    /// Copy constructor
+    TRACCC_HOST_DEVICE
+    pair(const pair& parent);
+    /// Move constructor
+    TRACCC_HOST_DEVICE
+    pair(pair&& parent);
+
+    /// Copy constructor from a different type
+    template <typename U1, typename U2,
+              std::enable_if_t<std::is_convertible<U1, T1>::value &&
+                                   std::is_convertible<U2, T2>::value,
+                               bool> = true>
+    TRACCC_HOST_DEVICE pair(const pair<U1, U2>& parent);
+    /// Move constructor from a different type
+    template <typename U1, typename U2,
+              std::enable_if_t<std::is_convertible<U1, T1>::value &&
+                                   std::is_convertible<U2, T2>::value,
+                               bool> = true>
+    TRACCC_HOST_DEVICE pair(pair<U1, U2>&& parent);
+
+    /// Copy assignment
+    TRACCC_HOST_DEVICE
+    pair& operator=(const pair& rhs);
+    /// Move assignment
+    TRACCC_HOST_DEVICE
+    pair& operator=(pair&& rhs);
+
+    /// The first element
+    first_type first;
+    /// The second element
+    second_type second;
+
+};  // struct pair
+
+}  // namespace traccc
+
+// Include the implementation.
+#include "traccc/utils/impl/pair.ipp"


### PR DESCRIPTION
Introduced `traccc::pair`, and updated the container code to use it.

Some functions of the [std::pair](https://en.cppreference.com/w/cpp/utility/pair) type are not available in device code, which required us declaring some awkward functions earlier. With the `traccc::pair` type those functions could be deleted.

However I still introduced more new lines of code than how many I managed to delete. :stuck_out_tongue: So I'm curious what everyone thinks about the merit of this PR... (I'll want to make additional updates to the EDM code after this, I just didn't like how `traccc::seed` looked like at the moment...)