### PR TITLE
Device Memory Caching, main branch (2022.12.02.)

### DIFF
--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -16,9 +16,13 @@
 #include "traccc/utils/algorithm.hpp"
 
 // VecMem include(s).
+#include <vecmem/memory/binary_page_memory_resource.hpp>
 #include <vecmem/memory/cuda/device_memory_resource.hpp>
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/utils/cuda/copy.hpp>
+
+// System include(s).
+#include <memory>
 
 namespace traccc::cuda {
 
@@ -38,6 +42,19 @@ class full_chain_algorithm
     ///
     full_chain_algorithm(vecmem::memory_resource& host_mr);
 
+    /// Copy constructor
+    ///
+    /// An explicit copy constructor is necessary because in the MT tests
+    /// we do want to copy such objects, but a default copy-constructor can
+    /// not be generated for them.
+    ///
+    /// @param parent The parent algorithm chain to copy
+    ///
+    full_chain_algorithm(const full_chain_algorithm& parent);
+
+    /// Algorithm destructor
+    ~full_chain_algorithm();
+
     /// Reconstruct track parameters in the entire detector
     ///
     /// @param cells The cells for every detector module in the event
@@ -47,8 +64,12 @@ class full_chain_algorithm
         const cell_container_types::host& cells) const override;
 
     private:
+    /// Host memory resource
+    vecmem::memory_resource& m_host_mr;
     /// Device memory resource
     vecmem::cuda::device_memory_resource m_device_mr;
+    /// Device caching memory resource
+    std::unique_ptr<vecmem::binary_page_memory_resource> m_cached_device_mr;
     /// Memory copy object
     mutable vecmem::cuda::copy m_copy;
 

--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -16,9 +16,13 @@
 #include "traccc/utils/algorithm.hpp"
 
 // VecMem include(s).
+#include <vecmem/memory/binary_page_memory_resource.hpp>
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/memory/sycl/device_memory_resource.hpp>
 #include <vecmem/utils/sycl/copy.hpp>
