### PR TITLE
Changed doublets & triplets data structure to spM based jagged vectors

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -60,6 +60,8 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/seeding/detail/lin_circle.hpp"
   "include/traccc/seeding/detail/doublet.hpp"
   "include/traccc/seeding/detail/triplet.hpp"
+  "include/traccc/seeding/detail/doublet_spM.hpp"
+  "include/traccc/seeding/detail/triplet_spM.hpp"
   "include/traccc/seeding/detail/singlet.hpp"
   "include/traccc/seeding/detail/seeding_config.hpp"
   "include/traccc/seeding/detail/spacepoint_grid.hpp"

--- a/core/include/traccc/seeding/detail/doublet_spM.hpp
+++ b/core/include/traccc/seeding/detail/doublet_spM.hpp
@@ -1,0 +1,44 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/seeding/detail/singlet.hpp"
+
+namespace traccc {
+
+/// Header: the number of doublets per spacepoint bin
+struct doublets_per_spM {
+
+    /// Index of the middle spacepoint.
+    sp_location spM;
+
+    /// The number of compatible middle-bottom/top doublets for the middle
+    /// spacepoint.
+    unsigned int n_doublets = 0;
+};
+
+/// Item: doublet of middle-bottom or middle-top
+struct doublet_spM {
+    // bottom (or top) spacepoint location in internal spacepoint container
+    sp_location sp2;
+};
+
+inline TRACCC_HOST_DEVICE bool operator==(const doublet_spM& lhs,
+                                          const doublet_spM& rhs) {
+    return (lhs.sp2.bin_idx == rhs.sp2.bin_idx &&
+            lhs.sp2.sp_idx == rhs.sp2.sp_idx);
+}
+
+/// Declare all doublet collection types
+using doublet_spM_collection_types = collection_types<doublet_spM>;
+
+/// Declare all doublet container types
+using doublet_spM_container_types =
+    container_types<doublets_per_spM, doublet_spM>;
+
+}  // namespace traccc

--- a/core/include/traccc/seeding/detail/triplet_spM.hpp
+++ b/core/include/traccc/seeding/detail/triplet_spM.hpp
@@ -1,0 +1,65 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/seeding/detail/singlet.hpp"
+
+namespace traccc {
+
+/// Header: the number of triplets per spacepoint middle
+struct triplets_per_spM {
+    sp_location m_spM;
+
+    unsigned int n_triplets = 0;
+};
+
+/// Item: triplets of middle-bottom-top
+struct triplet_spM {
+    // bottom spacepoint location in internal spacepoint container
+    sp_location spB;
+    // top spacepoint location in internal spacepoint container
+    sp_location spT;
+    // curvtaure of circle estimated from triplet
+    scalar curvature;
+    // weight of triplet
+    scalar weight;
+    // z origin of triplet
+    scalar z_vertex;
+
+    /// Position of the triplets which share this mb doublet
+    unsigned int triplets_mb_begin = 0;
+    unsigned int triplets_mb_end = 0;
+};
+
+inline TRACCC_HOST_DEVICE bool operator==(const triplet_spM& lhs,
+                                          const triplet_spM& rhs) {
+    return (lhs.spB.bin_idx == rhs.spB.bin_idx &&
+            lhs.spB.sp_idx == rhs.spB.sp_idx &&
+            lhs.spT.bin_idx == rhs.spT.bin_idx &&
+            lhs.spT.sp_idx == rhs.spT.sp_idx);
+}
+
+inline TRACCC_HOST_DEVICE bool operator!=(const triplet_spM& lhs,
+                                          const triplet_spM& rhs) {
+    return !(lhs == rhs);
+}
+
+inline TRACCC_HOST_DEVICE bool operator<(const triplet_spM& lhs,
+                                         const triplet_spM& rhs) {
+    return lhs.weight < rhs.weight;
+}
+
+/// Declare all triplet spM collection types
+using triplet_spM_collection_types = collection_types<triplet_spM>;
+
+/// Declare all triplet spM container types
+using triplet_spM_container_types =
+    container_types<triplets_per_spM, triplet_spM>;
+
+}  // namespace traccc

--- a/device/common/CMakeLists.txt
+++ b/device/common/CMakeLists.txt
@@ -21,7 +21,9 @@ traccc_add_library( traccc_device_common device_common TYPE SHARED
    "include/traccc/device/impl/container_d2h_copy_alg.ipp"
    # EDM class(es).
    "include/traccc/edm/device/doublet_counter.hpp"
+   "include/traccc/edm/device/doublet_counter_spM.hpp"
    "include/traccc/edm/device/triplet_counter.hpp"
+   "include/traccc/edm/device/triplet_counter_spM.hpp"
    "include/traccc/edm/device/partition.hpp"
    # Clusterization function(s).
    "include/traccc/clusterization/device/partitioning_algorithm.hpp"

--- a/device/common/include/traccc/edm/device/doublet_counter_spM.hpp
+++ b/device/common/include/traccc/edm/device/doublet_counter_spM.hpp
@@ -1,0 +1,37 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/edm/container.hpp"
+#include "traccc/seeding/detail/singlet.hpp"
+
+namespace traccc::device {
+
+/// Item type for the "doublet collection"
+///
+/// It stores the number of doublets for one specific middle spacepoint.
+///
+struct doublet_counter_spM {
+
+    /// Index of the middle spacepoint.
+    sp_location m_spM;
+
+    /// The number of compatible middle-bottom doublets.
+    unsigned int m_nMidBot = 0;
+
+    /// The number of compatible middle-top doublets.
+    unsigned int m_nMidTop = 0;
+
+};  // struct doublet_counter
+
+/// Declare all doublet counter spM collection types
+using doublet_counter_spM_collection_types =
+    collection_types<doublet_counter_spM>;
+
+}  // namespace traccc::device

--- a/device/common/include/traccc/edm/device/triplet_counter_spM.hpp
+++ b/device/common/include/traccc/edm/device/triplet_counter_spM.hpp
@@ -1,0 +1,55 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/edm/container.hpp"
+#include "traccc/seeding/detail/singlet.hpp"
+
+namespace traccc::device {
+
+/// Header type for the "triplet counter container"
+///
+/// The header stores summary information about the number of triplets found in
+/// a given geometric bin.
+///
+struct triplet_counter_spM_header {
+
+    /// Index of the middle spacepoint.
+    sp_location m_spM;
+
+    /// The total number of Triplets in a given geometric bin
+    unsigned int m_nTriplets = 0;
+
+};  // struct triplet_counter_header
+
+/// Item type for the "triplet counter container"
+///
+/// It stores the number of triplets for one specific Mid Bottom Doublet.
+///
+struct triplet_counter_spM {
+
+    /// Index of the bottom spacepoint
+    sp_location m_spB;
+
+    /// The number of compatible triplets for a the midbot doublet
+    unsigned int m_nTriplets = 0;
+
+    /// The position in which these triplets will be added
+    unsigned int posTriplets = 0;
+
+};  // struct triplet_counter
+
+/// Declare all triplet_counter_spM collection types
+using triplet_counter_spM_collection_types =
+    collection_types<triplet_counter_spM>;
+/// Declare all triplet_counter_spM container types
+using triplet_counter_spM_container_types =
+    container_types<triplet_counter_spM_header, triplet_counter_spM>;
+
+}  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/count_doublets.hpp
+++ b/device/common/include/traccc/seeding/device/count_doublets.hpp
@@ -10,7 +10,7 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/device/fill_prefix_sum.hpp"
-#include "traccc/edm/device/doublet_counter.hpp"
+#include "traccc/edm/device/doublet_counter_spM.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
 #include "traccc/seeding/detail/spacepoint_grid.hpp"
 
@@ -28,14 +28,14 @@ namespace traccc::device {
 /// @param[in] config        Seedfinder configuration
 /// @param[in] sp_view       The spacepoint grid to count doublets on
 /// @param[in] sp_ps_view    Prefix sum for iterating over the spacepoint grid
-/// @param[out] doublet_view Container storing the number of doublets
+/// @param[out] dc_view      Collection storing the number of doublets
 ///
 TRACCC_HOST_DEVICE
 inline void count_doublets(
-    std::size_t globalIndex, const seedfinder_config& config,
+    const std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>& sp_ps_view,
-    doublet_counter_container_types::view doublet_view);
+    doublet_counter_spM_collection_types::view dc_view);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/seeding/device/count_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/count_triplets.hpp
@@ -10,9 +10,8 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/device/fill_prefix_sum.hpp"
-#include "traccc/edm/device/doublet_counter.hpp"
-#include "traccc/edm/device/triplet_counter.hpp"
-#include "traccc/seeding/detail/doublet.hpp"
+#include "traccc/edm/device/triplet_counter_spM.hpp"
+#include "traccc/seeding/detail/doublet_spM.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
 #include "traccc/seeding/detail/spacepoint_grid.hpp"
 // System include(s).
@@ -28,21 +27,20 @@ namespace traccc::device {
 /// @param[in] globalIndex          The index of the current thread
 /// @param[in] config               Seedfinder configuration
 /// @param[in] sp_view              The spacepoint grid to count doublets on
-/// @param[in] doublet_ps_view      Prefix sum for iterating over the doublets
+/// @param[in] mb_ps_view           Prefix sum for iterating over mb doublets
 /// @param[in] mid_bot_doublet_view Container storing the midBot doublets
 /// @param[in] mid_top_doublet_view Container storing the midTop doublets
-/// @param[out] triplet_view        Container view storing the number of
+/// @param[out] tc_view             Container view storing the number of
 /// triplets
 ///
 TRACCC_HOST_DEVICE
 inline void count_triplets(
-    std::size_t globalIndex, const seedfinder_config& config,
+    const std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
-    const vecmem::data::vector_view<const prefix_sum_element_t>&
-        doublet_ps_view,
-    const doublet_container_types::const_view mid_bot_doublet_view,
-    const doublet_container_types::const_view mid_top_doublet_view,
-    triplet_counter_container_types::view triplet_view);
+    const vecmem::data::vector_view<const prefix_sum_element_t>& mb_ps_view,
+    const doublet_spM_container_types::const_view mid_bot_doublet_view,
+    const doublet_spM_container_types::const_view mid_top_doublet_view,
+    triplet_counter_spM_container_types::view tc_view);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/seeding/device/find_doublets.hpp
+++ b/device/common/include/traccc/seeding/device/find_doublets.hpp
@@ -10,8 +10,8 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/device/fill_prefix_sum.hpp"
-#include "traccc/edm/device/doublet_counter.hpp"
-#include "traccc/seeding/detail/doublet.hpp"
+#include "traccc/edm/device/doublet_counter_spM.hpp"
+#include "traccc/seeding/detail/doublet_spM.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
 #include "traccc/seeding/detail/spacepoint_grid.hpp"
 
@@ -28,20 +28,17 @@ namespace traccc::device {
 /// @param[in] globalIndex       The index of the current thread
 /// @param[in] config            Seedfinder configuration
 /// @param[in] sp_view           The spacepoint grid to count doublets on
-/// @param[in] doublet_view      Container with the number of doublets to find
-/// @param[in] doublet_ps_view   Prefix sum for @c doublet_view
+/// @param[in] dc_view           Collection with the number of doublets to find
 /// @param[out] mb_doublets_view Container of middle-bottom doublets
 /// @param[out] mt_doublets_view Container of middle-top doublets
 ///
 TRACCC_HOST_DEVICE
 inline void find_doublets(
-    std::size_t globalIndex, const seedfinder_config& config,
+    const std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
-    const device::doublet_counter_container_types::const_view& doublet_view,
-    const vecmem::data::vector_view<const prefix_sum_element_t>&
-        doublet_ps_view,
-    doublet_container_types::view mb_doublets_view,
-    doublet_container_types::view mt_doublets_view);
+    const device::doublet_counter_spM_collection_types::const_view& dc_view,
+    doublet_spM_container_types::view mb_doublets_view,
+    doublet_spM_container_types::view mt_doublets_view);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/seeding/device/find_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/find_triplets.hpp
@@ -10,10 +10,11 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/device/fill_prefix_sum.hpp"
-#include "traccc/edm/device/triplet_counter.hpp"
+#include "traccc/edm/device/doublet_counter_spM.hpp"
+#include "traccc/edm/device/triplet_counter_spM.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
 #include "traccc/seeding/detail/spacepoint_grid.hpp"
-#include "traccc/seeding/detail/triplet.hpp"
+#include "traccc/seeding/detail/triplet_spM.hpp"
 
 // System include(s).
 #include <cstddef>
@@ -27,20 +28,20 @@ namespace traccc::device {
 ///
 /// @param[in] globalIndex       The index of the current thread
 /// @param[in] config            Seedfinder configuration
+/// @param[in] filter_config     Seedfilter configuration
 /// @param[in] sp_view           The spacepoint grid to count triplets on
 /// @param[in] mid_top_doublet_view Container with the mid top doublets
 /// @param[in] tc_view           Container with the number of triplets to find
-/// @param[in] triplet_ps_view   Prefix sum for @c triplet_view
+/// @param[in] tc_ps_view        Prefix sum for @c tc_view
 /// @param[out] triplet_view     Container of triplets
 ///
 TRACCC_HOST_DEVICE
 inline void find_triplets(
     const std::size_t globalIndex, const seedfinder_config& config,
     const seedfilter_config& filter_config, const sp_grid_const_view& sp_view,
-    const doublet_container_types::const_view& mid_top_doublet_view,
-    const device::triplet_counter_container_types::const_view& tc_view,
-    const vecmem::data::vector_view<const prefix_sum_element_t>&
-        triplet_ps_view,
+    const doublet_spM_container_types::const_view& mid_top_doublet_view,
+    const device::triplet_counter_spM_container_types::const_view& tc_view,
+    const vecmem::data::vector_view<const prefix_sum_element_t>& tc_ps_view,
     triplet_container_types::view triplet_view);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/find_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/find_triplets.hpp
@@ -42,7 +42,7 @@ inline void find_triplets(
     const doublet_spM_container_types::const_view& mid_top_doublet_view,
     const device::triplet_counter_spM_container_types::const_view& tc_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>& tc_ps_view,
-    triplet_container_types::view triplet_view);
+    triplet_spM_container_types::view triplet_view);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -47,7 +47,7 @@ inline void count_triplets(
         mid_bot_doublet_device.get_items().at(bin_idx).at(item_idx).sp2;
 
     // Create device copy of input parameters
-    const doublet_container_types::const_device mid_top_doublet_device(
+    const doublet_spM_container_types::const_device mid_top_doublet_device(
         mid_top_doublet_view);
 
     // Get internal spacepoints for current bin
@@ -91,6 +91,9 @@ inline void count_triplets(
 
     triplet_counter_spM_header& header =
         triplet_counter.get_headers().at(bin_idx);
+    if (item_idx == 0) {
+        header.m_spM = spM_loc;
+    }
 
     // iterate over mid-top doublets
     for (unsigned int i = 0; i < num_top; ++i) {
@@ -119,7 +122,7 @@ inline void count_triplets(
             nTriplets.fetch_add(num_triplets_per_mb);
 
         triplet_counter.get_items().at(bin_idx).push_back(
-            {spB_ids, num_triplets_per_mb, posTriplets});
+            {spB_loc, num_triplets_per_mb, posTriplets});
     }
 }
 

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -19,61 +19,58 @@ TRACCC_HOST_DEVICE
 inline void count_triplets(
     const std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
-    const vecmem::data::vector_view<const prefix_sum_element_t>&
-        doublet_ps_view,
-    const doublet_container_types::const_view mid_bot_doublet_view,
-    const doublet_container_types::const_view mid_top_doublet_view,
-    triplet_counter_container_types::view triplet_view) {
+    const vecmem::data::vector_view<const prefix_sum_element_t>& mb_ps_view,
+    const doublet_spM_container_types::const_view mid_bot_doublet_view,
+    const doublet_spM_container_types::const_view mid_top_doublet_view,
+    triplet_counter_spM_container_types::view tc_view) {
 
     // Create device copy of input parameters
-    vecmem::device_vector<const prefix_sum_element_t> doublet_prefix_sum(
-        doublet_ps_view);
+    vecmem::device_vector<const prefix_sum_element_t> mb_prefix_sum(mb_ps_view);
 
     // Check if anything needs to be done.
-    if (globalIndex >= doublet_prefix_sum.size()) {
+    if (globalIndex >= mb_prefix_sum.size()) {
         return;
     }
 
     // Create device copy of input parameters
-    const doublet_container_types::const_device mid_bot_doublet_device(
+    const doublet_spM_container_types::const_device mid_bot_doublet_device(
         mid_bot_doublet_view);
 
     // Get ids
-    const prefix_sum_element_t ps_idx = doublet_prefix_sum[globalIndex];
+    const prefix_sum_element_t ps_idx = mb_prefix_sum[globalIndex];
     const unsigned int bin_idx = ps_idx.first;
     const unsigned int item_idx = ps_idx.second;
 
-    // Get current mid bottom doublet
-    const doublet mid_bot =
-        mid_bot_doublet_device.get_items().at(bin_idx).at(item_idx);
+    const traccc::sp_location spM_loc =
+        mid_bot_doublet_device.get_headers().at(bin_idx).spM;
+    const traccc::sp_location spB_loc =
+        mid_bot_doublet_device.get_items().at(bin_idx).at(item_idx).sp2;
 
     // Create device copy of input parameters
     const doublet_container_types::const_device mid_top_doublet_device(
         mid_top_doublet_view);
 
+    // Get internal spacepoints for current bin
+    const unsigned int num_top =
+        mid_top_doublet_device.get_headers().at(bin_idx).n_doublets;
+
     // Create device copy of output parameter
-    triplet_counter_container_types::device triplet_counter(triplet_view);
+    triplet_counter_spM_container_types::device triplet_counter(tc_view);
 
     // Get all spacepoints
     const const_sp_grid_device internal_sp_device(sp_view);
 
     // Header of doublet: number of mid_top doublets per bin
     // Item of doublet: doublet objects per bin
-    const vecmem::device_vector<const doublet> mid_top_doublets_per_bin =
+    const doublet_spM_collection_types::const_device mid_top_doublets_per_bin =
         mid_top_doublet_device.get_items().at(bin_idx);
 
-    // middle spacepoint indexes
-    const unsigned int spM_bin = mid_bot.sp1.bin_idx;
-    const unsigned int spM_idx = mid_bot.sp1.sp_idx;
     // middle spacepoint
     const traccc::internal_spacepoint<traccc::spacepoint> spM =
-        internal_sp_device.bin(spM_bin)[spM_idx];
-    // bottom spacepoint indexes
-    const unsigned int spB_bin = mid_bot.sp2.bin_idx;
-    const unsigned int spB_idx = mid_bot.sp2.sp_idx;
+        internal_sp_device.bin(spM_loc.bin_idx)[spM_loc.sp_idx];
     // bottom spacepoint
     const traccc::internal_spacepoint<traccc::spacepoint> spB =
-        internal_sp_device.bin(spB_bin)[spB_idx];
+        internal_sp_device.bin(spB_loc.bin_idx)[spB_loc.sp_idx];
 
     // Apply the conformal transformation to middle-bot doublet
     traccc::lin_circle lb = doublet_finding_helper::transform_coordinates<
@@ -89,22 +86,18 @@ inline void count_triplets(
     // triplet_finding_helper::isCompatible but their values are irrelevant
     scalar curvature, impact_parameter;
 
-    // find the reference (start) index of the mid-top doublet container
-    // item vector, where the doublets are recorded
-    const unsigned int mt_start_idx = mid_bot.m_mt_start_idx;
-    const unsigned int mt_end_idx = mid_bot.m_mt_end_idx;
-
     // number of triplets per middle-bot doublet
     unsigned int num_triplets_per_mb = 0;
 
-    // iterate over mid-top doublets
-    for (unsigned int i = mt_start_idx; i < mt_end_idx; ++i) {
-        const traccc::doublet mid_top_doublet = mid_top_doublets_per_bin[i];
+    triplet_counter_spM_header& header =
+        triplet_counter.get_headers().at(bin_idx);
 
-        const unsigned int spT_bin = mid_top_doublet.sp2.bin_idx;
-        const unsigned int spT_idx = mid_top_doublet.sp2.sp_idx;
+    // iterate over mid-top doublets
+    for (unsigned int i = 0; i < num_top; ++i) {
+        const traccc::sp_location spT_loc = mid_top_doublets_per_bin[i].sp2;
+
         const traccc::internal_spacepoint<traccc::spacepoint> spT =
-            internal_sp_device.bin(spT_bin)[spT_idx];
+            internal_sp_device.bin(spT_loc.bin_idx)[spT_loc.sp_idx];
 
         // Apply the conformal transformation to middle-top doublet
         traccc::lin_circle lt = doublet_finding_helper::transform_coordinates<
@@ -121,17 +114,12 @@ inline void count_triplets(
     // if the number of triplets per mb is larger than 0, write the triplet
     // counter into the container
     if (num_triplets_per_mb > 0) {
-        triplet_counter_header& header =
-            triplet_counter.get_headers().at(bin_idx);
-        vecmem::device_atomic_ref<unsigned int> nMidBot(header.m_nMidBot);
-        nMidBot.fetch_add(1);
         vecmem::device_atomic_ref<unsigned int> nTriplets(header.m_nTriplets);
         const unsigned int posTriplets =
             nTriplets.fetch_add(num_triplets_per_mb);
 
         triplet_counter.get_items().at(bin_idx).push_back(
-            {mid_bot, num_triplets_per_mb, mt_start_idx, mt_end_idx,
-             posTriplets});
+            {spB_ids, num_triplets_per_mb, posTriplets});
     }
 }
 

--- a/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
@@ -31,7 +31,7 @@ inline void find_doublets(
     }
 
     // Get the middle spacepoint that we need to be looking at.
-    const device::doublet_counter middle_sp_counter =
+    const device::doublet_counter_spM middle_sp_counter =
         doublet_counts.at(globalIndex);
 
     // Set up the device containers.

--- a/device/common/include/traccc/seeding/device/impl/update_triplet_weights.ipp
+++ b/device/common/include/traccc/seeding/device/impl/update_triplet_weights.ipp
@@ -18,7 +18,7 @@ inline void update_triplet_weights(
     const sp_grid_const_view& sp_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         triplet_ps_view,
-    scalar* data, triplet_container_types::view triplet_view) {
+    scalar* data, triplet_spM_container_types::view triplet_view) {
 
     // Check if anything needs to be done.
     const vecmem::device_vector<const prefix_sum_element_t> triplet_prefix_sum(
@@ -31,19 +31,18 @@ inline void update_triplet_weights(
     const const_sp_grid_device sp_grid(sp_view);
 
     const prefix_sum_element_t ps_idx = triplet_prefix_sum[globalIndex];
-    const unsigned int bin_idx = ps_idx.first;
 
-    triplet_container_types::device triplets(triplet_view);
-    vecmem::device_vector<triplet> triplets_per_bin =
-        triplets.get_items().at(bin_idx);
+    triplet_spM_container_types::device triplets_device(triplet_view);
+    triplet_spM_collection_types::device triplets_per_bin =
+        triplets_device.get_items().at(ps_idx.first);
 
     // Current work item
-    triplet this_triplet = triplets_per_bin[ps_idx.second];
+    triplet_spM this_triplet = triplets_per_bin[ps_idx.second];
 
-    const sp_location& spT_idx = this_triplet.sp3;
+    const sp_location& spT_loc = this_triplet.spT;
 
     const traccc::internal_spacepoint<traccc::spacepoint> current_spT =
-        sp_grid.bin(spT_idx.bin_idx)[spT_idx.sp_idx];
+        sp_grid.bin(spT_loc.bin_idx)[spT_loc.sp_idx];
 
     const scalar currentTop_r = current_spT.radius();
 
@@ -64,10 +63,10 @@ inline void update_triplet_weights(
             continue;
         }
 
-        const triplet& other_triplet = triplets_per_bin[i];
-        const sp_location other_spT_idx = other_triplet.sp3;
+        const triplet_spM& other_triplet = triplets_per_bin[i];
+        const sp_location other_spT_loc = other_triplet.spT;
         const traccc::internal_spacepoint<traccc::spacepoint> other_spT =
-            sp_grid.bin(other_spT_idx.bin_idx)[other_spT_idx.sp_idx];
+            sp_grid.bin(other_spT_loc.bin_idx)[other_spT_loc.sp_idx];
 
         // compared top SP should have at least deltaRMin distance
         const scalar otherTop_r = other_spT.radius();

--- a/device/common/include/traccc/seeding/device/make_doublet_buffers.hpp
+++ b/device/common/include/traccc/seeding/device/make_doublet_buffers.hpp
@@ -8,10 +8,10 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/device/doublet_counter.hpp"
+#include "traccc/edm/device/doublet_counter_spM.hpp"
 
 // Project include(s).
-#include "traccc/seeding/detail/doublet.hpp"
+#include "traccc/seeding/detail/doublet_spM.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
@@ -20,11 +20,11 @@
 namespace traccc::device {
 
 /// Helper struct for the return type of @c traccc::device::make_doublet_buffer
-struct doublet_buffer_pair {
+struct doublet_spM_buffer_pair {
     /// Middle-bottom doublet buffer
-    doublet_container_types::buffer middleBottom;
+    doublet_spM_container_types::buffer middleBottom;
     /// Middle-top doublet buffer
-    doublet_container_types::buffer middleTop;
+    doublet_spM_container_types::buffer middleTop;
 };
 
 /// Create the doublet buffers
@@ -40,8 +40,8 @@ struct doublet_buffer_pair {
 ///                buffer, in case @c mr is not host-accessible
 /// @return Buffers usable by @c traccc::device::find_doublets
 ///
-doublet_buffer_pair make_doublet_buffers(
-    const doublet_counter_container_types::const_view& doublet_counter,
+doublet_spM_buffer_pair make_doublet_buffers(
+    const doublet_counter_spM_collection_types::const_view& doublet_counter,
     vecmem::copy& copy, vecmem::memory_resource& mr,
     vecmem::memory_resource* mr_host = nullptr);
 

--- a/device/common/include/traccc/seeding/device/make_doublet_counter_buffer.hpp
+++ b/device/common/include/traccc/seeding/device/make_doublet_counter_buffer.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/device/doublet_counter.hpp"
+#include "traccc/edm/device/doublet_counter_spM.hpp"
 
 // Project include(s).
 #include "traccc/seeding/detail/spacepoint_grid.hpp"
@@ -27,12 +27,10 @@ namespace traccc::device {
 /// @param grid_sizes vector of grid sizes
 /// @param copy The object to use for accessing @c spacepoint_grid
 /// @param mr The memory resource for the buffer
-/// @param mr_host The (optional) host-accessible memory resource for the
-///                buffer, in case @c mr is not host-accessible
 /// @return A buffer usable by @c traccc::device::count_doublets
 ///
-doublet_counter_container_types::buffer make_doublet_counter_buffer(
+doublet_counter_spM_collection_types::buffer make_doublet_counter_buffer(
     const std::vector<unsigned int>& grid_sizes, vecmem::copy& copy,
-    vecmem::memory_resource& mr, vecmem::memory_resource* mr_host = nullptr);
+    vecmem::memory_resource& mr);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/make_triplet_buffer.hpp
+++ b/device/common/include/traccc/seeding/device/make_triplet_buffer.hpp
@@ -8,10 +8,10 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/device/triplet_counter.hpp"
+#include "traccc/edm/device/triplet_counter_spM.hpp"
 
 // Project include(s).
-#include "traccc/seeding/detail/triplet.hpp"
+#include "traccc/seeding/detail/triplet_spM.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
@@ -32,8 +32,8 @@ namespace traccc::device {
 ///                buffer, in case @c mr is not host-accessible
 /// @return Buffer usable by @c traccc::device::find_triplets
 ///
-triplet_container_types::buffer make_triplet_buffer(
-    const triplet_counter_container_types::const_view& triplet_counter,
+triplet_spM_container_types::buffer make_triplet_buffer(
+    const triplet_counter_spM_container_types::const_view& triplet_counter,
     vecmem::copy& copy, vecmem::memory_resource& mr,
     vecmem::memory_resource* mr_host = nullptr);
 

--- a/device/common/include/traccc/seeding/device/make_triplet_counter_buffer.hpp
+++ b/device/common/include/traccc/seeding/device/make_triplet_counter_buffer.hpp
@@ -33,7 +33,7 @@ namespace traccc::device {
 ///                buffer, in case @c mr is not host-accessible
 /// @return A buffer usable by @c traccc::device::count_triplets
 ///
-triplet_counter_container_types::buffer make_triplet_counter_buffer(
+triplet_counter_spM_container_types::buffer make_triplet_counter_buffer(
     const std::vector<doublet_spM_collection_types::view::size_type>&
         mb_doublet_sizes,
     vecmem::copy& copy, vecmem::memory_resource& mr,

--- a/device/common/include/traccc/seeding/device/make_triplet_counter_buffer.hpp
+++ b/device/common/include/traccc/seeding/device/make_triplet_counter_buffer.hpp
@@ -8,7 +8,8 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/device/triplet_counter.hpp"
+#include "traccc/edm/device/triplet_counter_spM.hpp"
+#include "traccc/seeding/detail/doublet_spM.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
@@ -33,7 +34,9 @@ namespace traccc::device {
 /// @return A buffer usable by @c traccc::device::count_triplets
 ///
 triplet_counter_container_types::buffer make_triplet_counter_buffer(
-    const std::vector<std::size_t>& mb_doublet_sizes, vecmem::copy& copy,
-    vecmem::memory_resource& mr, vecmem::memory_resource* mr_host = nullptr);
+    const std::vector<doublet_spM_collection_types::view::size_type>&
+        mb_doublet_sizes,
+    vecmem::copy& copy, vecmem::memory_resource& mr,
+    vecmem::memory_resource* mr_host = nullptr);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/select_seeds.hpp
+++ b/device/common/include/traccc/seeding/device/select_seeds.hpp
@@ -13,7 +13,7 @@
 #include "traccc/edm/seed.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
 #include "traccc/seeding/detail/spacepoint_grid.hpp"
-#include "traccc/seeding/detail/triplet.hpp"
+#include "traccc/seeding/detail/triplet_spM.hpp"
 
 // System include(s).
 #include <cassert>
@@ -26,9 +26,6 @@ namespace traccc::device {
 /// @param[in] globalIndex   The index of the current thread
 /// @param[in] filter_config seed filter config
 /// @param[in] spacepoints_view collection of internal spacepoints
-/// @param[in] dc_prefix_sum view of the vector prefix sum on
-/// doublet_counter_container
-/// @param[in] doublet_counter_container vecmem container for doublet_counter
 /// @param[in] tc_view view on vecmem container for triplets
 /// @param[in] data Array for temporary storage of triplets for
 /// comparison
@@ -36,13 +33,10 @@ namespace traccc::device {
 ///
 TRACCC_HOST_DEVICE
 inline void select_seeds(
-    std::size_t globalIndex, const seedfilter_config& filter_config,
+    const std::size_t globalIndex, const seedfilter_config& filter_config,
     const spacepoint_collection_types::const_view& spacepoints_view,
     const sp_grid_const_view& internal_sp_view,
-    const vecmem::data::vector_view<const prefix_sum_element_t>& dc_ps_view,
-    const device::doublet_counter_container_types::const_view&
-        doublet_counter_container,
-    const triplet_container_types::const_view& tc_view, triplet* data,
+    const triplet_spM_container_types::const_view& tc_view, triplet* data,
     alt_seed_collection_types::view seed_view);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/select_seeds.hpp
+++ b/device/common/include/traccc/seeding/device/select_seeds.hpp
@@ -26,7 +26,7 @@ namespace traccc::device {
 /// @param[in] globalIndex   The index of the current thread
 /// @param[in] filter_config seed filter config
 /// @param[in] spacepoints_view collection of internal spacepoints
-/// @param[in] tc_view view on vecmem container for triplets
+/// @param[in] triplets_view view on vecmem container for triplets
 /// @param[in] data Array for temporary storage of triplets for
 /// comparison
 /// @param[out] seed_container vecmem container for seeds
@@ -36,8 +36,8 @@ inline void select_seeds(
     const std::size_t globalIndex, const seedfilter_config& filter_config,
     const spacepoint_collection_types::const_view& spacepoints_view,
     const sp_grid_const_view& internal_sp_view,
-    const triplet_spM_container_types::const_view& tc_view, triplet* data,
-    alt_seed_collection_types::view seed_view);
+    const triplet_spM_container_types::const_view& triplets_view,
+    triplet_spM* data, alt_seed_collection_types::view seed_view);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/seeding/device/update_triplet_weights.hpp
+++ b/device/common/include/traccc/seeding/device/update_triplet_weights.hpp
@@ -10,10 +10,9 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/device/fill_prefix_sum.hpp"
-#include "traccc/edm/device/triplet_counter.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
 #include "traccc/seeding/detail/spacepoint_grid.hpp"
-#include "traccc/seeding/detail/triplet.hpp"
+#include "traccc/seeding/detail/triplet_spM.hpp"
 
 // System include(s)
 #include <cstddef>
@@ -36,7 +35,7 @@ inline void update_triplet_weights(
     const sp_grid_const_view& sp_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         triplet_ps_view,
-    scalar* data, triplet_container_types::view triplet_view);
+    scalar* data, triplet_spM_container_types::view triplet_view);
 
 }  // namespace traccc::device
 

--- a/device/common/src/seeding/make_doublet_buffers.cpp
+++ b/device/common/src/seeding/make_doublet_buffers.cpp
@@ -16,35 +16,32 @@
 
 namespace traccc::device {
 
-doublet_buffer_pair make_doublet_buffers(
-    const doublet_counter_container_types::const_view& doublet_counter,
+doublet_spM_buffer_pair make_doublet_buffers(
+    const doublet_counter_spM_collection_types::const_view& doublet_counter,
     vecmem::copy& copy, vecmem::memory_resource& mr,
     vecmem::memory_resource* mr_host) {
 
     // Get the number of doublets per geometric bin.
-    vecmem::vector<device::doublet_counter_header> doublet_counts(
+    vecmem::vector<device::doublet_counter_spM> doublet_counts(
         (mr_host != nullptr) ? mr_host : &mr);
-    copy(doublet_counter.headers, doublet_counts);
+    copy(doublet_counter, doublet_counts);
+
+    unsigned int size = doublet_counts.size();
 
     // Construct the size (vectors) for the buffers.
-    std::vector<std::size_t> mb_sizes(doublet_counts.size());
+    std::vector<unsigned int> mb_sizes(size);
     std::transform(
         doublet_counts.begin(), doublet_counts.end(), mb_sizes.begin(),
-        [](const device::doublet_counter_header& dc) { return dc.m_nMidBot; });
+        [](const device::doublet_counter_spM& dc) { return dc.m_nMidBot; });
 
-    std::vector<std::size_t> mt_sizes(doublet_counts.size());
+    std::vector<unsigned int> mt_sizes(size);
     std::transform(
         doublet_counts.begin(), doublet_counts.end(), mt_sizes.begin(),
-        [](const device::doublet_counter_header& dc) { return dc.m_nMidTop; });
-
-    const doublet_container_types::buffer::header_vector::size_type mb_size =
-        mb_sizes.size();
-    const doublet_container_types::buffer::header_vector::size_type mt_size =
-        mt_sizes.size();
+        [](const device::doublet_counter_spM& dc) { return dc.m_nMidTop; });
 
     // Create the result object.
-    doublet_buffer_pair buffers{{{mb_size, mr}, {mb_sizes, mr, mr_host}},
-                                {{mt_size, mr}, {mt_sizes, mr, mr_host}}};
+    doublet_buffer_pair buffers{{{size, mr}, {mb_sizes, mr, mr_host}},
+                                {{size, mr}, {mt_sizes, mr, mr_host}}};
 
     // Initialise the buffer(s).
     copy.setup(buffers.middleBottom.headers);

--- a/device/common/src/seeding/make_doublet_buffers.cpp
+++ b/device/common/src/seeding/make_doublet_buffers.cpp
@@ -29,29 +29,25 @@ doublet_spM_buffer_pair make_doublet_buffers(
     unsigned int size = doublet_counts.size();
 
     // Construct the size (vectors) for the buffers.
-    std::vector<unsigned int> mb_sizes(size);
+    std::vector<std::size_t> mb_sizes(size);
     std::transform(
         doublet_counts.begin(), doublet_counts.end(), mb_sizes.begin(),
         [](const device::doublet_counter_spM& dc) { return dc.m_nMidBot; });
 
-    std::vector<unsigned int> mt_sizes(size);
+    std::vector<std::size_t> mt_sizes(size);
     std::transform(
         doublet_counts.begin(), doublet_counts.end(), mt_sizes.begin(),
         [](const device::doublet_counter_spM& dc) { return dc.m_nMidTop; });
 
     // Create the result object.
-    doublet_buffer_pair buffers{{{size, mr}, {mb_sizes, mr, mr_host}},
-                                {{size, mr}, {mt_sizes, mr, mr_host}}};
+    doublet_spM_buffer_pair buffers{{{size, mr}, {mb_sizes, mr, mr_host}},
+                                    {{size, mr}, {mt_sizes, mr, mr_host}}};
 
     // Initialise the buffer(s).
     copy.setup(buffers.middleBottom.headers);
     copy.setup(buffers.middleBottom.items);
     copy.setup(buffers.middleTop.headers);
     copy.setup(buffers.middleTop.items);
-
-    // Make sure that the summary values are set to zero in the buffers.
-    copy.memset(buffers.middleBottom.headers, 0);
-    copy.memset(buffers.middleTop.headers, 0);
 
     // Return the created buffers.
     return buffers;

--- a/device/common/src/seeding/make_doublet_counter_buffer.cpp
+++ b/device/common/src/seeding/make_doublet_counter_buffer.cpp
@@ -18,8 +18,8 @@ make_doublet_counter_buffer(const std::vector<unsigned int>& grid_sizes,
                             vecmem::copy& copy, vecmem::memory_resource& mr) {
 
     // Calculate the capacities for the buffer.
-    const device::doublet_counter_spM_collection_types::buffer::size_type
-        buffer_size = std::accumulate(grid_sizes.begin(), grid_sizes.end(), 0);
+    const device::doublet_counter_spM_collection_types::buffer::size_type size =
+        std::accumulate(grid_sizes.begin(), grid_sizes.end(), 0);
 
     // Create the buffer object.
     device::doublet_counter_spM_collection_types::buffer buffer{size, 0, mr};

--- a/device/common/src/seeding/make_doublet_counter_buffer.cpp
+++ b/device/common/src/seeding/make_doublet_counter_buffer.cpp
@@ -8,27 +8,25 @@
 // Library include(s).
 #include "traccc/seeding/device/make_doublet_counter_buffer.hpp"
 
+// System include(s).
+#include <numeric>
+
 namespace traccc::device {
 
-device::doublet_counter_container_types::buffer make_doublet_counter_buffer(
-    const std::vector<unsigned int>& grid_sizes, vecmem::copy& copy,
-    vecmem::memory_resource& mr, vecmem::memory_resource* mr_host) {
+device::doublet_counter_spM_collection_types::buffer
+make_doublet_counter_buffer(const std::vector<unsigned int>& grid_sizes,
+                            vecmem::copy& copy, vecmem::memory_resource& mr) {
 
     // Calculate the capacities for the buffer.
-    const device::doublet_counter_container_types::buffer::header_vector::
-        size_type buffer_size = grid_sizes.size();
+    const device::doublet_counter_spM_collection_types::buffer::size_type
+        buffer_size = std::accumulate(grid_sizes.begin(), grid_sizes.end(), 0);
 
     // Create the buffer object.
-    device::doublet_counter_container_types::buffer buffer{
-        {buffer_size, mr},
-        {std::vector<std::size_t>(buffer_size, 0),
-         std::vector<std::size_t>(grid_sizes.begin(), grid_sizes.end()), mr,
-         mr_host}};
-    copy.setup(buffer.headers);
-    copy.setup(buffer.items);
+    device::doublet_counter_spM_collection_types::buffer buffer{size, 0, mr};
+    /// TODO: copy.setup(buffer) required here?
 
     // Make sure that the summary values are set to zero in the buffer.
-    copy.memset(buffer.headers, 0);
+    copy.memset(buffer, 0);
 
     // Return the buffer.
     return buffer;

--- a/device/common/src/seeding/make_triplet_buffer.cpp
+++ b/device/common/src/seeding/make_triplet_buffer.cpp
@@ -27,7 +27,7 @@ triplet_spM_container_types::buffer make_triplet_buffer(
     copy(triplet_counter.headers, triplet_counts);
 
     // Construct the size (vectors) for the buffers.
-    std::vector<triplet_container_types::buffer::item_vector::size_type>
+    std::vector<triplet_spM_container_types::buffer::item_vector::size_type>
         triplet_sizes(triplet_counts.size());
     std::transform(triplet_counts.begin(), triplet_counts.end(),
                    triplet_sizes.begin(),
@@ -47,6 +47,7 @@ triplet_spM_container_types::buffer make_triplet_buffer(
     copy.setup(result.items);
 
     // Make sure that the summary values are set to zero in the buffers.
+    /// TODO: This should not be necessary, but apparently is?!
     copy.memset(result.headers, 0);
 
     // Return the created buffers.

--- a/device/common/src/seeding/make_triplet_buffer.cpp
+++ b/device/common/src/seeding/make_triplet_buffer.cpp
@@ -16,30 +16,31 @@
 
 namespace traccc::device {
 
-triplet_container_types::buffer make_triplet_buffer(
-    const triplet_counter_container_types::const_view& triplet_counter,
+triplet_spM_container_types::buffer make_triplet_buffer(
+    const triplet_counter_spM_container_types::const_view& triplet_counter,
     vecmem::copy& copy, vecmem::memory_resource& mr,
     vecmem::memory_resource* mr_host) {
 
     // Get the number of triplets per geometric bin.
-    vecmem::vector<device::triplet_counter_header> triplet_counts(
+    vecmem::vector<device::triplet_counter_spM_header> triplet_counts(
         (mr_host != nullptr) ? mr_host : &mr);
     copy(triplet_counter.headers, triplet_counts);
 
     // Construct the size (vectors) for the buffers.
-    std::vector<std::size_t> triplet_sizes(triplet_counts.size());
+    std::vector<triplet_container_types::buffer::item_vector::size_type>
+        triplet_sizes(triplet_counts.size());
     std::transform(triplet_counts.begin(), triplet_counts.end(),
                    triplet_sizes.begin(),
-                   [](const device::triplet_counter_header& tc) {
+                   [](const device::triplet_counter_spM_header& tc) {
                        return tc.m_nTriplets;
                    });
 
-    const triplet_container_types::buffer::header_vector::size_type
+    const triplet_spM_container_types::buffer::header_vector::size_type
         triplets_size = triplet_sizes.size();
 
     // Create the result object.
-    triplet_container_types::buffer result{{triplets_size, mr},
-                                           {triplet_sizes, mr, mr_host}};
+    triplet_spM_container_types::buffer result{{triplets_size, mr},
+                                               {triplet_sizes, mr, mr_host}};
 
     // Initialise the buffer(s).
     copy.setup(result.headers);

--- a/device/common/src/seeding/make_triplet_counter_buffer.cpp
+++ b/device/common/src/seeding/make_triplet_counter_buffer.cpp
@@ -10,16 +10,18 @@
 
 namespace traccc::device {
 
-device::triplet_counter_container_types::buffer make_triplet_counter_buffer(
-    const std::vector<size_t>& mb_doublet_sizes, vecmem::copy& copy,
-    vecmem::memory_resource& mr, vecmem::memory_resource* mr_host) {
+device::triplet_counter_spM_container_types::buffer make_triplet_counter_buffer(
+    const std::vector<doublet_spM_collection_types::view::size_type>&
+        mb_doublet_sizes,
+    vecmem::copy& copy, vecmem::memory_resource& mr,
+    vecmem::memory_resource* mr_host) {
 
     // Calculate the capacities for the buffer.
-    const device::triplet_counter_container_types::buffer::header_vector::
+    const device::triplet_counter_spM_container_types::buffer::header_vector::
         size_type buffer_size = mb_doublet_sizes.size();
 
     // Create the buffer object.
-    device::triplet_counter_container_types::buffer buffer{
+    device::triplet_counter_spM_container_types::buffer buffer{
         {buffer_size, mr},
         {std::vector<std::size_t>(buffer_size, 0),
          std::vector<std::size_t>(mb_doublet_sizes.begin(),

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -91,17 +91,17 @@ seed_finding::output_type seed_finding::operator()(
         sp_grid_prefix_sum_view = sp_grid_prefix_sum_buff;
 
     // Set up the doublet counter buffer.
-    device::doublet_counter_container_types::buffer doublet_counter_buffer =
-        device::make_doublet_counter_buffer(grid_sizes, *m_copy, m_mr.main,
-                                            m_mr.host);
+    device::doublet_counter_spM_collection_types::buffer
+        doublet_counter_buffer =
+            device::make_doublet_counter_buffer(grid_sizes, *m_copy, m_mr.main);
 
     // Calculate the range to run the doublet counting for.
     static constexpr unsigned int doubletCountLocalSize = 32 * 2;
     auto doubletCountRange = traccc::sycl::calculate1DimNdRange(
-        sp_grid_prefix_sum_view.size(), doubletCountLocalSize);
+        m_copy->get_size(sp_grid_prefix_sum_view), doubletCountLocalSize);
 
     // Count the number of doublets that we need to produce.
-    device::doublet_counter_container_types::view doublet_counter_view =
+    device::doublet_counter_spM_collection_types::view doublet_counter_view =
         doublet_counter_buffer;
     details::get_queue(m_queue)
         .submit([&](::sycl::handler& h) {
@@ -116,66 +116,49 @@ seed_finding::output_type seed_finding::operator()(
         })
         .wait_and_throw();
 
-    // Get the summary values per bin.
-    vecmem::vector<device::doublet_counter_header> doublet_counts(
-        m_mr.host ? m_mr.host : &(m_mr.main));
-    (*m_copy)(doublet_counter_buffer.headers, doublet_counts);
-
     // Set up the doublet buffers.
-    device::doublet_buffer_pair doublet_buffers = device::make_doublet_buffers(
-        doublet_counter_buffer, *m_copy, m_mr.main, m_mr.host);
-
-    // Create prefix sum buffer and its view
-    vecmem::data::vector_buffer doublet_prefix_sum_buff =
-        make_prefix_sum_buff(m_copy->get_sizes(doublet_counter_buffer.items),
-                             *m_copy, m_mr, details::get_queue(m_queue));
-    vecmem::data::vector_view doublet_prefix_sum_view = doublet_prefix_sum_buff;
+    device::doublet_spM_buffer_pair doublet_buffers =
+        device::make_doublet_buffers(doublet_counter_view, *m_copy, m_mr.main,
+                                     m_mr.host);
 
     // Calculate the range to run the doublet finding for.
     static constexpr unsigned int doubletFindLocalSize = 32 * 2;
     auto doubletFindRange = traccc::sycl::calculate1DimNdRange(
-        doublet_prefix_sum_view.size(), doubletFindLocalSize);
+        m_copy->get_size(doublet_counter_view), doubletFindLocalSize);
 
     // Find all of the spacepoint doublets.
-    doublet_container_types::view mb_view = doublet_buffers.middleBottom;
-    doublet_container_types::view mt_view = doublet_buffers.middleTop;
+    doublet_spM_container_types::view mb_view = doublet_buffers.middleBottom;
+    doublet_spM_container_types::view mt_view = doublet_buffers.middleTop;
     auto find_doublets_kernel =
         details::get_queue(m_queue).submit([&](::sycl::handler& h) {
             h.parallel_for<kernels::find_doublets>(
                 doubletFindRange,
                 [config = m_seedfinder_config, g2_view, doublet_counter_view,
-                 doublet_prefix_sum_view, mb_view,
-                 mt_view](::sycl::nd_item<1> item) {
+                 mb_view, mt_view](::sycl::nd_item<1> item) {
                     device::find_doublets(item.get_global_linear_id(), config,
                                           g2_view, doublet_counter_view,
-                                          doublet_prefix_sum_view, mb_view,
-                                          mt_view);
+                                          mb_view, mt_view);
                 });
         });
 
-    std::vector<std::size_t> mb_buffer_sizes(doublet_counts.size());
-    std::transform(
-        doublet_counts.begin(), doublet_counts.end(), mb_buffer_sizes.begin(),
-        [](const device::doublet_counter_header& dc) { return dc.m_nMidBot; });
-
+    std::vector<unsigned int> mb_sizes = m_copy->get_sizes(mb_view.items);
     // Set up the triplet counter buffer and its view
-    device::triplet_counter_container_types::buffer triplet_counter_buffer =
-        device::make_triplet_counter_buffer(mb_buffer_sizes, *m_copy, m_mr.main,
+    device::triplet_counter_spM_container_types::buffer triplet_counter_buffer =
+        device::make_triplet_counter_buffer(mb_sizes, *m_copy, m_mr.main,
                                             m_mr.host);
 
-    device::triplet_counter_container_types::view triplet_counter_view =
+    device::triplet_counter_spM_container_types::view triplet_counter_view =
         triplet_counter_buffer;
 
     // Create prefix sum buffer and its view
     vecmem::data::vector_buffer mb_prefix_sum_buff = make_prefix_sum_buff(
-        m_copy->get_sizes(doublet_buffers.middleBottom.items), *m_copy, m_mr,
-        details::get_queue(m_queue));
+        mb_sizes, *m_copy, m_mr, details::get_queue(m_queue));
     vecmem::data::vector_view mb_prefix_sum_view = mb_prefix_sum_buff;
 
     // Calculate the range to run the triplet counting for.
     static constexpr unsigned int tripletCountLocalSize = 32 * 2;
     auto tripletCountRange = traccc::sycl::calculate1DimNdRange(
-        mb_prefix_sum_view.size(), tripletCountLocalSize);
+        m_copy->get_size(mb_prefix_sum_view), tripletCountLocalSize);
 
     // Wait here for the find_doublets kernel to finish
     find_doublets_kernel.wait_and_throw();
@@ -196,10 +179,10 @@ seed_finding::output_type seed_finding::operator()(
         .wait_and_throw();
 
     // Set up the triplet buffer and its view
-    triplet_container_types::buffer triplet_buffer =
+    triplet_spM_container_types::buffer triplet_buffer =
         device::make_triplet_buffer(triplet_counter_buffer, *m_copy, m_mr.main,
                                     m_mr.host);
-    triplet_container_types::view triplet_view = triplet_buffer;
+    triplet_spM_container_types::view triplet_view = triplet_buffer;
 
     // Create prefix sum buffer and its view
     vecmem::data::vector_buffer triplet_counter_prefix_sum_buff =
@@ -211,7 +194,8 @@ seed_finding::output_type seed_finding::operator()(
     // Calculate the range to run the triplet finding for
     static constexpr unsigned int tripletFindLocalSize = 32 * 2;
     auto tripletFindRange = traccc::sycl::calculate1DimNdRange(
-        triplet_counter_prefix_sum_view.size(), tripletFindLocalSize);
+        m_copy->get_size(triplet_counter_prefix_sum_view),
+        tripletFindLocalSize);
 
     // Find all of the spacepoint triplets.
     auto find_triplets_kernel =
@@ -238,7 +222,7 @@ seed_finding::output_type seed_finding::operator()(
     // Calculate the range to run the weight updating for
     static constexpr unsigned int weightUpdatingLocalSize = 32 * 2;
     auto weightUpdatingRange = traccc::sycl::calculate1DimNdRange(
-        triplet_prefix_sum_view.size(), weightUpdatingLocalSize);
+        m_copy->get_size(triplet_prefix_sum_view), weightUpdatingLocalSize);
 
     // Wait here for the find_triplets kernel to finish
     find_triplets_kernel.wait_and_throw();
@@ -277,7 +261,7 @@ seed_finding::output_type seed_finding::operator()(
         });
 
     // Take header of the triplet counter container buffer into host
-    vecmem::vector<device::triplet_counter_header> tcc_headers(
+    vecmem::vector<device::triplet_counter_spM_header> tcc_headers(
         m_mr.host ? m_mr.host : &(m_mr.main));
     (*m_copy)(triplet_counter_buffer.headers, tcc_headers);
 
@@ -295,13 +279,13 @@ seed_finding::output_type seed_finding::operator()(
     // Calculate the range to run the seed selecting for
     static constexpr unsigned int seedSelectingLocalSize = 32 * 2;
     auto seedSelectingRange = traccc::sycl::calculate1DimNdRange(
-        doublet_prefix_sum_view.size(), seedSelectingLocalSize);
+        tcc_headers.size(), seedSelectingLocalSize);
 
     // Wait here for the update_weights kernel to finish
     update_weights_kernel.wait_and_throw();
 
     // Check if device is capable of allocating sufficient local memory
-    assert(sizeof(triplet) * m_seedfilter_config.max_triplets_per_spM *
+    assert(sizeof(triplet_spM) * m_seedfilter_config.max_triplets_per_spM *
                seedSelectingLocalSize <
            details::get_queue(m_queue)
                .get_device()
@@ -312,7 +296,7 @@ seed_finding::output_type seed_finding::operator()(
         .submit([&](::sycl::handler& h) {
             // Array for temporary storage of triplets for comparing within seed
             // selecting kernel
-            ::sycl::accessor<triplet, 1, ::sycl::access::mode::read_write,
+            ::sycl::accessor<triplet_spM, 1, ::sycl::access::mode::read_write,
                              ::sycl::access::target::local>
                 local_mem(m_seedfilter_config.max_triplets_per_spM *
                               seedSelectingLocalSize,
@@ -321,17 +305,16 @@ seed_finding::output_type seed_finding::operator()(
             h.parallel_for<kernels::select_seeds>(
                 seedSelectingRange,
                 [filter_config = m_seedfilter_config, spacepoints_view, g2_view,
-                 doublet_prefix_sum_view, doublet_counter_view, triplet_view,
-                 local_mem, seed_view](::sycl::nd_item<1> item) {
+                 triplet_view, local_mem, seed_view](::sycl::nd_item<1> item) {
                     // Each thread uses compatSeedLimit elements of the array
-                    triplet* dataPos =
+                    triplet_spM* dataPos =
                         &local_mem[item.get_local_id() *
                                    filter_config.max_triplets_per_spM];
 
-                    device::select_seeds(
-                        item.get_global_linear_id(), filter_config,
-                        spacepoints_view, g2_view, doublet_prefix_sum_view,
-                        doublet_counter_view, triplet_view, dataPos, seed_view);
+                    device::select_seeds(item.get_global_linear_id(),
+                                         filter_config, spacepoints_view,
+                                         g2_view, triplet_view, dataPos,
+                                         seed_view);
                 });
         })
         .wait_and_throw();


### PR DESCRIPTION
Our current implementation of find_doublets (and count/find triplets) is currently based on storing the resulting information in jagged vectors based on each subvector sharing the same geometrical bin for it's spM. 
This, however, results in having poor reutilization of calculations already done in previous kernels. e.g. [the find_doublets kernel starts with finding the position in which the current work item can be positioned in the result object.](https://github.com/acts-project/traccc/blob/7143f0a8710eca0695f39f2899e14d2af54b17cf/device/common/include/traccc/seeding/device/impl/find_doublets.ipp#L81)

This PR implements an alternative structure where jagged vectors are based on each subvector sharing the same spM (so we get a more subvectors which are a smaller, but the same ammount of total items). This helps reusing previously calculated information and reduces the ammount of calculations needed in each device kernel.

The same logic can be applied to the count / find triplets kernels. As these use the same geometrical bin based jagged structure which then once again is inneficient especially when looking further downstream at select_seeds which once again bases it's calculations on triplets which share the same spM. As such, I intend on making similar changes to count/find_triplets in a following PR.