### PR TITLE
CI Update, main branch (2022.09.15.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         platform:
           - name: CPU
-            container: ghcr.io/acts-project/ubuntu2004:v11
+            container: ghcr.io/acts-project/ubuntu2004:v30
           - name: CUDA
-            container: ghcr.io/acts-project/ubuntu2004_cuda:v16.1
+            container: ghcr.io/acts-project/ubuntu2004_cuda:v30
           - name: SYCL
-            container: ghcr.io/acts-project/ubuntu2004_oneapi:v20
+            container: ghcr.io/acts-project/ubuntu2004_oneapi:v30
         build:
           - Release
           - Debug


### PR DESCRIPTION
Switched the CI to the latest Acts Docker images. Mainly for the inclusion of a newer CMake version in the "vanilla" image (needed for #231), but at that point we might as well just use the latest images for all build flavours.