+
+// System include(s).
+#include <memory>
 
 namespace traccc::sycl {
 namespace details {
@@ -41,6 +45,17 @@ class full_chain_algorithm
     ///           objects
     ///
     full_chain_algorithm(vecmem::memory_resource& host_mr);
+
+    /// Copy constructor
+    ///
+    /// An explicit copy constructor is necessary because in the MT tests
+    /// we do want to copy such objects, but a default copy-constructor can
+    /// not be generated for them.
+    ///
+    /// @param parent The parent algorithm chain to copy
+    ///
+    full_chain_algorithm(const full_chain_algorithm& parent);
+
     /// Algorithm destructor
     ~full_chain_algorithm();
 
@@ -55,10 +70,14 @@ class full_chain_algorithm
     private:
     /// Private data object
     details::full_chain_algorithm_data* m_data;
+    /// Host memory resource
+    vecmem::memory_resource& m_host_mr;
     /// Device memory resource
-    vecmem::sycl::device_memory_resource m_device_mr;
+    std::unique_ptr<vecmem::sycl::device_memory_resource> m_device_mr;
+    /// Device caching memory resource
+    std::unique_ptr<vecmem::binary_page_memory_resource> m_cached_device_mr;
     /// Memory copy object
-    mutable vecmem::sycl::copy m_copy;
+    mutable std::unique_ptr<vecmem::sycl::copy> m_copy;
 
     /// @name Sub-algorithms used by this full-chain algorithm
     /// @{

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -42,14 +42,20 @@ struct full_chain_algorithm_data {
 
 full_chain_algorithm::full_chain_algorithm(vecmem::memory_resource& host_mr)
     : m_data(new details::full_chain_algorithm_data{{::handle_async_error}}),
-      m_device_mr(&(m_data->m_queue)),
-      m_copy(&(m_data->m_queue)),
-      m_host2device(memory_resource{m_device_mr, &host_mr}, m_copy),
-      m_clusterization(memory_resource{m_device_mr, &host_mr},
+      m_host_mr(host_mr),
+      m_device_mr(std::make_unique<vecmem::sycl::device_memory_resource>(
+          &(m_data->m_queue))),
+      m_cached_device_mr(
+          std::make_unique<vecmem::binary_page_memory_resource>(*m_device_mr)),
+      m_copy(std::make_unique<vecmem::sycl::copy>(&(m_data->m_queue))),
+      m_host2device(memory_resource{*m_cached_device_mr, &m_host_mr}, *m_copy),
+      m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr},
                        &(m_data->m_queue)),
-      m_seeding(memory_resource{m_device_mr, &host_mr}, &(m_data->m_queue)),
-      m_track_parameter_estimation(memory_resource{m_device_mr, &host_mr},
-                                   &(m_data->m_queue)) {
+      m_seeding(memory_resource{*m_cached_device_mr, &m_host_mr},
+                &(m_data->m_queue)),
+      m_track_parameter_estimation(
+          memory_resource{*m_cached_device_mr, &m_host_mr},
+          &(m_data->m_queue)) {
 
     // Tell the user what device is being used.
     std::cout
@@ -58,7 +64,28 @@ full_chain_algorithm::full_chain_algorithm(vecmem::memory_resource& host_mr)
         << std::endl;
 }
 
+full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
+    : m_data(new details::full_chain_algorithm_data{{::handle_async_error}}),
+      m_host_mr(parent.m_host_mr),
+      m_device_mr(std::make_unique<vecmem::sycl::device_memory_resource>(
+          &(m_data->m_queue))),
+      m_cached_device_mr(
+          std::make_unique<vecmem::binary_page_memory_resource>(*m_device_mr)),
+      m_copy(std::make_unique<vecmem::sycl::copy>(&(m_data->m_queue))),
+      m_host2device(memory_resource{*m_cached_device_mr, &m_host_mr}, *m_copy),
+      m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr},
+                       &(m_data->m_queue)),
+      m_seeding(memory_resource{*m_cached_device_mr, &m_host_mr},
+                &(m_data->m_queue)),
+      m_track_parameter_estimation(
+          memory_resource{*m_cached_device_mr, &m_host_mr},
+          &(m_data->m_queue)) {}
+
 full_chain_algorithm::~full_chain_algorithm() {
+    // Need to ensure that objects would be deleted in the correct order.
+    m_cached_device_mr.reset();
+    m_device_mr.reset();
+    m_copy.reset();
     delete m_data;
 }
 
@@ -73,7 +100,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
 
     // Get the final data back to the host.
     bound_track_parameters_collection_types::host result;
-    m_copy(track_params, result);
+    (*m_copy)(track_params, result);
 
     // Return the host container.
     return result;


### PR DESCRIPTION
Added device memory caching to the throughput test algorithm sequences. This is meant to reduce the number of memory allocations and frees during the event processing.

At the same time made the Multi-Threaded test use a different set of algorithms for each CPU thread. To work around the fact that the [VecMem](https://github.com/acts-project/vecmem) caching memory resources are not thread safe at the moment. :frowning: (Something to be fixed at one point.)

Made the SYCL algorithm sequence a bit more robust by explicitly deleting all objects that use the SYCL queue, before the queue would be deleted.

The caching is pretty useful already with a single thread. With this new code (with caching) I get:

```
[bash][atspot01]:build-x86_64_ubuntu2004_llvm_intel > ./bin/traccc_throughput_st_cuda --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_full/ttbar_mu200/ --cold_run_events=10 --processed_events=1000

Single-threaded CUDA GPU throughput tests

>>> Throughput options <<<
Input data format   : csv
Input directory     : tml_full/ttbar_mu200/
Detector geometry   : tml_detector/trackml-detector.csv
Digitization config : tml_detector/default-geometric-config-generic.json
Loaded event(s)     : 10
Cold run event(s)   : 10
Processed event(s)  : 1000

Using CUDA device: NVIDIA GeForce RTX 2060 [id: 0, bus: 1, device: 0]
Reconstructed track parameters: 16070050
Time totals:
                  File reading  5787 ms
            Warm-up processing  178 ms
              Event processing  6726 ms
Throughput:
            Warm-up processing  17.8807 ms/event, 55.9263 events/s
              Event processing  6.72646 ms/event, 148.667 events/s
[bash][atspot01]:build-x86_64_ubuntu2004_llvm_intel >
```

While the code that's currently in the main branch achieves the following:

```
[bash][atspot01]:build-x86_64_ubuntu2004_llvm_intel > ./bin/traccc_throughput_st_cuda --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_full/ttbar_mu200/ --cold_run_events=10 --processed_events=1000

Single-threaded CUDA GPU throughput tests

>>> Throughput options <<<
Input data format   : csv
Input directory     : tml_full/ttbar_mu200/
Detector geometry   : tml_detector/trackml-detector.csv
Digitization config : tml_detector/default-geometric-config-generic.json
Loaded event(s)     : 10
Cold run event(s)   : 10
Processed event(s)  : 1000

Using CUDA device: NVIDIA GeForce RTX 2060 [id: 0, bus: 1, device: 0]
Reconstructed track parameters: 15979423
Time totals:
                  File reading  5808 ms
            Warm-up processing  193 ms
              Event processing  9022 ms
Throughput:
            Warm-up processing  19.3813 ms/event, 51.596 events/s
              Event processing  9.02271 ms/event, 110.831 events/s
[bash][atspot01]:build-x86_64_ubuntu2004_llvm_intel >
```

Unfortunately the MT scaling of the CUDA test is not too great even with `cudaMalloc` / `cudaFree` practically never being called during the event processing. As the threads are now hampered by the synchronous memory copies and kernel launches waiting on each other.

![image](https://user-images.githubusercontent.com/30694331/205298729-77ff74f6-31c2-44d6-a4e6-edec4126ffaa.png)

This will be some fun discussion at our last meeting of the year next week. :wink: