### PR TITLE
Seeding details EDM update

### DIFF
--- a/core/include/traccc/edm/track_parameters.hpp
+++ b/core/include/traccc/edm/track_parameters.hpp
@@ -98,19 +98,9 @@ inline bool operator==(const bound_track_parameters& lhs,
     return false;
 }
 
-/// Collection of bound_track_parameters
-template <template <typename> class vector_t>
-using bound_track_parameters_collection = vector_t<bound_track_parameters>;
-
-/// Convenient declaration for the bound track parameters collection type to use
-/// in host code
-using host_bound_track_parameters_collection =
-    bound_track_parameters_collection<vecmem::vector>;
-
-/// Convenient declaration for the bound track parameters collection type to use
-/// in device code
-using device_bound_track_parameters_collection =
-    bound_track_parameters_collection<vecmem::device_vector>;
+/// Declare all track_parameters collection types
+using bound_track_parameters_collection_types =
+    collection_types<bound_track_parameters>;
 
 struct curvilinear_track_parameters {
     using vector_t = bound_vector;

--- a/core/include/traccc/seeding/detail/doublet.hpp
+++ b/core/include/traccc/seeding/detail/doublet.hpp
@@ -32,33 +32,10 @@ inline TRACCC_HOST_DEVICE bool operator==(const doublet& lhs,
             lhs.sp2.sp_idx == rhs.sp2.sp_idx);
 }
 
-/// Container of doublet belonging to one detector module
-template <template <typename> class vector_t>
-using doublet_collection = vector_t<doublet>;
+/// Declare all doublet collection types
+using doublet_collection_types = collection_types<doublet>;
 
-/// Convenience declaration for the doublet collection type to use in host code
-using host_doublet_collection = doublet_collection<vecmem::vector>;
-
-/// Convenience declaration for the doublet collection type to use in device
-/// code
-using device_doublet_collection = doublet_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the doublet container type to use in host code
-using host_doublet_container = host_container<doublet_per_bin, doublet>;
-
-/// Convenience declaration for the doublet container type to use in device code
-using device_doublet_container = device_container<doublet_per_bin, doublet>;
-
-/// Convenience declaration for the doublet container data type to use in host
-/// code
-using doublet_container_data = container_data<doublet_per_bin, doublet>;
-
-/// Convenience declaration for the doublet container buffer type to use in host
-/// code
-using doublet_container_buffer = container_buffer<doublet_per_bin, doublet>;
-
-/// Convenience declaration for the doublet container view type to use in host
-/// code
-using doublet_container_view = container_view<doublet_per_bin, doublet>;
+/// Declare all doublet container types
+using doublet_container_types = container_types<doublet_per_bin, doublet>;
 
 }  // namespace traccc

--- a/core/include/traccc/seeding/detail/lin_circle.hpp
+++ b/core/include/traccc/seeding/detail/lin_circle.hpp
@@ -51,7 +51,4 @@ struct lin_circle {
 /// Declare all lin_circle collection types
 using lin_circle_collection_types = collection_types<lin_circle>;
 
-/// Declare all lin_circle container types
-using lin_circle_container_types = container_types<unsigned int, lin_circle>;
-
 }  // namespace traccc

--- a/core/include/traccc/seeding/detail/lin_circle.hpp
+++ b/core/include/traccc/seeding/detail/lin_circle.hpp
@@ -48,37 +48,10 @@ struct lin_circle {
     const scalar& V() const { return m_V; }
 };
 
-/// Container of lin_circle belonging to one detector module
-template <template <typename> class vector_t>
-using lin_circle_collection = vector_t<lin_circle>;
+/// Declare all lin_circle collection types
+using lin_circle_collection_types = collection_types<lin_circle>;
 
-/// Convenience declaration for the lin_circle collection type to use in host
-/// code
-using host_lin_circle_collection = lin_circle_collection<vecmem::vector>;
-
-/// Convenience declaration for the lin_circle collection type to use in device
-/// code
-using device_lin_circle_collection =
-    lin_circle_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the lin_circle container type to use in host
-/// code
-using host_lin_circle_container = host_container<unsigned int, lin_circle>;
-
-/// Convenience declaration for the lin_circle container type to use in device
-/// code
-using device_lin_circle_container = device_container<unsigned int, lin_circle>;
-
-/// Convenience declaration for the lin_circle container data type to use in
-/// host code
-using lin_circle_container_data = container_data<unsigned int, lin_circle>;
-
-/// Convenience declaration for the lin_circle container buffer type to use in
-/// host code
-using lin_circle_container_buffer = container_buffer<unsigned int, lin_circle>;
-
-/// Convenience declaration for the lin_circle container view type to use in
-/// host code
-using lin_circle_container_view = container_view<unsigned int, lin_circle>;
+/// Declare all lin_circle container types
+using lin_circle_container_types = container_types<unsigned int, lin_circle>;
 
 }  // namespace traccc

--- a/core/include/traccc/seeding/detail/singlet.hpp
+++ b/core/include/traccc/seeding/detail/singlet.hpp
@@ -30,10 +30,4 @@ inline TRACCC_HOST_DEVICE bool operator!=(const sp_location& lhs,
     return (lhs.bin_idx != rhs.bin_idx || lhs.sp_idx != rhs.sp_idx);
 }
 
-/// Declare all singlet collection types
-using singlet_collection_types = collection_types<sp_location>;
-
-/// Declare all singlet container types
-using singlet_container_types = container_types<unsigned int, sp_location>;
-
 }  // namespace traccc

--- a/core/include/traccc/seeding/detail/singlet.hpp
+++ b/core/include/traccc/seeding/detail/singlet.hpp
@@ -30,32 +30,10 @@ inline TRACCC_HOST_DEVICE bool operator!=(const sp_location& lhs,
     return (lhs.bin_idx != rhs.bin_idx || lhs.sp_idx != rhs.sp_idx);
 }
 
