### PR TITLE
Add Futhark implementation of spacepoint formation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ flowchart LR
     %% Futhark measurement creation
     cell -->|<a href='https://github.com/acts-project/traccc/blob/main/device/futhark/src/measurement_creation.fut'>CCA</a>| meas;
     linkStyle 23 stroke: brown;
+
+    %% Futhark spacepoint creation
+    meas -->|<a href='https://github.com/acts-project/traccc/blob/main/device/futhark/src/spacepoint_formation.fut'>L2G</a>| sp;
+    linkStyle 24 stroke: brown;
 ```
 
 ## Requirements and dependencies 

--- a/device/futhark/CMakeLists.txt
+++ b/device/futhark/CMakeLists.txt
@@ -14,8 +14,10 @@ traccc_add_library(
     TYPE SHARED
     "src/context.cpp"
     "src/component_connection.cpp"
+    "src/spacepoint_formation.cpp"
     "include/traccc/futhark/context.hpp"
     "include/traccc/futhark/component_connection.hpp"
+    "include/traccc/futhark/spacepoint_formation.hpp"
     "include/traccc/futhark/utils.hpp"
     "include/traccc/futhark/wrapper.hpp"
 )
@@ -40,4 +42,5 @@ add_futhark_to_library(
     src/maybe.fut
     src/zip.fut
     src/measurement_creation.fut
+    src/spacepoint_formation.fut
 )

--- a/device/futhark/include/traccc/futhark/spacepoint_formation.hpp
+++ b/device/futhark/include/traccc/futhark/spacepoint_formation.hpp
@@ -1,0 +1,31 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/spacepoint.hpp"
+#include "traccc/utils/algorithm.hpp"
+
+struct futhark_context_config;
+struct futhark_context;
+
+namespace traccc::futhark {
+struct spacepoint_formation
+    : public algorithm<spacepoint_collection_types::host(
+          const std::vector<std::pair<geometry_id, transform3>>&,
+          const measurement_container_types::host&)> {
+    spacepoint_formation(vecmem::memory_resource&);
+
+    output_type operator()(
+        const std::vector<std::pair<geometry_id, transform3>>&,
+        const measurement_container_types::host& cells) const;
+
+    private:
+    vecmem::memory_resource& m_mr;
+};
+}  // namespace traccc::futhark

--- a/device/futhark/src/entry.fut
+++ b/device/futhark/src/entry.fut
@@ -9,6 +9,7 @@ import "edm"
 import "zip"
 
 import "measurement_creation"
+import "spacepoint_formation"
 
 entry cells_to_measurements [n]
     (es: [n]u64) (gs: [n]u64) (c0s: [n]i64) (c1s: [n]i64) (as: [n]f32):
@@ -21,3 +22,14 @@ entry cells_to_measurements [n]
          (x.event, x.geometry, x.position.0, x.position.1,
           x.variance.0, x.variance.1)) >->
     unzip6
+
+entry measurements_to_spacepoints [n] [n'] [m]
+    (tis: [n]u64) (tts: [n']f32) (mes: [m]u64) (mgs: [m]u64) (mp0s: [m]f32)
+    (mp1s: [m]f32) (mv0s: [m]f32) (mv1s: [m]f32):
+    ([m]u64, [m]f32, [m]f32, [m]f32) =
+    let ttsr = unflatten_3d (n' / 16) 4 4 tts :> [n]Affine3
+    let ms = (zip4 mes mgs (zip mp0s mp1s) (zip mv0s mv1s)) |>
+        map (\(e, g, p, v) -> {event=e, geometry=g, position=p, variance=v}) in
+    measurements_to_spacepoints_impl (zip tis ttsr) ms |>
+    map (\(x: Spacepoint) ->
+         (x.event, x.position.0, x.position.1, x.position.2)) >-> unzip4

--- a/device/futhark/src/spacepoint_formation.cpp
+++ b/device/futhark/src/spacepoint_formation.cpp
@@ -1,0 +1,98 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <sstream>
+#include <traccc/edm/measurement.hpp>
+#include <traccc/edm/spacepoint.hpp>
+#include <traccc/futhark/spacepoint_formation.hpp>
+#include <traccc/futhark/wrapper.hpp>
+
+namespace traccc::futhark {
+struct measurements_to_spacepoints_wrapper
+    : public wrapper<
+          measurements_to_spacepoints_wrapper,
+          std::tuple<futhark_u64_1d_wrapper, futhark_f32_1d_wrapper,
+                     futhark_u64_1d_wrapper, futhark_u64_1d_wrapper,
+                     futhark_f32_1d_wrapper, futhark_f32_1d_wrapper,
+                     futhark_f32_1d_wrapper, futhark_f32_1d_wrapper>,
+          std::tuple<futhark_u64_1d_wrapper, futhark_f32_1d_wrapper,
+                     futhark_f32_1d_wrapper, futhark_f32_1d_wrapper>> {
+    static constexpr auto* entry_f = &futhark_entry_measurements_to_spacepoints;
+};
+
+spacepoint_formation::spacepoint_formation(vecmem::memory_resource& mr)
+    : m_mr(mr) {}
+
+spacepoint_formation::output_type spacepoint_formation::operator()(
+    const std::vector<std::pair<geometry_id, transform3>>& transforms,
+    const measurement_container_types::host& data) const {
+    std::size_t total_measurements = 0, total_transforms = transforms.size();
+    std::vector<measurement> measurements;
+    std::vector<geometry_id> geom_ids;
+
+    for (std::size_t i = 0; i < data.size(); ++i) {
+        for (std::size_t j = 0; j < data.at(i).items.size(); ++j) {
+            ++total_measurements;
+            measurements.push_back(data.at(i).items.at(j));
+            geom_ids.push_back(data.at(i).header.module);
+        }
+    }
+
+    std::vector<uint64_t> host_transform_geometry(total_transforms);
+    std::vector<float> host_transform_transform(4 * 4 * total_transforms);
+
+    std::vector<uint64_t> host_measurement_event(total_measurements);
+    std::vector<uint64_t> host_measurement_geometry(total_measurements);
+    std::vector<float> host_measurement_position0(total_measurements);
+    std::vector<float> host_measurement_position1(total_measurements);
+    std::vector<float> host_measurement_variance0(total_measurements);
+    std::vector<float> host_measurement_variance1(total_measurements);
+
+    for (std::size_t i = 0; i < total_transforms; ++i) {
+        host_transform_geometry[i] = std::get<0>(transforms[i]);
+        transform3 transform = std::get<1>(transforms[i]);
+        transform3::element_getter getter;
+        for (std::size_t x = 0; x < 4; ++x) {
+            for (std::size_t y = 0; y < 4; ++y) {
+                host_transform_transform[9 * i + 3 * x + y] =
+                    getter(transform.matrix(), x, y);
+            }
+        }
+    }
+
+    for (std::size_t i = 0, k = 0; i < data.size(); ++i) {
+        for (std::size_t j = 0; j < data.at(i).items.size(); ++j, ++k) {
+            host_measurement_event[k] = 0;
+            host_measurement_geometry[k] = geom_ids[k];
+            host_measurement_position0[k] = data.at(i).items.at(j).local[0];
+            host_measurement_position1[k] = data.at(i).items.at(j).local[1];
+            host_measurement_variance0[k] = data.at(i).items.at(j).variance[0];
+            host_measurement_variance1[k] = data.at(i).items.at(j).variance[1];
+        }
+    }
+
+    measurements_to_spacepoints_wrapper::output_t r =
+        measurements_to_spacepoints_wrapper::run(
+            std::move(host_transform_geometry),
+            std::move(host_transform_transform),
+            std::move(host_measurement_event),
+            std::move(host_measurement_geometry),
+            std::move(host_measurement_position0),
+            std::move(host_measurement_position1),
+            std::move(host_measurement_variance0),
+            std::move(host_measurement_variance1));
+
+    output_type out(&m_mr);
+
+    for (std::size_t i = 0; i < total_measurements; ++i) {
+        out.push_back({std::get<1>(r)[i], std::get<2>(r)[i], std::get<3>(r)[i],
+                       measurements[i]});
+    }
+
+    return out;
+}
+}  // namespace traccc::futhark

--- a/device/futhark/src/spacepoint_formation.fut
+++ b/device/futhark/src/spacepoint_formation.fut
@@ -1,0 +1,18 @@
+-- TRACCC library, part of the ACTS project (R&D line)
+--
+-- (c) 2022 CERN for the benefit of the ACTS project
+--
+-- Mozilla Public License Version 2.0
+
+import "linear"
+import "edm"
+
+def measurements_to_spacepoints_impl [n] [m]
+    (ts: [n](u64, Affine3)) (ms: *[m]Measurement): *[m]Spacepoint =
+    map (\x ->
+        { event=x.event
+        , position=transform (
+            filter ((== x.geometry) <-< (.0)) ts |> head |> (.1)
+            ) x.position
+        }
+    ) ms


### PR DESCRIPTION
This commit adds a Futhark implementation of spacepoint formation, which is extremely brief in this functional style. There are some improvements to be made by using accelerator structures such as search trees, but this will do for a proof of concept.