### PR TITLE
Improved count/find doublets performance

### DIFF
--- a/core/include/traccc/seeding/doublet_finding_helper.hpp
+++ b/core/include/traccc/seeding/doublet_finding_helper.hpp
@@ -45,46 +45,29 @@ bool doublet_finding_helper::isCompatible(
     const internal_spacepoint<spacepoint>& sp1,
     const internal_spacepoint<spacepoint>& sp2, const seedfinder_config& config,
     bool bottom) {
-    bool result = true;
+
     if (bottom) {
         scalar deltaR = sp1.radius() - sp2.radius();
-        // if r-distance is too big, try next SP in bin
-        if (deltaR > config.deltaRMax) {
-            result = false;
+        scalar cotTheta = sp1.z() - sp2.z();
+        scalar zOrigin = sp1.z() * deltaR - sp1.radius() * cotTheta;
+        if (deltaR > config.deltaRMax || deltaR < config.deltaRMin ||
+            std::fabs(cotTheta) > config.cotThetaMax * deltaR ||
+            zOrigin < config.collisionRegionMin * deltaR ||
+            zOrigin > config.collisionRegionMax * deltaR) {
+            return false;
         }
-        // if r-distance is too small, continue because bins are NOT r-sorted
-        if (deltaR < config.deltaRMin) {
-            result = false;
-        }
-        scalar cotTheta = (sp1.z() - sp2.z()) / deltaR;
-        if (std::fabs(cotTheta) > config.cotThetaMax) {
-            result = false;
-        }
-        scalar zOrigin = sp1.z() - sp1.radius() * cotTheta;
-        if (zOrigin < config.collisionRegionMin ||
-            zOrigin > config.collisionRegionMax) {
-            result = false;
-        }
-    } else if (!bottom) {
+    } else {
         scalar deltaR = sp2.radius() - sp1.radius();
-        if (deltaR > config.deltaRMax) {
-            result = false;
-        }
-        // if r-distance is too small, continue because bins are NOT r-sorted
-        if (deltaR < config.deltaRMin) {
-            result = false;
-        }
-        scalar cotTheta = (sp2.z() - sp1.z()) / deltaR;
-        if (std::fabs(cotTheta) > config.cotThetaMax) {
-            result = false;
-        }
-        scalar zOrigin = sp1.z() - sp1.radius() * cotTheta;
-        if (zOrigin < config.collisionRegionMin ||
-            zOrigin > config.collisionRegionMax) {
-            result = false;
+        scalar cotTheta = (sp2.z() - sp1.z());
+        scalar zOrigin = sp1.z() * deltaR - sp1.radius() * cotTheta;
+        if (deltaR > config.deltaRMax || deltaR < config.deltaRMin ||
+            std::fabs(cotTheta) > config.cotThetaMax * deltaR ||
+            zOrigin < config.collisionRegionMin * deltaR ||
+            zOrigin > config.collisionRegionMax * deltaR) {
+            return false;
         }
     }
-    return result;
+    return true;
 }
 
 lin_circle doublet_finding_helper::transform_coordinates(

--- a/core/include/traccc/seeding/doublet_finding_helper.hpp
+++ b/core/include/traccc/seeding/doublet_finding_helper.hpp
@@ -45,45 +45,46 @@ bool doublet_finding_helper::isCompatible(
     const internal_spacepoint<spacepoint>& sp1,
     const internal_spacepoint<spacepoint>& sp2, const seedfinder_config& config,
     bool bottom) {
+    bool result = true;
     if (bottom) {
         scalar deltaR = sp1.radius() - sp2.radius();
         // if r-distance is too big, try next SP in bin
         if (deltaR > config.deltaRMax) {
-            return false;
+            result = false;
         }
         // if r-distance is too small, continue because bins are NOT r-sorted
         if (deltaR < config.deltaRMin) {
-            return false;
+            result = false;
         }
         scalar cotTheta = (sp1.z() - sp2.z()) / deltaR;
         if (std::fabs(cotTheta) > config.cotThetaMax) {
-            return false;
+            result = false;
         }
         scalar zOrigin = sp1.z() - sp1.radius() * cotTheta;
         if (zOrigin < config.collisionRegionMin ||
             zOrigin > config.collisionRegionMax) {
-            return false;
+            result = false;
         }
     } else if (!bottom) {
         scalar deltaR = sp2.radius() - sp1.radius();
         if (deltaR > config.deltaRMax) {
-            return false;
+            result = false;
         }
         // if r-distance is too small, continue because bins are NOT r-sorted
         if (deltaR < config.deltaRMin) {
-            return false;
+            result = false;
         }
         scalar cotTheta = (sp2.z() - sp1.z()) / deltaR;
         if (std::fabs(cotTheta) > config.cotThetaMax) {
-            return false;
+            result = false;
         }
         scalar zOrigin = sp1.z() - sp1.radius() * cotTheta;
         if (zOrigin < config.collisionRegionMin ||
             zOrigin > config.collisionRegionMax) {
-            return false;
+            result = false;
         }
     }
-    return true;
+    return result;
 }
 
 lin_circle doublet_finding_helper::transform_coordinates(

--- a/core/include/traccc/seeding/doublet_finding_helper.hpp
+++ b/core/include/traccc/seeding/doublet_finding_helper.hpp
@@ -47,8 +47,11 @@ bool doublet_finding_helper::isCompatible(
     bool bottom) {
 
     if (bottom) {
+        // check if R distance is too small, because bins are not R-sorted
         scalar deltaR = sp1.radius() - sp2.radius();
+        // actually cotTheta * deltaR to avoid division by 0 statements
         scalar cotTheta = sp1.z() - sp2.z();
+        // actually zOrigin * deltaR to avoid division by 0 statements
         scalar zOrigin = sp1.z() * deltaR - sp1.radius() * cotTheta;
         if (deltaR > config.deltaRMax || deltaR < config.deltaRMin ||
             std::fabs(cotTheta) > config.cotThetaMax * deltaR ||
@@ -57,8 +60,11 @@ bool doublet_finding_helper::isCompatible(
             return false;
         }
     } else {
+        // check if R distance is too small, because bins are not R-sorted
         scalar deltaR = sp2.radius() - sp1.radius();
+        // actually cotTheta * deltaR to avoid division by 0 statements
         scalar cotTheta = (sp2.z() - sp1.z());
+        // actually zOrigin * deltaR to avoid division by 0 statements
         scalar zOrigin = sp1.z() * deltaR - sp1.radius() * cotTheta;
         if (deltaR > config.deltaRMax || deltaR < config.deltaRMin ||
             std::fabs(cotTheta) > config.cotThetaMax * deltaR ||

--- a/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
@@ -123,9 +123,10 @@ inline void find_doublets(
             const unsigned int other_bin_idx =
                 phi_bin + z_bin * sp_grid.axis_p0().bins();
 
+            const unsigned int size = spacepoints.size();
             // Loop over all of those spacepoints.
-            for (unsigned int other_sp_idx = 0;
-                 other_sp_idx < spacepoints.size(); ++other_sp_idx) {
+            for (unsigned int other_sp_idx = 0; other_sp_idx < size;
+                 ++other_sp_idx) {
 
                 // Access the "other spacepoint".
                 const internal_spacepoint<spacepoint> other_sp =


### PR DESCRIPTION
* Changed doublet finding compatibility checking function to always run the same ammount of if statements. This reduces divergence in between threads improving performance.

* Removed repeated usage of .size() of resizable vector which was very expensive.

This resulted in an improvement of ~8% in count doublets and ~20% in find doublets.