-/// Container of singlet belonging to one detector module
-template <template <typename> class vector_t>
-using singlet_collection = vector_t<sp_location>;
+/// Declare all singlet collection types
+using singlet_collection_types = collection_types<sp_location>;
 
-/// Convenience declaration for the singlet collection type to use in host code
-using host_singlet_collection = singlet_collection<vecmem::vector>;
+/// Declare all singlet container types
+using singlet_container_types = container_types<unsigned int, sp_location>;
 
-/// Convenience declaration for the singlet collection type to use in device
-/// code
-using device_singlet_collection = singlet_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the singlet container type to use in host code
-using host_singlet_container = host_container<unsigned int, sp_location>;
-
-/// Convenience declaration for the singlet container type to use in device code
-using device_singlet_container = device_container<unsigned int, sp_location>;
-
-/// Convenience declaration for the singlet container data type to use in host
-/// code
-using singlet_container_data = container_data<unsigned int, sp_location>;
-
-/// Convenience declaration for the singlet container buffer type to use in host
-/// code
-using singlet_container_buffer = container_buffer<unsigned int, sp_location>;
-
-/// Convenience declaration for the singlet container view type to use in host
-/// code
-using singlet_container_view = container_view<unsigned int, sp_location>;
 }  // namespace traccc

--- a/core/include/traccc/seeding/detail/triplet.hpp
+++ b/core/include/traccc/seeding/detail/triplet.hpp
@@ -53,33 +53,10 @@ inline TRACCC_HOST_DEVICE bool operator<(const triplet& lhs,
     return lhs.weight < rhs.weight;
 }
 
-/// Container of triplet belonging to one detector module
-template <template <typename> class vector_t>
-using triplet_collection = vector_t<triplet>;
+/// Declare all triplet collection types
+using triplet_collection_types = collection_types<triplet>;
 
-/// Convenience declaration for the triplet collection type to use in host code
-using host_triplet_collection = triplet_collection<vecmem::vector>;
-
-/// Convenience declaration for the triplet collection type to use in device
-/// code
-using device_triplet_collection = triplet_collection<vecmem::device_vector>;
-
-/// Convenience declaration for the triplet container type to use in host code
-using host_triplet_container = host_container<triplet_per_bin, triplet>;
-
-/// Convenience declaration for the triplet container type to use in device code
-using device_triplet_container = device_container<triplet_per_bin, triplet>;
-
-/// Convenience declaration for the triplet container data type to use in host
-/// code
-using triplet_container_data = container_data<triplet_per_bin, triplet>;
-
-/// Convenience declaration for the triplet container buffer type to use in host
-/// code
-using triplet_container_buffer = container_buffer<triplet_per_bin, triplet>;
-
-/// Convenience declaration for the triplet container view type to use in host
-/// code
-using triplet_container_view = container_view<triplet_per_bin, triplet>;
+/// Declare all triplet container types
+using triplet_container_types = container_types<triplet_per_bin, triplet>;
 
 }  // namespace traccc

