### PR TITLE
Internal Spacepoint Fix, main branch (2022.09.20.)

### DIFF
--- a/core/include/traccc/edm/internal_spacepoint.hpp
+++ b/core/include/traccc/edm/internal_spacepoint.hpp
@@ -8,21 +8,14 @@
 #pragma once
 
 // traccc include
-#include "traccc/edm/spacepoint.hpp"
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/edm/container.hpp"
 
 // detray core
 #include <detray/utils/invalid_values.hpp>
 
-// VecMem include(s).
-#include <vecmem/containers/data/jagged_vector_buffer.hpp>
-#include <vecmem/containers/data/vector_buffer.hpp>
-#include <vecmem/containers/device_vector.hpp>
-#include <vecmem/containers/jagged_device_vector.hpp>
-#include <vecmem/containers/jagged_vector.hpp>
-#include <vecmem/containers/vector.hpp>
-
-// std
-#include <algorithm>
+// Algebra plugins include(s).
+#include <algebra/math/common.hpp>
 
 namespace traccc {
 
@@ -53,8 +46,8 @@ struct internal_spacepoint {
         m_x = sp.global[0] - offsetXY[0];
         m_y = sp.global[1] - offsetXY[1];
         m_z = sp.global[2];
-        m_r = std::sqrt(m_x * m_x + m_y * m_y);
-        m_phi = std::atan2(m_y, m_x);
+        m_r = algebra::math::sqrt(m_x * m_x + m_y * m_y);
+        m_phi = algebra::math::atan2(m_y, m_x);
     }
 
     TRACCC_HOST_DEVICE

--- a/core/include/traccc/seeding/detail/spacepoint_grid.hpp
+++ b/core/include/traccc/seeding/detail/spacepoint_grid.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/edm/internal_spacepoint.hpp"
+#include "traccc/edm/spacepoint.hpp"
 
 // detray core
 #include <detray/definitions/indexing.hpp>


### PR DESCRIPTION
Unfortunately #239 had an unfortunate side-effect that our CI is currently blind to. (Which is something that I'll try to fix in another PR.) When trying to build the code with Intel's compiler, using an NVIDIA backend, the build would fail with:

```
[ 76%] Linking SYCL shared library ../../lib/libtraccc_sycl.so
ptxas fatal   : Unresolved extern function 'atan2f'
llvm-foreach: 
clang-15: error: ptxas command failed with exit code 255 (use -v to see invocation)
clang version 15.0.0 (https://github.com/intel/llvm.git 4043dda356af59d3d88607037955a0728dc0f466)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /atlas/software/intel/clang/2022-06/x86_64-ubuntu2004-gcc9-opt/bin
clang-15: note: diagnostic msg: Error generating preprocessed source(s).
make[2]: *** [device/sycl/CMakeFiles/traccc_sycl.dir/build.make:162: lib/libtraccc_sycl.so.0.2.0] Error 1
make[1]: *** [CMakeFiles/Makefile2:3485: device/sycl/CMakeFiles/traccc_sycl.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```

This is something that we've seen before in [algebra-plugins](https://github.com/acts-project/algebra-plugins) and in [detray](https://github.com/acts-project/detray). That not every `<cmath>` function is implemented in device code for every SYCL backend.

Since we already worked around this issue there, I just picked up the functions from `algebra::math`. But we should also think about the fact that the build not failing before means that `std::atan2` was not actually called in (SYCL) device code so far. Apparently `traccc::internal_spacepoint<T>::phi()` was not used in the code so far. So... #239 could've only made the code
 (SYCL) slower. :frowning: But for now let's just keep that change as-is, we can come back to this question in a later stage of optimisations.

At the same time I cleaned up the includes in `internal_spacepoint.hpp` and `spacepoint_grid.hpp` a little as well.