### PR TITLE
Prefix Sum SYCL Kernel Fix, main branch (2022.09.15.)

### DIFF
--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -87,7 +87,8 @@ vecmem::data::vector_buffer<device::prefix_sum_element_t> make_prefix_sum_buff(
                 ::sycl::nd_range<1>(((sizes_sum_view.size() / 32) + 1) * 32,
                                     32),
                 [sizes_sum_view, prefix_sum_view](::sycl::id<1> idx) {
-                    fill_prefix_sum(idx, sizes_sum_view, prefix_sum_view);
+                    device::fill_prefix_sum(idx, sizes_sum_view,
+                                            prefix_sum_view);
                 });
         })
         .wait_and_throw();


### PR DESCRIPTION
Fixed the name of the common function called in the SYCL kernel. The compiler not failing on this in all cases seems to point at a bug in the compiler... :confused:

@guilhermeAlmeida1, I only bumped into this with #231 for some reason. As you can see, even the CI build of the current main branch succeeds for some reason. :confused: