### PR TITLE
VecMem Update, Code Simplification, main branch (2022.10.10.)

### DIFF
--- a/device/common/include/traccc/device/container_d2h_copy_alg.hpp
+++ b/device/common/include/traccc/device/container_d2h_copy_alg.hpp
@@ -30,13 +30,11 @@ namespace traccc::device {
 template <typename CONTAINER_TYPES>
 class container_d2h_copy_alg
     : public algorithm<typename CONTAINER_TYPES::host(
-          const typename CONTAINER_TYPES::const_view&)>,
-      public algorithm<typename CONTAINER_TYPES::host(
-          const typename CONTAINER_TYPES::buffer&)>,
-      public algorithm<typename CONTAINER_TYPES::host(
-          typename CONTAINER_TYPES::buffer&&)> {
+          const typename CONTAINER_TYPES::const_view&)> {
 
     public:
+    /// Helper type declaration for the input type
+    typedef const typename CONTAINER_TYPES::const_view& input_type;
     /// Help the compiler understand what @c output_type is
     using output_type = typename algorithm<typename CONTAINER_TYPES::host(
         const typename CONTAINER_TYPES::const_view&)>::output_type;
@@ -45,20 +43,9 @@ class container_d2h_copy_alg
     container_d2h_copy_alg(const memory_resource& mr, vecmem::copy& copy);
 
     /// Function executing the copy to the host
-    virtual output_type operator()(
-        const typename CONTAINER_TYPES::const_view& input) const override;
-    /// Function executing the copy to the host
-    virtual output_type operator()(
-        const typename CONTAINER_TYPES::buffer& input) const override;
-    /// Function executing the copy to the host
-    virtual output_type operator()(
-        typename CONTAINER_TYPES::buffer&& input) const override;
+    virtual output_type operator()(input_type input) const override;
 
     private:
-    /// Helper function setting up the output container
-    output_type make_output(
-        const typename CONTAINER_TYPES::const_view& input) const;
-
     /// The memory resource(s) to use
     memory_resource m_mr;
     /// The copy object to use

--- a/device/common/include/traccc/device/impl/container_d2h_copy_alg.ipp
+++ b/device/common/include/traccc/device/impl/container_d2h_copy_alg.ipp
@@ -16,52 +16,7 @@ container_d2h_copy_alg<CONTAINER_TYPES>::container_d2h_copy_alg(
 
 template <typename CONTAINER_TYPES>
 typename container_d2h_copy_alg<CONTAINER_TYPES>::output_type
-container_d2h_copy_alg<CONTAINER_TYPES>::operator()(
-    const typename CONTAINER_TYPES::const_view& input) const {
-
-    // Create the result object.
-    output_type result = make_output(input);
-
-    // Perform the copy.
-    m_copy(input.headers, result.get_headers(),
-           vecmem::copy::type::device_to_host);
-    m_copy(input.items, result.get_items(), vecmem::copy::type::device_to_host);
-
-    // Return the host object.
-    return result;
-}
-
-template <typename CONTAINER_TYPES>
-typename container_d2h_copy_alg<CONTAINER_TYPES>::output_type
-container_d2h_copy_alg<CONTAINER_TYPES>::operator()(
-    const typename CONTAINER_TYPES::buffer& input) const {
-
-    // Create the result object.
-    output_type result = make_output(input);
-
-    // Perform the copy.
-    m_copy(input.headers, result.get_headers(),
-           vecmem::copy::type::device_to_host);
-    m_copy(input.items, result.get_items(), vecmem::copy::type::device_to_host);
-
-    // Return the host object.
-    return result;
-}
-
-template <typename CONTAINER_TYPES>
-typename container_d2h_copy_alg<CONTAINER_TYPES>::output_type
-container_d2h_copy_alg<CONTAINER_TYPES>::operator()(
-    typename CONTAINER_TYPES::buffer&& input) const {
-
-    // Call on the other function to do the work.
-    const typename CONTAINER_TYPES::buffer& input_ref = input;
-    return (*this)(input_ref);
-}
-
-template <typename CONTAINER_TYPES>
-typename container_d2h_copy_alg<CONTAINER_TYPES>::output_type
-container_d2h_copy_alg<CONTAINER_TYPES>::make_output(
-    const typename CONTAINER_TYPES::const_view& input) const {
+container_d2h_copy_alg<CONTAINER_TYPES>::operator()(input_type input) const {
 
     // Decide what memory resource to use for the host container.
     vecmem::memory_resource* mr = m_mr.host ? m_mr.host : &(m_mr.main);
@@ -74,7 +29,12 @@ container_d2h_copy_alg<CONTAINER_TYPES>::make_output(
             typename CONTAINER_TYPES::host::item_vector::value_type{mr};
     }
 
-    // Return the output object.
+    // Perform the copy.
+    m_copy(input.headers, result.get_headers(),
+           vecmem::copy::type::device_to_host);
+    m_copy(input.items, result.get_items(), vecmem::copy::type::device_to_host);
+
+    // Return the host object.
     return result;
 }
 

--- a/device/common/include/traccc/device/impl/container_d2h_copy_alg.ipp
+++ b/device/common/include/traccc/device/impl/container_d2h_copy_alg.ipp
@@ -68,7 +68,7 @@ container_d2h_copy_alg<CONTAINER_TYPES>::make_output(
 
     // Create the result object, giving it the appropriate memory resource for
     // all of its elements.
-    output_type result{input.items.m_size, mr};
+    output_type result{input.items.size(), mr};
     for (std::size_t i = 0; i < result.size(); ++i) {
         result[i].items =
             typename CONTAINER_TYPES::host::item_vector::value_type{mr};

--- a/device/common/include/traccc/device/impl/container_h2d_copy_alg.ipp
+++ b/device/common/include/traccc/device/impl/container_h2d_copy_alg.ipp
@@ -26,7 +26,7 @@ container_h2d_copy_alg<CONTAINER_TYPES>::operator()(input_type input) const {
     // Get the sizes of the jagged vector. Remember that the input comes from
     // host accessible memory. (Using the vecmem::copy object is not a good idea
     // in this case.)
-    assert(input.headers.size() == input.items.m_size);
+    assert(input.headers.size() == input.items.size());
     const typename std::remove_reference<typename std::remove_cv<
         input_type>::type>::type::header_vector::size_type size =
         input.headers.size();

--- a/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
@@ -25,12 +25,9 @@
 namespace traccc::cuda {
 
 /// Seed finding for cuda
-class seed_finding
-    : public algorithm<vecmem::data::vector_buffer<seed>(
-          const spacepoint_container_types::const_view&,
-          const sp_grid_const_view&)>,
-      public algorithm<vecmem::data::vector_buffer<seed>(
-          const spacepoint_container_types::buffer&, const sp_grid_buffer&)> {
+class seed_finding : public algorithm<vecmem::data::vector_buffer<seed>(
+                         const spacepoint_container_types::const_view&,
+                         const sp_grid_const_view&)> {
 
     public:
     /// Constructor for the cuda seed finding
@@ -52,23 +49,6 @@ class seed_finding
     vecmem::data::vector_buffer<seed> operator()(
         const spacepoint_container_types::const_view& spacepoints_view,
         const sp_grid_const_view& g2_view) const override;
-
-    /// Callable operator for the seed finding
-    ///
-    /// @param spacepoints_buffer   is a buffer of all spacepoints in the event
-    /// @param g2_buffer            is a buffer of the spacepoint grid
-    /// @return                     a vector buffer of seeds
-    ///
-    vecmem::data::vector_buffer<seed> operator()(
-        const spacepoint_container_types::buffer& spacepoints_buffer,
-        const sp_grid_buffer& g2_buffer) const override;
-
-    private:
-    /// Implementation for the public seed finding operators.
-    vecmem::data::vector_buffer<seed> operator()(
-        const spacepoint_container_types::const_view& spacepoints_view,
-        const sp_grid_const_view& g2_view,
-        const std::vector<unsigned int>& grid_sizes) const;
 
     private:
     seedfinder_config m_seedfinder_config;

--- a/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
@@ -26,9 +26,7 @@ namespace traccc::cuda {
 
 /// Main algorithm for performing the track seeding on an NVIDIA GPU
 class seeding_algorithm : public algorithm<vecmem::data::vector_buffer<seed>(
-                              const spacepoint_container_types::const_view&)>,
-                          public algorithm<vecmem::data::vector_buffer<seed>(
-                              const spacepoint_container_types::buffer&)> {
+                              const spacepoint_container_types::const_view&)> {
 
     public:
     /// Constructor for the seed finding algorithm
@@ -44,15 +42,6 @@ class seeding_algorithm : public algorithm<vecmem::data::vector_buffer<seed>(
     ///
     vecmem::data::vector_buffer<seed> operator()(
         const spacepoint_container_types::const_view& spacepoints_view)
-        const override;
-
-    /// Operator executing the algorithm.
-    ///
-    /// @param spacepoints_buffer is a buffer of all spacepoints in the event
-    /// @return the buffer of track seeds reconstructed from the spacepoints
-    ///
-    vecmem::data::vector_buffer<seed> operator()(
-        const spacepoint_container_types::buffer& spacepoints_buffer)
         const override;
 
     private:

--- a/device/cuda/include/traccc/cuda/seeding/spacepoint_binning.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/spacepoint_binning.hpp
@@ -25,9 +25,7 @@ namespace traccc::cuda {
 
 /// Spacepoing binning executed on a CUDA device
 class spacepoint_binning : public algorithm<sp_grid_buffer(
-                               const spacepoint_container_types::const_view&)>,
-                           public algorithm<sp_grid_buffer(
-                               const spacepoint_container_types::buffer&)> {
+                               const spacepoint_container_types::const_view&)> {
 
     public:
     /// Constructor for the algorithm
@@ -39,16 +37,7 @@ class spacepoint_binning : public algorithm<sp_grid_buffer(
     sp_grid_buffer operator()(const spacepoint_container_types::const_view&
                                   spacepoints_view) const override;
 
-    /// Function executing the algorithm with spacepoint buffer
-    sp_grid_buffer operator()(const spacepoint_container_types::buffer&
-                                  spacepoints_buffer) const override;
-
     private:
-    /// Implementation for the public spacepoint binning operators
-    sp_grid_buffer operator()(
-        const spacepoint_container_types::const_view& spacepoints_view,
-        const std::vector<unsigned int>& sp_sizes) const;
-
     /// Member variables
     seedfinder_config m_config;
     std::pair<sp_grid::axis_p0_type, sp_grid::axis_p1_type> m_axes;

--- a/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
@@ -22,10 +22,7 @@ namespace cuda {
 struct track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
           const spacepoint_container_types::const_view&,
-          const vecmem::data::vector_view<const seed>&)>,
-      public algorithm<host_bound_track_parameters_collection(
-          const spacepoint_container_types::buffer&,
-          const vecmem::data::vector_buffer<seed>&)> {
+          const vecmem::data::vector_view<const seed>&)> {
 
     public:
     /// Constructor for track_params_estimation
@@ -43,24 +40,10 @@ struct track_params_estimation
         const spacepoint_container_types::const_view& spacepoints_view,
         const vecmem::data::vector_view<const seed>& seeds_view) const override;
 
-    /// Callable operator for track_params_esitmation
-    ///
-    /// @param spaepoints_buffer   is the buffer of the spacepoint container
-    /// @param seeds_buffer        is the buffer of the seed container
-    /// @return                    vector of bound track parameters
-    ///
-    host_bound_track_parameters_collection operator()(
-        const spacepoint_container_types::buffer& spacepoints_buffer,
-        const vecmem::data::vector_buffer<seed>& seeds_buffer) const override;
-
     private:
-    /// Implementation for the public track params estimation operators
-    host_bound_track_parameters_collection operator()(
-        const spacepoint_container_types::const_view& spacepoints_view,
-        const vecmem::data::vector_view<const seed>& seeds_view,
-        std::size_t seeds_size) const;
-
+    /// Memory resource used by the algorithm
     traccc::memory_resource m_mr;
+    /// Copy object used by the algorithm
     std::unique_ptr<vecmem::copy> m_copy;
 };
 

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -147,25 +147,9 @@ seed_finding::seed_finding(const seedfinder_config& config,
 vecmem::data::vector_buffer<seed> seed_finding::operator()(
     const spacepoint_container_types::const_view& spacepoints_view,
     const sp_grid_const_view& g2_view) const {
+
     // Get the sizes from the grid view
     auto grid_sizes = m_copy->get_sizes(g2_view._data_view);
-
-    return this->operator()(spacepoints_view, g2_view, grid_sizes);
-}
-
-vecmem::data::vector_buffer<seed> seed_finding::operator()(
-    const spacepoint_container_types::buffer& spacepoints_buffer,
-    const sp_grid_buffer& g2_buffer) const {
-    // Get the sizes from the grid buffer
-    auto grid_sizes = m_copy->get_sizes(g2_buffer._buffer);
-
-    return this->operator()(spacepoints_buffer, g2_buffer, grid_sizes);
-}
-
-vecmem::data::vector_buffer<seed> seed_finding::operator()(
-    const spacepoint_container_types::const_view& spacepoints_view,
-    const sp_grid_const_view& g2_view,
-    const std::vector<unsigned int>& grid_sizes) const {
 
     // Create prefix sum buffer
     vecmem::data::vector_buffer sp_grid_prefix_sum_buff =

--- a/device/cuda/src/seeding/seeding_algorithm.cpp
+++ b/device/cuda/src/seeding/seeding_algorithm.cpp
@@ -66,11 +66,4 @@ vecmem::data::vector_buffer<seed> seeding_algorithm::operator()(
                           m_spacepoint_binning(spacepoints_view));
 }
 
-vecmem::data::vector_buffer<seed> seeding_algorithm::operator()(
-    const spacepoint_container_types::buffer& spacepoints_buffer) const {
-
-    return m_seed_finding(spacepoints_buffer,
-                          m_spacepoint_binning(spacepoints_buffer));
-}
-
 }  // namespace traccc::cuda

--- a/device/cuda/src/seeding/spacepoint_binning.cu
+++ b/device/cuda/src/seeding/spacepoint_binning.cu
@@ -70,22 +70,6 @@ sp_grid_buffer spacepoint_binning::operator()(
     // Get the spacepoint sizes from the view
     auto sp_sizes = m_copy->get_sizes(spacepoints_view.items);
 
-    return this->operator()(spacepoints_view, sp_sizes);
-}
-
-sp_grid_buffer spacepoint_binning::operator()(
-    const spacepoint_container_types::buffer& spacepoints_buffer) const {
-
-    // Get the spacepoint sizes from the buffer
-    auto sp_sizes = m_copy->get_sizes(spacepoints_buffer.items);
-
-    return this->operator()(spacepoints_buffer, sp_sizes);
-}
-
-sp_grid_buffer spacepoint_binning::operator()(
-    const spacepoint_container_types::const_view& spacepoints_view,
-    const std::vector<unsigned int>& sp_sizes) const {
-
     // Create prefix sum buffer
     vecmem::data::vector_buffer sp_prefix_sum_buff =
         make_prefix_sum_buff(sp_sizes, *m_copy, m_mr);

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -43,25 +43,7 @@ host_bound_track_parameters_collection track_params_estimation::operator()(
     const vecmem::data::vector_view<const seed>& seeds_view) const {
 
     // Get the size of the seeds view
-    auto seeds_size = m_copy->get_size(seeds_view);
-
-    return this->operator()(spacepoints_view, seeds_view, seeds_size);
-}
-
-host_bound_track_parameters_collection track_params_estimation::operator()(
-    const spacepoint_container_types::buffer& spacepoints_buffer,
-    const vecmem::data::vector_buffer<seed>& seeds_buffer) const {
-
-    // Get the size of the seeds buffer
-    auto seeds_size = m_copy->get_size(seeds_buffer);
-
-    return this->operator()(spacepoints_buffer, seeds_buffer, seeds_size);
-}
-
-host_bound_track_parameters_collection track_params_estimation::operator()(
-    const spacepoint_container_types::const_view& spacepoints_view,
-    const vecmem::data::vector_view<const seed>& seeds_view,
-    std::size_t seeds_size) const {
+    const std::size_t seeds_size = m_copy->get_size(seeds_view);
 
     // Create output host container
     host_bound_track_parameters_collection params(

--- a/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
@@ -28,12 +28,9 @@
 namespace traccc::sycl {
 
 // Sycl seeding function object
-class seed_finding
-    : public algorithm<vecmem::data::vector_buffer<seed>(
-          const spacepoint_container_types::const_view&,
-          const sp_grid_const_view&)>,
-      public algorithm<vecmem::data::vector_buffer<seed>(
-          const spacepoint_container_types::buffer&, const sp_grid_buffer&)> {
+class seed_finding : public algorithm<vecmem::data::vector_buffer<seed>(
+                         const spacepoint_container_types::const_view&,
+                         const sp_grid_const_view&)> {
 
     public:
     /// Constructor for the sycl seed finding
@@ -58,23 +55,7 @@ class seed_finding
         const spacepoint_container_types::const_view& spacepoints_view,
         const sp_grid_const_view& g2_view) const override;
 
-    /// Callable operator for the seed finding
-    ///
-    /// @param spacepoints_buffer   is a buffer of all spacepoints in the event
-    /// @param g2_buffer            is a buffer of the spacepoint grid
-    /// @return                     a vector buffer of seeds
-    ///
-    vecmem::data::vector_buffer<seed> operator()(
-        const spacepoint_container_types::buffer& spacepoints_buffer,
-        const sp_grid_buffer& g2_buffer) const override;
-
     private:
-    /// Implementation for the public seed finding operators.
-    vecmem::data::vector_buffer<seed> operator()(
-        const spacepoint_container_types::const_view& spacepoints_view,
-        const sp_grid_const_view& g2_view,
-        const std::vector<unsigned int>& grid_sizes) const;
-
     /// Private member variables
     seedfinder_config m_seedfinder_config;
     seedfilter_config m_seedfilter_config;

--- a/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
@@ -27,9 +27,7 @@ namespace traccc::sycl {
 
 /// Main algorithm for performing the track seeding using oneAPI/SYCL
 class seeding_algorithm : public algorithm<vecmem::data::vector_buffer<seed>(
-                              const spacepoint_container_types::const_view&)>,
-                          public algorithm<vecmem::data::vector_buffer<seed>(
-                              const spacepoint_container_types::buffer&)> {
+                              const spacepoint_container_types::const_view&)> {
 
     public:
     /// Constructor for the seed finding algorithm
@@ -47,15 +45,6 @@ class seeding_algorithm : public algorithm<vecmem::data::vector_buffer<seed>(
     ///
     vecmem::data::vector_buffer<seed> operator()(
         const spacepoint_container_types::const_view& spacepoints_view)
-        const override;
-
-    /// Operator executing the algorithm.
-    ///
-    /// @param spacepoints_buffer is a buffer of all spacepoints in the event
-    /// @return the buffer of track seeds reconstructed from the spacepoints
-    ///
-    vecmem::data::vector_buffer<seed> operator()(
-        const spacepoint_container_types::buffer& spacepoints_buffer)
         const override;
 
     private:

--- a/device/sycl/include/traccc/sycl/seeding/spacepoint_binning.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/spacepoint_binning.hpp
@@ -29,9 +29,7 @@ namespace traccc::sycl {
 
 /// Spacepoing binning executed on a SYCL device
 class spacepoint_binning : public algorithm<sp_grid_buffer(
-                               const spacepoint_container_types::const_view&)>,
-                           public algorithm<sp_grid_buffer(
-                               const spacepoint_container_types::buffer&)> {
+                               const spacepoint_container_types::const_view&)> {
 
     public:
     /// Constructor for the algorithm
@@ -43,16 +41,7 @@ class spacepoint_binning : public algorithm<sp_grid_buffer(
     sp_grid_buffer operator()(const spacepoint_container_types::const_view&
                                   spacepoints_view) const override;
 
-    /// Function executing the algorithm with spacepoint buffer
-    sp_grid_buffer operator()(const spacepoint_container_types::buffer&
-                                  spacepoints_buffer) const override;
-
     private:
-    /// Implementation for the public spacepoint binning operators
-    sp_grid_buffer operator()(
-        const spacepoint_container_types::const_view& spacepoints_view,
-        const std::vector<unsigned int>& sp_sizes) const;
-
     /// Member variables
     seedfinder_config m_config;
     std::pair<sp_grid::axis_p0_type, sp_grid::axis_p1_type> m_axes;

--- a/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
@@ -30,10 +30,7 @@ namespace traccc::sycl {
 struct track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
           const spacepoint_container_types::const_view&,
-          const vecmem::data::vector_view<const seed>&)>,
-      public algorithm<host_bound_track_parameters_collection(
-          const spacepoint_container_types::buffer&,
-          const vecmem::data::vector_buffer<seed>&)> {
+          const vecmem::data::vector_view<const seed>&)> {
 
     public:
     /// Constructor for track_params_estimation
@@ -55,23 +52,7 @@ struct track_params_estimation
         const spacepoint_container_types::const_view& spacepoints_view,
         const vecmem::data::vector_view<const seed>& seeds_view) const override;
 
-    /// Callable operator for track_params_esitmation
-    ///
-    /// @param spaepoints_buffer   is the buffer of the spacepoint container
-    /// @param seeds_buffer        is the buffer of the seed container
-    /// @return                    vector of bound track parameters
-    ///
-    host_bound_track_parameters_collection operator()(
-        const spacepoint_container_types::buffer& spacepoints_buffer,
-        const vecmem::data::vector_buffer<seed>& seeds_buffer) const override;
-
     private:
-    /// Implementation for the public track params estimation operators
-    host_bound_track_parameters_collection operator()(
-        const spacepoint_container_types::const_view& spacepoints_view,
-        const vecmem::data::vector_view<const seed>& seeds_view,
-        std::size_t seeds_size) const;
-
     // Private member variables
     traccc::memory_resource m_mr;
     mutable queue_wrapper m_queue;

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -80,25 +80,9 @@ seed_finding::seed_finding(const seedfinder_config& config,
 vecmem::data::vector_buffer<seed> seed_finding::operator()(
     const spacepoint_container_types::const_view& spacepoints_view,
     const sp_grid_const_view& g2_view) const {
+
     // Get the sizes from the grid view
     auto grid_sizes = m_copy->get_sizes(g2_view._data_view);
-
-    return this->operator()(spacepoints_view, g2_view, grid_sizes);
-}
-
-vecmem::data::vector_buffer<seed> seed_finding::operator()(
-    const spacepoint_container_types::buffer& spacepoints_buffer,
-    const sp_grid_buffer& g2_buffer) const {
-    // Get the sizes from the grid buffer
-    auto grid_sizes = m_copy->get_sizes(g2_buffer._buffer);
-
-    return this->operator()(spacepoints_buffer, g2_buffer, grid_sizes);
-}
-
-vecmem::data::vector_buffer<seed> seed_finding::operator()(
-    const spacepoint_container_types::const_view& spacepoints_view,
-    const sp_grid_const_view& g2_view,
-    const std::vector<unsigned int>& grid_sizes) const {
 
     // Create prefix sum buffer and its view
     vecmem::data::vector_buffer sp_grid_prefix_sum_buff = make_prefix_sum_buff(

--- a/device/sycl/src/seeding/seeding_algorithm.cpp
+++ b/device/sycl/src/seeding/seeding_algorithm.cpp
@@ -68,11 +68,4 @@ vecmem::data::vector_buffer<seed> seeding_algorithm::operator()(
                           m_spacepoint_binning(spacepoints_view));
 }
 
-vecmem::data::vector_buffer<seed> seeding_algorithm::operator()(
-    const spacepoint_container_types::buffer& spacepoints_buffer) const {
-
-    return m_seed_finding(spacepoints_buffer,
-                          m_spacepoint_binning(spacepoints_buffer));
-}
-
 }  // namespace traccc::sycl

--- a/device/sycl/src/seeding/spacepoint_binning.sycl
+++ b/device/sycl/src/seeding/spacepoint_binning.sycl
@@ -58,22 +58,6 @@ sp_grid_buffer spacepoint_binning::operator()(
     // Get the spacepoint sizes from the view
     auto sp_sizes = m_copy->get_sizes(spacepoints_view.items);
 
-    return this->operator()(spacepoints_view, sp_sizes);
-}
-
-sp_grid_buffer spacepoint_binning::operator()(
-    const spacepoint_container_types::buffer& spacepoints_buffer) const {
-
-    // Get the spacepoint sizes from the buffer
-    auto sp_sizes = m_copy->get_sizes(spacepoints_buffer.items);
-
-    return this->operator()(spacepoints_buffer, sp_sizes);
-}
-
-sp_grid_buffer spacepoint_binning::operator()(
-    const spacepoint_container_types::const_view& spacepoints_view,
-    const std::vector<unsigned int>& sp_sizes) const {
-
     // Create prefix sum buffer and its view
     vecmem::data::vector_buffer sp_prefix_sum_buff = make_prefix_sum_buff(
         sp_sizes, *m_copy, m_mr, details::get_queue(m_queue));

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -87,24 +87,6 @@ host_bound_track_parameters_collection track_params_estimation::operator()(
     // Get the size of the seeds view
     auto seeds_size = m_copy->get_size(seeds_view);
 
-    return this->operator()(spacepoints_view, seeds_view, seeds_size);
-}
-
-host_bound_track_parameters_collection track_params_estimation::operator()(
-    const spacepoint_container_types::buffer& spacepoints_buffer,
-    const vecmem::data::vector_buffer<seed>& seeds_buffer) const {
-
-    // Get the size of the seeds buffer
-    auto seeds_size = m_copy->get_size(seeds_buffer);
-
-    return this->operator()(spacepoints_buffer, seeds_buffer, seeds_size);
-}
-
-host_bound_track_parameters_collection track_params_estimation::operator()(
-    const spacepoint_container_types::const_view& spacepoints_view,
-    const vecmem::data::vector_view<const seed>& seeds_view,
-    std::size_t seeds_size) const {
-
     // Create output host container
     host_bound_track_parameters_collection params(
         seeds_size, (m_mr.host ? m_mr.host : &(m_mr.main)));

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.17.0.tar.gz;URL_MD5;4911795b54045159ac0428688f900210"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.19.0.tar.gz;URL_MD5;2bfc252d83b5b8f533e8b13e89ff9e9d"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
These are the simplifications that I wanted to achieve with https://github.com/acts-project/vecmem/pull/197. With the latest version of VecMem it is no longer necessary to handle `vecmem::data::jagged_vector_buffer` differently from `vecmem::data::jagged_vector_view`. Which meant that a lot of our algorithms could be simplified. :wink:

In my local tests everything still works, so I'm pretty sure that this is a safe update. :crossed_fingers: