### PR TITLE
File Read Fix, main branch (2022.12.05.)

### DIFF
--- a/io/include/traccc/io/read.hpp
+++ b/io/include/traccc/io/read.hpp
@@ -12,7 +12,7 @@
 #include "traccc/io/demonstrator_edm.hpp"
 
 // VecMem include(s).
-#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/memory/memory_resource.hpp>
 
 // System include(s).
 #include <string_view>
@@ -36,6 +36,6 @@ demonstrator_input read(std::size_t events, std::string_view directory,
                         std::string_view detector_file,
                         std::string_view digi_config_file,
                         data_format format = data_format::csv,
-                        vecmem::host_memory_resource *mr = nullptr);
+                        vecmem::memory_resource *mr = nullptr);
 
 }  // namespace traccc::io

--- a/io/src/read.cpp
+++ b/io/src/read.cpp
@@ -22,7 +22,7 @@ namespace traccc::io {
 demonstrator_input read(std::size_t events, std::string_view directory,
                         std::string_view detector_file,
                         std::string_view digi_config_file, data_format format,
-                        vecmem::host_memory_resource *mr) {
+                        vecmem::memory_resource *mr) {
 
     // Read in the detector configuration.
     const geometry geom = io::read_geometry(detector_file);


### PR DESCRIPTION
Made `traccc::io::read` with any kind of (host) memory resource. Since I had to realise while working on something that will soon receive its own PR, currently it's not possible to pass let's say a `vecmem::cuda::host_memory_resource` to this function. :frowning: