### PR TITLE
Switch traccc::container to thrust::pair, main branch (2022.09.14.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,26 @@ if( TRACCC_SETUP_EIGEN3 )
    endif()
 endif()
 
+# Set up Thrust.
+option( TRACCC_SETUP_THRUST
+   "Set up the Thrust target(s) explicitly" TRUE )
+option( TRACCC_USE_SYSTEM_THRUST
+   "Pick up an existing installation of Thrust from the build environment"
+   FALSE )
+if( TRACCC_SETUP_THRUST )
+   if( TRACCC_USE_SYSTEM_THRUST )
+      find_package( Thrust REQUIRED )
+   else()
+      add_subdirectory( extern/thrust )
+   endif()
+endif()
+# Set up an IMPORTED library on top of the Thrust library/libraries. One that
+# the TRACCC/Detray code could depend on publicly.
+set( TRACCC_THRUST_OPTIONS "" CACHE STRING
+   "Extra options for configuring how Thrust should be used" )
+mark_as_advanced( TRACCC_THRUST_OPTIONS )
+thrust_create_target( traccc::Thrust ${TRACCC_THRUST_OPTIONS} )
+
 # Set up Algebra Plugins.
 option( TRACCC_SETUP_ALGEBRA_PLUGINS
    "Set up the Algebra Plugins target(s) explicitly" TRUE )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -70,4 +70,5 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/seeding/spacepoint_binning.hpp"
   "src/seeding/spacepoint_binning.cpp" )
 target_link_libraries( traccc_core
-  PUBLIC Eigen3::Eigen vecmem::core detray::core ActsCore ActsPluginJson traccc::algebra )
+  PUBLIC Eigen3::Eigen vecmem::core detray::core ActsCore ActsPluginJson
+         traccc::Thrust traccc::algebra )

--- a/core/include/traccc/edm/details/container_base.hpp
+++ b/core/include/traccc/edm/details/container_base.hpp
@@ -14,6 +14,9 @@
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
 
+// Thrust include(s).
+#include <thrust/pair.h>
+
 // System include(s).
 #include <cassert>
 #include <stdexcept>
@@ -35,7 +38,7 @@ namespace traccc {
 template <typename header_t, typename item_t,
           template <typename> class vector_t,
           template <typename> class jagged_vector_t,
-          template <typename, typename> class pair_t = std::pair>
+          template <typename, typename> class pair_t = thrust::pair>
 class container_base {
     public:
     /// @name Type definitions

--- a/core/include/traccc/edm/details/device_container.hpp
+++ b/core/include/traccc/edm/details/device_container.hpp
@@ -17,7 +17,6 @@
 
 // System include(s).
 #include <cassert>
-#include <utility>
 
 namespace traccc {
 
@@ -25,11 +24,11 @@ namespace traccc {
 template <typename header_t, typename item_t>
 class device_container
     : public container_base<header_t, item_t, vecmem::device_vector,
-                            vecmem::jagged_device_vector, std::pair> {
+                            vecmem::jagged_device_vector> {
     public:
     /// Base class type
     using base_type = container_base<header_t, item_t, vecmem::device_vector,
-                                     vecmem::jagged_device_vector, std::pair>;
+                                     vecmem::jagged_device_vector>;
 
     /// Inherit all of the base class's constructors
     using base_type::base_type;

--- a/core/include/traccc/edm/details/host_container.hpp
+++ b/core/include/traccc/edm/details/host_container.hpp
@@ -17,18 +17,17 @@
 
 // System include(s).
 #include <cassert>
-#include <utility>
 
 namespace traccc {
 
 /// Host container describing objects in a given event
 template <typename header_t, typename item_t>
 class host_container : public container_base<header_t, item_t, vecmem::vector,
-                                             vecmem::jagged_vector, std::pair> {
+                                             vecmem::jagged_vector> {
     public:
     /// Base class type
-    using base_type = container_base<header_t, item_t, vecmem::vector,
-                                     vecmem::jagged_vector, std::pair>;
+    using base_type =
+        container_base<header_t, item_t, vecmem::vector, vecmem::jagged_vector>;
 
     /// Inherit all of the base class's constructors
     using base_type::base_type;

--- a/core/include/traccc/edm/internal_spacepoint.hpp
+++ b/core/include/traccc/edm/internal_spacepoint.hpp
@@ -47,9 +47,8 @@ struct internal_spacepoint {
     TRACCC_HOST_DEVICE internal_spacepoint(
         const spacepoint_container_t& sp_container, const link_type& sp_link,
         const vector2& offsetXY)
-        : m_link(std::move(sp_link)) {
-        const spacepoint_t& sp =
-            sp_container.at({sp_link.first, sp_link.second});
+        : m_link(sp_link) {
+        const spacepoint_t& sp = sp_container.at(sp_link);
         m_x = sp.global[0] - offsetXY[0];
         m_y = sp.global[1] - offsetXY[1];
         m_z = sp.global[2];
@@ -57,36 +56,12 @@ struct internal_spacepoint {
     }
 
     TRACCC_HOST_DEVICE
-    internal_spacepoint(const link_type& sp_link) : m_link(std::move(sp_link)) {
+    internal_spacepoint(const link_type& sp_link) : m_link(sp_link) {
 
         m_x = 0;
         m_y = 0;
         m_z = 0;
         m_r = 0;
-    }
-
-    TRACCC_HOST_DEVICE
-    internal_spacepoint(const internal_spacepoint<spacepoint_t>& sp)
-        : m_link(std::move(sp.m_link)) {
-
-        m_x = sp.m_x;
-        m_y = sp.m_y;
-        m_z = sp.m_z;
-        m_r = sp.m_r;
-    }
-
-    TRACCC_HOST_DEVICE
-    internal_spacepoint& operator=(
-        const internal_spacepoint<spacepoint_t>& sp) {
-
-        m_link.first = sp.m_link.first;
-        m_link.second = sp.m_link.second;
-        m_x = sp.m_x;
-        m_y = sp.m_y;
-        m_z = sp.m_z;
-        m_r = sp.m_r;
-
-        return *this;
     }
 
     TRACCC_HOST_DEVICE

--- a/core/include/traccc/edm/seed.hpp
+++ b/core/include/traccc/edm/seed.hpp
@@ -24,26 +24,6 @@ struct seed {
     scalar weight;
     scalar z_vertex;
 
-    seed() = default;
-    seed(const seed&) = default;
-
-    TRACCC_HOST_DEVICE
-    seed& operator=(const seed& aSeed) {
-
-        spB_link.first = aSeed.spB_link.first;
-        spB_link.second = aSeed.spB_link.second;
-
-        spM_link.first = aSeed.spM_link.first;
-        spM_link.second = aSeed.spM_link.second;
-
-        spT_link.first = aSeed.spT_link.first;
-        spT_link.second = aSeed.spT_link.second;
-
-        weight = aSeed.weight;
-        z_vertex = aSeed.z_vertex;
-        return *this;
-    }
-
     TRACCC_HOST_DEVICE
     std::array<measurement, 3> get_measurements(
         const spacepoint_container_types::const_view& spacepoints_view) const {

--- a/device/common/CMakeLists.txt
+++ b/device/common/CMakeLists.txt
@@ -58,4 +58,4 @@ traccc_add_library( traccc_device_common device_common TYPE SHARED
    "include/traccc/seeding/device/select_seeds.hpp"
    "include/traccc/seeding/device/impl/select_seeds.ipp" )
 target_link_libraries( traccc_device_common
-   PUBLIC traccc::core vecmem::core )
+   PUBLIC traccc::Thrust traccc::core vecmem::core )

--- a/device/common/include/traccc/device/get_prefix_sum.hpp
+++ b/device/common/include/traccc/device/get_prefix_sum.hpp
@@ -16,20 +16,16 @@
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/utils/copy.hpp>
 
+// Thrust include(s).
+#include <thrust/pair.h>
+
 // System include(s).
 #include <utility>
 
 namespace traccc::device {
 
-struct prefix_sum_element {
-    // Bin id
-    std::size_t first;
-
-    // Local id
-    std::size_t second;
-};
-
-typedef prefix_sum_element prefix_sum_element_t;
+/// Type for the individual elements in the prefix sum vector
+typedef thrust::pair<std::size_t, std::size_t> prefix_sum_element_t;
 
 /// Convenience type definition for the return value of the helper function
 typedef vecmem::vector<prefix_sum_element_t> prefix_sum_t;

--- a/device/common/include/traccc/seeding/device/impl/count_grid_capacities.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_grid_capacities.ipp
@@ -35,7 +35,7 @@ void count_grid_capacities(
     const prefix_sum_element_t sp_idx = sp_prefix_sum[globalIndex];
     const spacepoint_container_types::const_device spacepoints(
         spacepoints_view);
-    const spacepoint sp = spacepoints.at({sp_idx.first, sp_idx.second});
+    const spacepoint sp = spacepoints.at(sp_idx);
 
     /// Check out if the spacepoint can be used for seeding.
     if (is_valid_sp(config, sp) != detray::invalid_value<size_t>()) {

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.8.0.tar.gz;URL_MD5;17bc6260be77ffb8d69fd1fd06a4c22f"
+   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.11.0.tar.gz;URL_MD5;da8b6c15eb990eba355dace69071dae9"
    CACHE STRING "Source for Detray, when built as part of this project" )
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
 FetchContent_Declare( Detray ${TRACCC_DETRAY_SOURCE} )
@@ -39,6 +39,8 @@ set( DETRAY_SETUP_GOOGLETEST FALSE CACHE BOOL
    "Do not set up GoogleTest as part of Detray" )
 set( DETRAY_SETUP_BENCHMARK FALSE CACHE BOOL
    "Do not set up Google Benchmark as part of Detray" )
+set( DETRAY_SETUP_THRUST FALSE CACHE BOOL
+   "Do not set up Thrust as part of Detray" )
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( Detray )

--- a/extern/thrust/CMakeLists.txt
+++ b/extern/thrust/CMakeLists.txt
@@ -1,0 +1,26 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.14 )
+include( FetchContent )
+
+# Tell the user what's happening.
+message( STATUS "Building Thrust as part of the TRACCC project" )
+
+# Declare where to get Thrust from.
+set( TRACCC_THRUST_SOURCE
+   "GIT_REPOSITORY;https://github.com/NVIDIA/thrust.git;GIT_TAG;1.15.0"
+   CACHE STRING "Source for Thrust, when built as part of this project" )
+mark_as_advanced( TRACCC_THRUST_SOURCE )
+FetchContent_Declare( Thrust ${TRACCC_THRUST_SOURCE} )
+
+# Options used in the build of Thrust.
+set( THRUST_ENABLE_INSTALL_RULES TRUE CACHE BOOL
+   "Install Thrust together with this project" )
+
+# Get it into the current directory.
+FetchContent_MakeAvailable( Thrust )

--- a/extern/thrust/README.md
+++ b/extern/thrust/README.md
@@ -1,0 +1,4 @@
+# Build Recipe for Thrust
+
+This directory holds a build recipe for building
+[thrust](https://github.com/NVIDIA/thrust) for this project.


### PR DESCRIPTION
This is a replacement for #229. Instead of writing our own `traccc::pair` type it seemed better to just use `thrust::pair`. Since we already use [Thrust](https://github.com/NVIDIA/thrust) in [detray](https://github.com/acts-project/detray) anyway.

Note that this needs to wait for an update to a version of detray that will include https://github.com/acts-project/detray/pull/298. Until then this will remain a draft.