### PR TITLE
Seed EDM Update, main branch (2022.10.10.)

### DIFF
--- a/core/include/traccc/edm/seed.hpp
+++ b/core/include/traccc/edm/seed.hpp
@@ -58,36 +58,7 @@ TRACCC_HOST std::vector<std::array<spacepoint, 3>> get_spacepoint_vector(
     return result;
 }
 
-/// Container of internal_spacepoint for an event
-template <template <typename> class vector_t>
-using seed_collection = vector_t<seed>;
-
-/// Convenience declaration for the seed collection type to use
-/// in host code
-using host_seed_collection = seed_collection<vecmem::vector>;
-
-/// Convenience declaration for the seed collection type to use
-/// in device code
-using device_seed_collection = seed_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the seed container type to use in
-/// host code
-using host_seed_container = host_container<unsigned int, seed>;
-
-/// Convenience declaration for the seed container type to use in
-/// device code
-using device_seed_container = device_container<unsigned int, seed>;
-
-/// Convenience declaration for the seed container data type to
-/// use in host code
-using seed_container_data = container_data<unsigned int, seed>;
-
-/// Convenience declaration for the seed container buffer type to
-/// use in host code
-using seed_container_buffer = container_buffer<unsigned int, seed>;
-
-/// Convenience declaration for the seed container view type to
-/// use in host code
-using seed_container_view = container_view<unsigned int, seed>;
+/// Declare all seed collection types
+using seed_collection_types = collection_types<seed>;
 
 }  // namespace traccc

--- a/core/include/traccc/seeding/seed_filtering.hpp
+++ b/core/include/traccc/seeding/seed_filtering.hpp
@@ -34,7 +34,7 @@ class seed_filtering {
     /// added
     void operator()(const spacepoint_container_types::host& sp_container,
                     const sp_grid& g2, host_triplet_collection& triplets,
-                    host_seed_collection& seeds) const;
+                    seed_collection_types::host& seeds) const;
 
     private:
     /// Seed filter configuration