--- a/core/include/traccc/seeding/doublet_finding.hpp
+++ b/core/include/traccc/seeding/doublet_finding.hpp
@@ -18,9 +18,9 @@ namespace traccc {
 
 /// Doublet finding to search the combinations of two compatible spacepoints
 struct doublet_finding
-    : public algorithm<
-          std::pair<doublet_collection_types::host, lin_circle_collection_types::host>(
-              const sp_grid&, const sp_location&, const bool&)> {
+    : public algorithm<std::pair<doublet_collection_types::host,
+                                 lin_circle_collection_types::host>(
+          const sp_grid&, const sp_location&, const bool&)> {
 
     /// Constructor for the doublet finding
     ///

--- a/core/include/traccc/seeding/doublet_finding.hpp
+++ b/core/include/traccc/seeding/doublet_finding.hpp
@@ -19,7 +19,7 @@ namespace traccc {
 /// Doublet finding to search the combinations of two compatible spacepoints
 struct doublet_finding
     : public algorithm<
-          std::pair<host_doublet_collection, host_lin_circle_collection>(
+          std::pair<doublet_collection_types::host, host_lin_circle_collection>(
               const sp_grid&, const sp_location&, const bool&)> {
 
     /// Constructor for the doublet finding

--- a/core/include/traccc/seeding/doublet_finding.hpp
+++ b/core/include/traccc/seeding/doublet_finding.hpp
@@ -19,7 +19,7 @@ namespace traccc {
 /// Doublet finding to search the combinations of two compatible spacepoints
 struct doublet_finding
     : public algorithm<
-          std::pair<doublet_collection_types::host, host_lin_circle_collection>(
+          std::pair<doublet_collection_types::host, lin_circle_collection_types::host>(
               const sp_grid&, const sp_location&, const bool&)> {
 
     /// Constructor for the doublet finding

--- a/core/include/traccc/seeding/seed_filtering.hpp
+++ b/core/include/traccc/seeding/seed_filtering.hpp
@@ -33,7 +33,7 @@ class seed_filtering {
     /// @return seeds are the vector of seeds where the new compatible seeds are
     /// added
     void operator()(const spacepoint_container_types::host& sp_container,
-                    const sp_grid& g2, host_triplet_collection& triplets,
+                    const sp_grid& g2, triplet_collection_types::host& triplets,
                     seed_collection_types::host& seeds) const;
 
     private:

--- a/core/include/traccc/seeding/track_params_estimation.hpp
+++ b/core/include/traccc/seeding/track_params_estimation.hpp
@@ -26,7 +26,7 @@ namespace traccc {
 /// Transcribed from Acts/Seeding/EstimateTrackParamsFromSeed.hpp.
 ///
 class track_params_estimation
-    : public algorithm<host_bound_track_parameters_collection(
+    : public algorithm<bound_track_parameters_collection_types::host(
           const spacepoint_container_types::host&,
           const seed_collection_types::host&)> {
 

--- a/core/include/traccc/seeding/triplet_finding.hpp
+++ b/core/include/traccc/seeding/triplet_finding.hpp
@@ -17,10 +17,10 @@ namespace traccc {
 
 /// Triplet finding to search the compatible combintations of two doublets which
 /// share same middle spacepoint
-struct triplet_finding
-    : public algorithm<triplet_collection_types::host(
-          const sp_grid&, const doublet&, const lin_circle&,
-          const doublet_collection_types::host&, const lin_circle_collection_types::host&)> {
+struct triplet_finding : public algorithm<triplet_collection_types::host(
+                             const sp_grid&, const doublet&, const lin_circle&,
+                             const doublet_collection_types::host&,
+                             const lin_circle_collection_types::host&)> {
     /// Constructor for the triplet finding
     ///
     /// @param seedfinder_config is the configuration parameters
@@ -58,11 +58,11 @@ struct triplet_finding
     /// void interface
     ///
     /// @return a vector of triplets
-    void operator()(const sp_grid& g2, const doublet& mid_bot,
-                    const lin_circle& lb,
-                    const doublet_collection_types::host& doublets_mid_top,
-                    const lin_circle_collection_types::host& lin_circles_mid_top,
-                    output_type& o) const {
+    void operator()(
+        const sp_grid& g2, const doublet& mid_bot, const lin_circle& lb,
+        const doublet_collection_types::host& doublets_mid_top,
+        const lin_circle_collection_types::host& lin_circles_mid_top,
+        output_type& o) const {
         // output
         auto& triplets = o;
 

--- a/core/include/traccc/seeding/triplet_finding.hpp
+++ b/core/include/traccc/seeding/triplet_finding.hpp
@@ -20,7 +20,7 @@ namespace traccc {
 struct triplet_finding
     : public algorithm<triplet_collection_types::host(
           const sp_grid&, const doublet&, const lin_circle&,
-          const doublet_collection_types::host&, const host_lin_circle_collection&)> {
+          const doublet_collection_types::host&, const lin_circle_collection_types::host&)> {
     /// Constructor for the triplet finding
     ///
     /// @param seedfinder_config is the configuration parameters
@@ -40,7 +40,7 @@ struct triplet_finding
     output_type operator()(
         const sp_grid& g2, const doublet& d, const lin_circle& lc,
         const doublet_collection_types::host& doublet,
-        const host_lin_circle_collection& lincol) const override {
+        const lin_circle_collection_types::host& lincol) const override {
         output_type result;
         this->operator()(g2, d, lc, doublet, lincol, result);
         return result;
@@ -61,7 +61,7 @@ struct triplet_finding
     void operator()(const sp_grid& g2, const doublet& mid_bot,
                     const lin_circle& lb,
                     const doublet_collection_types::host& doublets_mid_top,
-                    const host_lin_circle_collection& lin_circles_mid_top,
+                    const lin_circle_collection_types::host& lin_circles_mid_top,
                     output_type& o) const {
         // output
         auto& triplets = o;

--- a/core/include/traccc/seeding/triplet_finding.hpp
+++ b/core/include/traccc/seeding/triplet_finding.hpp
@@ -20,7 +20,7 @@ namespace traccc {
 struct triplet_finding
     : public algorithm<host_triplet_collection(
           const sp_grid&, const doublet&, const lin_circle&,
-          const host_doublet_collection&, const host_lin_circle_collection&)> {
+          const doublet_collection_types::host&, const host_lin_circle_collection&)> {
     /// Constructor for the triplet finding
     ///
     /// @param seedfinder_config is the configuration parameters
@@ -39,7 +39,7 @@ struct triplet_finding
     /// @return a vector of triplets
     output_type operator()(
         const sp_grid& g2, const doublet& d, const lin_circle& lc,
-        const host_doublet_collection& doublet,
+        const doublet_collection_types::host& doublet,
         const host_lin_circle_collection& lincol) const override {
         output_type result;
         this->operator()(g2, d, lc, doublet, lincol, result);
@@ -60,7 +60,7 @@ struct triplet_finding
     /// @return a vector of triplets
     void operator()(const sp_grid& g2, const doublet& mid_bot,
                     const lin_circle& lb,
-                    const host_doublet_collection& doublets_mid_top,
+                    const doublet_collection_types::host& doublets_mid_top,
                     const host_lin_circle_collection& lin_circles_mid_top,
                     output_type& o) const {
         // output

--- a/core/include/traccc/seeding/triplet_finding.hpp
+++ b/core/include/traccc/seeding/triplet_finding.hpp
@@ -18,7 +18,7 @@ namespace traccc {
 /// Triplet finding to search the compatible combintations of two doublets which
 /// share same middle spacepoint
 struct triplet_finding
-    : public algorithm<host_triplet_collection(
+    : public algorithm<triplet_collection_types::host(
           const sp_grid&, const doublet&, const lin_circle&,
           const doublet_collection_types::host&, const host_lin_circle_collection&)> {
     /// Constructor for the triplet finding

--- a/core/src/seeding/seed_filtering.cpp
+++ b/core/src/seeding/seed_filtering.cpp
@@ -17,7 +17,7 @@ seed_filtering::seed_filtering(const seedfilter_config& config)
 
 void seed_filtering::operator()(
     const spacepoint_container_types::host& sp_container, const sp_grid& g2,
-    host_triplet_collection& triplets,
+    triplet_collection_types::host& triplets,
     seed_collection_types::host& seeds) const {
 
     seed_collection_types::host seeds_per_spM;

--- a/core/src/seeding/seed_finding.cpp
+++ b/core/src/seeding/seed_finding.cpp
@@ -45,7 +45,7 @@ seed_finding::output_type seed_finding::operator()(
             if (mid_top.first.empty())
                 continue;
 
-            host_triplet_collection triplets_per_spM;
+            triplet_collection_types::host triplets_per_spM;
 
             // triplet search from the combinations of two doublets which
             // share middle spacepoint
@@ -53,7 +53,7 @@ seed_finding::output_type seed_finding::operator()(
                 auto& doublet_mb = mid_bot.first[k];
                 auto& lb = mid_bot.second[k];
 
-                host_triplet_collection triplets = m_triplet_finding(
+                triplet_collection_types::host triplets = m_triplet_finding(
                     g2, doublet_mb, lb, mid_top.first, mid_top.second);
 
                 triplets_per_spM.insert(std::end(triplets_per_spM),

--- a/device/common/include/traccc/seeding/device/count_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/count_triplets.hpp
@@ -42,8 +42,8 @@ void count_triplets(
     const doublet_counter_container_types::const_view doublet_counter_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         doublet_ps_view,
-    const doublet_container_view mid_bot_doublet_view,
-    const doublet_container_view mid_top_doublet_view,
+    const doublet_container_types::const_view mid_bot_doublet_view,
+    const doublet_container_types::const_view mid_top_doublet_view,
     triplet_counter_container_types::view triplet_view);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/find_doublets.hpp
+++ b/device/common/include/traccc/seeding/device/find_doublets.hpp
@@ -40,8 +40,8 @@ void find_doublets(
     const device::doublet_counter_container_types::const_view& doublet_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         doublet_ps_view,
-    doublet_container_view mb_doublets_view,
-    doublet_container_view mt_doublets_view);
+    doublet_container_types::view mb_doublets_view,
+    doublet_container_types::view mt_doublets_view);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/seeding/device/find_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/find_triplets.hpp
@@ -39,7 +39,7 @@ void find_triplets(
     const std::size_t globalIndex, const seedfinder_config& config,
     const seedfilter_config& filter_config, const sp_grid_const_view& sp_view,
     const device::doublet_counter_container_types::const_view& dc_view,
-    const doublet_container_view& mid_top_doublet_view,
+    const doublet_container_types::const_view& mid_top_doublet_view,
     const device::triplet_counter_container_types::const_view& tc_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         triplet_ps_view,

--- a/device/common/include/traccc/seeding/device/find_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/find_triplets.hpp
@@ -43,7 +43,7 @@ void find_triplets(
     const device::triplet_counter_container_types::const_view& tc_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         triplet_ps_view,
-    triplet_container_view triplet_view);
+    triplet_container_types::view triplet_view);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -22,8 +22,8 @@ void count_triplets(
     const doublet_counter_container_types::const_view doublet_counter_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         doublet_ps_view,
-    const doublet_container_view mid_bot_doublet_view,
-    const doublet_container_view mid_top_doublet_view,
+    const doublet_container_types::const_view mid_bot_doublet_view,
+    const doublet_container_types::const_view mid_top_doublet_view,
     triplet_counter_container_types::view triplet_view) {
 
     // Create device copy of input parameters
@@ -36,7 +36,7 @@ void count_triplets(
     }
 
     // Create device copy of input parameters
-    const device_doublet_container mid_bot_doublet_device(mid_bot_doublet_view);
+    const doublet_container_types::const_device mid_bot_doublet_device(mid_bot_doublet_view);
 
     // Get ids
     const prefix_sum_element_t ps_idx = doublet_prefix_sum[globalIndex];
@@ -50,7 +50,7 @@ void count_triplets(
     // Create device copy of input parameters
     const device::doublet_counter_container_types::const_device
         doublet_counter_device(doublet_counter_view);
-    const device_doublet_container mid_top_doublet_device(mid_top_doublet_view);
+    const doublet_container_types::const_device mid_top_doublet_device(mid_top_doublet_view);
 
     // Create device copy of output parameter
     triplet_counter_container_types::device triplet_counter(triplet_view);

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -36,7 +36,8 @@ void count_triplets(
     }
 
     // Create device copy of input parameters
-    const doublet_container_types::const_device mid_bot_doublet_device(mid_bot_doublet_view);
+    const doublet_container_types::const_device mid_bot_doublet_device(
+        mid_bot_doublet_view);
 
     // Get ids
     const prefix_sum_element_t ps_idx = doublet_prefix_sum[globalIndex];
@@ -50,7 +51,8 @@ void count_triplets(
     // Create device copy of input parameters
     const device::doublet_counter_container_types::const_device
         doublet_counter_device(doublet_counter_view);
-    const doublet_container_types::const_device mid_top_doublet_device(mid_top_doublet_view);
+    const doublet_container_types::const_device mid_top_doublet_device(
+        mid_top_doublet_view);
 
     // Create device copy of output parameter
     triplet_counter_container_types::device triplet_counter(triplet_view);

--- a/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
@@ -25,8 +25,8 @@ void find_doublets(
     const device::doublet_counter_container_types::const_view& doublet_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         doublet_ps_view,
-    doublet_container_view mb_doublets_view,
-    doublet_container_view mt_doublets_view) {
+    doublet_container_types::view mb_doublets_view,
+    doublet_container_types::view mt_doublets_view) {
 
     // Check if anything needs to be done.
     vecmem::device_vector<const prefix_sum_element_t> doublet_prefix_sum(
@@ -47,14 +47,14 @@ void find_doublets(
 
     // Set up the device containers.
     const const_sp_grid_device sp_grid(sp_view);
-    device_doublet_container mb_doublets(mb_doublets_view);
-    device_doublet_container mt_doublets(mt_doublets_view);
+    doublet_container_types::device mb_doublets(mb_doublets_view);
+    doublet_container_types::device mt_doublets(mt_doublets_view);
 
     // Get the doublet vectors just for the geometric bin of the middle
     // spacepoint.
-    device_doublet_collection mb_doublets_in_bin =
+    doublet_collection_types::device mb_doublets_in_bin =
         mb_doublets.get_items().at(middle_sp_counter.m_spM.bin_idx);
-    device_doublet_collection mt_doublets_in_bin =
+    doublet_collection_types::device mt_doublets_in_bin =
         mt_doublets.get_items().at(middle_sp_counter.m_spM.bin_idx);
 
     // Atomic references for the doublet summary values for the bin of the

--- a/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
@@ -21,7 +21,7 @@ void find_triplets(
     const seedfilter_config& filter_config, const sp_grid_const_view& sp_view,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_view,
-    const doublet_container_view& mid_top_doublet_view,
+    const doublet_container_types::const_view& mid_top_doublet_view,
     const device::triplet_counter_container_types::const_view& tc_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         triplet_ps_view,
@@ -37,7 +37,7 @@ void find_triplets(
     // Get device copy of input parameters
     const device::doublet_counter_container_types::const_device
         doublet_counter_device(doublet_counter_view);
-    const device_doublet_container mid_top_doublet_device(mid_top_doublet_view);
+    const doublet_container_types::const_device mid_top_doublet_device(mid_top_doublet_view);
     const const_sp_grid_device sp_grid(sp_view);
 
     // Get the current work item

--- a/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
@@ -25,7 +25,7 @@ void find_triplets(
     const device::triplet_counter_container_types::const_view& tc_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         triplet_ps_view,
-    triplet_container_view triplet_view) {
+    triplet_container_types::view triplet_view) {
 
     // Check if anything needs to be done.
     const vecmem::device_vector<const prefix_sum_element_t> triplet_prefix_sum(
@@ -79,7 +79,7 @@ void find_triplets(
         mid_top_doublet_device.get_items().at(spM_bin);
 
     // Set up the device result container
-    device_triplet_container triplets(triplet_view);
+    triplet_container_types::device triplets(triplet_view);
 
     // Apply the conformal transformation to middle-bot doublet
     const traccc::lin_circle lb =

--- a/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
@@ -37,7 +37,8 @@ void find_triplets(
     // Get device copy of input parameters
     const device::doublet_counter_container_types::const_device
         doublet_counter_device(doublet_counter_view);
-    const doublet_container_types::const_device mid_top_doublet_device(mid_top_doublet_view);
+    const doublet_container_types::const_device mid_top_doublet_device(
+        mid_top_doublet_view);
     const const_sp_grid_device sp_grid(sp_view);
 
     // Get the current work item

--- a/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
+++ b/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
@@ -88,7 +88,7 @@ void select_seeds(
     // Item of triplet: triplet objects per bin
     const unsigned int num_triplets_per_bin =
         triplet_device.get_headers().at(bin_idx).n_triplets;
-    const vecmem::device_vector<const triplet> triplets_per_bin =
+    const triplet_collection_types::const_device triplets_per_bin =
         triplet_device.get_items().at(bin_idx);
 
     // Current work item = middle spacepoint

--- a/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
+++ b/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
@@ -61,7 +61,7 @@ void select_seeds(
     const vecmem::data::vector_view<const prefix_sum_element_t>& dc_ps_view,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,
-    const triplet_container_view& triplet_view, triplet* data,
+    const triplet_container_types::const_view& triplet_view, triplet* data,
     seed_collection_types::view seed_view) {
 
     // Check if anything needs to be done.
@@ -81,14 +81,14 @@ void select_seeds(
 
     device::doublet_counter_container_types::const_device
         doublet_counter_device(doublet_counter_container);
-    device_triplet_container triplet_device(triplet_view);
+    triplet_container_types::const_device triplet_device(triplet_view);
     seed_collection_types::device seed_device(seed_view);
 
     // Header of triplet: number of triplets per bin
     // Item of triplet: triplet objects per bin
     const unsigned int num_triplets_per_bin =
         triplet_device.get_headers().at(bin_idx).n_triplets;
-    const vecmem::device_vector<triplet> triplets_per_bin =
+    const vecmem::device_vector<const triplet> triplets_per_bin =
         triplet_device.get_items().at(bin_idx);
 
     // Current work item = middle spacepoint

--- a/device/common/include/traccc/seeding/device/impl/update_triplet_weights.ipp
+++ b/device/common/include/traccc/seeding/device/impl/update_triplet_weights.ipp
@@ -18,7 +18,7 @@ void update_triplet_weights(
     const sp_grid_const_view& sp_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         triplet_ps_view,
-    scalar* data, triplet_container_view triplet_view) {
+    scalar* data, triplet_container_types::view triplet_view) {
 
     // Check if anything needs to be done.
     const vecmem::device_vector<const prefix_sum_element_t> triplet_prefix_sum(
@@ -33,7 +33,7 @@ void update_triplet_weights(
     const prefix_sum_element_t ps_idx = triplet_prefix_sum[globalIndex];
     const unsigned int bin_idx = ps_idx.first;
 
-    device_triplet_container triplets(triplet_view);
+    triplet_container_types::device triplets(triplet_view);
     vecmem::device_vector<triplet> triplets_per_bin =
         triplets.get_items().at(bin_idx);
 

--- a/device/common/include/traccc/seeding/device/make_doublet_buffers.hpp
+++ b/device/common/include/traccc/seeding/device/make_doublet_buffers.hpp
@@ -22,9 +22,9 @@ namespace traccc::device {
 /// Helper struct for the return type of @c traccc::device::make_doublet_buffer
 struct doublet_buffer_pair {
     /// Middle-bottom doublet buffer
-    doublet_container_buffer middleBottom;
+    doublet_container_types::buffer middleBottom;
     /// Middle-top doublet buffer
-    doublet_container_buffer middleTop;
+    doublet_container_types::buffer middleTop;
 };
 
 /// Create the doublet buffers

--- a/device/common/include/traccc/seeding/device/make_triplet_buffer.hpp
+++ b/device/common/include/traccc/seeding/device/make_triplet_buffer.hpp
@@ -32,7 +32,7 @@ namespace traccc::device {
 ///                buffer, in case @c mr is not host-accessible
 /// @return Buffer usable by @c traccc::device::find_triplets
 ///
-triplet_container_buffer make_triplet_buffer(
+triplet_container_types::buffer make_triplet_buffer(
     const triplet_counter_container_types::const_view& triplet_counter,
     vecmem::copy& copy, vecmem::memory_resource& mr,
     vecmem::memory_resource* mr_host = nullptr);

--- a/device/common/include/traccc/seeding/device/select_seeds.hpp
+++ b/device/common/include/traccc/seeding/device/select_seeds.hpp
@@ -41,7 +41,7 @@ void select_seeds(
     const vecmem::data::vector_view<const prefix_sum_element_t>& dc_ps_view,
     const device::doublet_counter_container_types::const_view&
         doublet_counter_container,
-    const triplet_container_view& tc_view, triplet* data,
+    const triplet_container_types::const_view& tc_view, triplet* data,
     seed_collection_types::view seed_view);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/update_triplet_weights.hpp
+++ b/device/common/include/traccc/seeding/device/update_triplet_weights.hpp
@@ -36,7 +36,7 @@ void update_triplet_weights(
     const sp_grid_const_view& sp_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         triplet_ps_view,
-    scalar* data, triplet_container_view triplet_view);
+    scalar* data, triplet_container_types::view triplet_view);
 
 }  // namespace traccc::device
 

--- a/device/common/src/seeding/make_doublet_buffers.cpp
+++ b/device/common/src/seeding/make_doublet_buffers.cpp
@@ -37,9 +37,9 @@ doublet_buffer_pair make_doublet_buffers(
         doublet_counts.begin(), doublet_counts.end(), mt_sizes.begin(),
         [](const device::doublet_counter_header& dc) { return dc.m_nMidTop; });
 
-    const doublet_container_buffer::header_vector::size_type mb_size =
+    const doublet_container_types::buffer::header_vector::size_type mb_size =
         mb_sizes.size();
-    const doublet_container_buffer::header_vector::size_type mt_size =
+    const doublet_container_types::buffer::header_vector::size_type mt_size =
         mt_sizes.size();
 
     // Create the result object.

--- a/device/common/src/seeding/make_triplet_buffer.cpp
+++ b/device/common/src/seeding/make_triplet_buffer.cpp
@@ -34,13 +34,14 @@ triplet_container_types::buffer make_triplet_buffer(
                        return tc.m_nTriplets;
                    });
 
-    const triplet_container_types::buffer::header_vector::size_type triplets_size =
-        triplet_sizes.size();
+    const triplet_container_types::buffer::header_vector::size_type
+        triplets_size = triplet_sizes.size();
 
     // Create the result object.
-    triplet_container_types::buffer result{{triplets_size, mr},
-                                    {std::vector<std::size_t>(triplets_size, 0),
-                                     triplet_sizes, mr, mr_host}};
+    triplet_container_types::buffer result{
+        {triplets_size, mr},
+        {std::vector<std::size_t>(triplets_size, 0), triplet_sizes, mr,
+         mr_host}};
 
     // Initialise the buffer(s).
     copy.setup(result.headers);

--- a/device/common/src/seeding/make_triplet_buffer.cpp
+++ b/device/common/src/seeding/make_triplet_buffer.cpp
@@ -16,7 +16,7 @@
 
 namespace traccc::device {
 
-triplet_container_buffer make_triplet_buffer(
+triplet_container_types::buffer make_triplet_buffer(
     const triplet_counter_container_types::const_view& triplet_counter,
     vecmem::copy& copy, vecmem::memory_resource& mr,
     vecmem::memory_resource* mr_host) {
@@ -34,11 +34,11 @@ triplet_container_buffer make_triplet_buffer(
                        return tc.m_nTriplets;
                    });
 
-    const triplet_container_buffer::header_vector::size_type triplets_size =
+    const triplet_container_types::buffer::header_vector::size_type triplets_size =
         triplet_sizes.size();
 
     // Create the result object.
-    triplet_container_buffer result{{triplets_size, mr},
+    triplet_container_types::buffer result{{triplets_size, mr},
                                     {std::vector<std::size_t>(triplets_size, 0),
                                      triplet_sizes, mr, mr_host}};
 

--- a/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
@@ -20,7 +20,7 @@ namespace cuda {
 
 /// track parameter estimation for cuda
 struct track_params_estimation
-    : public algorithm<host_bound_track_parameters_collection(
+    : public algorithm<bound_track_parameters_collection_types::host(
           const spacepoint_container_types::const_view&,
           const seed_collection_types::const_view&)> {
 
@@ -36,7 +36,7 @@ struct track_params_estimation
     /// @param seeds_view        is the view of the seed container
     /// @return                  vector of bound track parameters
     ///
-    host_bound_track_parameters_collection operator()(
+    bound_track_parameters_collection_types::host operator()(
         const spacepoint_container_types::const_view& spacepoints_view,
         const seed_collection_types::const_view& seeds_view) const override;
 

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -80,7 +80,7 @@ __global__ void find_triplets(
     device::triplet_counter_container_types::const_view tc_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         triplet_prefix_sum,
-    triplet_container_view triplet_view) {
+    triplet_container_types::view triplet_view) {
 
     device::find_triplets(threadIdx.x + blockIdx.x * blockDim.x, config,
                           filter_config, sp_grid, doublet_counter_view,
@@ -92,7 +92,7 @@ __global__ void update_triplet_weights(
     seedfilter_config filter_config, sp_grid_const_view sp_grid,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         triplet_prefix_sum,
-    triplet_container_view triplet_view) {
+    triplet_container_types::view triplet_view) {
 
     // Array for temporary storage of quality parameters for comparing triplets
     // within weight updating kernel
@@ -113,7 +113,7 @@ __global__ void select_seeds(
     vecmem::data::vector_view<const device::prefix_sum_element_t> dc_ps_view,
     device::doublet_counter_container_types::const_view
         doublet_counter_container,
-    triplet_container_view tc_view, seed_collection_types::view seed_view) {
+    triplet_container_types::const_view tc_view, seed_collection_types::view seed_view) {
 
     // Array for temporary storage of triplets for comparing within seed
     // selecting kernel
@@ -232,7 +232,7 @@ seed_collection_types::buffer seed_finding::operator()(
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
     // Set up the triplet buffer.
-    triplet_container_buffer triplet_buffer = device::make_triplet_buffer(
+    triplet_container_types::buffer triplet_buffer = device::make_triplet_buffer(
         triplet_counter_buffer, *m_copy, m_mr.main, m_mr.host);
 
     // Create prefix sum buffer

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -51,7 +51,8 @@ __global__ void find_doublets(
     device::doublet_counter_container_types::const_view doublet_counter,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         doublet_prefix_sum,
-    doublet_container_types::view mb_doublets, doublet_container_types::view mt_doublets) {
+    doublet_container_types::view mb_doublets,
+    doublet_container_types::view mt_doublets) {
 
     device::find_doublets(threadIdx.x + blockIdx.x * blockDim.x, config,
                           sp_grid, doublet_counter, doublet_prefix_sum,
@@ -64,7 +65,8 @@ __global__ void count_triplets(
     device::doublet_counter_container_types::const_view doublet_counter_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         doublet_prefix_sum,
-    doublet_container_types::const_view mb_doublets, doublet_container_types::const_view mt_doublets,
+    doublet_container_types::const_view mb_doublets,
+    doublet_container_types::const_view mt_doublets,
     device::triplet_counter_container_types::view triplet_view) {
 
     device::count_triplets(threadIdx.x + blockIdx.x * blockDim.x, config,
@@ -113,7 +115,8 @@ __global__ void select_seeds(
     vecmem::data::vector_view<const device::prefix_sum_element_t> dc_ps_view,
     device::doublet_counter_container_types::const_view
         doublet_counter_container,
-    triplet_container_types::const_view tc_view, seed_collection_types::view seed_view) {
+    triplet_container_types::const_view tc_view,
+    seed_collection_types::view seed_view) {
 
     // Array for temporary storage of triplets for comparing within seed
     // selecting kernel
@@ -232,8 +235,9 @@ seed_collection_types::buffer seed_finding::operator()(
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
     // Set up the triplet buffer.
-    triplet_container_types::buffer triplet_buffer = device::make_triplet_buffer(
-        triplet_counter_buffer, *m_copy, m_mr.main, m_mr.host);
+    triplet_container_types::buffer triplet_buffer =
+        device::make_triplet_buffer(triplet_counter_buffer, *m_copy, m_mr.main,
+                                    m_mr.host);
 
     // Create prefix sum buffer
     vecmem::data::vector_buffer triplet_counter_prefix_sum_buff =

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -51,7 +51,7 @@ __global__ void find_doublets(
     device::doublet_counter_container_types::const_view doublet_counter,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         doublet_prefix_sum,
-    doublet_container_view mb_doublets, doublet_container_view mt_doublets) {
+    doublet_container_types::view mb_doublets, doublet_container_types::view mt_doublets) {
 
     device::find_doublets(threadIdx.x + blockIdx.x * blockDim.x, config,
                           sp_grid, doublet_counter, doublet_prefix_sum,
@@ -64,7 +64,7 @@ __global__ void count_triplets(
     device::doublet_counter_container_types::const_view doublet_counter_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         doublet_prefix_sum,
-    doublet_container_view mb_doublets, doublet_container_view mt_doublets,
+    doublet_container_types::const_view mb_doublets, doublet_container_types::const_view mt_doublets,
     device::triplet_counter_container_types::view triplet_view) {
 
     device::count_triplets(threadIdx.x + blockIdx.x * blockDim.x, config,
@@ -76,7 +76,7 @@ __global__ void find_triplets(
     seedfinder_config config, seedfilter_config filter_config,
     sp_grid_const_view sp_grid,
     device::doublet_counter_container_types::const_view doublet_counter_view,
-    doublet_container_view mt_doublets,
+    doublet_container_types::const_view mt_doublets,
     device::triplet_counter_container_types::const_view tc_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         triplet_prefix_sum,

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -24,7 +24,7 @@ namespace cuda {
 __global__ void track_params_estimating_kernel(
     spacepoint_container_types::const_view spacepoints_view,
     seed_collection_types::const_view seeds_view,
-    vecmem::data::vector_view<bound_track_parameters> params_view);
+    bound_track_parameters_collection_types::view params_view);
 
 track_params_estimation::track_params_estimation(
     const traccc::memory_resource& mr)
@@ -38,7 +38,8 @@ track_params_estimation::track_params_estimation(
     }
 }
 
-host_bound_track_parameters_collection track_params_estimation::operator()(
+bound_track_parameters_collection_types::host
+track_params_estimation::operator()(
     const spacepoint_container_types::const_view& spacepoints_view,
     const seed_collection_types::const_view& seeds_view) const {
 
@@ -46,7 +47,7 @@ host_bound_track_parameters_collection track_params_estimation::operator()(
     const std::size_t seeds_size = m_copy->get_size(seeds_view);
 
     // Create output host container
-    host_bound_track_parameters_collection params(
+    bound_track_parameters_collection_types::host params(
         seeds_size, (m_mr.host ? m_mr.host : &(m_mr.main)));
 
     // Check if anything needs to be done.
@@ -55,8 +56,8 @@ host_bound_track_parameters_collection track_params_estimation::operator()(
     }
 
     // Create device buffer for the parameters
-    vecmem::data::vector_buffer<bound_track_parameters> params_buffer(
-        seeds_size, m_mr.main);
+    bound_track_parameters_collection_types::buffer params_buffer(seeds_size,
+                                                                  m_mr.main);
     m_copy->setup(params_buffer);
 
     // -- Num threads
@@ -84,13 +85,13 @@ host_bound_track_parameters_collection track_params_estimation::operator()(
 __global__ void track_params_estimating_kernel(
     spacepoint_container_types::const_view spacepoints_view,
     seed_collection_types::const_view seeds_view,
-    vecmem::data::vector_view<bound_track_parameters> params_view) {
+    bound_track_parameters_collection_types::view params_view) {
 
     // Get device container for input parameters
     const spacepoint_container_types::const_device spacepoints_device(
         spacepoints_view);
     seed_collection_types::const_device seeds_device(seeds_view);
-    device_bound_track_parameters_collection params_device(params_view);
+    bound_track_parameters_collection_types::device params_device(params_view);
 
     // vector index for threads
     unsigned int gid = threadIdx.x + blockIdx.x * blockDim.x;

--- a/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
@@ -28,7 +28,7 @@ namespace traccc::sycl {
 
 /// track parameter estimation for sycl
 struct track_params_estimation
-    : public algorithm<host_bound_track_parameters_collection(
+    : public algorithm<bound_track_parameters_collection_types::host(
           const spacepoint_container_types::const_view&,
           const seed_collection_types::const_view&)> {
 
@@ -48,7 +48,7 @@ struct track_params_estimation
     /// @param seeds_view        is the view of the seed container
     /// @return                  vector of bound track parameters
     ///
-    host_bound_track_parameters_collection operator()(
+    bound_track_parameters_collection_types::host operator()(
         const spacepoint_container_types::const_view& spacepoints_view,
         const seed_collection_types::const_view& seeds_view) const override;
 

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -195,9 +195,9 @@ seed_collection_types::buffer seed_finding::operator()(
         .wait_and_throw();
 
     // Set up the triplet buffer and its view
-    triplet_container_buffer triplet_buffer = device::make_triplet_buffer(
+    triplet_container_types::buffer triplet_buffer = device::make_triplet_buffer(
         triplet_counter_buffer, *m_copy, m_mr.main, m_mr.host);
-    triplet_container_view triplet_view = triplet_buffer;
+    triplet_container_types::view triplet_view = triplet_buffer;
 
     // Create prefix sum buffer and its view
     vecmem::data::vector_buffer triplet_counter_prefix_sum_buff =

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -195,8 +195,9 @@ seed_collection_types::buffer seed_finding::operator()(
         .wait_and_throw();
 
     // Set up the triplet buffer and its view
-    triplet_container_types::buffer triplet_buffer = device::make_triplet_buffer(
-        triplet_counter_buffer, *m_copy, m_mr.main, m_mr.host);
+    triplet_container_types::buffer triplet_buffer =
+        device::make_triplet_buffer(triplet_counter_buffer, *m_copy, m_mr.main,
+                                    m_mr.host);
     triplet_container_types::view triplet_view = triplet_buffer;
 
     // Create prefix sum buffer and its view

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -137,8 +137,8 @@ seed_collection_types::buffer seed_finding::operator()(
         doublet_prefix_sum_view.size(), doubletFindLocalSize);
 
     // Find all of the spacepoint doublets.
-    doublet_container_view mb_view = doublet_buffers.middleBottom;
-    doublet_container_view mt_view = doublet_buffers.middleTop;
+    doublet_container_types::view mb_view = doublet_buffers.middleBottom;
+    doublet_container_types::view mt_view = doublet_buffers.middleTop;
     details::get_queue(m_queue)
         .submit([&](::sycl::handler& h) {
             h.parallel_for<kernels::find_doublets>(

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -23,7 +23,7 @@ class TrackParamsEstimation {
     TrackParamsEstimation(
         const spacepoint_container_types::const_view& spacepoints_view,
         const seed_collection_types::const_view& seeds_view,
-        vecmem::data::vector_view<bound_track_parameters>& params_view)
+        bound_track_parameters_collection_types::view& params_view)
         : m_spacepoints_view(spacepoints_view),
           m_seeds_view(seeds_view),
           m_params_view(params_view) {}
@@ -41,7 +41,8 @@ class TrackParamsEstimation {
         const spacepoint_container_types::const_device spacepoints_device(
             m_spacepoints_view);
         seed_collection_types::const_device seeds_device(m_seeds_view);
-        device_bound_track_parameters_collection params_device(m_params_view);
+        bound_track_parameters_collection_types::device params_device(
+            m_params_view);
 
         // vector index for threads
         unsigned int gid = workItemIdx + groupIdx * groupDim;
@@ -65,7 +66,7 @@ class TrackParamsEstimation {
     private:
     spacepoint_container_types::const_view m_spacepoints_view;
     seed_collection_types::const_view m_seeds_view;
-    vecmem::data::vector_view<bound_track_parameters> m_params_view;
+    bound_track_parameters_collection_types::view m_params_view;
 };
 
 track_params_estimation::track_params_estimation(
@@ -80,7 +81,8 @@ track_params_estimation::track_params_estimation(
     }
 }
 
-host_bound_track_parameters_collection track_params_estimation::operator()(
+bound_track_parameters_collection_types::host
+track_params_estimation::operator()(
     const spacepoint_container_types::const_view& spacepoints_view,
     const seed_collection_types::const_view& seeds_view) const {
 
@@ -88,7 +90,7 @@ host_bound_track_parameters_collection track_params_estimation::operator()(
     auto seeds_size = m_copy->get_size(seeds_view);
 
     // Create output host container
-    host_bound_track_parameters_collection params(
+    bound_track_parameters_collection_types::host params(
         seeds_size, (m_mr.host ? m_mr.host : &(m_mr.main)));
 
     // Check if anything needs to be done.
@@ -97,8 +99,8 @@ host_bound_track_parameters_collection track_params_estimation::operator()(
     }
 
     // Create device buffer for the parameters
-    vecmem::data::vector_buffer<bound_track_parameters> params_buffer(
-        seeds_size, m_mr.main);
+    bound_track_parameters_collection_types::buffer params_buffer(seeds_size,
+                                                                  m_mr.main);
     m_copy->setup(params_buffer);
 
     // -- localSize


### PR DESCRIPTION
Similarly to #248 , updated the seeding specific data types (listed below) to match others.

- singlet (not actually being used anywhere in the code, might be worth revisiting
- doublet
- triplet
- lin_circle
- bound_track_parameters
