### PR TITLE
Refactor: Changed triplet counter class to include item_idx

### DIFF
--- a/device/common/include/traccc/edm/device/triplet_counter.hpp
+++ b/device/common/include/traccc/edm/device/triplet_counter.hpp
@@ -41,6 +41,9 @@ struct triplet_counter {
     /// The number of compatible triplets for a the midbot doublet
     unsigned int m_nTriplets = 0;
 
+    /// The position of the middle bottom doublet in its jagged vector
+    unsigned int m_mb_idx = 0;
+
 };  // struct triplet_counter
 
 /// Declare all triplet counter collection types

--- a/device/common/include/traccc/seeding/device/find_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/find_triplets.hpp
@@ -29,7 +29,6 @@ namespace traccc::device {
 /// @param[in] config            Seedfinder configuration
 /// @param[in] sp_view           The spacepoint grid to count triplets on
 /// @param[in] dc_view           Container with the number of doublets per bin
-/// @param[in] mid_bot_doublet_view Container with the mid bottom doublets
 /// @param[in] mid_top_doublet_view Container with the mid top doublets
 /// @param[in] tc_view           Container with the number of triplets to find
 /// @param[in] triplet_ps_view   Prefix sum for @c triplet_view
@@ -40,7 +39,6 @@ void find_triplets(
     const std::size_t globalIndex, const seedfinder_config& config,
     const seedfilter_config& filter_config, const sp_grid_const_view& sp_view,
     const device::doublet_counter_container_types::const_view& dc_view,
-    const doublet_container_view& mid_bot_doublet_view,
     const doublet_container_view& mid_top_doublet_view,
     const device::triplet_counter_container_types::const_view& tc_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -161,7 +161,7 @@ void count_triplets(
         nTriplets.fetch_add(num_triplets_per_mb);
 
         triplet_counter.get_items().at(bin_idx).push_back(
-            {mid_bot, num_triplets_per_mb});
+            {mid_bot, num_triplets_per_mb, item_idx});
     }
 }
 