--- a/core/include/traccc/seeding/seed_finding.hpp
+++ b/core/include/traccc/seeding/seed_finding.hpp
@@ -21,7 +21,7 @@ namespace traccc {
 
 /// Seed finding
 class seed_finding
-    : public algorithm<host_seed_collection(
+    : public algorithm<seed_collection_types::host(
           const spacepoint_container_types::host&, const sp_grid&)> {
 
     public:

--- a/core/include/traccc/seeding/seeding_algorithm.hpp
+++ b/core/include/traccc/seeding/seeding_algorithm.hpp
@@ -20,7 +20,7 @@
 namespace traccc {
 
 /// Main algorithm for performing the track seeding on the CPU
-class seeding_algorithm : public algorithm<host_seed_collection(
+class seeding_algorithm : public algorithm<seed_collection_types::host(
                               const spacepoint_container_types::host&)> {
 
     public:

--- a/core/include/traccc/seeding/track_params_estimation.hpp
+++ b/core/include/traccc/seeding/track_params_estimation.hpp
@@ -28,7 +28,7 @@ namespace traccc {
 class track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
           const spacepoint_container_types::host&,
-          const host_seed_collection&)> {
+          const seed_collection_types::host&)> {
 
     public:
     /// Constructor for track_params_estimation
@@ -42,8 +42,9 @@ class track_params_estimation
     /// @param seeds The reconstructed track seeds of the event
     /// @return A vector of bound track parameters
     ///
-    output_type operator()(const spacepoint_container_types::host& spacepoints,
-                           const host_seed_collection& seeds) const override;
+    output_type operator()(
+        const spacepoint_container_types::host& spacepoints,
+        const seed_collection_types::host& seeds) const override;
 
     private:
     /// The memory resource to use in the algorithm

--- a/core/src/seeding/seed_filtering.cpp
+++ b/core/src/seeding/seed_filtering.cpp
@@ -17,9 +17,10 @@ seed_filtering::seed_filtering(const seedfilter_config& config)
 
 void seed_filtering::operator()(
     const spacepoint_container_types::host& sp_container, const sp_grid& g2,
-    host_triplet_collection& triplets, host_seed_collection& seeds) const {
+    host_triplet_collection& triplets,
+    seed_collection_types::host& seeds) const {
 
-    host_seed_collection seeds_per_spM;
+    seed_collection_types::host seeds_per_spM;
 
     for (triplet& triplet : triplets) {
         // bottom
@@ -68,7 +69,7 @@ void seed_filtering::operator()(
                   }
               });
 
-    host_seed_collection new_seeds;
+    seed_collection_types::host new_seeds;
     if (seeds_per_spM.size() > 1) {
         new_seeds.push_back(seeds_per_spM[0]);
 

--- a/core/src/seeding/track_params_estimation.cpp
+++ b/core/src/seeding/track_params_estimation.cpp
@@ -17,7 +17,7 @@ track_params_estimation::track_params_estimation(vecmem::memory_resource& mr)
 
 track_params_estimation::output_type track_params_estimation::operator()(
     const spacepoint_container_types::host& spacepoints,
-    const host_seed_collection& seeds) const {
+    const seed_collection_types::host& seeds) const {
 
     output_type result(&m_mr.get());
 

--- a/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
+++ b/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
@@ -62,7 +62,7 @@ void select_seeds(
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,
     const triplet_container_view& triplet_view, triplet* data,
-    vecmem::data::vector_view<seed> seed_view) {
+    seed_collection_types::view seed_view) {
 
     // Check if anything needs to be done.
     const vecmem::device_vector<const prefix_sum_element_t> dc_prefix_sum(
@@ -82,7 +82,7 @@ void select_seeds(
     device::doublet_counter_container_types::const_device
         doublet_counter_device(doublet_counter_container);
     device_triplet_container triplet_device(triplet_view);
-    device_seed_collection seed_device(seed_view);
+    seed_collection_types::device seed_device(seed_view);
 
     // Header of triplet: number of triplets per bin
     // Item of triplet: triplet objects per bin

--- a/device/common/include/traccc/seeding/device/select_seeds.hpp
+++ b/device/common/include/traccc/seeding/device/select_seeds.hpp
@@ -1,3 +1,10 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/device/fill_prefix_sum.hpp"
@@ -35,7 +42,7 @@ void select_seeds(
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,
     const triplet_container_view& tc_view, triplet* data,
-    vecmem::data::vector_view<seed> seed_view);
+    seed_collection_types::view seed_view);
 
 }  // namespace traccc::device
 

--- a/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
@@ -16,7 +16,6 @@
 #include "traccc/utils/memory_resource.hpp"
 
 // VecMem include(s).
-#include <vecmem/containers/data/vector_buffer.hpp>
 #include <vecmem/utils/copy.hpp>
 
 // System include(s).
@@ -25,7 +24,7 @@
 namespace traccc::cuda {
 
 /// Seed finding for cuda
-class seed_finding : public algorithm<vecmem::data::vector_buffer<seed>(
+class seed_finding : public algorithm<seed_collection_types::buffer(
                          const spacepoint_container_types::const_view&,
                          const sp_grid_const_view&)> {
 
@@ -46,7 +45,7 @@ class seed_finding : public algorithm<vecmem::data::vector_buffer<seed>(
     /// @param g2_view              is a view of the spacepoint grid
     /// @return                     a vector buffer of seeds
     ///
-    vecmem::data::vector_buffer<seed> operator()(
+    seed_collection_types::buffer operator()(
         const spacepoint_container_types::const_view& spacepoints_view,
         const sp_grid_const_view& g2_view) const override;
 

--- a/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
@@ -25,7 +25,7 @@
 namespace traccc::cuda {
 
 /// Main algorithm for performing the track seeding on an NVIDIA GPU
-class seeding_algorithm : public algorithm<vecmem::data::vector_buffer<seed>(
+class seeding_algorithm : public algorithm<seed_collection_types::buffer(
                               const spacepoint_container_types::const_view&)> {
 
     public:
@@ -40,7 +40,7 @@ class seeding_algorithm : public algorithm<vecmem::data::vector_buffer<seed>(
     /// @param spacepoints_view is a view of all spacepoints in the event
     /// @return the buffer of track seeds reconstructed from the spacepoints
     ///
-    vecmem::data::vector_buffer<seed> operator()(
+    seed_collection_types::buffer operator()(
         const spacepoint_container_types::const_view& spacepoints_view)
         const override;
 

--- a/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
@@ -22,7 +22,7 @@ namespace cuda {
 struct track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
           const spacepoint_container_types::const_view&,
-          const vecmem::data::vector_view<const seed>&)> {
+          const seed_collection_types::const_view&)> {
 
     public:
     /// Constructor for track_params_estimation
@@ -38,7 +38,7 @@ struct track_params_estimation
     ///
     host_bound_track_parameters_collection operator()(
         const spacepoint_container_types::const_view& spacepoints_view,
-        const vecmem::data::vector_view<const seed>& seeds_view) const override;
+        const seed_collection_types::const_view& seeds_view) const override;
 
     private:
     /// Memory resource used by the algorithm

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -113,7 +113,7 @@ __global__ void select_seeds(
     vecmem::data::vector_view<const device::prefix_sum_element_t> dc_ps_view,
     device::doublet_counter_container_types::const_view
         doublet_counter_container,
-    triplet_container_view tc_view, vecmem::data::vector_view<seed> seed_view) {
+    triplet_container_view tc_view, seed_collection_types::view seed_view) {
 
     // Array for temporary storage of triplets for comparing within seed
     // selecting kernel
@@ -144,7 +144,7 @@ seed_finding::seed_finding(const seedfinder_config& config,
     }
 }
 
-vecmem::data::vector_buffer<seed> seed_finding::operator()(
+seed_collection_types::buffer seed_finding::operator()(
     const spacepoint_container_types::const_view& spacepoints_view,
     const sp_grid_const_view& g2_view) const {
 
@@ -287,7 +287,7 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
         n_triplets += h.m_nTriplets;
     }
 
-    vecmem::data::vector_buffer<seed> seed_buffer(n_triplets, 0, m_mr.main);
+    seed_collection_types::buffer seed_buffer(n_triplets, 0, m_mr.main);
     m_copy->setup(seed_buffer);
 
     // Calculate the number of threads and thread blocks to run the seed

--- a/device/cuda/src/seeding/seeding_algorithm.cpp
+++ b/device/cuda/src/seeding/seeding_algorithm.cpp
@@ -59,7 +59,7 @@ seeding_algorithm::seeding_algorithm(const traccc::memory_resource& mr)
                            default_spacepoint_grid_config(), mr),
       m_seed_finding(default_seedfinder_config(), seedfilter_config(), mr) {}
 
-vecmem::data::vector_buffer<seed> seeding_algorithm::operator()(
+seed_collection_types::buffer seeding_algorithm::operator()(
     const spacepoint_container_types::const_view& spacepoints_view) const {
 
     return m_seed_finding(spacepoints_view,

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -23,7 +23,7 @@ namespace cuda {
 /// spacepoints
 __global__ void track_params_estimating_kernel(
     spacepoint_container_types::const_view spacepoints_view,
-    vecmem::data::vector_view<const seed> seeds_view,
+    seed_collection_types::const_view seeds_view,
     vecmem::data::vector_view<bound_track_parameters> params_view);
 
 track_params_estimation::track_params_estimation(
@@ -40,7 +40,7 @@ track_params_estimation::track_params_estimation(
 
 host_bound_track_parameters_collection track_params_estimation::operator()(
     const spacepoint_container_types::const_view& spacepoints_view,
-    const vecmem::data::vector_view<const seed>& seeds_view) const {
+    const seed_collection_types::const_view& seeds_view) const {
 
     // Get the size of the seeds view
     const std::size_t seeds_size = m_copy->get_size(seeds_view);
@@ -83,13 +83,13 @@ host_bound_track_parameters_collection track_params_estimation::operator()(
 
 __global__ void track_params_estimating_kernel(
     spacepoint_container_types::const_view spacepoints_view,
-    vecmem::data::vector_view<const seed> seeds_view,
+    seed_collection_types::const_view seeds_view,
     vecmem::data::vector_view<bound_track_parameters> params_view) {
 
     // Get device container for input parameters
     const spacepoint_container_types::const_device spacepoints_device(
         spacepoints_view);
-    vecmem::device_vector<const seed> seeds_device(seeds_view);
+    seed_collection_types::const_device seeds_device(seeds_view);
     device_bound_track_parameters_collection params_device(params_view);
 
     // vector index for threads

--- a/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
@@ -28,7 +28,7 @@
 namespace traccc::sycl {
 
 // Sycl seeding function object
-class seed_finding : public algorithm<vecmem::data::vector_buffer<seed>(
+class seed_finding : public algorithm<seed_collection_types::buffer(
                          const spacepoint_container_types::const_view&,
                          const sp_grid_const_view&)> {
 
@@ -51,7 +51,7 @@ class seed_finding : public algorithm<vecmem::data::vector_buffer<seed>(
     /// @param g2_view              is a view of the spacepoint grid
     /// @return                     a vector buffer of seeds
     ///
-    vecmem::data::vector_buffer<seed> operator()(
+    seed_collection_types::buffer operator()(
         const spacepoint_container_types::const_view& spacepoints_view,
         const sp_grid_const_view& g2_view) const override;
 

--- a/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
@@ -26,7 +26,7 @@
 namespace traccc::sycl {
 
 /// Main algorithm for performing the track seeding using oneAPI/SYCL
-class seeding_algorithm : public algorithm<vecmem::data::vector_buffer<seed>(
+class seeding_algorithm : public algorithm<seed_collection_types::buffer(
                               const spacepoint_container_types::const_view&)> {
 
     public:
@@ -43,7 +43,7 @@ class seeding_algorithm : public algorithm<vecmem::data::vector_buffer<seed>(
     /// @param spacepoints_view is a view of all spacepoints in the event
     /// @return the buffer of track seeds reconstructed from the spacepoints
     ///
-    vecmem::data::vector_buffer<seed> operator()(
+    seed_collection_types::buffer operator()(
         const spacepoint_container_types::const_view& spacepoints_view)
         const override;
 

--- a/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
@@ -30,7 +30,7 @@ namespace traccc::sycl {
 struct track_params_estimation
     : public algorithm<host_bound_track_parameters_collection(
           const spacepoint_container_types::const_view&,
-          const vecmem::data::vector_view<const seed>&)> {
+          const seed_collection_types::const_view&)> {
 
     public:
     /// Constructor for track_params_estimation
@@ -50,7 +50,7 @@ struct track_params_estimation
     ///
     host_bound_track_parameters_collection operator()(
         const spacepoint_container_types::const_view& spacepoints_view,
-        const vecmem::data::vector_view<const seed>& seeds_view) const override;
+        const seed_collection_types::const_view& seeds_view) const override;
 
     private:
     // Private member variables

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -77,7 +77,7 @@ seed_finding::seed_finding(const seedfinder_config& config,
     }
 }
 
-vecmem::data::vector_buffer<seed> seed_finding::operator()(
+seed_collection_types::buffer seed_finding::operator()(
     const spacepoint_container_types::const_view& spacepoints_view,
     const sp_grid_const_view& g2_view) const {
 
@@ -287,9 +287,9 @@ vecmem::data::vector_buffer<seed> seed_finding::operator()(
     }
 
     // Create seed buffer object and its view
-    vecmem::data::vector_buffer<seed> seed_buffer(n_triplets, 0, m_mr.main);
+    seed_collection_types::buffer seed_buffer(n_triplets, 0, m_mr.main);
     m_copy->setup(seed_buffer);
-    vecmem::data::vector_view<seed> seed_view(seed_buffer);
+    seed_collection_types::view seed_view(seed_buffer);
 
     // Calculate the range to run the seed selecting for
     static constexpr unsigned int seedSelectingLocalSize = 32 * 2;

--- a/device/sycl/src/seeding/seeding_algorithm.cpp
+++ b/device/sycl/src/seeding/seeding_algorithm.cpp
@@ -61,7 +61,7 @@ seeding_algorithm::seeding_algorithm(const traccc::memory_resource& mr,
       m_seed_finding(default_seedfinder_config(), seedfilter_config(), mr,
                      queue) {}
 
-vecmem::data::vector_buffer<seed> seeding_algorithm::operator()(
+seed_collection_types::buffer seeding_algorithm::operator()(
     const spacepoint_container_types::const_view& spacepoints_view) const {
 
     return m_seed_finding(spacepoints_view,

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -22,7 +22,7 @@ class TrackParamsEstimation {
     public:
     TrackParamsEstimation(
         const spacepoint_container_types::const_view& spacepoints_view,
-        const vecmem::data::vector_view<const seed>& seeds_view,
+        const seed_collection_types::const_view& seeds_view,
         vecmem::data::vector_view<bound_track_parameters>& params_view)
         : m_spacepoints_view(spacepoints_view),
           m_seeds_view(seeds_view),
@@ -40,7 +40,7 @@ class TrackParamsEstimation {
         // Get device container for input parameters
         const spacepoint_container_types::const_device spacepoints_device(
             m_spacepoints_view);
-        vecmem::device_vector<const seed> seeds_device(m_seeds_view);
+        seed_collection_types::const_device seeds_device(m_seeds_view);
         device_bound_track_parameters_collection params_device(m_params_view);
 
         // vector index for threads
@@ -64,7 +64,7 @@ class TrackParamsEstimation {
 
     private:
     spacepoint_container_types::const_view m_spacepoints_view;
-    vecmem::data::vector_view<const seed> m_seeds_view;
+    seed_collection_types::const_view m_seeds_view;
     vecmem::data::vector_view<bound_track_parameters> m_params_view;
 };
 
@@ -82,7 +82,7 @@ track_params_estimation::track_params_estimation(
 
 host_bound_track_parameters_collection track_params_estimation::operator()(
     const spacepoint_container_types::const_view& spacepoints_view,
-    const vecmem::data::vector_view<const seed>& seeds_view) const {
+    const seed_collection_types::const_view& seeds_view) const {
 
     // Get the size of the seeds view
     auto seeds_size = m_copy->get_size(seeds_view);

--- a/examples/performance/include/traccc/efficiency/seeding_performance_writer.hpp
+++ b/examples/performance/include/traccc/efficiency/seeding_performance_writer.hpp
@@ -70,7 +70,7 @@ class seeding_performance_writer {
         m_duplication_plot_tool.book(name, m_duplication_plot_caches[name]);
     }
 
-    void write(std::string name, const host_seed_collection& seeds,
+    void write(std::string name, const seed_collection_types::host& seeds,
                const spacepoint_container_types::host& spacepoints,
                event_map& evt_map) {
 

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -162,7 +162,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
 
         // Copy the seeds to the host for comparisons
         vecmem::copy copy;
-        traccc::host_seed_collection seeds_cuda;
+        traccc::seed_collection_types::host seeds_cuda;
         copy(seeds_cuda_buffer, seeds_cuda);
 
         if (run_cpu) {

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -241,7 +241,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         vecmem::cuda::copy copy;
         traccc::spacepoint_container_types::host spacepoints_per_event_cuda;
-        traccc::host_seed_collection seeds_cuda;
+        traccc::seed_collection_types::host seeds_cuda;
 
         if (run_cpu) {
 

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -179,7 +179,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
 
         // Copy the seeds to the host for comparisons
         vecmem::copy copy;
-        traccc::host_seed_collection seeds_sycl;
+        traccc::seed_collection_types::host seeds_sycl;
         copy(seeds_sycl_buffer, seeds_sycl);
 
         if (run_cpu) {

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -271,7 +271,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         // Copy the seeds and spacepoints to the host for comparisons
         vecmem::sycl::copy copy(&q);
         traccc::spacepoint_container_types::host spacepoints_per_event_sycl;
-        traccc::host_seed_collection seeds_sycl;
+        traccc::seed_collection_types::host seeds_sycl;
 
         /*----------------------------------
           compare cpu and sycl result


### PR DESCRIPTION
While working on #247 I was reminded that we should really continue with making all the EDM types be defined in the same way.

@guilhermeAlmeida1, once this is in, you should also harmonise the implementations of `traccc::cuda::track_parameter_estimation` and `traccc::sycl::track_parameter_estimation`. (Introducing common code into the `traccc::device` namespace as for all the other algorithms.) That should be a relatively simple exercise.

Note that this PR depends on #247, so it's a Draft until that one gets merged in.