### PR TITLE
Container Copy Algorithms, main branch (2022.09.19.)

### DIFF
--- a/device/common/CMakeLists.txt
+++ b/device/common/CMakeLists.txt
@@ -17,6 +17,11 @@ traccc_add_library( traccc_device_common device_common TYPE SHARED
    "src/get_prefix_sum.cpp"
    "include/traccc/device/make_prefix_sum_buffer.hpp"
    "src/make_prefix_sum_buffer.cpp"
+   # General algorithm(s).
+   "include/traccc/device/container_h2d_copy_alg.hpp"
+   "include/traccc/device/impl/container_h2d_copy_alg.ipp"
+   "include/traccc/device/container_d2h_copy_alg.hpp"
+   "include/traccc/device/impl/container_d2h_copy_alg.ipp"
    # EDM class(es).
    "include/traccc/edm/device/doublet_counter.hpp"
    "include/traccc/edm/device/triplet_counter.hpp"

--- a/device/common/include/traccc/device/container_d2h_copy_alg.hpp
+++ b/device/common/include/traccc/device/container_d2h_copy_alg.hpp
@@ -1,0 +1,72 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/memory_resource.hpp"
+
+// VecMem include(s).
+#include <vecmem/utils/copy.hpp>
+
+namespace traccc::device {
+
+/// Algorithm to copy a container from a device to the host
+///
+/// Specialisations of this algorithm can be used to get a container back
+/// from a device to the host. Ideally at the end of an algorithm chain that
+/// would've produced something in device memory.
+///
+/// Note that the algorithm needs to treat constant views and buffers a little
+/// differently, so the user should make sure to pass in the correct type.
+///
+/// @tparam CONTAINER_TYPES One of the "container types" traits
+///
+template <typename CONTAINER_TYPES>
+class container_d2h_copy_alg
+    : public algorithm<typename CONTAINER_TYPES::host(
+          const typename CONTAINER_TYPES::const_view&)>,
+      public algorithm<typename CONTAINER_TYPES::host(
+          const typename CONTAINER_TYPES::buffer&)>,
+      public algorithm<typename CONTAINER_TYPES::host(
+          typename CONTAINER_TYPES::buffer&&)> {
+
+    public:
+    /// Help the compiler understand what @c output_type is
+    using output_type = typename algorithm<typename CONTAINER_TYPES::host(
+        const typename CONTAINER_TYPES::const_view&)>::output_type;
+
+    /// Constructor with the needed resources
+    container_d2h_copy_alg(const memory_resource& mr, vecmem::copy& copy);
+
+    /// Function executing the copy to the host
+    virtual output_type operator()(
+        const typename CONTAINER_TYPES::const_view& input) const override;
+    /// Function executing the copy to the host
+    virtual output_type operator()(
+        const typename CONTAINER_TYPES::buffer& input) const override;
+    /// Function executing the copy to the host
+    virtual output_type operator()(
+        typename CONTAINER_TYPES::buffer&& input) const override;
+
+    private:
+    /// Helper function setting up the output container
+    output_type make_output(
+        const typename CONTAINER_TYPES::const_view& input) const;
+
+    /// The memory resource(s) to use
+    memory_resource m_mr;
+    /// The copy object to use
+    vecmem::copy& m_copy;
+
+};  // class container_d2h_copy_alg
+
+}  // namespace traccc::device
+
+// Include the implementation.
+#include "traccc/device/impl/container_d2h_copy_alg.ipp"

--- a/device/common/include/traccc/device/container_h2d_copy_alg.hpp
+++ b/device/common/include/traccc/device/container_h2d_copy_alg.hpp
@@ -1,0 +1,60 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/memory_resource.hpp"
+
+// VecMem include(s).
+#include <vecmem/utils/copy.hpp>
+
+namespace traccc::device {
+
+/// Algorithm to copy a container from the host to the device
+///
+/// Specialisations of this algorithm can be used to copy a container to a
+/// device for a subsequent algorithm that expects its input to already be on
+/// the device that it wants to run on.
+///
+/// Note that the input type is not a "host type", but rather a constant view.
+/// This is meant to allow using this algorithm on top of more complicated
+/// data objects.
+///
+/// @tparam CONTAINER_TYPES One of the "container types" traits
+///
+template <typename CONTAINER_TYPES>
+class container_h2d_copy_alg
+    : public algorithm<typename CONTAINER_TYPES::buffer(
+          const typename CONTAINER_TYPES::const_view&)> {
+
+    public:
+    /// Helper type declaration for the input type
+    typedef const typename CONTAINER_TYPES::const_view& input_type;
+    /// Help the compiler understand what @c output_type is
+    using output_type = typename algorithm<typename CONTAINER_TYPES::buffer(
+        const typename CONTAINER_TYPES::const_view&)>::output_type;
+
+    /// Constructor with the needed resources
+    container_h2d_copy_alg(const memory_resource& mr, vecmem::copy& copy);
+
+    /// Function executing the copy to the device
+    virtual output_type operator()(input_type input) const override;
+
+    private:
+    /// The memory resource(s) to use
+    memory_resource m_mr;
+    /// The copy object to use
+    vecmem::copy& m_copy;
+
+};  // class container_h2d_copy_alg
+
+}  // namespace traccc::device
+
+// Include the implementation.
+#include "traccc/device/impl/container_h2d_copy_alg.ipp"

--- a/device/common/include/traccc/device/impl/container_d2h_copy_alg.ipp
+++ b/device/common/include/traccc/device/impl/container_d2h_copy_alg.ipp
@@ -1,0 +1,81 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::device {
+
+template <typename CONTAINER_TYPES>
+container_d2h_copy_alg<CONTAINER_TYPES>::container_d2h_copy_alg(
+    const memory_resource& mr, vecmem::copy& copy)
+    : m_mr(mr), m_copy(copy) {}
+
+template <typename CONTAINER_TYPES>
+typename container_d2h_copy_alg<CONTAINER_TYPES>::output_type
+container_d2h_copy_alg<CONTAINER_TYPES>::operator()(
+    const typename CONTAINER_TYPES::const_view& input) const {
+
+    // Create the result object.
+    output_type result = make_output(input);
+
+    // Perform the copy.
+    m_copy(input.headers, result.get_headers(),
+           vecmem::copy::type::device_to_host);
+    m_copy(input.items, result.get_items(), vecmem::copy::type::device_to_host);
+
+    // Return the host object.
+    return result;
+}
+
+template <typename CONTAINER_TYPES>
+typename container_d2h_copy_alg<CONTAINER_TYPES>::output_type
+container_d2h_copy_alg<CONTAINER_TYPES>::operator()(
+    const typename CONTAINER_TYPES::buffer& input) const {
+
+    // Create the result object.
+    output_type result = make_output(input);
+
+    // Perform the copy.
+    m_copy(input.headers, result.get_headers(),
+           vecmem::copy::type::device_to_host);
+    m_copy(input.items, result.get_items(), vecmem::copy::type::device_to_host);
+
+    // Return the host object.
+    return result;
+}
+
+template <typename CONTAINER_TYPES>
+typename container_d2h_copy_alg<CONTAINER_TYPES>::output_type
+container_d2h_copy_alg<CONTAINER_TYPES>::operator()(
+    typename CONTAINER_TYPES::buffer&& input) const {
+
+    // Call on the other function to do the work.
+    const typename CONTAINER_TYPES::buffer& input_ref = input;
+    return (*this)(input_ref);
+}
+
+template <typename CONTAINER_TYPES>
+typename container_d2h_copy_alg<CONTAINER_TYPES>::output_type
+container_d2h_copy_alg<CONTAINER_TYPES>::make_output(
+    const typename CONTAINER_TYPES::const_view& input) const {
+
+    // Decide what memory resource to use for the host container.
+    vecmem::memory_resource* mr = m_mr.host ? m_mr.host : &(m_mr.main);
+
+    // Create the result object, giving it the appropriate memory resource for
+    // all of its elements.
+    output_type result{input.items.m_size, mr};
+    for (std::size_t i = 0; i < result.size(); ++i) {
+        result[i].items =
+            typename CONTAINER_TYPES::host::item_vector::value_type{mr};
+    }
+
+    // Return the output object.
+    return result;
+}
+
+}  // namespace traccc::device

--- a/device/common/include/traccc/device/impl/container_h2d_copy_alg.ipp
+++ b/device/common/include/traccc/device/impl/container_h2d_copy_alg.ipp
@@ -1,0 +1,51 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// System include(s).
+#include <algorithm>
+#include <cassert>
+#include <type_traits>
+
+namespace traccc::device {
+
+template <typename CONTAINER_TYPES>
+container_h2d_copy_alg<CONTAINER_TYPES>::container_h2d_copy_alg(
+    const memory_resource& mr, vecmem::copy& copy)
+    : m_mr(mr), m_copy(copy) {}
+
+template <typename CONTAINER_TYPES>
+typename container_h2d_copy_alg<CONTAINER_TYPES>::output_type
+container_h2d_copy_alg<CONTAINER_TYPES>::operator()(input_type input) const {
+
+    // Get the sizes of the jagged vector. Remember that the input comes from
+    // host accessible memory. (Using the vecmem::copy object is not a good idea
+    // in this case.)
+    assert(input.headers.size() == input.items.m_size);
+    const typename std::remove_reference<typename std::remove_cv<
+        input_type>::type>::type::header_vector::size_type size =
+        input.headers.size();
+    std::vector<std::size_t> sizes(size, 0);
+    const typename CONTAINER_TYPES::const_device device(input);
+    std::transform(device.get_items().begin(), device.get_items().end(),
+                   sizes.begin(), [](const auto& vec) { return vec.size(); });
+
+    // Create the output buffer with the correct sizes.
+    output_type result{{size, m_mr.main}, {sizes, m_mr.main, m_mr.host}};
+
+    // Set it up, and copy data into it.
+    m_copy.setup(result.headers);
+    m_copy.setup(result.items);
+    m_copy(input.headers, result.headers, vecmem::copy::type::host_to_device);
+    m_copy(input.items, result.items, vecmem::copy::type::host_to_device);
+
+    // Return the created buffer.
+    return result;
+}
+
+}  // namespace traccc::device

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -29,10 +29,13 @@ traccc_add_test(
     # Define the sources for the test.
     test_basic.cu
     test_cca.cpp
+    test_copy_algs.cpp
 
     LINK_LIBRARIES
     GTest::gtest
+    vecmem::cuda
     traccc::core
+    traccc::device_common
     traccc::cuda
     traccc::io
     traccc_tests_cuda_main

--- a/tests/cuda/test_copy_algs.cpp
+++ b/tests/cuda/test_copy_algs.cpp
@@ -1,0 +1,70 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/device/container_d2h_copy_alg.hpp"
+#include "traccc/device/container_h2d_copy_alg.hpp"
+#include "traccc/edm/cell.hpp"
+#include "traccc/utils/memory_resource.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+GTEST_TEST(CUDAContainerCopy, CellHostToDeviceToHost) {
+
+    // Create the memory resource(s).
+    vecmem::host_memory_resource host_mr;
+    vecmem::cuda::device_memory_resource device_mr;
+    traccc::memory_resource mr{device_mr, &host_mr};
+
+    // Create a cell container on the host.
+    traccc::pixel_data pdata;
+    traccc::cell_container_types::host host_orig{&host_mr};
+    static constexpr std::size_t CONTAINER_SIZE = 100;
+    host_orig.reserve(CONTAINER_SIZE);
+    for (std::size_t i = 0; i < CONTAINER_SIZE; ++i) {
+        host_orig.push_back(
+            traccc::cell_container_types::host::header_type{
+                0, i + 1, {}, 0, {5, 0}, {4, 0}, pdata},
+            traccc::cell_container_types::host::vector_type<
+                traccc::cell_container_types::host::item_type>{
+                i + 1,
+                {static_cast<traccc::channel_id>(i + 1),
+                 static_cast<traccc::channel_id>(i + 2)},
+                &host_mr});
+    }
+
+    // Construct the copy algorithm(s).
+    vecmem::cuda::copy copy;
+    traccc::device::container_h2d_copy_alg<traccc::cell_container_types> h2d{
+        mr, copy};
+    traccc::device::container_d2h_copy_alg<traccc::cell_container_types> d2h{
+        mr, copy};
+
+    // Copy the container to the device, and back.
+    traccc::cell_container_types::host host_copy =
+        d2h(h2d(traccc::get_data(host_orig)));
+
+    // Compare the two host containers.
+    EXPECT_EQ(host_orig.size(), host_copy.size());
+    for (std::size_t i = 0; i < host_orig.size(); ++i) {
+        const traccc::cell_container_types::host::element_view orig_view =
+            host_orig[i];
+        const traccc::cell_container_types::host::element_view copy_view =
+            host_copy[i];
+        EXPECT_EQ(orig_view.header, copy_view.header);
+        EXPECT_EQ(orig_view.items.size(), copy_view.items.size());
+        for (std::size_t j = 0; j < orig_view.items.size(); ++j) {
+            EXPECT_EQ(orig_view.items[j], copy_view.items[j]);
+        }
+    }
+}


### PR DESCRIPTION
After some discussion with @stephenswat last week, added H->D and D->H container copy algorithms to the project. These are meant to become useful in full algorithm chains a bit later, once the algorithms have been re-worked a little. As "reconstruction algorithms" should not have to deal with memory movement. They should just assume that whatever is given to them as input, is already on the appropriate device.

Added a simple unit test for the code, just to check that the most basic things would work.