### PR TITLE
Allow use of system libraries by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ option( TRACCC_BUILD_FUTHARK "Build the Futhark sources included in traccc" FALS
 option( TRACCC_BUILD_TESTING "Build the (unit) tests of traccc" TRUE )
 option( TRACCC_BUILD_EXAMPLES "Build the examples of traccc" TRUE )
 
+# Flags controlling the meta-build system.
+option( TRACCC_USE_SYSTEM_LIBS "Use system libraries be default" FALSE )
+
 # Clean up.
 unset( TRACCC_BUILD_CUDA_DEFAULT )
 
@@ -59,7 +62,7 @@ option( TRACCC_SETUP_VECMEM
    "Set up the VecMem target(s) explicitly" TRUE )
 option( TRACCC_USE_SYSTEM_VECMEM
    "Pick up an existing installation of VecMem from the build environment"
-   FALSE )
+   ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_VECMEM )
    if( TRACCC_USE_SYSTEM_VECMEM )
       find_package( vecmem 0.7.0 REQUIRED COMPONENTS LANGUAGE )
@@ -75,7 +78,7 @@ option( TRACCC_SETUP_EIGEN3
    "Set up the Eigen3 target(s) explicitly" TRUE )
 option( TRACCC_USE_SYSTEM_EIGEN3
    "Pick up an existing installation of Eigen3 from the build environment"
-   FALSE )
+   ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_EIGEN3 )
    if( TRACCC_USE_SYSTEM_EIGEN3 )
       find_package( Eigen3 REQUIRED )
@@ -89,7 +92,7 @@ option( TRACCC_SETUP_THRUST
    "Set up the Thrust target(s) explicitly" TRUE )
 option( TRACCC_USE_SYSTEM_THRUST
    "Pick up an existing installation of Thrust from the build environment"
-   FALSE )
+   ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_THRUST )
    if( TRACCC_USE_SYSTEM_THRUST )
       find_package( Thrust REQUIRED )
@@ -109,7 +112,7 @@ option( TRACCC_SETUP_ALGEBRA_PLUGINS
    "Set up the Algebra Plugins target(s) explicitly" TRUE )
 option( TRACCC_USE_SYSTEM_ALGEBRA_PLUGINS
    "Pick up an existing installation of Algebra Plugins from the build environment"
-   FALSE )
+   ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_ALGEBRA_PLUGINS )
    if( TRACCC_USE_SYSTEM_ALGEBRA_PLUGINS )
       find_package( algebra-plugins REQUIRED )
@@ -123,7 +126,7 @@ option( TRACCC_SETUP_DFELIBS
    "Set up the dfelibs target(s) explicitly" TRUE )
 option( TRACCC_USE_SYSTEM_DFELIBS
    "Pick up an existing installation of dfelibs from the build environment"
-   FALSE )
+   ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_DFELIBS )
    if( TRACCC_USE_SYSTEM_DFELIBS )
       find_package( dfelibs REQUIRED )
@@ -137,7 +140,7 @@ option( TRACCC_SETUP_DETRAY
    "Set up the Detray target(s) explicitly" TRUE )
 option( TRACCC_USE_SYSTEM_DETRAY
    "Pick up an existing installation of Detray from the build environment"
-   FALSE )
+   ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_DETRAY )
    if( TRACCC_USE_SYSTEM_DETRAY )
       find_package( detray REQUIRED )
@@ -151,7 +154,7 @@ option( TRACCC_SETUP_ACTS
    "Set up the Acts target(s) explicitly" TRUE )
 option( TRACCC_USE_SYSTEM_ACTS
    "Pick up an existing installation of Acts from the build environment"
-   FALSE )
+   ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_ACTS )
    if( TRACCC_USE_SYSTEM_ACTS )
       find_package( Acts REQUIRED )
@@ -165,7 +168,7 @@ option( TRACCC_SETUP_GOOGLETEST
    "Set up the GoogleTest target(s) explicitly" TRUE )
 option( TRACCC_USE_SYSTEM_GOOGLETEST
    "Pick up an existing installation of GoogleTest from the build environment"
-   FALSE )
+   ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_GOOGLETEST )
    if( TRACCC_USE_SYSTEM_GOOGLETEST )
       find_package( GTest REQUIRED )


### PR DESCRIPTION
This commit adds a new flag to the CMake build system that enables the use of system-installed libraries by default, as an alternative to the current default of fetching libraries on the fly.