### PR TITLE
Packaging (Fix), main branch (2022.11.25.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,3 +246,6 @@ endif()
 if(TRACCC_BUILD_FUTHARK)
    add_subdirectory(device/futhark)
 endif()
+
+# Set up the packaging of the project.
+include( traccc-packaging )

--- a/cmake/traccc-config.cmake.in
+++ b/cmake/traccc-config.cmake.in
@@ -1,0 +1,57 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Set up the helper functions/macros.
+@PACKAGE_INIT@
+
+# Remember the options that traccc was built with.
+set( TRACCC_BUILD_CUDA     @TRACCC_BUILD_CUDA@ )
+set( TRACCC_BUILD_SYCL     @TRACCC_BUILD_SYCL@ )
+set( TRACCC_BUILD_FUTHARK  @TRACCC_BUILD_FUTHARK@ )
+set( TRACCC_BUILD_KOKKOS   @TRACCC_BUILD_KOKKOS@ )
+set( TRACCC_BUILD_EXAMPLES @TRACCC_BUILD_EXAMPLES@ )
+
+# Make the "traccc modules" visible to CMake.
+list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}" )
+
+# Find all packages that traccc needs to function.
+include( CMakeFindDependencyMacro )
+find_dependency( Eigen3 )
+find_dependency( Thrust )
+find_dependency( dfelibs )
+if( TRACCC_BUILD_KOKKOS )
+   find_dependency( Kokkos )
+endif()
+if( TRACCC_BUILD_FUTHARK )
+   find_dependency( Futhark )
+endif()
+find_dependency( Acts )
+find_dependency( vecmem )
+find_dependency( algebra-plugins )
+find_dependency( detray )
+if( TRACCC_BUILD_EXAMPLES )
+   find_dependency( Boost COMPONENTS program_options )
+   find_dependency( ROOT COMPONENTS Core RIO Tree Hist )
+endif()
+
+# Set up the traccc::Thrust target.
+set( TRACCC_THRUST_OPTIONS @TRACCC_THRUST_OPTIONS@ )
+thrust_create_target( traccc::Thrust ${TRACCC_THRUST_OPTIONS} )
+
+# Set up some simple variables for using the package.
+set( traccc_VERSION "@PROJECT_VERSION@" )
+set_and_check( traccc_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@" )
+set_and_check( traccc_LIBRARY_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@" )
+set_and_check( traccc_CMAKE_DIR   "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@" )
+
+# Include the file listing all the imported targets and options.
+include( "${traccc_CMAKE_DIR}/traccc-config-targets.cmake" )
+
+# Print a standard information message about the package being found.
+include( FindPackageHandleStandardArgs )
+find_package_handle_standard_args( traccc REQUIRED_VARS
+   CMAKE_CURRENT_LIST_FILE
+   VERSION_VAR traccc_VERSION )

--- a/cmake/traccc-functions.cmake
+++ b/cmake/traccc-functions.cmake
@@ -32,14 +32,16 @@ function( traccc_add_library fullname basename )
    add_library( ${fullname} ${ARG_TYPE} ${_sources} )
 
    # Set up how clients should find its headers.
-   set( _depType PUBLIC )
-   if( "${ARG_TYPE}" STREQUAL "INTERFACE" )
-      set( _depType INTERFACE )
+   if( IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" )
+      set( _depType PUBLIC )
+      if( "${ARG_TYPE}" STREQUAL "INTERFACE" )
+         set( _depType INTERFACE )
+      endif()
+      target_include_directories( ${fullname} ${_depType}
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
+      unset( _depType )
    endif()
-   target_include_directories( ${fullname} ${_depType}
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
-   unset( _depType )
 
    # Make sure that the library is available as "traccc::${basename}" in every
    # situation.
@@ -59,8 +61,10 @@ function( traccc_add_library fullname basename )
       LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
       ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
       RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" )
-   install( DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
-      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" )
+   if( IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" )
+      install( DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" )
+   endif()
 
 endfunction( traccc_add_library )
 

--- a/cmake/traccc-packaging.cmake
+++ b/cmake/traccc-packaging.cmake
@@ -1,0 +1,38 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+include( CPack )
+
+# Export the configuration of the project.
+include( CMakePackageConfigHelpers )
+set( CMAKE_INSTALL_CMAKEDIR
+   "${CMAKE_INSTALL_LIBDIR}/cmake/traccc-${PROJECT_VERSION}" )
+install( EXPORT traccc-exports
+   NAMESPACE "traccc::"
+   FILE "traccc-config-targets.cmake"
+   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}" )
+configure_package_config_file(
+   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/traccc-config.cmake.in"
+   "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/traccc-config.cmake"
+   INSTALL_DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
+   PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR
+             CMAKE_INSTALL_CMAKEDIR
+   NO_CHECK_REQUIRED_COMPONENTS_MACRO )
+write_basic_package_version_file(
+   "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/traccc-config-version.cmake"
+   COMPATIBILITY "AnyNewerVersion" )
+install( FILES
+   "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/traccc-config.cmake"
+   "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/traccc-config-version.cmake"
+   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}" )
+
+# Install the "language helper" file(s).
+install( FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindFuthark.cmake"
+   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}" )
+
+# Clean up.
+unset( CMAKE_INSTALL_CMAKEDIR )


### PR DESCRIPTION
Made it possible to install the project. If one tries to do so right now, this happens:

```
DESTDIR=../install make install
...
-- Up-to-date: ../install/usr/local/include/traccc/io/read_measurements.hpp
-- Up-to-date: ../install/usr/local/include/traccc/io/read_spacepoints.hpp
-- Up-to-date: ../install/usr/local/include/traccc/io/write.hpp
CMake Error at plugins/algebra/cmake_install.cmake:46 (file):
  file INSTALL cannot find
  "/home/krasznaa/afs-projects/traccc/traccc/plugins/algebra/include": No
  such file or directory.
Call Stack (most recent call first):
  plugins/cmake_install.cmake:47 (include)
  cmake_install.cmake:63 (include)


make: *** [Makefile:130: install] Error 1
```

I.e. there is an issue with `traccc::algebra` not providing any public headers itself, but `traccc_add_library(...)` assuming that all libraries would always do that.

While at it, I also added a semi-functional CMake configuration for the installation. When trying to use it I bump into some warnings like

```
...
-- Enabled Kokkos devices: SERIAL
CMake Warning at /home/krasznaa/ATLAS/projects/traccc/install/usr/local/lib/cmake/Kokkos/KokkosConfigCommon.cmake:35 (MESSAGE):
  The installed Kokkos configuration does not support CXX extensions.                                                             
  Forcing -DCMAKE_CXX_EXTENSIONS=Off                                                                                              
Call Stack (most recent call first):                                                                                              
  /home/krasznaa/ATLAS/projects/traccc/install/usr/local/lib/cmake/Kokkos/KokkosConfig.cmake:43 (INCLUDE)                         
  /software/cmake/3.24.1/x86_64-ubuntu2004-gcc9-opt/share/cmake-3.24/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)     
  /home/krasznaa/ATLAS/projects/traccc/install/usr/local/lib/cmake/traccc-0.2.0/traccc-config.cmake:40 (find_dependency)          
  CMakeLists.txt:4 (find_package)                                                                                                 


-- found Acts version 21.1.0 commit GITDIR-NO-dirty
CMake Warning (dev) at /software/cmake/3.24.1/x86_64-ubuntu2004-gcc9-opt/share/cmake-3.24/Modules/CMakeFindDependencyMacro.cmake:47 (find_package):                                                                                                                 
  Ignoring EXACT since no version is requested.                                                                                   
Call Stack (most recent call first):                                                                                              
  /home/krasznaa/ATLAS/projects/traccc/install/usr/local/lib/cmake/Acts/ActsConfig.cmake:83 (find_dependency)                     
  /software/cmake/3.24.1/x86_64-ubuntu2004-gcc9-opt/share/cmake-3.24/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)     
  /home/krasznaa/ATLAS/projects/traccc/install/usr/local/lib/cmake/traccc-0.2.0/traccc-config.cmake:45 (find_dependency)          
  CMakeLists.txt:4 (find_package)                                                                                                 
This warning is for project developers.  Use -Wno-dev to suppress it.
...
```

, but those are no immediate concerns. (The Kokkos one is not really an error, it's a weird expectation on Kokkos's side. It's a long story.)