### PR TITLE
Made all single source kernels inline

### DIFF
--- a/device/common/include/traccc/clusterization/device/connect_components.hpp
+++ b/device/common/include/traccc/clusterization/device/connect_components.hpp
@@ -40,7 +40,7 @@ namespace traccc::device {
 /// cluster
 ///
 TRACCC_HOST_DEVICE
-void connect_components(
+inline void connect_components(
     std::size_t globalIndex, const cell_container_types::const_view& cells_view,
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,

--- a/device/common/include/traccc/clusterization/device/count_cluster_cells.hpp
+++ b/device/common/include/traccc/clusterization/device/count_cluster_cells.hpp
@@ -37,7 +37,7 @@ namespace traccc::device {
 /// for each cluster
 ///
 TRACCC_HOST_DEVICE
-void count_cluster_cells(
+inline void count_cluster_cells(
     std::size_t globalIndex,
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,

--- a/device/common/include/traccc/clusterization/device/create_measurements.hpp
+++ b/device/common/include/traccc/clusterization/device/create_measurements.hpp
@@ -32,10 +32,10 @@ namespace traccc::device {
 /// for each module
 ///
 TRACCC_HOST_DEVICE
-void create_measurements(std::size_t globalIndex,
-                         cluster_container_types::const_view clusters_view,
-                         const cell_container_types::const_view& cells_view,
-                         measurement_container_types::view measurements_view);
+inline void create_measurements(
+    std::size_t globalIndex, cluster_container_types::const_view clusters_view,
+    const cell_container_types::const_view& cells_view,
+    measurement_container_types::view measurements_view);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/clusterization/device/find_clusters.hpp
+++ b/device/common/include/traccc/clusterization/device/find_clusters.hpp
@@ -34,7 +34,7 @@ namespace traccc::device {
 /// in each module
 ///
 TRACCC_HOST_DEVICE
-void find_clusters(
+inline void find_clusters(
     std::size_t globalIndex, const cell_container_types::const_view& cells_view,
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
     vecmem::data::vector_view<std::size_t> clusters_per_module_view);

--- a/device/common/include/traccc/clusterization/device/form_spacepoints.hpp
+++ b/device/common/include/traccc/clusterization/device/form_spacepoints.hpp
@@ -34,7 +34,7 @@ namespace traccc::device {
 /// each module
 ///
 TRACCC_HOST_DEVICE
-void form_spacepoints(
+inline void form_spacepoints(
     std::size_t globalIndex,
     measurement_container_types::const_view measurements_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>

--- a/device/common/include/traccc/clusterization/device/impl/connect_components.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/connect_components.ipp
@@ -10,7 +10,7 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE
-void connect_components(
+inline void connect_components(
     std::size_t globalIndex, const cell_container_types::const_view& cells_view,
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,

--- a/device/common/include/traccc/clusterization/device/impl/count_cluster_cells.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/count_cluster_cells.ipp
@@ -13,7 +13,7 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE
-void count_cluster_cells(
+inline void count_cluster_cells(
     std::size_t globalIndex,
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
     vecmem::data::vector_view<std::size_t> cluster_prefix_sum_view,

--- a/device/common/include/traccc/clusterization/device/impl/create_measurements.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/create_measurements.ipp
@@ -13,10 +13,10 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE
-void create_measurements(std::size_t globalIndex,
-                         cluster_container_types::const_view clusters_view,
-                         const cell_container_types::const_view& cells_view,
-                         measurement_container_types::view measurements_view) {
+inline void create_measurements(
+    std::size_t globalIndex, cluster_container_types::const_view clusters_view,
+    const cell_container_types::const_view& cells_view,
+    measurement_container_types::view measurements_view) {
 
     // Initialize device vector that gives us the execution range
     const cluster_container_types::const_device clusters_device(clusters_view);

--- a/device/common/include/traccc/clusterization/device/impl/find_clusters.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/find_clusters.ipp
@@ -10,7 +10,7 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE
-void find_clusters(
+inline void find_clusters(
     std::size_t globalIndex, const cell_container_types::const_view& cells_view,
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view,
     vecmem::data::vector_view<std::size_t> clusters_per_module_view) {

--- a/device/common/include/traccc/clusterization/device/impl/form_spacepoints.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/form_spacepoints.ipp
@@ -10,7 +10,7 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE
-void form_spacepoints(
+inline void form_spacepoints(
     std::size_t globalIndex,
     measurement_container_types::const_view measurements_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>

--- a/device/common/include/traccc/seeding/device/count_doublets.hpp
+++ b/device/common/include/traccc/seeding/device/count_doublets.hpp
@@ -31,7 +31,7 @@ namespace traccc::device {
 /// @param[out] doublet_view Container storing the number of doublets
 ///
 TRACCC_HOST_DEVICE
-void count_doublets(
+inline void count_doublets(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>& sp_ps_view,

--- a/device/common/include/traccc/seeding/device/count_grid_capacities.hpp
+++ b/device/common/include/traccc/seeding/device/count_grid_capacities.hpp
@@ -41,7 +41,7 @@ namespace traccc::device {
 /// @param[out] grid_capacities Capacity required for each spacepoint grid bin
 ///
 TRACCC_HOST_DEVICE
-void count_grid_capacities(
+inline void count_grid_capacities(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid::axis_p0_type& phi_axis, const sp_grid::axis_p1_type& z_axis,
     const spacepoint_container_types::const_view& spacepoints,

--- a/device/common/include/traccc/seeding/device/count_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/count_triplets.hpp
@@ -36,7 +36,7 @@ namespace traccc::device {
 /// triplets
 ///
 TRACCC_HOST_DEVICE
-void count_triplets(
+inline void count_triplets(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
     const doublet_counter_container_types::const_view doublet_counter_view,

--- a/device/common/include/traccc/seeding/device/find_doublets.hpp
+++ b/device/common/include/traccc/seeding/device/find_doublets.hpp
@@ -34,7 +34,7 @@ namespace traccc::device {
 /// @param[out] mt_doublets_view Container of middle-top doublets
 ///
 TRACCC_HOST_DEVICE
-void find_doublets(
+inline void find_doublets(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
     const device::doublet_counter_container_types::const_view& doublet_view,

--- a/device/common/include/traccc/seeding/device/find_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/find_triplets.hpp
@@ -35,7 +35,7 @@ namespace traccc::device {
 /// @param[out] triplet_view     Container of triplets
 ///
 TRACCC_HOST_DEVICE
-void find_triplets(
+inline void find_triplets(
     const std::size_t globalIndex, const seedfinder_config& config,
     const seedfilter_config& filter_config, const sp_grid_const_view& sp_view,
     const device::doublet_counter_container_types::const_view& dc_view,

--- a/device/common/include/traccc/seeding/device/impl/count_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_doublets.ipp
@@ -19,7 +19,7 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE
-void count_doublets(
+inline void count_doublets(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>& sp_ps_view,

--- a/device/common/include/traccc/seeding/device/impl/count_grid_capacities.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_grid_capacities.ipp
@@ -16,7 +16,7 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE
-void count_grid_capacities(
+inline void count_grid_capacities(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid::axis_p0_type& phi_axis, const sp_grid::axis_p1_type& z_axis,
     const spacepoint_container_types::const_view& spacepoints_view,

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -16,7 +16,7 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE
-void count_triplets(
+inline void count_triplets(
     const std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
     const doublet_counter_container_types::const_view doublet_counter_view,

--- a/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
@@ -19,7 +19,7 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE
-void find_doublets(
+inline void find_doublets(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
     const device::doublet_counter_container_types::const_view& doublet_view,

--- a/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
@@ -16,7 +16,7 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE
-void find_triplets(
+inline void find_triplets(
     const std::size_t globalIndex, const seedfinder_config& config,
     const seedfilter_config& filter_config, const sp_grid_const_view& sp_view,
     const device::doublet_counter_container_types::const_view&

--- a/device/common/include/traccc/seeding/device/impl/populate_grid.ipp
+++ b/device/common/include/traccc/seeding/device/impl/populate_grid.ipp
@@ -13,7 +13,7 @@
 namespace traccc::device {
 
 TRACCC_DEVICE
-void populate_grid(
+inline void populate_grid(
     std::size_t globalIndex, const seedfinder_config& config,
     const spacepoint_container_types::const_view& spacepoints_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&

--- a/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
+++ b/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
@@ -54,7 +54,7 @@ TRACCC_HOST_DEVICE void insertionSort(triplet* arr, const std::size_t begin_idx,
 
 // Select seeds kernel
 TRACCC_HOST_DEVICE
-void select_seeds(
+inline void select_seeds(
     const std::size_t globalIndex, const seedfilter_config& filter_config,
     const spacepoint_container_types::const_view& spacepoints_view,
     const sp_grid_const_view& internal_sp_view,

--- a/device/common/include/traccc/seeding/device/impl/update_triplet_weights.ipp
+++ b/device/common/include/traccc/seeding/device/impl/update_triplet_weights.ipp
@@ -13,7 +13,7 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE
-void update_triplet_weights(
+inline void update_triplet_weights(
     const std::size_t globalIndex, const seedfilter_config& filter_config,
     const sp_grid_const_view& sp_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&

--- a/device/common/include/traccc/seeding/device/populate_grid.hpp
+++ b/device/common/include/traccc/seeding/device/populate_grid.hpp
@@ -31,7 +31,7 @@ namespace traccc::device {
 /// @param[out] grid         The spacepoint grid to populate
 ///
 TRACCC_DEVICE
-void populate_grid(
+inline void populate_grid(
     std::size_t globalIndex, const seedfinder_config& config,
     const spacepoint_container_types::const_view& spacepoints,
     const vecmem::data::vector_view<const prefix_sum_element_t>& sp_prefix_sum,

--- a/device/common/include/traccc/seeding/device/select_seeds.hpp
+++ b/device/common/include/traccc/seeding/device/select_seeds.hpp
@@ -34,7 +34,7 @@ namespace traccc::device {
 /// @param[out] seed_container vecmem container for seeds
 ///
 TRACCC_HOST_DEVICE
-void select_seeds(
+inline void select_seeds(
     std::size_t globalIndex, const seedfilter_config& filter_config,
     const spacepoint_container_types::const_view& spacepoints_view,
     const sp_grid_const_view& internal_sp_view,

--- a/device/common/include/traccc/seeding/device/update_triplet_weights.hpp
+++ b/device/common/include/traccc/seeding/device/update_triplet_weights.hpp
@@ -31,7 +31,7 @@ namespace traccc::device {
 /// @param[out] triplet_view Container storing the triplets
 ///
 TRACCC_HOST_DEVICE
-void update_triplet_weights(
+inline void update_triplet_weights(
     const std::size_t globalIndex, const seedfilter_config& filter_config,
     const sp_grid_const_view& sp_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&


### PR DESCRIPTION
Our current status of single source files with the header file include the implementation can easily lead to compile-time multiple definition errors if a header file is simultaneously included in different places. For this reason, we changed all of these to inline which prevents such error.