### PR TITLE
Added common implementation of track parameters estimation

### DIFF
--- a/device/common/CMakeLists.txt
+++ b/device/common/CMakeLists.txt
@@ -58,6 +58,9 @@ traccc_add_library( traccc_device_common device_common TYPE SHARED
    "include/traccc/seeding/device/update_triplet_weights.hpp"
    "include/traccc/seeding/device/impl/update_triplet_weights.ipp"
    "include/traccc/seeding/device/select_seeds.hpp"
-   "include/traccc/seeding/device/impl/select_seeds.ipp" )
+   "include/traccc/seeding/device/impl/select_seeds.ipp"
+   # Track parameters estimation function(s).
+   "include/traccc/seeding/device/estimate_track_params.hpp"
+   "include/traccc/seeding/device/impl/estimate_track_params.ipp" )
 target_link_libraries( traccc_device_common
    PUBLIC traccc::Thrust traccc::core vecmem::core )

--- a/device/common/include/traccc/seeding/device/estimate_track_params.hpp
+++ b/device/common/include/traccc/seeding/device/estimate_track_params.hpp
@@ -1,0 +1,34 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/edm/seed.hpp"
+#include "traccc/edm/spacepoint.hpp"
+#include "traccc/edm/track_parameters.hpp"
+
+namespace traccc::device {
+
+/// Function used for calculating the bound track parameters for each seed
+///
+/// @param[in] globalIndex      The index of the current thread
+/// @param[in] spacepoints_view Container storing the spacepoints
+/// @param[in] seeds_view       Container storing the seeds
+/// @param[out] params_view     Container storing the bound track parameters
+///
+TRACCC_HOST_DEVICE
+inline void estimate_track_params(
+    const std::size_t globalIndex,
+    const spacepoint_container_types::const_view& spacepoints_view,
+    const seed_collection_types::const_view& seeds_view,
+    bound_track_parameters_collection_types::view params_view);
+
+}  // namespace traccc::device
+
+// Include the implementation.
+#include "traccc/seeding/device/impl/estimate_track_params.ipp"

--- a/device/common/include/traccc/seeding/device/impl/estimate_track_params.ipp
+++ b/device/common/include/traccc/seeding/device/impl/estimate_track_params.ipp
@@ -1,0 +1,45 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/seeding/device/estimate_track_params.hpp"
+#include "traccc/seeding/track_params_estimation_helper.hpp"
+
+namespace traccc::device {
+
+TRACCC_HOST_DEVICE
+inline void estimate_track_params(
+    const std::size_t globalIndex,
+    const spacepoint_container_types::const_view& spacepoints_view,
+    const seed_collection_types::const_view& seeds_view,
+    bound_track_parameters_collection_types::view params_view) {
+
+    // Check if anything needs to be done.
+    const seed_collection_types::const_device seeds_device(seeds_view);
+    if (globalIndex >= seeds_device.size()) {
+        return;
+    }
+
+    const spacepoint_container_types::const_device spacepoints_device(
+        spacepoints_view);
+
+    bound_track_parameters_collection_types::device params_device(params_view);
+
+    // convenient assumption on bfield and mass
+    vector3 bfield = {0, 0, 2};
+
+    const seed& this_seed = seeds_device.at(globalIndex);
+    bound_vector& param = params_device[globalIndex].vector();
+
+    // Get bound track parameter
+    param = seed_to_bound_vector(spacepoints_device, this_seed, bfield,
+                                 PION_MASS_MEV);
+}
+
+}  // namespace traccc::device

--- a/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
@@ -8,7 +8,9 @@
 #pragma once
 
 // Project include(s)
-#include "traccc/seeding/track_params_estimation_helper.hpp"
+#include "traccc/edm/seed.hpp"
+#include "traccc/edm/spacepoint.hpp"
+#include "traccc/edm/track_parameters.hpp"
 #include "traccc/utils/algorithm.hpp"
 #include "traccc/utils/memory_resource.hpp"
 

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -8,6 +8,7 @@
 // Project include(s).
 #include "traccc/cuda/seeding/track_params_estimation.hpp"
 #include "traccc/cuda/utils/definitions.hpp"
+#include "traccc/seeding/device/estimate_track_params.hpp"
 
 // VecMem include(s).
 #include <vecmem/utils/cuda/copy.hpp>
@@ -15,16 +16,17 @@
 namespace traccc {
 namespace cuda {
 
-/// Forward declaration of track parameter estimating kernel
-/// The bound track parameters at the bottom spacepoints are obtained
-///
-/// @param seeds_view seeds found by seed finding
-/// @param params_view vector of bound track parameters at the bottom
-/// spacepoints
-__global__ void track_params_estimating_kernel(
+namespace kernels {
+/// CUDA kernel for running @c traccc::device::estimate_track_params
+__global__ void estimate_track_params(
     spacepoint_container_types::const_view spacepoints_view,
-    seed_collection_types::const_view seeds_view,
-    bound_track_parameters_collection_types::view params_view);
+    seed_collection_types::const_view seed_view,
+    bound_track_parameters_collection_types::view params_view) {
+
+    device::estimate_track_params(threadIdx.x + blockIdx.x * blockDim.x,
+                                  spacepoints_view, seed_view, params_view);
+}
+}  // namespace kernels
 
 track_params_estimation::track_params_estimation(
     const traccc::memory_resource& mr)
@@ -65,11 +67,12 @@ track_params_estimation::operator()(
     unsigned int num_threads = WARP_SIZE * 2;
 
     // -- Num blocks
-    // The dimension of grid is number_of_seeds / num_threads + 1
-    unsigned int num_blocks = seeds_size / num_threads + 1;
+    // The dimension of grid is (number_of_seeds + num_threads - 1) /
+    // num_threads + 1
+    unsigned int num_blocks = (seeds_size + num_threads - 1) / num_threads;
 
     // run the kernel
-    track_params_estimating_kernel<<<num_blocks, num_threads>>>(
+    kernels::estimate_track_params<<<num_blocks, num_threads>>>(
         spacepoints_view, seeds_view, params_buffer);
 
     // cuda error check
@@ -80,37 +83,6 @@ track_params_estimation::operator()(
     (*m_copy)(params_buffer, params);
 
     return params;
-}
-
-__global__ void track_params_estimating_kernel(
-    spacepoint_container_types::const_view spacepoints_view,
-    seed_collection_types::const_view seeds_view,
-    bound_track_parameters_collection_types::view params_view) {
-
-    // Get device container for input parameters
-    const spacepoint_container_types::const_device spacepoints_device(
-        spacepoints_view);
-    seed_collection_types::const_device seeds_device(seeds_view);
-    bound_track_parameters_collection_types::device params_device(params_view);
-
-    // vector index for threads
-    unsigned int gid = threadIdx.x + blockIdx.x * blockDim.x;
-
-    // prevent overflow
-    if (gid >= seeds_device.size()) {
-        return;
-    }
-
-    // convenient assumption on bfield and mass
-    // TODO: make use of bfield extension for the future
-    vector3 bfield = {0, 0, 2};
-
-    const auto& seed = seeds_device.at(gid);
-    auto& param = params_device[gid].vector();
-
-    // Get bound track parameter
-    param =
-        seed_to_bound_vector(spacepoints_device, seed, bfield, PION_MASS_MEV);
 }
 
 }  // namespace cuda

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -8,66 +8,21 @@
 // SYCL library include(s).
 #include "../utils/get_queue.hpp"
 #include "traccc/sycl/seeding/track_params_estimation.hpp"
+#include "traccc/sycl/utils/calculate1DimNdRange.hpp"
 
 // Project include(s).
-#include "traccc/seeding/track_params_estimation_helper.hpp"
+#include "traccc/seeding/device/estimate_track_params.hpp"
 
 // VecMem include(s).
 #include <vecmem/utils/sycl/copy.hpp>
 
 namespace traccc::sycl {
 
-// kernel class
-class TrackParamsEstimation {
-    public:
-    TrackParamsEstimation(
-        const spacepoint_container_types::const_view& spacepoints_view,
-        const seed_collection_types::const_view& seeds_view,
-        bound_track_parameters_collection_types::view& params_view)
-        : m_spacepoints_view(spacepoints_view),
-          m_seeds_view(seeds_view),
-          m_params_view(params_view) {}
-
-    void operator()(::sycl::nd_item<1> item) const {
-
-        // Equivalent to blockIdx.x in cuda
-        auto groupIdx = item.get_group(0);
-        // Equivalent to blockDim.x in cuda
-        auto groupDim = item.get_local_range(0);
-        // Equivalent to threadIdx.x in cuda
-        auto workItemIdx = item.get_local_id(0);
-
-        // Get device container for input parameters
-        const spacepoint_container_types::const_device spacepoints_device(
-            m_spacepoints_view);
-        seed_collection_types::const_device seeds_device(m_seeds_view);
-        bound_track_parameters_collection_types::device params_device(
-            m_params_view);
-
-        // vector index for threads
-        unsigned int gid = workItemIdx + groupIdx * groupDim;
-
-        // prevent overflow
-        if (gid >= seeds_device.size()) {
-            return;
-        }
-
-        // convenient assumption on bfield and mass
-        vector3 bfield = {0, 0, 2};
-
-        const auto& seed = seeds_device.at(gid);
-        auto& param = params_device[gid].vector();
-
-        // Get bound track parameter
-        param = seed_to_bound_vector(spacepoints_device, seed, bfield,
-                                     PION_MASS_MEV);
-    }
-
-    private:
-    spacepoint_container_types::const_view m_spacepoints_view;
-    seed_collection_types::const_view m_seeds_view;
-    bound_track_parameters_collection_types::view m_params_view;
-};
+namespace kernels {
+/// Class identifying the kernel running @c
+/// traccc::device::estimate_track_params
+class estimate_track_params;
+}  // namespace kernels
 
 track_params_estimation::track_params_estimation(
     const traccc::memory_resource& mr, queue_wrapper queue)
@@ -102,26 +57,26 @@ track_params_estimation::operator()(
     bound_track_parameters_collection_types::buffer params_buffer(seeds_size,
                                                                   m_mr.main);
     m_copy->setup(params_buffer);
+    bound_track_parameters_collection_types::view params_view(params_buffer);
 
     // -- localSize
     // The dimension of workGroup (block) is the integer multiple of WARP_SIZE
     // (=32)
     unsigned int localSize = 64;
 
-    // -- Num groups
-    // The dimension of grid is number_of_seeds / localSize + 1
-    unsigned int num_groups = (seeds_size + localSize - 1) / localSize;
-
-    unsigned int globalSize = localSize * num_groups;
     // 1 dim ND Range for the kernel
-    auto trackParamsNdRange = ::sycl::nd_range<1>{globalSize, localSize};
-    details::get_queue(m_queue)
-        .submit([&trackParamsNdRange, &spacepoints_view, &seeds_view,
-                 &params_buffer](::sycl::handler& h) {
-            TrackParamsEstimation kernel(spacepoints_view, seeds_view,
-                                         params_buffer);
+    auto trackParamsNdRange =
+        traccc::sycl::calculate1DimNdRange(seeds_size, localSize);
 
-            h.parallel_for<TrackParamsEstimation>(trackParamsNdRange, kernel);
+    details::get_queue(m_queue)
+        .submit([&](::sycl::handler& h) {
+            h.parallel_for<kernels::estimate_track_params>(
+                trackParamsNdRange, [spacepoints_view, seeds_view,
+                                     params_view](::sycl::nd_item<1> item) {
+                    device::estimate_track_params(item.get_global_linear_id(),
+                                                  spacepoints_view, seeds_view,
+                                                  params_view);
+                });
         })
         .wait_and_throw();
 


### PR DESCRIPTION
Similarly to #221  , a common implementation of the track parameters estimation was created, now being used by both SYCL and CUDA backends.

No significant differences in performance were observed.