### PR TITLE
Memory Resource Cleanup (Part 1), main branch (2022.10.26.)

### DIFF
--- a/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
@@ -9,24 +9,21 @@
 
 // Project include(s).
 #include "traccc/edm/cell.hpp"
-#include "traccc/edm/cluster.hpp"
-#include "traccc/edm/measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/utils/algorithm.hpp"
 #include "traccc/utils/memory_resource.hpp"
 
 // VecMem include(s).
-#include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/utils/copy.hpp>
 
-//// Traccc library include(s).
-//#include "traccc/utils/memory_resource.hpp"
+// System include(s).
+#include <memory>
 
 namespace traccc::cuda {
 
 class clusterization_algorithm
     : public algorithm<spacepoint_container_types::buffer(
-          const cell_container_types::host&)> {
+          const cell_container_types::const_view&)> {
 
     public:
     /// Constructor for clusterization algorithm
@@ -41,7 +38,7 @@ class clusterization_algorithm
     /// @return a spacepoint container (buffer) - jagged vector of spacepoints
     /// per module.
     output_type operator()(
-        const cell_container_types::host& cells_per_event) const override;
+        const cell_container_types::const_view& cells_view) const override;
 
     private:
     traccc::memory_resource m_mr;

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -28,7 +28,7 @@ namespace traccc::sycl {
 
 class clusterization_algorithm
     : public algorithm<spacepoint_container_types::buffer(
-          const cell_container_types::host&)> {
+          const cell_container_types::const_view&)> {
 
     public:
     /// Constructor for clusterization algorithm
@@ -41,12 +41,12 @@ class clusterization_algorithm
 
     /// Callable operator for clusterization algorithm
     ///
-    /// @param cells_per_event is a container with cell modules as headers
+    /// @param cells_view is a container with cell modules as headers
     /// and cells as the items
     /// @return a spacepoint container (buffer) - jagged vector of spacepoints
     /// per module.
     output_type operator()(
-        const cell_container_types::host& cells_per_event) const override;
+        const cell_container_types::const_view& cells_view) const override;
 
     private:
     traccc::memory_resource m_mr;

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -58,19 +58,18 @@ clusterization_algorithm::clusterization_algorithm(
 }
 
 clusterization_algorithm::output_type clusterization_algorithm::operator()(
-    const cell_container_types::host& cells_per_event) const {
+    const cell_container_types::const_view& cells_view) const {
 
     // Number of modules
-    unsigned int num_modules = cells_per_event.size();
+    const cell_container_types::const_device::header_vector::size_type
+        num_modules = m_copy->get_size(cells_view.headers);
     // Work group size for kernel execution
-    std::size_t localSize = 64;
-
-    // Get the view of the cells container
-    auto cells_data =
-        get_data(cells_per_event, (m_mr.host ? m_mr.host : &(m_mr.main)));
+    const std::size_t localSize = 64;
 
     // Get the sizes of the cells in each module
-    auto cell_sizes = m_copy->get_sizes(cells_data.items);
+    const std::vector<
+        cell_container_types::const_device::item_vector::value_type::size_type>
+        cell_sizes = m_copy->get_sizes(cells_view.items);
 
     /*
      * Helper container for sparse CCL calculations.
@@ -117,7 +116,6 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     m_copy->setup(cl_per_module_prefix_buff);
 
     // Create views to pass to cluster finding kernel
-    const cell_container_types::const_view cells_view(cells_data);
     vecmem::data::jagged_vector_view<unsigned int> sparse_ccl_indices_view =
         sparse_ccl_indices_buff;
     vecmem::data::vector_view<std::size_t> cl_per_module_prefix_view =

--- a/examples/run/cuda/CMakeLists.txt
+++ b/examples/run/cuda/CMakeLists.txt
@@ -8,9 +8,10 @@
 include( traccc-compiler-options-cuda )
 
 traccc_add_executable( seq_example_cuda "seq_example_cuda.cpp"
-   LINK_LIBRARIES vecmem::core vecmem::cuda traccc::io traccc::performance 
+   LINK_LIBRARIES vecmem::core vecmem::cuda traccc::io traccc::performance
                   traccc::core traccc::device_common traccc::cuda
-                  traccc::options)
+                  traccc::options )
 traccc_add_executable( seeding_example_cuda "seeding_example_cuda.cpp"
    LINK_LIBRARIES vecmem::core vecmem::cuda traccc::io traccc::performance
-                  traccc::core traccc::cuda traccc::options)
+                  traccc::core traccc::device_common traccc::cuda
+                  traccc::options )

--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -17,7 +17,8 @@ traccc_add_executable( traccc_sycl_language_example
 # SYCL seeding executable(s).
 traccc_add_executable( seeding_example_sycl "seeding_example_sycl.sycl"
    LINK_LIBRARIES traccc::options vecmem::core vecmem::sycl traccc::io
-                  traccc::core traccc::sycl traccc::performance)
+                  traccc::core traccc::device_common traccc::sycl
+                  traccc::performance )
 
 target_compile_definitions( traccc_seeding_example_sycl PRIVATE EIGEN_NO_CUDA )
 

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -9,6 +9,7 @@
 #include <CL/sycl.hpp>
 
 // algorithms
+#include "traccc/device/container_h2d_copy_alg.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
 #include "traccc/sycl/seeding/seeding_algorithm.hpp"
@@ -30,8 +31,8 @@
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
-#include <vecmem/memory/sycl/shared_memory_resource.hpp>
-#include <vecmem/utils/copy.hpp>
+#include <vecmem/memory/sycl/device_memory_resource.hpp>
+#include <vecmem/utils/sycl/copy.hpp>
 
 // System include(s).
 #include <chrono>
@@ -53,16 +54,15 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     uint64_t n_seeds = 0;
     uint64_t n_seeds_sycl = 0;
 
-    // Memory resource used by the EDM.
-    vecmem::host_memory_resource host_mr;
-
     // Creating sycl queue object
     ::sycl::queue q(::sycl::gpu_selector{});
     std::cout << "Running on device: "
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
-    // Memory resource used by the EDM.
-    vecmem::sycl::shared_memory_resource shared_mr(&q);
+    // Memory resources used by the application.
+    vecmem::host_memory_resource host_mr;
+    vecmem::sycl::device_memory_resource device_mr{&q};
+    traccc::memory_resource mr{device_mr, &host_mr};
 
     // Elapsed time
     float wall_time(0);
@@ -75,8 +75,12 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     traccc::seeding_algorithm sa(host_mr);
     traccc::track_params_estimation tp(host_mr);
 
-    traccc::sycl::seeding_algorithm sa_sycl({shared_mr}, &q);
-    traccc::sycl::track_params_estimation tp_sycl({shared_mr}, &q);
+    vecmem::sycl::copy copy{&q};
+
+    traccc::device::container_h2d_copy_alg<traccc::spacepoint_container_types>
+        spacepoint_h2d{mr, copy};
+    traccc::sycl::seeding_algorithm sa_sycl{mr, &q};
+    traccc::sycl::track_params_estimation tp_sycl{mr, &q};
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
@@ -102,7 +106,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         traccc::spacepoint_container_types::host spacepoints_per_event =
             traccc::read_spacepoints_from_event(
                 event, common_opts.input_directory,
-                common_opts.input_data_format, surface_transforms, shared_mr);
+                common_opts.input_data_format, surface_transforms, host_mr);
 
         /*time*/ auto end_hit_reading_cpu = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_hit_reading_cpu =
@@ -117,8 +121,14 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
 
         /*time*/ auto start_seeding_sycl = std::chrono::system_clock::now();
 
-        auto seeds_sycl_buffer =
-            sa_sycl(traccc::get_data(spacepoints_per_event, &shared_mr));
+        // Copy the spacepoint data to the device.
+        const traccc::spacepoint_container_types::buffer
+            spacepoints_sycl_buffer =
+                spacepoint_h2d(traccc::get_data(spacepoints_per_event));
+
+        // Reconstruct the spacepoints into seeds.
+        const traccc::seed_collection_types::buffer seeds_sycl_buffer =
+            sa_sycl(spacepoints_sycl_buffer);
 
         /*time*/ auto end_seeding_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_seeding_sycl =
@@ -149,9 +159,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         /*time*/ auto start_tp_estimating_sycl =
             std::chrono::system_clock::now();
 
-        auto params_sycl =
-            tp_sycl(traccc::get_data(spacepoints_per_event, &shared_mr),
-                    seeds_sycl_buffer);
+        auto params_sycl = tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer);
 
         /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =
@@ -178,8 +186,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
           compare seeds from cpu and sycl
           ----------------------------------*/
 
-        // Copy the seeds to the host for comparisons
-        vecmem::copy copy;
+        // Copy the seeds to the host for comparison.
         traccc::seed_collection_types::host seeds_sycl;
         copy(seeds_sycl_buffer, seeds_sycl);
 

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -18,6 +18,7 @@
 #include "traccc/clusterization/clusterization_algorithm.hpp"
 #include "traccc/clusterization/spacepoint_formation.hpp"
 #include "traccc/device/container_d2h_copy_alg.hpp"
+#include "traccc/device/container_h2d_copy_alg.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
 #include "traccc/sycl/clusterization/clusterization_algorithm.hpp"
@@ -100,30 +101,25 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     std::cout << "Running Seeding on device: "
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
-    // Memory resource used by the EDM.
-    vecmem::sycl::shared_memory_resource shared_mr(&q);
-    vecmem::sycl::host_memory_resource sycl_host_mr(&q);
-    vecmem::sycl::device_memory_resource device_mr(&q);
-
-    // Struct with memory resources to pass to SYCL algorithms
-    traccc::memory_resource mr{device_mr, &sycl_host_mr};
-
-    // Memory resource used by the EDM.
+    // Memory resources used by the application.
     vecmem::host_memory_resource host_mr;
+    vecmem::sycl::device_memory_resource device_mr{&q};
+    traccc::memory_resource mr{device_mr, &host_mr};
 
     traccc::clusterization_algorithm ca(host_mr);
     traccc::spacepoint_formation sf(host_mr);
     traccc::seeding_algorithm sa(host_mr);
     traccc::track_params_estimation tp(host_mr);
 
+    vecmem::sycl::copy copy{&q};
+
+    traccc::device::container_h2d_copy_alg<traccc::cell_container_types>
+        cell_h2d{mr, copy};
     traccc::sycl::clusterization_algorithm ca_sycl(mr, &q);
     traccc::sycl::seeding_algorithm sa_sycl(mr, &q);
     traccc::sycl::track_params_estimation tp_sycl(mr, &q);
-
-    // Create the algorithm(s) for copying device data back to the host.
-    vecmem::sycl::copy copy(&q);
     traccc::device::container_d2h_copy_alg<traccc::spacepoint_container_types>
-        spacepoint_copy{traccc::memory_resource{device_mr, &host_mr}, copy};
+        spacepoint_copy{mr, copy};
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
@@ -141,22 +137,12 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         /*time*/ auto start_file_reading_cpu = std::chrono::system_clock::now();
 
-        // Read the cells from the relevant event file for CPU algorithm
-        traccc::cell_container_types::host cells_per_event;
-
-        if (run_cpu) {
-            cells_per_event = traccc::read_cells_from_event(
-                event, common_opts.input_directory,
-                common_opts.input_data_format, surface_transforms, digi_cfg,
-                host_mr);
-        }
-
-        // Read the cells from the relevant event file for SYCL algorithm
-        traccc::cell_container_types::host cells_per_event_sycl =
+        // Read the cells from the relevant event file into host memory.
+        const traccc::cell_container_types::host cells_per_event =
             traccc::read_cells_from_event(event, common_opts.input_directory,
                                           common_opts.input_data_format,
                                           surface_transforms, digi_cfg,
-                                          (mr.host ? *(mr.host) : mr.main));
+                                          host_mr);
 
         /*time*/ auto end_file_reading_cpu = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_file_reading_cpu =
@@ -170,7 +156,12 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         /*time*/ auto start_clusterization_sycl =
             std::chrono::system_clock::now();
 
-        auto spacepoints_sycl_buffer = ca_sycl(cells_per_event_sycl);
+        // Copy the cell data to the device.
+        const traccc::cell_container_types::buffer cells_sycl_buffer =
+            cell_h2d(traccc::get_data(cells_per_event));
+
+        // Reconstruct it into spacepoints on the device.
+        auto spacepoints_sycl_buffer = ca_sycl(cells_sycl_buffer);
 
         /*time*/ auto end_clusterization_sycl =
             std::chrono::system_clock::now();


### PR DESCRIPTION
This is the beginning of a set of updates, which I should've looked at long ago. Having the end goal of only using `vecmem::host_memory_resource` and `vecmem::<type>::device_memory_resource` for memory allocations in all our (main) executables.

As a first step, made `traccc::sycl::clusterization_algorithm` expect device memory as input. Very sneakily the clusterization code so far was running off of host memory. Which technically worked as long as the host memory was allocated with `vecmem::sycl::host_memory_resource`. It "just" provided a significant overhead for the runtimes of those kernels.

For now let's keep it as a draft, as I'll also want to clean up what we do in the track parameter estimation algorithm(s).

@guilhermeAlmeida1, I believe this is the issue that you were running into recently. :wink: