### PR TITLE
Kokkos Base Setup, main branch (2022.10.06.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -26,6 +26,8 @@ jobs:
             container: ghcr.io/acts-project/ubuntu2004_cuda:v30
           - name: SYCL
             container: ghcr.io/acts-project/ubuntu2004_oneapi:v30
+          - name: KOKKOS
+            container: ghcr.io/acts-project/ubuntu2004:v30
         build:
           - Release
           - Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,10 @@ endif()
 option( TRACCC_BUILD_CUDA "Build the CUDA sources included in traccc"
    ${TRACCC_BUILD_CUDA_DEFAULT} )
 option( TRACCC_BUILD_SYCL "Build the SYCL sources included in traccc" FALSE )
-option( TRACCC_BUILD_FUTHARK "Build the Futhark sources included in traccc" FALSE)
+option( TRACCC_BUILD_FUTHARK "Build the Futhark sources included in traccc"
+   FALSE )
+option( TRACCC_BUILD_KOKKOS "Build the Kokkos sources included in traccc"
+   FALSE )
 option( TRACCC_BUILD_TESTING "Build the (unit) tests of traccc" TRUE )
 option( TRACCC_BUILD_EXAMPLES "Build the examples of traccc" TRUE )
 
@@ -106,6 +109,20 @@ set( TRACCC_THRUST_OPTIONS "" CACHE STRING
    "Extra options for configuring how Thrust should be used" )
 mark_as_advanced( TRACCC_THRUST_OPTIONS )
 thrust_create_target( traccc::Thrust ${TRACCC_THRUST_OPTIONS} )
+
+# Set up Kokkos.
+option( TRACCC_SETUP_KOKKOS
+   "Set up the Kokkos library" TRUE )
+option( TRACCC_USE_SYSTEM_KOKKOS
+   "Pick up an existing installation of Kokkos from the build environment"
+   ${TRACCC_USE_SYSTEM_LIBS} )
+if( TRACCC_SETUP_KOKKOS )
+   if( TRACCC_USE_SYSTEM_KOKKOS )
+      find_package( Kokkos REQUIRED )
+   else()
+      add_subdirectory( extern/kokkos )
+   endif()
+endif()
 
 # Set up Algebra Plugins.
 option( TRACCC_SETUP_ALGEBRA_PLUGINS

--- a/extern/acts/CMakeLists.txt
+++ b/extern/acts/CMakeLists.txt
@@ -1,12 +1,17 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # CMake include(s).
 cmake_minimum_required( VERSION 3.11 )
 include( FetchContent )
+
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
 
 # Tell the user what's happening.
 message( STATUS "Building Acts as part of the TRACCC project" )

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.14 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building Algebra Plugins as part of the TRACCC project" )
 

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.14 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building Detray as part of the TRACCC project" )
 

--- a/extern/dfelibs/CMakeLists.txt
+++ b/extern/dfelibs/CMakeLists.txt
@@ -1,12 +1,17 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # CMake include(s).
 cmake_minimum_required( VERSION 3.11 )
 include( FetchContent )
+
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
 
 # Tell the user what's happening.
 message( STATUS "Building dfelibs as part of the TRACCC project" )

--- a/extern/eigen3/CMakeLists.txt
+++ b/extern/eigen3/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.14 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building Eigen3 as part of the TRACCC project" )
 

--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -1,12 +1,17 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # CMake include(s).
 cmake_minimum_required( VERSION 3.11 )
 include( FetchContent )
+
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
 
 # Tell the user what's happening.
 message( STATUS "Building GoogleTest as part of the TRACCC project" )

--- a/extern/kokkos/CMakeLists.txt
+++ b/extern/kokkos/CMakeLists.txt
@@ -1,0 +1,37 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.16 )
+include( FetchContent )
+
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
+# Tell the user what's happening.
+message( STATUS "Building Kokkos as part of the TRACCC project" )
+
+# Declare where to get Kokkos from.
+set( TRACCC_KOKKOS_SOURCE
+   "URL;https://github.com/kokkos/kokkos/archive/refs/tags/3.7.00.tar.gz;URL_MD5;84991eca9f066383abe119a5bc7a11c4"
+   CACHE STRING "Source for Kokkos, when built as part of this project" )
+mark_as_advanced( TRACCC_KOKKOS_SOURCE )
+FetchContent_Declare( Kokkos ${TRACCC_KOKKOS_SOURCE} )
+
+# Default options for the Kokkos build.
+set( Kokkos_ENABLE_SERIAL TRUE CACHE BOOL
+   "Enable the serial backend of Kokkos" )
+set( Kokkos_ENABLE_CUDA_DEFAULT FALSE )
+if( CMAKE_CUDA_COMPILER )
+   set( Kokkos_ENABLE_CUDA_DEFAULT TRUE )
+endif()
+set( Kokkos_ENABLE_CUDA ${Kokkos_ENABLE_CUDA_DEFAULT} CACHE BOOL
+   "Enable the CUDA backend of Kokkos" )
+
+# Get it into the current directory.
+FetchContent_MakeAvailable( Kokkos )

--- a/extern/kokkos/CMakeLists.txt
+++ b/extern/kokkos/CMakeLists.txt
@@ -26,12 +26,6 @@ FetchContent_Declare( Kokkos ${TRACCC_KOKKOS_SOURCE} )
 # Default options for the Kokkos build.
 set( Kokkos_ENABLE_SERIAL TRUE CACHE BOOL
    "Enable the serial backend of Kokkos" )
-set( Kokkos_ENABLE_CUDA_DEFAULT FALSE )
-if( CMAKE_CUDA_COMPILER )
-   set( Kokkos_ENABLE_CUDA_DEFAULT TRUE )
-endif()
-set( Kokkos_ENABLE_CUDA ${Kokkos_ENABLE_CUDA_DEFAULT} CACHE BOOL
-   "Enable the CUDA backend of Kokkos" )
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( Kokkos )

--- a/extern/kokkos/README.md
+++ b/extern/kokkos/README.md
@@ -1,0 +1,4 @@
+# Build Recipe for Kokkos
+
+This directory holds a simple build recipe for the
+[Kokkos](https://github.com/kokkos/kokkos) core libraries.

--- a/extern/thrust/CMakeLists.txt
+++ b/extern/thrust/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.14 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building Thrust as part of the TRACCC project" )
 

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.14 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building VecMem as part of the TRACCC project" )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,10 @@ if( TRACCC_BUILD_CUDA )
     add_subdirectory( cuda )
 endif()
 
+if( TRACCC_BUILD_KOKKOS )
+    add_subdirectory( kokkos )
+endif()
+
 if(TRACCC_BUILD_FUTHARK)
     add_subdirectory(futhark)
 endif()

--- a/tests/kokkos/CMakeLists.txt
+++ b/tests/kokkos/CMakeLists.txt
@@ -1,0 +1,13 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+traccc_add_test( kokkos
+   kokkos_main.cpp
+   kokkos_basic.cpp
+   LINK_LIBRARIES
+   GTest::gtest
+   Kokkos::kokkos
+)

--- a/tests/kokkos/kokkos_basic.cpp
+++ b/tests/kokkos/kokkos_basic.cpp
@@ -1,0 +1,37 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Kokkos include(s).
+#include <Kokkos_Core.hpp>
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s).
+#include <vector>
+
+/// Trivial test for a host-run parallel-for.
+GTEST_TEST(KokkosBasic, ParalleFor) {
+
+    // Allocate an integer vector.
+    std::vector<int> test_vec(100);
+    int* test_vec_ptr = test_vec.data();
+
+    // Set all elements to some value. Forecfully running serially on the host.
+    // In case the default execution space would be CUDA. (Which would not be
+    // compatible with the host-allocated std::vector of course.)
+    Kokkos::parallel_for(
+        "test_vec_init",
+        Kokkos::RangePolicy<Kokkos::Serial>(0, test_vec.size()),
+        KOKKOS_LAMBDA(int i) { test_vec_ptr[i] = 1; });
+
+    // Check that we succeeded.
+    for (int v : test_vec) {
+        EXPECT_EQ(v, 1);
+    }
+}

--- a/tests/kokkos/kokkos_main.cpp
+++ b/tests/kokkos/kokkos_main.cpp
@@ -1,0 +1,39 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Kokkos include(s).
+#include <Kokkos_Core.hpp>
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+/// Main function for the Kokkos unit test(s)
+///
+/// In order to ensure that Kokkos is initialised and finalised just once in the
+/// test jobs, we need to use a custom @c main function instead of the GoogeTest
+/// provided one.
+///
+/// @param argc The number of command line arguments
+/// @param argv The array of command line arguments
+/// @return @c 0 if successful, something else if not
+///
+int main(int argc, char** argv) {
+
+    // Initialise both Kokkos and GoogleTest.
+    Kokkos::initialize(argc, argv);
+    testing::InitGoogleTest(&argc, argv);
+
+    // Run all of the tests.
+    const int r = RUN_ALL_TESTS();
+
+    // Finalise Kokkos.
+    Kokkos::finalize();
+
+    // Return the appropriate code.
+    return r;
+}


### PR DESCRIPTION
This is meant as a replacement for #225.

I pretty much just stole / transcribed @Yhatoh's code from that PR into this one. Such that it would be able to work...

Note that I disabled the CUDA support in Kokkos for now. Because I just didn't find a good way in which to enable it.
  - If I don't specify for Kokkos explicitly what CUDA architecture to use, it tries to auto-detect it. And fails in the CI with:

```
CMake Error at build/_deps/kokkos-src/cmake/kokkos_arch.cmake:776 (MESSAGE):
-- Built-in Execution Spaces:
  CUDA enabled but no NVIDIA GPU architecture currently enabled and
--     Device Parallel: Kokkos::Cuda
--     Host Parallel: NoTypeDefined
--       Host Serial: SERIAL
-- 
-- Architectures:
  auto-detection failed.  Please give one -DKokkos_ARCH_{..}=ON' to enable an
  NVIDIA GPU architecture.

  You can yourself try to compile
  /__w/traccc/traccc/build/_deps/kokkos-src/cmake/compile_tests/cuda_compute_capability.cc
  and run the executable.  If you are cross-compiling, you should try to do
  this on a compute node.
Call Stack (most recent call first):
  build/_deps/kokkos-src/cmake/kokkos_tribits.cmake:243 (INCLUDE)
  build/_deps/kokkos-src/CMakeLists.txt:188 (KOKKOS_SETUP_BUILD_ENVIRONMENT)
```

  - If I just specify an older architecture manually, one that matches the value set for `CMAKE_CUDA_ARCHITECTURES`, then I got the following error during the build on a machine with a newer GPU:

```
[ 56%] Linking CXX executable ../../bin/traccc_test_kokkos
Kokkos::Cuda::initialize ERROR: running kernels compiled for compute capability 5.2 on device with compute capability 7.5 is not supported by CUDA!

Backtrace:
                                     Kokkos::Impl::save_stacktrace() [0x7f220a5b5082]
                    Kokkos::Impl::traceback_callstack(std::ostream&) [0x7f220a5aceda]
                               Kokkos::Impl::host_abort(char const*) [0x7f220a5acf5b]
                                                                           [0x403836]
     Kokkos::Impl::CudaInternal::initialize(int, CUstream_st*, bool) [0x7f220a5be1ea]
Kokkos::Cuda::impl_initialize(Kokkos::InitializationSettings const&) [0x7f220a5c0048]
                                                                     [0x7f220a5a7eac]
                                    Kokkos::initialize(int&, char**) [0x7f220a5a7e01]
                                                                           [0x402748]
                                                   __libc_start_main [0x7f2208930083]
                                                                           [0x40266e]
CMake Error at /software/cmake/3.24.1/x86_64-ubuntu2004-gcc9-opt/share/cmake-3.24/Modules/GoogleTestAddTests.cmake:112 (message):
  Error running test executable.

    Path: '/home/krasznaa/ATLAS/projects/traccc/build/bin/traccc_test_kokkos'
    Result: Subprocess aborted
    Output:
      

Call Stack (most recent call first):
  /software/cmake/3.24.1/x86_64-ubuntu2004-gcc9-opt/share/cmake-3.24/Modules/GoogleTestAddTests.cmake:225 (gtest_discover_tests_impl)
```

Which is really bull@%&*. :frowning: @Yhatoh, is it really not possible to tell Kokkos to include PTX code in the binaries? (For JIT-ing it at runtime.) Please try to look this up. Because otherwise we won't be able to test this code properly.

It's also not a good look that `Kokkos::initialize(...)` seems to require a GPU to be available if CUDA support was turned on. That again will make using Kokkos very difficult in this project. :frowning:

P.S. I added a bunch of

```cmake
if( POLICY CMP0135 )
   cmake_policy( SET CMP0135 NEW )
endif()
```

statements to the PR as well. Just because I was lazy to open a separate PR for these...