### PR TITLE
Removed redundant information from cell EDM type

### DIFF
--- a/core/include/traccc/edm/cell.hpp
+++ b/core/include/traccc/edm/cell.hpp
@@ -62,13 +62,9 @@ inline bool operator==(const cell& lhs, const cell& rhs) {
 ///
 struct cell_module {
 
-    event_id event = 0;
     geometry_id module = 0;
     transform3 placement = transform3{};
     scalar threshold = 0;
-
-    channel_id range0[2] = {std::numeric_limits<channel_id>::max(), 0};
-    channel_id range1[2] = {std::numeric_limits<channel_id>::max(), 0};
 
     pixel_data pixel;
 

--- a/io/src/csv/read_cells.cpp
+++ b/io/src/csv/read_cells.cpp
@@ -157,20 +157,6 @@ cell_container_types::host read_cells(std::string_view filename,
             .at(last_module_index)
             .push_back({iocell.channel0, iocell.channel1, iocell.value,
                         iocell.timestamp});
-
-        // Update the min/max values for this module.
-        result.get_headers().at(last_module_index).range0[0] =
-            std::min(result.get_headers().at(last_module_index).range0[0],
-                     iocell.channel0);
-        result.get_headers().at(last_module_index).range0[1] =
-            std::max(result.get_headers().at(last_module_index).range0[1],
-                     iocell.channel0);
-        result.get_headers().at(last_module_index).range1[0] =
-            std::min(result.get_headers().at(last_module_index).range1[0],
-                     iocell.channel1);
-        result.get_headers().at(last_module_index).range1[1] =
-            std::max(result.get_headers().at(last_module_index).range1[1],
-                     iocell.channel1);
     }
 
     // Do some post-processing on the cells.

--- a/tests/cuda/test_copy_algs.cpp
+++ b/tests/cuda/test_copy_algs.cpp
@@ -34,7 +34,7 @@ GTEST_TEST(CUDAContainerCopy, CellHostToDeviceToHost) {
     for (std::size_t i = 0; i < CONTAINER_SIZE; ++i) {
         host_orig.push_back(
             traccc::cell_container_types::host::header_type{
-                0, i + 1, {}, 0, {5, 0}, {4, 0}, pdata},
+                i + 1, {}, 0, pdata},
             traccc::cell_container_types::host::vector_type<
                 traccc::cell_container_types::host::item_type>{
                 i + 1,

--- a/tests/io/test_csv.cpp
+++ b/tests/io/test_csv.cpp
@@ -34,11 +34,11 @@ TEST_F(io, csv_read_single_module) {
     auto module = single_module_cells.at(0).header;
 
     ASSERT_EQ(module.module, 0u);
-    ASSERT_EQ(module.range0[0], 123u);
-    ASSERT_EQ(module.range0[1], 174u);
-    ASSERT_EQ(module.range1[0], 32u);
-    ASSERT_EQ(module.range1[1], 880u);
     ASSERT_EQ(module_cells.size(), 6u);
+    ASSERT_EQ(module_cells.at(0).channel0, 123u);
+    ASSERT_EQ(module_cells.at(0).channel1, 32u);
+    ASSERT_EQ(module_cells.at(5).channel0, 174u);
+    ASSERT_EQ(module_cells.at(5).channel1, 880u);
 }
 
 // This defines the local frame test suite
@@ -52,23 +52,23 @@ TEST_F(io, csv_read_two_modules) {
     auto first_module = two_module_cells.at(0).header;
 
     ASSERT_EQ(first_module_cells.size(), 6u);
+    ASSERT_EQ(first_module_cells.at(0).channel0, 123u);
+    ASSERT_EQ(first_module_cells.at(0).channel1, 32u);
+    ASSERT_EQ(first_module_cells.at(5).channel0, 174u);
+    ASSERT_EQ(first_module_cells.at(5).channel1, 880u);
 
     ASSERT_EQ(first_module.module, 0u);
-    ASSERT_EQ(first_module.range0[0], 123u);
-    ASSERT_EQ(first_module.range0[1], 174u);
-    ASSERT_EQ(first_module.range1[0], 32u);
-    ASSERT_EQ(first_module.range1[1], 880u);
 
     auto second_module_cells = two_module_cells.at(1).items;
     auto second_module = two_module_cells.at(1).header;
 
     ASSERT_EQ(second_module_cells.size(), 8u);
+    ASSERT_EQ(second_module_cells.at(0).channel0, 0u);
+    ASSERT_EQ(second_module_cells.at(0).channel1, 4u);
+    ASSERT_EQ(second_module_cells.at(7).channel0, 5u);
+    ASSERT_EQ(second_module_cells.at(7).channel1, 98u);
 
     ASSERT_EQ(second_module.module, 1u);
-    EXPECT_EQ(second_module.range0[0], 0u);
-    EXPECT_EQ(second_module.range0[1], 22u);
-    EXPECT_EQ(second_module.range1[0], 4u);
-    EXPECT_EQ(second_module.range1[1], 98u);
 }
 
 // This reads in the tml pixel barrel first event


### PR DESCRIPTION
Stumbled upon this while working on #288 . It turns out that we had some information being stored in our cell modules which isn't being used anywhere other than some testing. I don't really see any reason to keep it.