### PR TITLE
Changed track_params_estimation return type to collection buffer

### DIFF
--- a/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
@@ -22,7 +22,7 @@ namespace cuda {
 
 /// track parameter estimation for cuda
 struct track_params_estimation
-    : public algorithm<bound_track_parameters_collection_types::host(
+    : public algorithm<bound_track_parameters_collection_types::buffer(
           const spacepoint_container_types::const_view&,
           const seed_collection_types::const_view&)> {
 
@@ -38,7 +38,7 @@ struct track_params_estimation
     /// @param seeds_view        is the view of the seed container
     /// @return                  vector of bound track parameters
     ///
-    bound_track_parameters_collection_types::host operator()(
+    output_type operator()(
         const spacepoint_container_types::const_view& spacepoints_view,
         const seed_collection_types::const_view& seeds_view) const override;
 

--- a/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
@@ -28,7 +28,7 @@ namespace traccc::sycl {
 
 /// track parameter estimation for sycl
 struct track_params_estimation
-    : public algorithm<bound_track_parameters_collection_types::host(
+    : public algorithm<bound_track_parameters_collection_types::buffer(
           const spacepoint_container_types::const_view&,
           const seed_collection_types::const_view&)> {
 
@@ -48,7 +48,7 @@ struct track_params_estimation
     /// @param seeds_view        is the view of the seed container
     /// @return                  vector of bound track parameters
     ///
-    bound_track_parameters_collection_types::host operator()(
+    output_type operator()(
         const spacepoint_container_types::const_view& spacepoints_view,
         const seed_collection_types::const_view& seeds_view) const override;
 

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -36,27 +36,23 @@ track_params_estimation::track_params_estimation(
     }
 }
 
-bound_track_parameters_collection_types::host
-track_params_estimation::operator()(
+track_params_estimation::output_type track_params_estimation::operator()(
     const spacepoint_container_types::const_view& spacepoints_view,
     const seed_collection_types::const_view& seeds_view) const {
 
     // Get the size of the seeds view
     auto seeds_size = m_copy->get_size(seeds_view);
 
-    // Create output host container
-    bound_track_parameters_collection_types::host params(
-        seeds_size, (m_mr.host ? m_mr.host : &(m_mr.main)));
-
-    // Check if anything needs to be done.
-    if (seeds_size == 0) {
-        return params;
-    }
-
     // Create device buffer for the parameters
     bound_track_parameters_collection_types::buffer params_buffer(seeds_size,
                                                                   m_mr.main);
     m_copy->setup(params_buffer);
+
+    // Check if anything needs to be done.
+    if (seeds_size == 0) {
+        return params_buffer;
+    }
+
     bound_track_parameters_collection_types::view params_view(params_buffer);
 
     // -- localSize
@@ -80,10 +76,7 @@ track_params_estimation::operator()(
         })
         .wait_and_throw();
 
-    // Copy the results back to the host
-    (*m_copy)(params_buffer, params);
-
-    return params;
+    return params_buffer;
 }
 
 }  // namespace traccc::sycl

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -145,7 +145,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         /*time*/ auto start_tp_estimating_cuda =
             std::chrono::system_clock::now();
 
-        auto params_cuda = tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer);
+        traccc::cuda::track_params_estimation::output_type params_cuda_buffer =
+            tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer);
 
         /*time*/ auto end_tp_estimating_cuda = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_cuda =
@@ -174,7 +175,9 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
 
         // Copy the seeds to the host for comparisons
         traccc::seed_collection_types::host seeds_cuda;
+        traccc::bound_track_parameters_collection_types::host params_cuda;
         copy(seeds_cuda_buffer, seeds_cuda);
+        copy(params_cuda_buffer, params_cuda);
 
         if (run_cpu) {
             // Show which event we are currently presenting the results for.

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -212,7 +212,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         /*time*/ auto start_tp_estimating_cuda =
             std::chrono::system_clock::now();
 
-        auto params_cuda = tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer);
+        traccc::cuda::track_params_estimation::output_type params_cuda_buffer =
+            tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer);
 
         /*time*/ auto end_tp_estimating_cuda = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_cuda =
@@ -241,10 +242,12 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         traccc::spacepoint_container_types::host spacepoints_per_event_cuda;
         traccc::seed_collection_types::host seeds_cuda;
+        traccc::bound_track_parameters_collection_types::host params_cuda;
         if (run_cpu || i_cfg.check_performance) {
             spacepoints_per_event_cuda =
                 spacepoint_copy(spacepoints_cuda_buffer);
             copy(seeds_cuda_buffer, seeds_cuda);
+            copy(params_cuda_buffer, params_cuda);
         }
 
         if (run_cpu) {

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -159,7 +159,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         /*time*/ auto start_tp_estimating_sycl =
             std::chrono::system_clock::now();
 
-        auto params_sycl = tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer);
+        traccc::sycl::track_params_estimation::output_type params_sycl_buffer =
+            tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer);
 
         /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =
@@ -188,7 +189,9 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
 
         // Copy the seeds to the host for comparison.
         traccc::seed_collection_types::host seeds_sycl;
+        traccc::bound_track_parameters_collection_types::host params_sycl;
         copy(seeds_sycl_buffer, seeds_sycl);
+        copy(params_sycl_buffer, params_sycl);
 
         if (run_cpu) {
             // Show which event we are currently presenting the results for.

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -244,7 +244,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         /*time*/ auto start_tp_estimating_sycl =
             std::chrono::system_clock::now();
 
-        auto params_sycl = tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer);
+        traccc::sycl::track_params_estimation::output_type params_sycl_buffer =
+            tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer);
 
         /*time*/ auto end_tp_estimating_sycl = std::chrono::system_clock::now();
         /*time*/ std::chrono::duration<double> time_tp_estimating_sycl =
@@ -273,10 +274,12 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
         traccc::spacepoint_container_types::host spacepoints_per_event_sycl;
         traccc::seed_collection_types::host seeds_sycl;
+        traccc::bound_track_parameters_collection_types::host params_sycl;
         if (run_cpu || i_cfg.check_performance) {
             spacepoints_per_event_sycl =
                 spacepoint_copy(spacepoints_sycl_buffer);
             copy(seeds_sycl_buffer, seeds_sycl);
+            copy(params_sycl_buffer, params_sycl);
         }
 
         if (run_cpu) {


### PR DESCRIPTION
The track parameters estimation algorithm was returning a host collection. Changed this to a buffer created on the device. This will be used in further steps when introducing fitting on the device.