### PR TITLE
SYCL2020 v5 Compatibility, main branch (2022.11.08.)

### DIFF
--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -55,7 +55,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     uint64_t n_seeds_sycl = 0;
 
     // Creating sycl queue object
-    ::sycl::queue q(::sycl::gpu_selector{});
+    ::sycl::queue q;
     std::cout << "Running on device: "
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.20.0.tar.gz;URL_MD5;de1af876a12e6ce4f97df2a59f1b365d"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.21.0.tar.gz;URL_MD5;ab361d4ca2b26f673956e81f2cdd4c56"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Let me revive #265. I actually tried to re-open that one, but GitHub didn't think so. :confused:

I removed the changes with the usage of "local memory". This way the code at least compiles with the latest version of the Intel compiler. Even if it emits some warnings while doing so.

As before, stopped using `sycl::gpu_selector` in the example application, and updated to the latest version of VecMem. Which was made compatible with SYCL2020 v5 as well.