### PR TITLE
Improve memory performance of CUDA CCA code

### DIFF
--- a/device/cuda/include/traccc/cuda/cca/component_connection.hpp
+++ b/device/cuda/include/traccc/cuda/cca/component_connection.hpp
@@ -11,10 +11,17 @@
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/memory_resource.hpp"
 
 namespace traccc::cuda {
 struct component_connection : algorithm<measurement_container_types::host(
                                   const cell_container_types::host& cells)> {
+    public:
+    component_connection(const traccc::memory_resource& mr);
+
     output_type operator()(const cell_container_types::host& cells) const;
+
+    private:
+    traccc::memory_resource m_mr;
 };
 }  // namespace traccc::cuda

--- a/tests/cuda/test_cca.cpp
+++ b/tests/cuda/test_cca.cpp
@@ -13,7 +13,8 @@
 #include "traccc/cuda/cca/component_connection.hpp"
 
 namespace {
-traccc::cuda::component_connection cc;
+vecmem::host_memory_resource resource;
+traccc::cuda::component_connection cc({resource});
 
 cca_function_t f = [](const traccc::cell_container_types::host &data) {
     std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>> result;


### PR DESCRIPTION
As it stands, the CUDA CCA code uses managed memory because it's the path of least resistance. Sadly, it is also the path of least performance. In this commit, we change the CUDA CCA code to use device memory rather than managed memory, and this speeds up the algorithm significantly. In my preliminary measurements, the difference is roughly a factor five.

Also changes the code to use the new `traccc::memory_resource` type, and switches from 64-bit to 32-bit integers for better on-GPU performance.