### PR TITLE
Async CUDA Clusterization, main branch (2022.12.05.)

### DIFF
--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Enable CUDA as a language.
 enable_language( CUDA )
 
+# Find the CUDA toolkit
+find_package( CUDAToolkit REQUIRED )
+
 # Project include(s).
 include( traccc-compiler-options-cpp )
 include( traccc-compiler-options-cuda )
@@ -17,6 +20,12 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "include/traccc/cuda/utils/definitions.hpp"
   "include/traccc/cuda/utils/make_prefix_sum_buff.hpp"
   "src/utils/make_prefix_sum_buff.cu"
+  "include/traccc/cuda/utils/stream.hpp"
+  "src/utils/stream.cpp"
+  "src/utils/opaque_stream.hpp"
+  "src/utils/opaque_stream.cpp"
+  "src/utils/utils.hpp"
+  "src/utils/utils.cpp"
   # Seed finding code.
   "include/traccc/cuda/seeding/track_params_estimation.hpp"
   "include/traccc/cuda/seeding/seed_finding.hpp"
@@ -37,4 +46,4 @@ target_compile_options( traccc_cuda
   PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr> )
 target_link_libraries( traccc_cuda
   PUBLIC traccc::core vecmem::core
-  PRIVATE traccc::device_common vecmem::cuda )
+  PRIVATE CUDA::cudart traccc::device_common vecmem::cuda )

--- a/device/cuda/include/traccc/cuda/utils/make_prefix_sum_buff.hpp
+++ b/device/cuda/include/traccc/cuda/utils/make_prefix_sum_buff.hpp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// Library include(s).
+#include "traccc/cuda/utils/stream.hpp"
+
 // Project include(s).
 #include "traccc/device/fill_prefix_sum.hpp"
 #include "traccc/utils/memory_resource.hpp"
@@ -22,10 +25,25 @@ namespace traccc::cuda {
 ///
 /// @param[in] sizes       The sizes of the jagged vector
 /// @param copy A "copy object" capable of dealing with the view
+/// @param mr   The memory resource to create the buffer with
 /// @return     A vector buffer of prefix_sum element
 ///
 vecmem::data::vector_buffer<device::prefix_sum_element_t> make_prefix_sum_buff(
     const std::vector<device::prefix_sum_size_t>& sizes, vecmem::copy& copy,
     const traccc::memory_resource& mr);
+
+/// Function that returns vector of prefix_sum_element_t for accessing a jagged
+/// vector's elements in device Example: Jagged vector with sizes = {3,2,1,...}
+/// Returns: {[0,0], [0,1], [0,2], [1,0], [1,1], [2,0], ...}
+///
+/// @param[in] sizes       The sizes of the jagged vector
+/// @param copy A "copy object" capable of dealing with the view
+/// @param mr   The memory resource to create the buffer with
+/// @param str  The CUDA stream to create the buffer with
+/// @return     A vector buffer of prefix_sum element
+///
+vecmem::data::vector_buffer<device::prefix_sum_element_t> make_prefix_sum_buff(
+    const std::vector<device::prefix_sum_size_t>& sizes, vecmem::copy& copy,
+    const traccc::memory_resource& mr, const stream& str);
 
 }  // namespace traccc::cuda

--- a/device/cuda/include/traccc/cuda/utils/stream.hpp
+++ b/device/cuda/include/traccc/cuda/utils/stream.hpp
@@ -1,0 +1,55 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// System include(s).
+#include <memory>
+
+namespace traccc::cuda {
+
+// Forward declaration(s).
+namespace details {
+struct opaque_stream;
+}
+
+/// Owning wrapper class around @c cudaStream_t
+///
+/// It is necessary for passing around CUDA stream objects in code that should
+/// not be directly exposed to the CUDA header(s).
+///
+class stream {
+
+    public:
+    /// Invalid/default device identifier
+    static constexpr int INVALID_DEVICE = -1;
+
+    /// Construct a new stream (possibly for a specified device)
+    stream(int device = INVALID_DEVICE);
+
+    /// Move constructor
+    stream(stream&& parent);
+
+    /// Destructor
+    ~stream();
+
+    /// Move assignment
+    stream& operator=(stream&& rhs);
+
+    /// Access a typeless pointer to the managed @c cudaStream_t object
+    void* cudaStream() const;
+
+    /// Wait for all queued tasks from the stream to complete
+    void synchronize() const;
+
+    private:
+    /// Smart pointer to the managed @c cudaStream_t object
+    std::unique_ptr<details::opaque_stream> m_stream;
+
+};  // class stream
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/utils/opaque_stream.cpp
+++ b/device/cuda/src/utils/opaque_stream.cpp
@@ -1,0 +1,34 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "opaque_stream.hpp"
+
+#include "traccc/cuda/utils/definitions.hpp"
+
+namespace traccc::cuda::details {
+
+opaque_stream::opaque_stream() : m_stream(nullptr) {
+
+    CUDA_ERROR_CHECK(cudaStreamCreate(&m_stream));
+}
+
+opaque_stream::~opaque_stream() {
+
+    // Don't check the return value of the stream destruction. This is because
+    // if the holder of this opaque stream is only destroyed during the
+    // termination of the application in which it was created, the CUDA runtime
+    // may have already deleted all streams by the time that this function would
+    // try to delete it.
+    //
+    // This is not the most robust thing ever, but detecting reliably when this
+    // destructor is executed as part of the final operations of an application,
+    // would be too platform specific and fragile of an operation.
+    cudaStreamDestroy(m_stream);
+}
+
+}  // namespace traccc::cuda::details

--- a/device/cuda/src/utils/opaque_stream.hpp
+++ b/device/cuda/src/utils/opaque_stream.hpp
@@ -1,0 +1,32 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// CUDA include(s).
+#include <cuda_runtime_api.h>
+
+namespace traccc::cuda::details {
+
+/// RAII wrapper around @c cudaStream_t
+///
+/// It is used only internally by the CUDA library, so it does not need to
+/// provide any nice interface.
+///
+struct opaque_stream {
+
+    /// Default constructor
+    opaque_stream();
+    /// Destructor
+    ~opaque_stream();
+
+    /// Stream managed by the object
+    cudaStream_t m_stream;
+
+};  // class opaque_stream
+
+}  // namespace traccc::cuda::details

--- a/device/cuda/src/utils/stream.cpp
+++ b/device/cuda/src/utils/stream.cpp
@@ -1,0 +1,60 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "traccc/cuda/utils/stream.hpp"
+
+#include "opaque_stream.hpp"
+#include "traccc/cuda/utils/definitions.hpp"
+#include "utils.hpp"
+
+// CUDA include(s).
+#include <cuda_runtime_api.h>
+
+namespace traccc::cuda {
+
+stream::stream(int device) {
+
+    // Make sure that the stream is constructed on the correct device.
+    details::select_device dev_selector{
+        device == INVALID_DEVICE ? details::get_device() : device};
+
+    // Construct the stream.
+    m_stream = std::make_unique<details::opaque_stream>();
+}
+
+stream::stream(stream&& parent) : m_stream(std::move(parent.m_stream)) {}
+
+/// The destructor is implemented explicitly to avoid clients of the class
+/// having to know how to destruct @c traccc::cuda::details::opaque_stream.
+stream::~stream() {}
+
+stream& stream::operator=(stream&& rhs) {
+
+    // Avoid self-assignment.
+    if (this == &rhs) {
+        return *this;
+    }
+
+    // Move the managed queue object.
+    m_stream = std::move(rhs.m_stream);
+
+    // Return this object.
+    return *this;
+}
+
+void* stream::cudaStream() const {
+
+    return m_stream->m_stream;
+}
+
+void stream::synchronize() const {
+
+    CUDA_ERROR_CHECK(cudaStreamSynchronize(m_stream->m_stream));
+}
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/utils/utils.cpp
+++ b/device/cuda/src/utils/utils.cpp
@@ -1,0 +1,50 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "utils.hpp"
+
+#include "traccc/cuda/utils/definitions.hpp"
+
+namespace traccc::cuda::details {
+
+int get_device() {
+
+    int d = -1;
+    cudaGetDevice(&d);
+    return d;
+}
+
+cudaStream_t get_stream(const stream& stream) {
+
+    return reinterpret_cast<cudaStream_t>(stream.cudaStream());
+}
+
+select_device::select_device(int device) {
+    /*
+     * When the object is constructed, grab the current device number and
+     * store it as a member variable. Then set the device to whatever was
+     * specified.
+     */
+    CUDA_ERROR_CHECK(cudaGetDevice(&m_device));
+    CUDA_ERROR_CHECK(cudaSetDevice(device));
+}
+
+select_device::~select_device() {
+    /*
+     * On destruction, reset the device number to whatever it was before the
+     * object was constructed.
+     */
+    CUDA_ERROR_CHECK(cudaSetDevice(m_device));
+}
+
+int select_device::device() const {
+
+    return m_device;
+}
+
+}  // namespace traccc::cuda::details

--- a/device/cuda/src/utils/utils.hpp
+++ b/device/cuda/src/utils/utils.hpp
@@ -1,0 +1,67 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "traccc/cuda/utils/stream.hpp"
+
+// CUDA include(s).
+#include <cuda_runtime_api.h>
+
+namespace traccc::cuda::details {
+
+/// Get current CUDA device number.
+///
+/// This function wraps the cudaGetDevice function in a way that returns the
+/// device number rather than use a reference argument to write to.
+///
+/// Note that calling the function on a machine with no CUDA device does not
+/// result in an error, the function just returns -1 in that case.
+///
+int get_device();
+
+/// Get concrete @c cudaStream_t object out of our wrapper
+cudaStream_t get_stream(const stream& str);
+
+/// Class with RAII mechanism for selecting a CUDA device.
+///
+/// This class can be used to select CUDA devices in a modern C++ way, with
+/// scope safety. When an object of this class is constructed, it will switch
+/// the thread-local device selector to the device number specified in the
+/// constructor argument. When this object goes out of scope or gets
+/// destructed in any other way, it will restore the device that was set
+/// before the object was constructed. This allows us to easily write methods
+/// with few side-effects.
+///
+/// @warning The behaviour of this class is not well-defined if you construct
+/// more than one in the same scope.
+///
+class select_device {
+
+    public:
+    /// Constructs the object, switching the current CUDA device
+    /// to the requested number.
+    ///
+    /// @param device The CUDA device number to switch to.
+    ///
+    select_device(int device);
+
+    /// Deconstructs the object, returning to the device that was
+    /// selected before constructing this object.
+    ~select_device();
+
+    /// Return the identifier for the device being seleced
+    int device() const;
+
+    private:
+    /// The old device number, this is what we restore when the
+    /// object goes out of scope.
+    int m_device;
+};
+
+}  // namespace traccc::cuda::details

--- a/examples/run/common/throughput_mt.hpp
+++ b/examples/run/common/throughput_mt.hpp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+
 // System include(s).
 #include <string_view>
 
@@ -15,12 +18,14 @@ namespace traccc {
 /// Helper function running a multi-threaded throughput test
 ///
 /// @tparam FULL_CHAIN_ALG The type of the full chain algorithm to use
+/// @tparam HOST_MR The host memory resource type to use
 /// @param description A short description of the application
 /// @param argc The count of command line arguments (from @c main(...))
 /// @param argv The command line arguments (from @c main(...))
 /// @return The value to be returned from @c main(...)
 ///
-template <typename FULL_CHAIN_ALG>
+template <typename FULL_CHAIN_ALG,
+          typename HOST_MR = vecmem::host_memory_resource>
 int throughput_mt(std::string_view description, int argc, char* argv[]);
 
 }  // namespace traccc

--- a/examples/run/common/throughput_st.hpp
+++ b/examples/run/common/throughput_st.hpp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+
 // System include(s).
 #include <string_view>
 
@@ -15,12 +18,14 @@ namespace traccc {
 /// Helper function running a single-threaded throughput test
 ///
 /// @tparam FULL_CHAIN_ALG The type of the full chain algorithm to use
+/// @tparam HOST_MR The host memory resource type to use
 /// @param description A short description of the application
 /// @param argc The count of command line arguments (from @c main(...))
 /// @param argv The command line arguments (from @c main(...))
 /// @return The value to be returned from @c main(...)
 ///
-template <typename FULL_CHAIN_ALG>
+template <typename FULL_CHAIN_ALG,
+          typename HOST_MR = vecmem::host_memory_resource>
 int throughput_st(std::string_view description, int argc, char* argv[]);
 
 }  // namespace traccc

--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -11,6 +11,7 @@
 #include "traccc/cuda/clusterization/clusterization_algorithm.hpp"
 #include "traccc/cuda/seeding/seeding_algorithm.hpp"
 #include "traccc/cuda/seeding/track_params_estimation.hpp"
+#include "traccc/cuda/utils/stream.hpp"
 #include "traccc/device/container_h2d_copy_alg.hpp"
 #include "traccc/edm/cell.hpp"
 #include "traccc/utils/algorithm.hpp"
@@ -19,7 +20,7 @@
 #include <vecmem/memory/binary_page_memory_resource.hpp>
 #include <vecmem/memory/cuda/device_memory_resource.hpp>
 #include <vecmem/memory/memory_resource.hpp>
-#include <vecmem/utils/cuda/copy.hpp>
+#include <vecmem/utils/cuda/async_copy.hpp>
 
 // System include(s).
 #include <memory>
@@ -66,12 +67,14 @@ class full_chain_algorithm
     private:
     /// Host memory resource
     vecmem::memory_resource& m_host_mr;
+    /// CUDA stream to use
+    stream m_stream;
     /// Device memory resource
     vecmem::cuda::device_memory_resource m_device_mr;
     /// Device caching memory resource
     std::unique_ptr<vecmem::binary_page_memory_resource> m_cached_device_mr;
-    /// Memory copy object
-    mutable vecmem::cuda::copy m_copy;
+    /// (Asynchronous) Memory copy object
+    mutable vecmem::cuda::async_copy m_copy;
 
     /// @name Sub-algorithms used by this full-chain algorithm
     /// @{

--- a/examples/run/cuda/throughput_mt.cpp
+++ b/examples/run/cuda/throughput_mt.cpp
@@ -10,9 +10,13 @@
 
 #include "full_chain_algorithm.hpp"
 
+// VecMem include(s).
+#include <vecmem/memory/cuda/host_memory_resource.hpp>
+
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
-    return traccc::throughput_mt<traccc::cuda::full_chain_algorithm>(
+    return traccc::throughput_mt<traccc::cuda::full_chain_algorithm,
+                                 vecmem::cuda::host_memory_resource>(
         "Multi-threaded CUDA GPU throughput tests", argc, argv);
 }

--- a/examples/run/cuda/throughput_st.cpp
+++ b/examples/run/cuda/throughput_st.cpp
@@ -10,9 +10,13 @@
 
 #include "full_chain_algorithm.hpp"
 
+// VecMem include(s).
+#include <vecmem/memory/cuda/host_memory_resource.hpp>
+
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
-    return traccc::throughput_st<traccc::cuda::full_chain_algorithm>(
+    return traccc::throughput_st<traccc::cuda::full_chain_algorithm,
+                                 vecmem::cuda::host_memory_resource>(
         "Single-threaded CUDA GPU throughput tests", argc, argv);
 }


### PR DESCRIPTION
As noted in #290 the main bottleneck for the throughput tests at this point is that synchronous operations from multiple CPU threads can not work in parallel. So we pretty much serialize all GPU operations regardless of how many CPU threads we use.

This PR is meant to be a first step in getting rid of this bottleneck. It introduces some "basic machinery" code for handling CUDA streams in the project, and then it updates `traccc::cuda::clusterization_algorithm` to perform all of its memory operations and kernel launches asynchronously.

Now... This still makes the amount of "asynchronicity" in the code pretty small. But as I was very pleased to see in some profiles, there **is** some parallelism in GPU operations now.

![image](https://user-images.githubusercontent.com/30694331/205689128-1cc2db25-0c6a-45ae-afbf-8f02a6b7e747.png)

Not a lot, but at least something. :smile: The (4-thread) MT throughput on my development system goes from:

```
[bash][atspot01]:build-x86_64_ubuntu2004_gcc9 > ./bin/traccc_throughput_mt_cuda --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_full/ttbar_mu200/ --cold_run_events=100 --processed_events=1000 --threads=4

Multi-threaded CUDA GPU throughput tests

>>> Throughput options <<<
Input data format   : csv
Input directory     : tml_full/ttbar_mu200/
Detector geometry   : tml_detector/trackml-detector.csv
Digitization config : tml_detector/default-geometric-config-generic.json
Loaded event(s)     : 10
Cold run event(s)   : 100
Processed event(s)  : 1000
>>> Multi-threading options <<<
CPU threads: 4

Using CUDA device: NVIDIA GeForce RTX 2060 [id: 0, bus: 1, device: 0]
Reconstructed track parameters: 15976769
Time totals:
                  File reading  1068 ms
            Warm-up processing  753 ms
              Event processing  6392 ms
Throughput:
            Warm-up processing  7.53544 ms/event, 132.706 events/s
              Event processing  6.39269 ms/event, 156.429 events/s
[bash][atspot01]:build-x86_64_ubuntu2004_gcc9 >
```

To something like:

```
[bash][atspot01]:build-x86_64_ubuntu2004_gcc9 > ./bin/traccc_throughput_mt_cuda --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_full/ttbar_mu200/ --cold_run_events=100 --processed_events=1000 --threads=4

Multi-threaded CUDA GPU throughput tests

>>> Throughput options <<<
Input data format   : csv
Input directory     : tml_full/ttbar_mu200/
Detector geometry   : tml_detector/trackml-detector.csv
Digitization config : tml_detector/default-geometric-config-generic.json
Loaded event(s)     : 10
Cold run event(s)   : 100
Processed event(s)  : 1000
>>> Multi-threading options <<<
CPU threads: 4

Using CUDA device: NVIDIA GeForce RTX 2060 [id: 0, bus: 1, device: 0]
Using CUDA device: NVIDIA GeForce RTX 2060 [id: 0, bus: 1, device: 0]
Using CUDA device: NVIDIA GeForce RTX 2060 [id: 0, bus: 1, device: 0]
Using CUDA device: NVIDIA GeForce RTX 2060 [id: 0, bus: 1, device: 0]
Using CUDA device: NVIDIA GeForce RTX 2060 [id: 0, bus: 1, device: 0]
Reconstructed track parameters: 14620103
Time totals:
                  File reading  1194 ms
            Warm-up processing  693 ms
              Event processing  5504 ms
Throughput:
            Warm-up processing  6.93214 ms/event, 144.256 events/s
              Event processing  5.5048 ms/event, 181.66 events/s
[bash][atspot01]:build-x86_64_ubuntu2004_gcc9 >
```

Though there are some significant uncertainties on the latter values. (I've seen them vary quite a bit run-to-run.)

Still, I believe that making all of the algorithms asynchronous (including the cell H->D copy, which will require some VecMem tweaks) is a worthy time investment. :wink: