### PR TITLE
Type Conversion Fix, main branch (2022.11.18.)

### DIFF
--- a/device/common/include/traccc/seeding/device/impl/populate_grid.ipp
+++ b/device/common/include/traccc/seeding/device/impl/populate_grid.ipp
@@ -31,7 +31,7 @@ inline void populate_grid(
     const prefix_sum_element_t sp_idx = sp_prefix_sum[globalIndex];
     const spacepoint_container_types::const_device spacepoints(
         spacepoints_view);
-    const spacepoint sp = spacepoints.at({sp_idx.first, sp_idx.second});
+    const spacepoint sp = spacepoints.at(sp_idx);
 
     /// Check out if the spacepoint can be used for seeding.
     if (is_valid_sp(config, sp) != detray::detail::invalid_value<size_t>()) {


### PR DESCRIPTION
Avoiding explicit type conversion in `traccc::device::populate_grid`. The formalism left in the function was from a time before the container code would've been cleaned up a bit. The explicit conversion was just producing a warning with GCC 9 by now.

This issue was found by @Yhatoh's PR #277. This will need to go in before that PR could be accepted.

The explanation to why the "more explicit" formalism triggered a complaint from GCC while the "simpler" one doesn't, is actually sort of interesting. It boils down to the "number 5 constructors" from https://en.cppreference.com/w/cpp/utility/pair/pair. :wink: