### PR TITLE
Add traccc::performance::throughput, main branch (2022.11.23.)

### DIFF
--- a/examples/run/cpu/throughput_seq_example.cpp
+++ b/examples/run/cpu/throughput_seq_example.cpp
@@ -15,7 +15,9 @@
 #include "traccc/seeding/track_params_estimation.hpp"
 
 // performance
+#include "traccc/performance/throughput.hpp"
 #include "traccc/performance/timer.hpp"
+#include "traccc/performance/timing_info.hpp"
 
 // options
 #include "traccc/options/handle_argument_errors.hpp"
@@ -25,9 +27,8 @@
 #include <vecmem/memory/host_memory_resource.hpp>
 
 // System include(s).
-#include <time.h>
-
 #include <cstdlib>
+#include <ctime>
 #include <exception>
 #include <iostream>
 
@@ -71,7 +72,7 @@ int throughput_seq_run(
 
         {
 
-            traccc::performance::timer t("Events processing", elapsedTimes);
+            traccc::performance::timer t("Event processing", elapsedTimes);
 
             traccc::cell_container_types::host& cells_per_event =
                 cells_event_vec[event];
@@ -103,21 +104,13 @@ int throughput_seq_run(
     }
     std::cout << "dummy_count = " << dummy_count << std::endl;
 
-    std::cout << "==> Statistics ... " << std::endl;
-    std::cout << "- Processed " << i_cfg.processed_events << " events from "
-              << i_cfg.loaded_events << " loaded events." << std::endl;
-
-    std::cout << "File reading throughput (ms/event) = "
-              << elapsedTimes.get_time("File reading").count() * 1.e-6 /
-                     (double)i_cfg.loaded_events
-              << std::endl;
-    std::cout << "Event processing        (ms/event) = "
-              << elapsedTimes.get_time("Events processing").count() * 1.e-6 /
-                     (double)i_cfg.processed_events
-              << std::endl;
-    std::cout << "Processing throughput   (event/s) = "
-              << (double)i_cfg.processed_events /
-                     elapsedTimes.get_time("Events processing").count() * 1.e9
+    std::cout << "Time totals:" << std::endl;
+    std::cout << elapsedTimes << std::endl;
+    std::cout << "Throughput:" << std::endl;
+    std::cout << traccc::performance::throughput{static_cast<std::size_t>(
+                                                     i_cfg.processed_events),
+                                                 elapsedTimes,
+                                                 "Event processing"}
               << std::endl;
 
     return 0;

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -207,7 +207,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
               << n_modules << " modules" << std::endl;
     std::cout << "- created  (cpu)  " << n_seeds << " seeds" << std::endl;
     std::cout << "- created (cuda) " << n_seeds_cuda << " seeds" << std::endl;
-    std::cout << "==>Elapsed time (ms)..." << elapsedTimes << std::endl;
+    std::cout << "==>Elapsed times...\n" << elapsedTimes << std::endl;
 
     return 0;
 }

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -281,7 +281,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
     std::cout << "- created  (cpu) " << n_seeds << " seeds" << std::endl;
     std::cout << "- created (cuda) " << n_seeds_cuda << " seeds" << std::endl;
-    std::cout << "==>Elapsed time (ms)..." << elapsedTimes << std::endl;
+    std::cout << "==>Elapsed times...\n" << elapsedTimes << std::endl;
 
     return 0;
 }

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -163,7 +163,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     std::cout << "- created (cpu)  " << n_seeds << " seeds" << std::endl;
     std::cout << "- created (kokkos) " << n_seeds_kokkos << " seeds"
               << std::endl;
-    std::cout << "==>Elapsed time (ms)..." << elapsedTimes << std::endl;
+    std::cout << "==>Elapsed times...\n" << elapsedTimes << std::endl;
 
     return 0;
 }

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -222,7 +222,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
               << n_modules << " modules" << std::endl;
     std::cout << "- created  (cpu)  " << n_seeds << " seeds" << std::endl;
     std::cout << "- created (sycl) " << n_seeds_sycl << " seeds" << std::endl;
-    std::cout << "==>Elapsed time (ms)..." << elapsedTimes << std::endl;
+    std::cout << "==>Elapsed times...\n" << elapsedTimes << std::endl;
 
     return 0;
 }

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -310,7 +310,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
     std::cout << "- created  (cpu) " << n_seeds << " seeds" << std::endl;
     std::cout << "- created (sycl) " << n_seeds_sycl << " seeds" << std::endl;
-    std::cout << "==>Elapsed time (ms)..." << elapsedTimes << std::endl;
+    std::cout << "==>Elapsed times...\n" << elapsedTimes << std::endl;
 
     return 0;
 }

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -38,6 +38,8 @@ traccc_add_library( traccc_performance performance TYPE SHARED
    "include/traccc/performance/timer.hpp"
    "src/performance/timer.cpp"
    "include/traccc/performance/timing_info.hpp"
-   "src/performance/timing_info.cpp" )
+   "src/performance/timing_info.cpp"
+   "include/traccc/performance/throughput.hpp"
+   "src/performance/throughput.cpp" )
 target_link_libraries( traccc_performance
    PUBLIC ROOT::Core ROOT::RIO ROOT::Tree ROOT::Hist traccc::core )

--- a/performance/include/traccc/performance/throughput.hpp
+++ b/performance/include/traccc/performance/throughput.hpp
@@ -1,0 +1,39 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/performance/timing_info.hpp"
+
+// System include(s).
+#include <iosfwd>
+#include <string>
+#include <string_view>
+
+namespace traccc::performance {
+
+/// Convenience type for printing throughput information
+struct throughput {
+
+    /// Constructor with a "timer name" and event processing time
+    throughput(std::size_t events, const timing_info& ti,
+               std::string_view timer_name);
+
+    /// The timer name
+    std::string m_timer_name;
+    /// The milliseconds per event value
+    double m_perEvent;
+    /// The events per second value
+    double m_perSecond;
+
+};  // class throughput
+
+/// Printout operator
+std::ostream& operator<<(std::ostream& out, const throughput& thr);
+
+}  // namespace traccc::performance

--- a/performance/include/traccc/performance/timing_info.hpp
+++ b/performance/include/traccc/performance/timing_info.hpp
@@ -9,22 +9,33 @@
 
 // System include(s).
 #include <chrono>
+#include <iosfwd>
 #include <string_view>
 #include <utility>
 #include <vector>
 
 namespace traccc::performance {
 
+/// Helper type used for timing information storage
 using timing_info_pair = std::pair<std::string, std::chrono::nanoseconds>;
 
 /// Struct for storing time measurements collected in timer class
 ///
 struct timing_info {
+
+    /// The low level data.
     std::vector<timing_info_pair> data;
 
-    std::chrono::nanoseconds get_time(const std::string_view timer_name);
-};
+    /// Get the time taken by a given component
+    ///
+    /// @param timer_name The name of the component
+    /// @return The time taken by the component in question
+    ///
+    std::chrono::nanoseconds get_time(std::string_view timer_name) const;
 
+};  // struct timing_info
+
+/// Printout helper for @c traccc::performance::timing_info
 std::ostream& operator<<(std::ostream& out, const timing_info& info);
 
 }  // namespace traccc::performance

--- a/performance/src/performance/throughput.cpp
+++ b/performance/src/performance/throughput.cpp
@@ -1,0 +1,34 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "traccc/performance/throughput.hpp"
+
+// System include(s).
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+
+namespace traccc::performance {
+
+throughput::throughput(std::size_t events, const timing_info& ti,
+                       std::string_view timer_name)
+    : m_timer_name(timer_name) {
+
+    auto totalTime = ti.get_time(timer_name);
+    m_perEvent = (totalTime / static_cast<double>(events)).count() * 1e-6;
+    m_perSecond = 1000. / m_perEvent;
+}
+
+std::ostream& operator<<(std::ostream& out, const throughput& thr) {
+
+    out << std::setw(30) << std::right << thr.m_timer_name << "  "
+        << thr.m_perEvent << " ms/event, " << thr.m_perSecond << " events/s";
+    return out;
+}
+
+}  // namespace traccc::performance

--- a/performance/src/performance/timing_info.cpp
+++ b/performance/src/performance/timing_info.cpp
@@ -10,34 +10,37 @@
 
 // System include(s).
 #include <algorithm>
-#include <exception>
 #include <iomanip>
 #include <iostream>
+#include <stdexcept>
 
 namespace traccc::performance {
 
-/// Printout timer ids (string name) & elapsed time in miliseconds
-std::ostream& operator<<(std::ostream& out, const timing_info& info) {
-    for (auto i : info.data) {
-        out << "\n"
-            << std::setw(30) << std::right << i.first << "  " << std::setw(12)
-            << std::left << (i.second.count() * 1.e-6);
-    }
-    return out;
-}
-
-/// Return time taken by timer identified with given name, in miliseconds
 std::chrono::nanoseconds timing_info::get_time(
-    const std::string_view timer_name) {
-    const std::string name(timer_name);
-    auto it =
-        std::find_if(data.begin(), data.end(),
-                     [&name](timing_info_pair it) { return it.first == name; });
+    std::string_view timer_name) const {
+
+    auto it = std::find_if(
+        data.begin(), data.end(),
+        [&timer_name](timing_info_pair it) { return it.first == timer_name; });
     if (it == data.end()) {
-        throw std::invalid_argument(
-            "Called timing_info::get_timer with a name not listed: " + name);
+        throw std::invalid_argument("Unknown component name received");
     }
     return it->second;
+}
+
+std::ostream& operator<<(std::ostream& out, const timing_info& info) {
+
+    for (std::size_t i = 0; i < info.data.size(); ++i) {
+        const timing_info_pair ti = info.data.at(i);
+        out << std::setw(30) << std::right << ti.first << "  "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(ti.second)
+                   .count()
+            << " ms";
+        if ((i + 1) < info.data.size()) {
+            out << "\n";
+        }
+    }
+    return out;
 }
 
 }  // namespace traccc::performance


### PR DESCRIPTION
In order to harmonise how all future applications would print their throughput performance, introduced `traccc::performance::throughput` for helping with this.

At the same time tweaked a bit how `traccc::performance::timing_info` would do its own unit conversions, to use a bit fewer magic numbers.

Updated all clients to account for the slightly modified printout formalism. The "new output" looks like this:

```
[bash][atspot01]:build-x86_64_ubuntu2004_llvm_intel > ./bin/traccc_throughput_seq_example --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_full/ttbar_mu200/ --processed_events=10
Running ./bin/traccc_throughput_seq_example tml_detector/trackml-detector.csv tml_full/ttbar_mu200/ 10 10
dummy_count = 164307
Time totals:
                  File reading  5838 ms
              Event processing  2202 ms
Throughput:
              Event processing  220.246 ms/event, 4.54038 events/s
[bash][atspot01]:build-x86_64_ubuntu2004_llvm_intel >
```