--- a/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
@@ -72,10 +72,6 @@ void find_triplets(
 
     // Header of doublet counter : number of compatible middle sp per bin
     // Item of doublet counter : doublet counter objects per bin
-    // const
-    // doublet_counter_container_types::const_device::item_vector::value_type
-    // doublet_counter_per_bin =
-    //     doublet_counter_device.get_items().at(spM_bin);
     const vecmem::device_vector<const doublet_counter> doublet_counter_per_bin =
         doublet_counter_device.get_items().at(spM_bin);
 
@@ -116,15 +112,7 @@ void find_triplets(
     unsigned int mb_end_idx = 0;
     unsigned int mt_start_idx = 0;
     unsigned int mt_end_idx = 0;
-    unsigned int mb_idx;
-
-    // First, find the index of middle-bottom doublet
-    for (unsigned int i = 0; i < num_mid_bot_doublets_per_bin; i++) {
-        if (mid_bot_doublet == mid_bot_doublets_per_bin[i]) {
-            mb_idx = i;
-            break;
-        }
-    }
+    unsigned int mb_idx = mid_bot_counter.m_mb_idx;
 
     for (unsigned int i = 0; i < num_compat_spM_per_bin; ++i) {
         mb_end_idx += doublet_counter_per_bin[i].m_nMidBot;

--- a/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
@@ -21,7 +21,6 @@ void find_triplets(
     const seedfilter_config& filter_config, const sp_grid_const_view& sp_view,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_view,
-    const doublet_container_view& mid_bot_doublet_view,
     const doublet_container_view& mid_top_doublet_view,
     const device::triplet_counter_container_types::const_view& tc_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
@@ -38,7 +37,6 @@ void find_triplets(
     // Get device copy of input parameters
     const device::doublet_counter_container_types::const_device
         doublet_counter_device(doublet_counter_view);
-    const device_doublet_container mid_bot_doublet_device(mid_bot_doublet_view);
     const device_doublet_container mid_top_doublet_device(mid_top_doublet_view);
     const const_sp_grid_device sp_grid(sp_view);
 
@@ -74,13 +72,6 @@ void find_triplets(
     // Item of doublet counter : doublet counter objects per bin
     const vecmem::device_vector<const doublet_counter> doublet_counter_per_bin =
         doublet_counter_device.get_items().at(spM_bin);
-
-    // Header of doublet: number of mid_bot doublets per bin
-    // Item of doublet: doublet objects per bin
-    const unsigned int num_mid_bot_doublets_per_bin =
-        mid_bot_doublet_device.get_headers().at(spM_bin).n_doublets;
-    const vecmem::device_vector<const doublet> mid_bot_doublets_per_bin =
-        mid_bot_doublet_device.get_items().at(spM_bin);
 
     // Header of doublet: number of mid_top doublets per bin
     // Item of doublet: doublet objects per bin

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -258,8 +258,8 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     m_copy->setup(spacepoints_buffer.items);
 
     // Calculating grid size for measurements creation kernel (block size 64)
-    blocksPerGrid =
-        (clusters_buffer.headers.size() - 1 + threadsPerBlock) / threadsPerBlock;
+    blocksPerGrid = (clusters_buffer.headers.size() - 1 + threadsPerBlock) /
+                    threadsPerBlock;
 
     // Invoke measurements creation will call create measurements kernel
     kernels::create_measurements<<<blocksPerGrid, threadsPerBlock>>>(

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -76,7 +76,7 @@ __global__ void find_triplets(
     seedfinder_config config, seedfilter_config filter_config,
     sp_grid_const_view sp_grid,
     device::doublet_counter_container_types::const_view doublet_counter_view,
-    doublet_container_view mb_doublets, doublet_container_view mt_doublets,
+    doublet_container_view mt_doublets,
     device::triplet_counter_container_types::const_view tc_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         triplet_prefix_sum,
@@ -84,7 +84,7 @@ __global__ void find_triplets(
 
     device::find_triplets(threadIdx.x + blockIdx.x * blockDim.x, config,
                           filter_config, sp_grid, doublet_counter_view,
-                          mb_doublets, mt_doublets, tc_view, triplet_prefix_sum,
+                          mt_doublets, tc_view, triplet_prefix_sum,
                           triplet_view);
 }
 /// CUDA kernel for running @c traccc::device::update_triplet_weights
@@ -266,9 +266,9 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // Find all of the spacepoint triplets.
     kernels::find_triplets<<<nTripletFindBlocks, nTripletFindThreads>>>(
         m_seedfinder_config, m_seedfilter_config, g2_view,
-        doublet_counter_buffer, doublet_buffers.middleBottom,
-        doublet_buffers.middleTop, triplet_counter_buffer,
-        triplet_counter_prefix_sum_buff, triplet_buffer);
+        doublet_counter_buffer, doublet_buffers.middleTop,
+        triplet_counter_buffer, triplet_counter_prefix_sum_buff,
+        triplet_buffer);
     CUDA_ERROR_CHECK(cudaGetLastError());
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -180,7 +180,8 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // counting kernel for.
     const unsigned int nDoubletCountThreads = WARP_SIZE * 2;
     const unsigned int nDoubletCountBlocks =
-        (sp_grid_prefix_sum_buff.size() + nDoubletCountThreads - 1) / nDoubletCountThreads;
+        (sp_grid_prefix_sum_buff.size() + nDoubletCountThreads - 1) /
+        nDoubletCountThreads;
 
     // Count the number of doublets that we need to produce.
     kernels::count_doublets<<<nDoubletCountBlocks, nDoubletCountThreads>>>(
@@ -206,7 +207,8 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // finding kernel for.
     const unsigned int nDoubletFindThreads = WARP_SIZE * 2;
     const unsigned int nDoubletFindBlocks =
-        (doublet_prefix_sum_buff.size() + nDoubletFindThreads - 1) / nDoubletFindThreads;
+        (doublet_prefix_sum_buff.size() + nDoubletFindThreads - 1) /
+        nDoubletFindThreads;
 
     // Find all of the spacepoint doublets.
     kernels::find_doublets<<<nDoubletFindBlocks, nDoubletFindThreads>>>(
@@ -234,7 +236,8 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // counting kernel for.
     const unsigned int nTripletCountThreads = WARP_SIZE * 2;
     const unsigned int nTripletCountBlocks =
-        (mb_prefix_sum_buff.size() + nTripletCountThreads - 1) / nTripletCountThreads;
+        (mb_prefix_sum_buff.size() + nTripletCountThreads - 1) /
+        nTripletCountThreads;
 
     // Count the number of triplets that we need to produce.
     kernels::count_triplets<<<nTripletCountBlocks, nTripletCountThreads>>>(
@@ -257,7 +260,8 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // finding kernel for.
     const unsigned int nTripletFindThreads = WARP_SIZE * 2;
     const unsigned int nTripletFindBlocks =
-        (triplet_counter_prefix_sum_buff.size() + nTripletFindThreads - 1) / nTripletFindThreads;
+        (triplet_counter_prefix_sum_buff.size() + nTripletFindThreads - 1) /
+        nTripletFindThreads;
 
     // Find all of the spacepoint triplets.
     kernels::find_triplets<<<nTripletFindBlocks, nTripletFindThreads>>>(
@@ -276,7 +280,8 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // updating kernel for.
     const unsigned int nWeightUpdatingThreads = WARP_SIZE * 2;
     const unsigned int nWeightUpdatingBlocks =
-        (triplet_prefix_sum_buff.size() + nWeightUpdatingThreads - 1) / nWeightUpdatingThreads;
+        (triplet_prefix_sum_buff.size() + nWeightUpdatingThreads - 1) /
+        nWeightUpdatingThreads;
 
     // Update the weights of all spacepoint triplets.
     kernels::update_triplet_weights<<<
@@ -305,7 +310,8 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // selecting kernel for.
     const unsigned int nSeedSelectingThreads = WARP_SIZE * 2;
     const unsigned int nSeedSelectingBlocks =
-        (doublet_prefix_sum_buff.size() + nSeedSelectingThreads - 1) / nSeedSelectingThreads;
+        (doublet_prefix_sum_buff.size() + nSeedSelectingThreads - 1) /
+        nSeedSelectingThreads;
 
     // Create seeds out of selected triplets
     kernels::select_seeds<<<nSeedSelectingBlocks, nSeedSelectingThreads,

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -180,7 +180,7 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // counting kernel for.
     const unsigned int nDoubletCountThreads = WARP_SIZE * 2;
     const unsigned int nDoubletCountBlocks =
-        sp_grid_prefix_sum_buff.size() / nDoubletCountThreads + 1;
+        (sp_grid_prefix_sum_buff.size() + nDoubletCountThreads - 1) / nDoubletCountThreads;
 
     // Count the number of doublets that we need to produce.
     kernels::count_doublets<<<nDoubletCountBlocks, nDoubletCountThreads>>>(
@@ -206,7 +206,7 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // finding kernel for.
     const unsigned int nDoubletFindThreads = WARP_SIZE * 2;
     const unsigned int nDoubletFindBlocks =
-        doublet_prefix_sum_buff.size() / nDoubletFindThreads + 1;
+        (doublet_prefix_sum_buff.size() + nDoubletFindThreads - 1) / nDoubletFindThreads;
 
     // Find all of the spacepoint doublets.
     kernels::find_doublets<<<nDoubletFindBlocks, nDoubletFindThreads>>>(
@@ -234,7 +234,7 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // counting kernel for.
     const unsigned int nTripletCountThreads = WARP_SIZE * 2;
     const unsigned int nTripletCountBlocks =
-        mb_prefix_sum_buff.size() / nTripletCountThreads + 1;
+        (mb_prefix_sum_buff.size() + nTripletCountThreads - 1) / nTripletCountThreads;
 
     // Count the number of triplets that we need to produce.
     kernels::count_triplets<<<nTripletCountBlocks, nTripletCountThreads>>>(
@@ -247,7 +247,6 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // Set up the triplet buffer.
     triplet_container_buffer triplet_buffer = device::make_triplet_buffer(
         triplet_counter_buffer, *m_copy, m_mr.main, m_mr.host);
-    triplet_container_view triplet_view(triplet_buffer);
 
     // Create prefix sum buffer
     vecmem::data::vector_buffer triplet_counter_prefix_sum_buff =
@@ -258,7 +257,7 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // finding kernel for.
     const unsigned int nTripletFindThreads = WARP_SIZE * 2;
     const unsigned int nTripletFindBlocks =
-        triplet_counter_prefix_sum_buff.size() / nTripletFindThreads + 1;
+        (triplet_counter_prefix_sum_buff.size() + nTripletFindThreads - 1) / nTripletFindThreads;
 
     // Find all of the spacepoint triplets.
     kernels::find_triplets<<<nTripletFindBlocks, nTripletFindThreads>>>(
@@ -277,7 +276,7 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // updating kernel for.
     const unsigned int nWeightUpdatingThreads = WARP_SIZE * 2;
     const unsigned int nWeightUpdatingBlocks =
-        triplet_prefix_sum_buff.size() / nWeightUpdatingThreads + 1;
+        (triplet_prefix_sum_buff.size() + nWeightUpdatingThreads - 1) / nWeightUpdatingThreads;
 
     // Update the weights of all spacepoint triplets.
     kernels::update_triplet_weights<<<
@@ -306,7 +305,7 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     // selecting kernel for.
     const unsigned int nSeedSelectingThreads = WARP_SIZE * 2;
     const unsigned int nSeedSelectingBlocks =
-        doublet_prefix_sum_buff.size() / nSeedSelectingThreads + 1;
+        (doublet_prefix_sum_buff.size() + nSeedSelectingThreads - 1) / nSeedSelectingThreads;
 
     // Create seeds out of selected triplets
     kernels::select_seeds<<<nSeedSelectingBlocks, nSeedSelectingThreads,

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -234,12 +234,12 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
                 tripletFindRange,
                 [config = m_seedfinder_config,
                  filter_config = m_seedfilter_config, g2_view,
-                 doublet_counter_view, mb_view, mt_view, triplet_counter_view,
+                 doublet_counter_view, mt_view, triplet_counter_view,
                  triplet_counter_prefix_sum_view,
                  triplet_view](::sycl::nd_item<1> item) {
                     device::find_triplets(
                         item.get_global_linear_id(), config, filter_config,
-                        g2_view, doublet_counter_view, mb_view, mt_view,
+                        g2_view, doublet_counter_view, mt_view,
                         triplet_counter_view, triplet_counter_prefix_sum_view,
                         triplet_view);
                 });


### PR DESCRIPTION
This PR introduces the item_idx to the triplet counter class. 
Before, the find_triplets kernel started by finding this position given the midBot doublet contained in the class. This was extremely inefficient.
The find_triplets kernel is now ~15x faster than it was before (e.g. for a 17k seed event: 1.886ms -> 0.126ms).

Also a bit of cleanup:
Removed unnecesary creation of view objects on top of buffers in cuda clusterization algorithm, as kernels can be directly called with the buffers with implicit translation to views.
Changed cuda seed_finding calculation of number of blocks to correctly match sycl implementation.