### PR TITLE
Draft: SYCL2020 v5 Compatibility, main branch (2022.11.02.)

### DIFF
--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -255,11 +255,9 @@ seed_collection_types::buffer seed_finding::operator()(
         details::get_queue(m_queue).submit([&](::sycl::handler& h) {
             // Array for temporary storage of triplets for comparing within seed
             // selecting kernel
-            ::sycl::accessor<scalar, 1, ::sycl::access::mode::read_write,
-                             ::sycl::access::target::local>
-                local_mem(m_seedfilter_config.compatSeedLimit *
-                              weightUpdatingLocalSize,
-                          h);
+            ::sycl::local_accessor<scalar, 1> local_mem(
+                m_seedfilter_config.compatSeedLimit * weightUpdatingLocalSize,
+                h);
 
             h.parallel_for<kernels::update_triplet_weights>(
                 weightUpdatingRange,
@@ -312,11 +310,10 @@ seed_collection_types::buffer seed_finding::operator()(
         .submit([&](::sycl::handler& h) {
             // Array for temporary storage of triplets for comparing within seed
             // selecting kernel
-            ::sycl::accessor<triplet, 1, ::sycl::access::mode::read_write,
-                             ::sycl::access::target::local>
-                local_mem(m_seedfilter_config.max_triplets_per_spM *
-                              seedSelectingLocalSize,
-                          h);
+            ::sycl::local_accessor<triplet, 1> local_mem(
+                m_seedfilter_config.max_triplets_per_spM *
+                    seedSelectingLocalSize,
+                h);
 
             h.parallel_for<kernels::select_seeds>(
                 seedSelectingRange,

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -55,7 +55,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     uint64_t n_seeds_sycl = 0;
 
     // Creating sycl queue object
-    ::sycl::queue q(::sycl::gpu_selector{});
+    ::sycl::queue q;
     std::cout << "Running on device: "
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.20.0.tar.gz;URL_MD5;de1af876a12e6ce4f97df2a59f1b365d"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.21.0.tar.gz;URL_MD5;ab361d4ca2b26f673956e81f2cdd4c56"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Made the SYCL code compatible with [SYCL2020 v5](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html).

Switched to using [sycl::local_accessor](https://sycl.readthedocs.io/en/latest/iface/local-accessor.html) for local memory access, and stopped using [sycl::gpu_selector](https://sycl.readthedocs.io/en/latest/iface/device-selector.html) in the example application. (Switching the code to the new-style [sycl::gpu_selector_v](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:device-selector) was just not worth it.)

Also updated to the latest version of [VecMem](https://github.com/acts-project/vecmem), which was made compatible with SYCL2020 v5 as well.

This is all to make the project build (and work) with [intel/llvm 2022-09](https://github.com/intel/llvm/releases/tag/2022-09). :wink: