### PR TITLE
TBB Thread Number Fix, main branch (2022.11.24.)

### DIFF
--- a/examples/run/cpu/throughput_tbb_seq_example.cpp
+++ b/examples/run/cpu/throughput_tbb_seq_example.cpp
@@ -28,6 +28,7 @@
 #include <vecmem/memory/host_memory_resource.hpp>
 
 // TBB include(s).
+#include <tbb/global_control.h>
 #include <tbb/task_arena.h>
 #include <tbb/task_group.h>
 
@@ -65,6 +66,8 @@ int main(int argc, char* argv[]) {
     traccc::performance::timing_info times;
 
     // Set up the TBB arena and thread group.
+    tbb::global_control global_thread_limit(
+        tbb::global_control::max_allowed_parallelism, mt_cfg.threads + 1);
     tbb::task_arena arena{static_cast<int>(mt_cfg.threads), 0};
     tbb::task_group group;
 


### PR DESCRIPTION
@guilhermeAlmeida1 very correctly pointed out in #283 that I forgot about one thing. I was just too eager to push that PR in. :frowning:

TBB has a global limit on the number of threads that it would use. The limits used in a given task arena can not exceed that global limit. This change now allows the executable to oversubscribe the CPU as I intended originally.

(The `+1` is a weird thing in the code. TBB likes to reserve one thread for "global control". So we have to allow for 1 more threads to be created than the number that the task arena would use.)