### PR TITLE
Changed seeding classes to include previously known positions of doublets & triplets

### DIFF
--- a/core/include/traccc/seeding/detail/doublet.hpp
+++ b/core/include/traccc/seeding/detail/doublet.hpp
@@ -22,6 +22,10 @@ struct doublet {
     sp_location sp1;
     // bottom (or top) spacepoint location in internal spacepoint container
     sp_location sp2;
+
+    // Position of the mid top doublets for this which share this spM
+    unsigned int m_mt_start_idx = 0;
+    unsigned int m_mt_end_idx = 0;
 };
 
 inline TRACCC_HOST_DEVICE bool operator==(const doublet& lhs,

--- a/core/include/traccc/seeding/detail/triplet.hpp
+++ b/core/include/traccc/seeding/detail/triplet.hpp
@@ -31,6 +31,10 @@ struct triplet {
     scalar weight;
     // z origin of triplet
     scalar z_vertex;
+
+    /// Position of the triplets which share this mb doublet
+    unsigned int triplets_mb_begin = 0;
+    unsigned int triplets_mb_end = 0;
 };
 
 inline TRACCC_HOST_DEVICE bool operator==(const triplet& lhs,

--- a/device/common/include/traccc/edm/device/doublet_counter.hpp
+++ b/device/common/include/traccc/edm/device/doublet_counter.hpp
@@ -51,6 +51,12 @@ struct doublet_counter {
     /// spacepoint.
     unsigned int m_nMidTop = 0;
 
+    /// The position of the middle-bottom doublets
+    unsigned int m_posMidBot = 0;
+
+    /// The position of the middle-top doublets
+    unsigned int m_posMidTop = 0;
+
 };  // struct doublet_counter
 
 /// Declare all doublet counter collection types

--- a/device/common/include/traccc/edm/device/triplet_counter.hpp
+++ b/device/common/include/traccc/edm/device/triplet_counter.hpp
@@ -41,8 +41,9 @@ struct triplet_counter {
     /// The number of compatible triplets for a the midbot doublet
     unsigned int m_nTriplets = 0;
 
-    /// The position of the middle bottom doublet in its jagged vector
-    unsigned int m_mb_idx = 0;
+    /// The position of the middle top doublets with this spM
+    unsigned int m_mt_start_idx = 0;
+    unsigned int m_mt_end_idx;
 
 };  // struct triplet_counter
 

--- a/device/common/include/traccc/edm/device/triplet_counter.hpp
+++ b/device/common/include/traccc/edm/device/triplet_counter.hpp
@@ -45,6 +45,9 @@ struct triplet_counter {
     unsigned int m_mt_start_idx = 0;
     unsigned int m_mt_end_idx;
 
+    /// The position in which these triplets will be added
+    unsigned int posTriplets = 0;
+
 };  // struct triplet_counter
 
 /// Declare all triplet counter collection types

--- a/device/common/include/traccc/seeding/device/count_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/count_triplets.hpp
@@ -28,7 +28,6 @@ namespace traccc::device {
 /// @param[in] globalIndex          The index of the current thread
 /// @param[in] config               Seedfinder configuration
 /// @param[in] sp_view              The spacepoint grid to count doublets on
-/// @param[in] doublet_counter_view Container storing the number of doublets
 /// @param[in] doublet_ps_view      Prefix sum for iterating over the doublets
 /// @param[in] mid_bot_doublet_view Container storing the midBot doublets
 /// @param[in] mid_top_doublet_view Container storing the midTop doublets
@@ -39,7 +38,6 @@ TRACCC_HOST_DEVICE
 inline void count_triplets(
     std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
-    const doublet_counter_container_types::const_view doublet_counter_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         doublet_ps_view,
     const doublet_container_types::const_view mid_bot_doublet_view,

--- a/device/common/include/traccc/seeding/device/find_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/find_triplets.hpp
@@ -28,7 +28,6 @@ namespace traccc::device {
 /// @param[in] globalIndex       The index of the current thread
 /// @param[in] config            Seedfinder configuration
 /// @param[in] sp_view           The spacepoint grid to count triplets on
-/// @param[in] dc_view           Container with the number of doublets per bin
 /// @param[in] mid_top_doublet_view Container with the mid top doublets
 /// @param[in] tc_view           Container with the number of triplets to find
 /// @param[in] triplet_ps_view   Prefix sum for @c triplet_view
@@ -38,7 +37,6 @@ TRACCC_HOST_DEVICE
 inline void find_triplets(
     const std::size_t globalIndex, const seedfinder_config& config,
     const seedfilter_config& filter_config, const sp_grid_const_view& sp_view,
-    const device::doublet_counter_container_types::const_view& dc_view,
     const doublet_container_types::const_view& mid_top_doublet_view,
     const device::triplet_counter_container_types::const_view& tc_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&

--- a/device/common/include/traccc/seeding/device/impl/count_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_doublets.ipp
@@ -115,9 +115,9 @@ inline void count_doublets(
         vecmem::device_atomic_ref<unsigned int> nSpM(header.m_nSpM);
         nSpM.fetch_add(1);
         vecmem::device_atomic_ref<unsigned int> nMidBot(header.m_nMidBot);
-        nMidBot.fetch_add(n_mb_cand);
+        const unsigned int posBot = nMidBot.fetch_add(n_mb_cand);
         vecmem::device_atomic_ref<unsigned int> nMidTop(header.m_nMidTop);
-        nMidTop.fetch_add(n_mt_cand);
+        const unsigned int posTop = nMidTop.fetch_add(n_mt_cand);
 
         // Add the number of candidates for the "current bin".
         doublet_counter.get_items()
@@ -125,7 +125,9 @@ inline void count_doublets(
             .push_back({{static_cast<unsigned int>(middle_sp_idx.first),
                          static_cast<unsigned int>(middle_sp_idx.second)},
                         n_mb_cand,
-                        n_mt_cand});
+                        n_mt_cand,
+                        posBot,
+                        posTop});
     }
 }
 

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -19,7 +19,6 @@ TRACCC_HOST_DEVICE
 inline void count_triplets(
     const std::size_t globalIndex, const seedfinder_config& config,
     const sp_grid_const_view& sp_view,
-    const doublet_counter_container_types::const_view doublet_counter_view,
     const vecmem::data::vector_view<const prefix_sum_element_t>&
         doublet_ps_view,
     const doublet_container_types::const_view mid_bot_doublet_view,
@@ -49,8 +48,6 @@ inline void count_triplets(
         mid_bot_doublet_device.get_items().at(bin_idx).at(item_idx);
 
     // Create device copy of input parameters
-    const device::doublet_counter_container_types::const_device
-        doublet_counter_device(doublet_counter_view);
     const doublet_container_types::const_device mid_top_doublet_device(
         mid_top_doublet_view);
 
@@ -59,16 +56,6 @@ inline void count_triplets(
 
     // Get all spacepoints
     const const_sp_grid_device internal_sp_device(sp_view);
-
-    // Get internal spacepoints for current bin
-    const unsigned int num_compat_spM_per_bin =
-        doublet_counter_device.get_headers().at(bin_idx).m_nSpM;
-
-    // Header of doublet counter : number of compatible middle sp per bin
-    // Item of doublet counter : doublet counter objects per bin
-    const doublet_counter_collection_types::const_device
-        doublet_counter_per_bin =
-            doublet_counter_device.get_items().at(bin_idx);
 
     // Header of doublet: number of mid_top doublets per bin
     // Item of doublet: doublet objects per bin
@@ -104,16 +91,8 @@ inline void count_triplets(
 
     // find the reference (start) index of the mid-top doublet container
     // item vector, where the doublets are recorded
-    unsigned int mt_start_idx = 0;
-    unsigned int mt_end_idx = 0;
-
-    for (unsigned int i = 0; i < num_compat_spM_per_bin; ++i) {
-        if (doublet_counter_per_bin[i].m_spM == mid_bot.sp1) {
-            mt_start_idx = doublet_counter_per_bin[i].m_posMidTop;
-            mt_end_idx = mt_start_idx + doublet_counter_per_bin[i].m_nMidTop;
-            break;
-        }
-    }
+    const unsigned int mt_start_idx = mid_bot.m_mt_start_idx;
+    const unsigned int mt_end_idx = mid_bot.m_mt_end_idx;
 
     // number of triplets per middle-bot doublet
     unsigned int num_triplets_per_mb = 0;

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -126,10 +126,12 @@ inline void count_triplets(
         vecmem::device_atomic_ref<unsigned int> nMidBot(header.m_nMidBot);
         nMidBot.fetch_add(1);
         vecmem::device_atomic_ref<unsigned int> nTriplets(header.m_nTriplets);
-        nTriplets.fetch_add(num_triplets_per_mb);
+        const unsigned int posTriplets =
+            nTriplets.fetch_add(num_triplets_per_mb);
 
         triplet_counter.get_items().at(bin_idx).push_back(
-            {mid_bot, num_triplets_per_mb, mt_start_idx, mt_end_idx});
+            {mid_bot, num_triplets_per_mb, mt_start_idx, mt_end_idx,
+             posTriplets});
     }
 }
 

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -103,29 +103,15 @@ inline void count_triplets(
     scalar curvature, impact_parameter;
 
     // find the reference (start) index of the mid-top doublet container
-    // item vector, where the doublets are recorded The start index is
-    // calculated by accumulating the number of mid-top doublets of all
-    // previous compatible middle spacepoints
-    unsigned int mb_end_idx = 0;
+    // item vector, where the doublets are recorded
     unsigned int mt_start_idx = 0;
     unsigned int mt_end_idx = 0;
 
     for (unsigned int i = 0; i < num_compat_spM_per_bin; ++i) {
-        mb_end_idx += doublet_counter_per_bin[i].m_nMidBot;
-        mt_end_idx += doublet_counter_per_bin[i].m_nMidTop;
-
-        if (mb_end_idx > item_idx) {
-            break;
+        if (doublet_counter_per_bin[i].m_spM == mid_bot.sp1) {
+            mt_start_idx = doublet_counter_per_bin[i].m_posMidTop;
+            mt_end_idx = mt_start_idx + doublet_counter_per_bin[i].m_nMidTop;
         }
-        mt_start_idx += doublet_counter_per_bin[i].m_nMidTop;
-    }
-
-    if (mt_end_idx >= mid_top_doublets_per_bin.size()) {
-        mt_end_idx = std::min(mid_top_doublets_per_bin.size(), mt_end_idx);
-    }
-
-    if (mt_start_idx >= mid_top_doublets_per_bin.size()) {
-        return;
     }
 
     // number of triplets per middle-bot doublet

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -111,6 +111,7 @@ inline void count_triplets(
         if (doublet_counter_per_bin[i].m_spM == mid_bot.sp1) {
             mt_start_idx = doublet_counter_per_bin[i].m_posMidTop;
             mt_end_idx = mt_start_idx + doublet_counter_per_bin[i].m_nMidTop;
+            break;
         }
     }
 
@@ -149,7 +150,7 @@ inline void count_triplets(
         nTriplets.fetch_add(num_triplets_per_mb);
 
         triplet_counter.get_items().at(bin_idx).push_back(
-            {mid_bot, num_triplets_per_mb, item_idx});
+            {mid_bot, num_triplets_per_mb, mt_start_idx, mt_end_idx});
     }
 }
 

--- a/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
@@ -75,14 +75,10 @@ inline void find_doublets(
             .at(middle_sp_counter.m_spM.sp_idx);
 
     // Find the reference (start) index of the doublet container item vector,
-    // where the doublets are recorded. The start index is calculated by
-    // accumulating the number of doublets of all previous compatible middle
-    // spacepoints.
-    unsigned int mid_bot_start_idx = 0, mid_top_start_idx = 0;
-    for (unsigned int i = 0; i < middle_sp_idx.second; i++) {
-        mid_bot_start_idx += doublet_counts_in_bin[i].m_nMidBot;
-        mid_top_start_idx += doublet_counts_in_bin[i].m_nMidTop;
-    }
+    // where the doublets are recorded.
+    const unsigned int mid_bot_start_idx = middle_sp_counter.m_posMidBot;
+    const unsigned int mid_top_start_idx = middle_sp_counter.m_posMidTop;
+
     // The running indices for the middle-bottom and middle-top pairs.
     unsigned int mid_bot_idx = 0, mid_top_idx = 0;
 

--- a/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
@@ -78,6 +78,8 @@ inline void find_doublets(
     // where the doublets are recorded.
     const unsigned int mid_bot_start_idx = middle_sp_counter.m_posMidBot;
     const unsigned int mid_top_start_idx = middle_sp_counter.m_posMidTop;
+    const unsigned int mid_top_end_idx =
+        middle_sp_counter.m_posMidTop + middle_sp_counter.m_nMidTop;
 
     // The running indices for the middle-bottom and middle-top pairs.
     unsigned int mid_bot_idx = 0, mid_top_idx = 0;
@@ -142,7 +144,9 @@ inline void find_doublets(
                              middle_sp_counter.m_spM.bin_idx),
                          static_cast<unsigned int>(
                              middle_sp_counter.m_spM.sp_idx)},
-                        {other_bin_idx, other_sp_idx}};
+                        {other_bin_idx, other_sp_idx},
+                        mid_top_start_idx,
+                        mid_top_end_idx};
                     mb_doublet_count.fetch_add(1);
                 }
                 // Check if this spacepoint is a compatible "top" spacepoint to

--- a/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
@@ -98,30 +98,15 @@ inline void find_triplets(
     scalar curvature, impact_parameter;
 
     // find the reference (start) index of the mid-top doublet container
-    // item vector, where the doublets are recorded The start index is
-    // calculated by accumulating the number of mid-top doublets of all
-    // previous compatible middle spacepoints
-    unsigned int mb_end_idx = 0;
+    // item vector, where the doublets are recorded
     unsigned int mt_start_idx = 0;
     unsigned int mt_end_idx = 0;
-    unsigned int mb_idx = mid_bot_counter.m_mb_idx;
 
     for (unsigned int i = 0; i < num_compat_spM_per_bin; ++i) {
-        mb_end_idx += doublet_counter_per_bin[i].m_nMidBot;
-        mt_end_idx += doublet_counter_per_bin[i].m_nMidTop;
-
-        if (mb_end_idx > mb_idx) {
-            break;
+        if (doublet_counter_per_bin[i].m_spM == mid_bot_doublet.sp1) {
+            mt_start_idx = doublet_counter_per_bin[i].m_posMidTop;
+            mt_end_idx = mt_start_idx + doublet_counter_per_bin[i].m_nMidTop;
         }
-        mt_start_idx += doublet_counter_per_bin[i].m_nMidTop;
-    }
-
-    if (mt_end_idx >= mid_top_doublets_per_bin.size()) {
-        mt_end_idx = std::min(mid_top_doublets_per_bin.size(), mt_end_idx);
-    }
-
-    if (mt_start_idx >= mid_top_doublets_per_bin.size()) {
-        return;
     }
 
     // iterate over mid-top doublets

--- a/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
@@ -86,6 +86,10 @@ inline void find_triplets(
     // item vector, where the doublets are recorded
     const unsigned int mt_start_idx = mid_bot_counter.m_mt_start_idx;
     const unsigned int mt_end_idx = mid_bot_counter.m_mt_end_idx;
+    const unsigned int triplets_mb_begin = mid_bot_counter.posTriplets;
+    const unsigned int triplets_mb_end =
+        triplets_mb_begin + mid_bot_counter.m_nTriplets;
+    unsigned int posTriplets = triplets_mb_begin;
 
     // iterate over mid-top doublets
     for (unsigned int i = mt_start_idx; i < mt_end_idx; ++i) {
@@ -111,11 +115,11 @@ inline void find_triplets(
             num_triplets_per_bin.fetch_add(1);
 
             // Add triplet to jagged vector
-            triplets.get_items().at(spM_bin).push_back(
+            triplets.get_items().at(spM_bin).at(posTriplets++) =
                 triplet({mid_bot_doublet.sp2, mid_bot_doublet.sp1,
                          mid_top_doublet.sp2, curvature,
                          -impact_parameter * filter_config.impactWeightFactor,
-                         lb.Zo()}));
+                         lb.Zo(), triplets_mb_begin, triplets_mb_end});
         }
     }
 }

--- a/device/common/include/traccc/seeding/device/impl/update_triplet_weights.ipp
+++ b/device/common/include/traccc/seeding/device/impl/update_triplet_weights.ipp
@@ -57,15 +57,14 @@ inline void update_triplet_weights(
     std::size_t num_compat_seedR = 0;
 
     // iterate over triplets
-    for (auto tr_it = triplets_per_bin.begin(); tr_it != triplets_per_bin.end();
-         tr_it++) {
-        // only use other triplets which share same midBot doublet
-        if (this_triplet == *tr_it || !(this_triplet.sp1 == tr_it->sp1) ||
-            !(this_triplet.sp2 == tr_it->sp2)) {
+    for (unsigned int i = this_triplet.triplets_mb_begin;
+         i < this_triplet.triplets_mb_end; ++i) {
+        // skip same triplet
+        if (i == ps_idx.second) {
             continue;
         }
 
-        const triplet& other_triplet = *tr_it;
+        const triplet& other_triplet = triplets_per_bin[i];
         const sp_location other_spT_idx = other_triplet.sp3;
         const traccc::internal_spacepoint<traccc::spacepoint> other_spT =
             sp_grid.bin(other_spT_idx.bin_idx)[other_spT_idx.sp_idx];

--- a/device/common/src/seeding/make_triplet_buffer.cpp
+++ b/device/common/src/seeding/make_triplet_buffer.cpp
@@ -38,10 +38,8 @@ triplet_container_types::buffer make_triplet_buffer(
         triplets_size = triplet_sizes.size();
 
     // Create the result object.
-    triplet_container_types::buffer result{
-        {triplets_size, mr},
-        {std::vector<std::size_t>(triplets_size, 0), triplet_sizes, mr,
-         mr_host}};
+    triplet_container_types::buffer result{{triplets_size, mr},
+                                           {triplet_sizes, mr, mr_host}};
 
     // Initialise the buffer(s).
     copy.setup(result.headers);

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -62,7 +62,6 @@ __global__ void find_doublets(
 /// CUDA kernel for running @c traccc::device::count_triplets
 __global__ void count_triplets(
     seedfinder_config config, sp_grid_const_view sp_grid,
-    device::doublet_counter_container_types::const_view doublet_counter_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         doublet_prefix_sum,
     doublet_container_types::const_view mb_doublets,
@@ -70,8 +69,8 @@ __global__ void count_triplets(
     device::triplet_counter_container_types::view triplet_view) {
 
     device::count_triplets(threadIdx.x + blockIdx.x * blockDim.x, config,
-                           sp_grid, doublet_counter_view, doublet_prefix_sum,
-                           mb_doublets, mt_doublets, triplet_view);
+                           sp_grid, doublet_prefix_sum, mb_doublets,
+                           mt_doublets, triplet_view);
 }
 /// CUDA kernel for running @c traccc::device::find_triplets
 __global__ void find_triplets(
@@ -225,9 +224,9 @@ seed_collection_types::buffer seed_finding::operator()(
 
     // Count the number of triplets that we need to produce.
     kernels::count_triplets<<<nTripletCountBlocks, nTripletCountThreads>>>(
-        m_seedfinder_config, g2_view, doublet_counter_buffer,
-        mb_prefix_sum_buff, doublet_buffers.middleBottom,
-        doublet_buffers.middleTop, triplet_counter_buffer);
+        m_seedfinder_config, g2_view, mb_prefix_sum_buff,
+        doublet_buffers.middleBottom, doublet_buffers.middleTop,
+        triplet_counter_buffer);
     CUDA_ERROR_CHECK(cudaGetLastError());
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -76,18 +76,15 @@ __global__ void count_triplets(
 /// CUDA kernel for running @c traccc::device::find_triplets
 __global__ void find_triplets(
     seedfinder_config config, seedfilter_config filter_config,
-    sp_grid_const_view sp_grid,
-    device::doublet_counter_container_types::const_view doublet_counter_view,
-    doublet_container_types::const_view mt_doublets,
+    sp_grid_const_view sp_grid, doublet_container_types::const_view mt_doublets,
     device::triplet_counter_container_types::const_view tc_view,
     vecmem::data::vector_view<const device::prefix_sum_element_t>
         triplet_prefix_sum,
     triplet_container_types::view triplet_view) {
 
     device::find_triplets(threadIdx.x + blockIdx.x * blockDim.x, config,
-                          filter_config, sp_grid, doublet_counter_view,
-                          mt_doublets, tc_view, triplet_prefix_sum,
-                          triplet_view);
+                          filter_config, sp_grid, mt_doublets, tc_view,
+                          triplet_prefix_sum, triplet_view);
 }
 /// CUDA kernel for running @c traccc::device::update_triplet_weights
 __global__ void update_triplet_weights(
@@ -254,9 +251,8 @@ seed_collection_types::buffer seed_finding::operator()(
     // Find all of the spacepoint triplets.
     kernels::find_triplets<<<nTripletFindBlocks, nTripletFindThreads>>>(
         m_seedfinder_config, m_seedfilter_config, g2_view,
-        doublet_counter_buffer, doublet_buffers.middleTop,
-        triplet_counter_buffer, triplet_counter_prefix_sum_buff,
-        triplet_buffer);
+        doublet_buffers.middleTop, triplet_counter_buffer,
+        triplet_counter_prefix_sum_buff, triplet_buffer);
     CUDA_ERROR_CHECK(cudaGetLastError());
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -183,13 +183,12 @@ seed_collection_types::buffer seed_finding::operator()(
         .submit([&](::sycl::handler& h) {
             h.parallel_for<kernels::count_triplets>(
                 tripletCountRange,
-                [config = m_seedfinder_config, g2_view, doublet_counter_view,
-                 mb_prefix_sum_view, mb_view, mt_view,
+                [config = m_seedfinder_config, g2_view, mb_prefix_sum_view,
+                 mb_view, mt_view,
                  triplet_counter_view](::sycl::nd_item<1> item) {
                     device::count_triplets(item.get_global_linear_id(), config,
-                                           g2_view, doublet_counter_view,
-                                           mb_prefix_sum_view, mb_view, mt_view,
-                                           triplet_counter_view);
+                                           g2_view, mb_prefix_sum_view, mb_view,
+                                           mt_view, triplet_counter_view);
                 });
         })
         .wait_and_throw();

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -218,15 +218,13 @@ seed_collection_types::buffer seed_finding::operator()(
             h.parallel_for<kernels::find_triplets>(
                 tripletFindRange,
                 [config = m_seedfinder_config,
-                 filter_config = m_seedfilter_config, g2_view,
-                 doublet_counter_view, mt_view, triplet_counter_view,
-                 triplet_counter_prefix_sum_view,
+                 filter_config = m_seedfilter_config, g2_view, mt_view,
+                 triplet_counter_view, triplet_counter_prefix_sum_view,
                  triplet_view](::sycl::nd_item<1> item) {
                     device::find_triplets(
                         item.get_global_linear_id(), config, filter_config,
-                        g2_view, doublet_counter_view, mt_view,
-                        triplet_counter_view, triplet_counter_prefix_sum_view,
-                        triplet_view);
+                        g2_view, mt_view, triplet_counter_view,
+                        triplet_counter_prefix_sum_view, triplet_view);
                 });
         })
         .wait_and_throw();


### PR DESCRIPTION
The current implementation of find doublets, count triplets, and find triplets contain a for loop in each which finds the positions of  doublets to be used in those kernels. In this PR, these are eliminated by including this information in the items created in previous kernels, to then be reused.

However, despite the apparent reduced workload in these kernels, their performance seems to remain essencially the same.