### PR TITLE
Moved device syncronisation statements to as late as possible

### DIFF
--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -172,12 +172,13 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     kernels::find_clusters<<<blocksPerGrid, threadsPerBlock>>>(
         cells_view, sparse_ccl_indices_buff, cl_per_module_prefix_buff);
 
-    CUDA_ERROR_CHECK(cudaGetLastError());
-    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
-
     // Create prefix sum buffer
     vecmem::data::vector_buffer cells_prefix_sum_buff =
         make_prefix_sum_buff(cell_sizes, *m_copy, m_mr);
+
+    // Wait here for the find_clusters kernel to finish
+    CUDA_ERROR_CHECK(cudaGetLastError());
+    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
     // Copy the sizes of clusters per module to the host
     // and create a copy of "clusters per module" vector
@@ -237,8 +238,6 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     kernels::connect_components<<<blocksPerGrid, threadsPerBlock>>>(
         cells_view, sparse_ccl_indices_buff, cl_per_module_prefix_buff,
         cells_prefix_sum_buff, clusters_buffer);
-    CUDA_ERROR_CHECK(cudaGetLastError());
-    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
     // Resizable buffer for the measurements
     measurement_container_types::buffer measurements_buffer{
@@ -260,6 +259,10 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     // Calculating grid size for measurements creation kernel (block size 64)
     blocksPerGrid = (clusters_buffer.headers.size() - 1 + threadsPerBlock) /
                     threadsPerBlock;
+
+    // Wait here for the connect_components kernel to finish
+    CUDA_ERROR_CHECK(cudaGetLastError());
+    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
     // Invoke measurements creation will call create measurements kernel
     kernels::create_measurements<<<blocksPerGrid, threadsPerBlock>>>(

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -198,8 +198,6 @@ seed_collection_types::buffer seed_finding::operator()(
         m_seedfinder_config, g2_view, doublet_counter_buffer,
         doublet_prefix_sum_buff, doublet_buffers.middleBottom,
         doublet_buffers.middleTop);
-    CUDA_ERROR_CHECK(cudaGetLastError());
-    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
     std::vector<std::size_t> mb_buffer_sizes(doublet_counts.size());
     std::transform(
@@ -221,6 +219,9 @@ seed_collection_types::buffer seed_finding::operator()(
     const unsigned int nTripletCountBlocks =
         (mb_prefix_sum_buff.size() + nTripletCountThreads - 1) /
         nTripletCountThreads;
+
+    CUDA_ERROR_CHECK(cudaGetLastError());
+    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
     // Count the number of triplets that we need to produce.
     kernels::count_triplets<<<nTripletCountBlocks, nTripletCountThreads>>>(
@@ -252,8 +253,6 @@ seed_collection_types::buffer seed_finding::operator()(
         m_seedfinder_config, m_seedfilter_config, g2_view,
         doublet_buffers.middleTop, triplet_counter_buffer,
         triplet_counter_prefix_sum_buff, triplet_buffer);
-    CUDA_ERROR_CHECK(cudaGetLastError());
-    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
     // Create prefix sum buffer
     vecmem::data::vector_buffer triplet_prefix_sum_buff = make_prefix_sum_buff(
@@ -266,14 +265,15 @@ seed_collection_types::buffer seed_finding::operator()(
         (triplet_prefix_sum_buff.size() + nWeightUpdatingThreads - 1) /
         nWeightUpdatingThreads;
 
+    CUDA_ERROR_CHECK(cudaGetLastError());
+    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+
     // Update the weights of all spacepoint triplets.
     kernels::update_triplet_weights<<<
         nWeightUpdatingBlocks, nWeightUpdatingThreads,
         sizeof(scalar) * m_seedfilter_config.compatSeedLimit *
             nWeightUpdatingThreads>>>(m_seedfilter_config, g2_view,
                                       triplet_prefix_sum_buff, triplet_buffer);
-    CUDA_ERROR_CHECK(cudaGetLastError());
-    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
     // Take header of the triplet counter container buffer into host
     vecmem::vector<device::triplet_counter_header> tcc_headers(
@@ -295,6 +295,9 @@ seed_collection_types::buffer seed_finding::operator()(
     const unsigned int nSeedSelectingBlocks =
         (doublet_prefix_sum_buff.size() + nSeedSelectingThreads - 1) /
         nSeedSelectingThreads;
+
+    CUDA_ERROR_CHECK(cudaGetLastError());
+    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
     // Create seeds out of selected triplets
     kernels::select_seeds<<<nSeedSelectingBlocks, nSeedSelectingThreads,

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -246,14 +246,14 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     m_copy->setup(spacepoints_buffer.headers);
     m_copy->setup(spacepoints_buffer.items);
 
-    // Wait here for the component_connection kernel to finish
-    component_connection_kernel.wait_and_throw();
-
     // Create views to pass to measurement creation kernel
     measurement_container_types::view measurements_view = measurements_buffer;
 
     // Calculate nd_range to run measurement creation (localSize = 64)
     ndrange = calculate1DimNdRange(clusters_view.headers.size(), localSize);
+
+    // Wait here for the component_connection kernel to finish
+    component_connection_kernel.wait_and_throw();
 
     // Run measurement_creation kernel
     details::get_queue(m_queue)

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -139,8 +139,8 @@ seed_collection_types::buffer seed_finding::operator()(
     // Find all of the spacepoint doublets.
     doublet_container_types::view mb_view = doublet_buffers.middleBottom;
     doublet_container_types::view mt_view = doublet_buffers.middleTop;
-    details::get_queue(m_queue)
-        .submit([&](::sycl::handler& h) {
+    auto find_doublets_kernel =
+        details::get_queue(m_queue).submit([&](::sycl::handler& h) {
             h.parallel_for<kernels::find_doublets>(
                 doubletFindRange,
                 [config = m_seedfinder_config, g2_view, doublet_counter_view,
@@ -151,8 +151,7 @@ seed_collection_types::buffer seed_finding::operator()(
                                           doublet_prefix_sum_view, mb_view,
                                           mt_view);
                 });
-        })
-        .wait_and_throw();
+        });
 
     std::vector<std::size_t> mb_buffer_sizes(doublet_counts.size());
     std::transform(
@@ -177,6 +176,9 @@ seed_collection_types::buffer seed_finding::operator()(
     static constexpr unsigned int tripletCountLocalSize = 32 * 2;
     auto tripletCountRange = traccc::sycl::calculate1DimNdRange(
         mb_prefix_sum_view.size(), tripletCountLocalSize);
+
+    // Wait here for the find_doublets kernel to finish
+    find_doublets_kernel.wait_and_throw();
 
     // Count the number of triplets that we need to produce.
     details::get_queue(m_queue)
@@ -212,8 +214,8 @@ seed_collection_types::buffer seed_finding::operator()(
         triplet_counter_prefix_sum_view.size(), tripletFindLocalSize);
 
     // Find all of the spacepoint triplets.
-    details::get_queue(m_queue)
-        .submit([&](::sycl::handler& h) {
+    auto find_triplets_kernel =
+        details::get_queue(m_queue).submit([&](::sycl::handler& h) {
             h.parallel_for<kernels::find_triplets>(
                 tripletFindRange,
                 [config = m_seedfinder_config,
@@ -225,8 +227,7 @@ seed_collection_types::buffer seed_finding::operator()(
                         g2_view, mt_view, triplet_counter_view,
                         triplet_counter_prefix_sum_view, triplet_view);
                 });
-        })
-        .wait_and_throw();
+        });
 
     // Create prefix sum buffer and its view
     vecmem::data::vector_buffer triplet_prefix_sum_buff =
@@ -239,6 +240,9 @@ seed_collection_types::buffer seed_finding::operator()(
     auto weightUpdatingRange = traccc::sycl::calculate1DimNdRange(
         triplet_prefix_sum_view.size(), weightUpdatingLocalSize);
 
+    // Wait here for the find_triplets kernel to finish
+    find_triplets_kernel.wait_and_throw();
+
     // Check if device is capable of allocating sufficient local memory
     assert(sizeof(scalar) * m_seedfilter_config.compatSeedLimit *
                weightUpdatingLocalSize <
@@ -247,8 +251,8 @@ seed_collection_types::buffer seed_finding::operator()(
                .get_info<::sycl::info::device::local_mem_size>());
 
     // Update the weight of all of the spacepoint triplets.
-    details::get_queue(m_queue)
-        .submit([&](::sycl::handler& h) {
+    auto update_weights_kernel =
+        details::get_queue(m_queue).submit([&](::sycl::handler& h) {
             // Array for temporary storage of triplets for comparing within seed
             // selecting kernel
             ::sycl::accessor<scalar, 1, ::sycl::access::mode::read_write,
@@ -270,8 +274,7 @@ seed_collection_types::buffer seed_finding::operator()(
                         item.get_global_linear_id(), filter_config, g2_view,
                         triplet_prefix_sum_view, dataPos, triplet_view);
                 });
-        })
-        .wait_and_throw();
+        });
 
     // Take header of the triplet counter container buffer into host
     vecmem::vector<device::triplet_counter_header> tcc_headers(
@@ -293,6 +296,9 @@ seed_collection_types::buffer seed_finding::operator()(
     static constexpr unsigned int seedSelectingLocalSize = 32 * 2;
     auto seedSelectingRange = traccc::sycl::calculate1DimNdRange(
         doublet_prefix_sum_view.size(), seedSelectingLocalSize);
+
+    // Wait here for the update_weights kernel to finish
+    update_weights_kernel.wait_and_throw();
 
     // Check if device is capable of allocating sufficient local memory
     assert(sizeof(triplet) * m_seedfilter_config.max_triplets_per_spM *


### PR DESCRIPTION
This one's a simple one, moving device synchronisations to a later stage allows for simultaneous computations on the host while the device is busy.

The impact on performance is nothing major, but visible.