### PR TITLE
Changed configuration parameters' units to match ACTS

### DIFF
--- a/core/src/seeding/seed_finding.cpp
+++ b/core/src/seeding/seed_finding.cpp
@@ -12,9 +12,9 @@ namespace traccc {
 
 seed_finding::seed_finding(const seedfinder_config& finder_config,
                            const seedfilter_config& filter_config)
-    : m_doublet_finding(finder_config),
-      m_triplet_finding(finder_config),
-      m_seed_filtering(filter_config) {}
+    : m_doublet_finding(finder_config.toInternalUnits()),
+      m_triplet_finding(finder_config.toInternalUnits()),
+      m_seed_filtering(filter_config.toInternalUnits()) {}
 
 seed_finding::output_type seed_finding::operator()(
     const spacepoint_container_types::host& sp_container,

--- a/core/src/seeding/seeding_algorithm.cpp
+++ b/core/src/seeding/seeding_algorithm.cpp
@@ -19,16 +19,16 @@ namespace {
 traccc::seedfinder_config default_seedfinder_config() {
 
     traccc::seedfinder_config config;
-    config.highland = 13.6 * std::sqrt(config.radLengthPerSeed) *
-                      (1 + 0.038 * std::log(config.radLengthPerSeed));
-    float maxScatteringAngle = config.highland / config.minPt;
+    traccc::seedfinder_config config_copy = config.toInternalUnits();
+    config.highland = 13.6 * std::sqrt(config_copy.radLengthPerSeed) *
+                      (1 + 0.038 * std::log(config_copy.radLengthPerSeed));
+    float maxScatteringAngle = config.highland / config_copy.minPt;
     config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
     // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV
     // and millimeter
-    // TODO: change using ACTS units
-    config.pTPerHelixRadius = 300. * config.bFieldInZ;
+    config.pTPerHelixRadius = 300. * config_copy.bFieldInZ;
     config.minHelixDiameter2 =
-        std::pow(config.minPt * 2 / config.pTPerHelixRadius, 2);
+        std::pow(config_copy.minPt * 2 / config.pTPerHelixRadius, 2);
     config.pT2perRadius =
         std::pow(config.highland / config.pTPerHelixRadius, 2);
     return config;

--- a/core/src/seeding/spacepoint_binning.cpp
+++ b/core/src/seeding/spacepoint_binning.cpp
@@ -16,9 +16,9 @@ namespace traccc {
 spacepoint_binning::spacepoint_binning(
     const seedfinder_config& config, const spacepoint_grid_config& grid_config,
     vecmem::memory_resource& mr)
-    : m_config(config),
-      m_grid_config(grid_config),
-      m_axes(get_axes(grid_config, mr)),
+    : m_config(config.toInternalUnits()),
+      m_grid_config(grid_config.toInternalUnits()),
+      m_axes(get_axes(grid_config.toInternalUnits(), mr)),
       m_mr(mr) {}
 
 spacepoint_binning::output_type spacepoint_binning::operator()(

--- a/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
@@ -36,9 +36,11 @@ class seed_finding
     /// Constructor for the cuda seed finding
     ///
     /// @param config is seed finder configuration parameters
+    /// @param filter_config is seed filter configuration parameters
     /// @param sp_grid spacepoint grid
     /// @param mr vecmem memory resource
     seed_finding(const seedfinder_config& config,
+                 const seedfilter_config& filter_config,
                  const traccc::memory_resource& mr);
 
     /// Callable operator for the seed finding

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -163,8 +163,11 @@ vecmem::data::vector_buffer<device::prefix_sum_element_t> make_prefix_sum_buff(
 }
 
 seed_finding::seed_finding(const seedfinder_config& config,
+                           const seedfilter_config& filter_config,
                            const traccc::memory_resource& mr)
-    : m_seedfinder_config(config), m_mr(mr) {
+    : m_seedfinder_config(config.toInternalUnits()),
+      m_seedfilter_config(filter_config.toInternalUnits()),
+      m_mr(mr) {
 
     // Initialize m_copy ptr based on memory resources that were given
     if (mr.host) {

--- a/device/cuda/src/seeding/seeding_algorithm.cpp
+++ b/device/cuda/src/seeding/seeding_algorithm.cpp
@@ -20,16 +20,16 @@ namespace {
 traccc::seedfinder_config default_seedfinder_config() {
 
     traccc::seedfinder_config config;
-    config.highland = 13.6 * std::sqrt(config.radLengthPerSeed) *
-                      (1 + 0.038 * std::log(config.radLengthPerSeed));
-    float maxScatteringAngle = config.highland / config.minPt;
+    traccc::seedfinder_config config_copy = config.toInternalUnits();
+    config.highland = 13.6 * std::sqrt(config_copy.radLengthPerSeed) *
+                      (1 + 0.038 * std::log(config_copy.radLengthPerSeed));
+    float maxScatteringAngle = config.highland / config_copy.minPt;
     config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
     // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV
     // and millimeter
-    // TODO: change using ACTS units
-    config.pTPerHelixRadius = 300. * config.bFieldInZ;
+    config.pTPerHelixRadius = 300. * config_copy.bFieldInZ;
     config.minHelixDiameter2 =
-        std::pow(config.minPt * 2 / config.pTPerHelixRadius, 2);
+        std::pow(config_copy.minPt * 2 / config.pTPerHelixRadius, 2);
     config.pT2perRadius =
         std::pow(config.highland / config.pTPerHelixRadius, 2);
     return config;
@@ -57,7 +57,7 @@ namespace traccc::cuda {
 seeding_algorithm::seeding_algorithm(const traccc::memory_resource& mr)
     : m_spacepoint_binning(default_seedfinder_config(),
                            default_spacepoint_grid_config(), mr),
-      m_seed_finding(default_seedfinder_config(), mr) {}
+      m_seed_finding(default_seedfinder_config(), seedfilter_config(), mr) {}
 
 vecmem::data::vector_buffer<seed> seeding_algorithm::operator()(
     const spacepoint_container_types::const_view& spacepoints_view) const {

--- a/device/cuda/src/seeding/spacepoint_binning.cu
+++ b/device/cuda/src/seeding/spacepoint_binning.cu
@@ -50,8 +50,9 @@ __global__ void populate_grid(
 spacepoint_binning::spacepoint_binning(
     const seedfinder_config& config, const spacepoint_grid_config& grid_config,
     const traccc::memory_resource& mr)
-    : m_config(config),
-      m_axes(get_axes(grid_config, (mr.host ? *(mr.host) : mr.main))),
+    : m_config(config.toInternalUnits()),
+      m_axes(get_axes(grid_config.toInternalUnits(),
+                      (mr.host ? *(mr.host) : mr.main))),
       m_mr(mr) {
 
     // Initialize m_copy ptr based on memory resources that were given

--- a/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
@@ -39,11 +39,13 @@ class seed_finding
     /// Constructor for the sycl seed finding
     ///
     /// @param config   is seed finder configuration parameters
+    /// @param filter_config is seed filter configuration parameters
     /// @param mr       is a struct of memory resources (shared or
     /// host & device)
     /// @param queue    is a wrapper for the sycl queue for kernel
     /// invocation
     seed_finding(const seedfinder_config& config,
+                 const seedfilter_config& filter_config,
                  const traccc::memory_resource& mr, queue_wrapper queue);
 
     /// Callable operator for the seed finding

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -97,9 +97,13 @@ vecmem::data::vector_buffer<device::prefix_sum_element_t> make_prefix_sum_buff(
 }
 
 seed_finding::seed_finding(const seedfinder_config& config,
+                           const seedfilter_config& filter_config,
                            const traccc::memory_resource& mr,
                            queue_wrapper queue)
-    : m_seedfinder_config(config), m_mr(mr), m_queue(queue) {
+    : m_seedfinder_config(config.toInternalUnits()),
+      m_seedfilter_config(filter_config.toInternalUnits()),
+      m_mr(mr),
+      m_queue(queue) {
 
     // Initialize m_copy ptr based on memory resources that were given
     if (mr.host) {

--- a/device/sycl/src/seeding/seeding_algorithm.cpp
+++ b/device/sycl/src/seeding/seeding_algorithm.cpp
@@ -20,16 +20,16 @@ namespace {
 traccc::seedfinder_config default_seedfinder_config() {
 
     traccc::seedfinder_config config;
-    config.highland = 13.6 * std::sqrt(config.radLengthPerSeed) *
-                      (1 + 0.038 * std::log(config.radLengthPerSeed));
-    float maxScatteringAngle = config.highland / config.minPt;
+    traccc::seedfinder_config config_copy = config.toInternalUnits();
+    config.highland = 13.6 * std::sqrt(config_copy.radLengthPerSeed) *
+                      (1 + 0.038 * std::log(config_copy.radLengthPerSeed));
+    float maxScatteringAngle = config.highland / config_copy.minPt;
     config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
     // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV
     // and millimeter
-    // TODO: change using ACTS units
-    config.pTPerHelixRadius = 300. * config.bFieldInZ;
+    config.pTPerHelixRadius = 300. * config_copy.bFieldInZ;
     config.minHelixDiameter2 =
-        std::pow(config.minPt * 2 / config.pTPerHelixRadius, 2);
+        std::pow(config_copy.minPt * 2 / config.pTPerHelixRadius, 2);
     config.pT2perRadius =
         std::pow(config.highland / config.pTPerHelixRadius, 2);
     return config;
@@ -58,7 +58,8 @@ seeding_algorithm::seeding_algorithm(const traccc::memory_resource& mr,
                                      const queue_wrapper& queue)
     : m_spacepoint_binning(default_seedfinder_config(),
                            default_spacepoint_grid_config(), mr, queue),
-      m_seed_finding(default_seedfinder_config(), mr, queue) {}
+      m_seed_finding(default_seedfinder_config(), seedfilter_config(), mr,
+                     queue) {}
 
 vecmem::data::vector_buffer<seed> seeding_algorithm::operator()(
     const spacepoint_container_types::const_view& spacepoints_view) const {

--- a/device/sycl/src/seeding/spacepoint_binning.sycl
+++ b/device/sycl/src/seeding/spacepoint_binning.sycl
@@ -37,8 +37,9 @@ class populate_grid;
 spacepoint_binning::spacepoint_binning(
     const seedfinder_config& config, const spacepoint_grid_config& grid_config,
     const traccc::memory_resource& mr, queue_wrapper queue)
-    : m_config(config),
-      m_axes(get_axes(grid_config, (mr.host ? *(mr.host) : mr.main))),
+    : m_config(config.toInternalUnits()),
+      m_axes(get_axes(grid_config.toInternalUnits(),
+                      (mr.host ? *(mr.host) : mr.main))),
       m_mr(mr),
       m_queue(queue) {
 

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -95,17 +95,17 @@ TEST_P(CompareWithActsSeedingTests, Run) {
     traccc::seedfinder_config traccc_config;
     traccc::spacepoint_grid_config grid_config;
 
+    traccc::seedfinder_config config_copy = traccc_config.toInternalUnits();
     traccc_config.highland =
-        13.6 * std::sqrt(traccc_config.radLengthPerSeed) *
-        (1 + 0.038 * std::log(traccc_config.radLengthPerSeed));
-    float maxScatteringAngle = traccc_config.highland / traccc_config.minPt;
+        13.6 * std::sqrt(config_copy.radLengthPerSeed) *
+        (1 + 0.038 * std::log(config_copy.radLengthPerSeed));
+    float maxScatteringAngle = traccc_config.highland / config_copy.minPt;
     traccc_config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
     // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV
     // and millimeter
-    // TODO: change using ACTS units
-    traccc_config.pTPerHelixRadius = 300. * traccc_config.bFieldInZ;
+    traccc_config.pTPerHelixRadius = 300. * config_copy.bFieldInZ;
     traccc_config.minHelixDiameter2 =
-        std::pow(traccc_config.minPt * 2 / traccc_config.pTPerHelixRadius, 2);
+        std::pow(config_copy.minPt * 2 / traccc_config.pTPerHelixRadius, 2);
     traccc_config.pT2perRadius =
         std::pow(traccc_config.highland / traccc_config.pTPerHelixRadius, 2);
 
@@ -184,34 +184,34 @@ TEST_P(CompareWithActsSeedingTests, Run) {
     Acts::SeedfinderConfig<SpacePoint> acts_config;
 
     // silicon detector max
-    acts_config.phiMin = traccc_config.phiMin;
-    acts_config.phiMax = traccc_config.phiMax;
+    acts_config.phiMin = config_copy.phiMin;
+    acts_config.phiMax = config_copy.phiMax;
 
-    acts_config.rMin = traccc_config.rMin;
-    acts_config.rMax = traccc_config.rMax;
-    acts_config.deltaRMin = traccc_config.deltaRMin;
-    acts_config.deltaRMax = traccc_config.deltaRMax;
-    acts_config.collisionRegionMin = traccc_config.collisionRegionMin;
-    acts_config.collisionRegionMax = traccc_config.collisionRegionMax;
+    acts_config.rMin = config_copy.rMin;
+    acts_config.rMax = config_copy.rMax;
+    acts_config.deltaRMin = config_copy.deltaRMin;
+    acts_config.deltaRMax = config_copy.deltaRMax;
+    acts_config.collisionRegionMin = config_copy.collisionRegionMin;
+    acts_config.collisionRegionMax = config_copy.collisionRegionMax;
 
-    acts_config.zMin = traccc_config.zMin;
-    acts_config.zMax = traccc_config.zMax;
-    acts_config.maxSeedsPerSpM = traccc_config.maxSeedsPerSpM;
+    acts_config.zMin = config_copy.zMin;
+    acts_config.zMax = config_copy.zMax;
+    acts_config.maxSeedsPerSpM = config_copy.maxSeedsPerSpM;
 
     // 2.7 eta
-    acts_config.cotThetaMax = traccc_config.cotThetaMax;
-    acts_config.sigmaScattering = traccc_config.sigmaScattering;
-    acts_config.maxPtScattering = traccc_config.maxPtScattering;
+    acts_config.cotThetaMax = config_copy.cotThetaMax;
+    acts_config.sigmaScattering = config_copy.sigmaScattering;
+    acts_config.maxPtScattering = config_copy.maxPtScattering;
 
-    acts_config.minPt = traccc_config.minPt;
-    acts_config.bFieldInZ = traccc_config.bFieldInZ;
+    acts_config.minPt = config_copy.minPt;
+    acts_config.bFieldInZ = config_copy.bFieldInZ;
 
-    acts_config.beamPos[0] = traccc_config.beamPos[0];
-    acts_config.beamPos[1] = traccc_config.beamPos[1];
+    acts_config.beamPos[0] = config_copy.beamPos[0];
+    acts_config.beamPos[1] = config_copy.beamPos[1];
 
-    acts_config.impactMax = traccc_config.impactMax;
+    acts_config.impactMax = config_copy.impactMax;
 
-    acts_config.sigmaError = traccc_config.sigmaError;
+    acts_config.sigmaError = config_copy.sigmaError;
 
     auto bottomBinFinder = std::make_shared<Acts::BinFinder<SpacePoint>>(
         Acts::BinFinder<SpacePoint>());


### PR DESCRIPTION
Changed parameters in seeding configs to use explicit units using ACTS::UnitConstants, matching current ACTS formalism. 

OUTDATED: [ This PR will currently **not work** as the version of ACTS in use (10.x , from July 1, 2021) still uses the old formalism of implicit units. ]

EDIT: I changed compare_with_acts.cpp to work with the old version of ACTS currently in use so that we can push these changes without a major rewrite of the whole code, but these changes should be reverted when upgrading to the current version of ACTS