### PR TITLE
I/O Code Fix, main branch (2022.12.07.)

### DIFF
--- a/io/src/write.cpp
+++ b/io/src/write.cpp
@@ -34,15 +34,14 @@ void write(std::size_t event, std::string_view directory,
            spacepoint_container_types::const_view spacepoints) {
 
     switch (format) {
-        case data_format::binary: {
+        case data_format::binary:
             details::write_binary_container(
                 data_directory() + directory.data() +
                     get_event_filename(event, "-hits.dat"),
                 traccc::spacepoint_container_types::const_device{spacepoints});
             break;
-            default:
-                throw std::invalid_argument("Unsupported data format");
-        }
+        default:
+            throw std::invalid_argument("Unsupported data format");
     }
 }
 


### PR DESCRIPTION
Removed a pair of unnecessary/erroneous braces from the code.

The crazy thing is that already in https://github.com/acts-project/traccc/pull/275/files#r1023031699 that the code formatting looked funky here. But I didn't realise back then why [clang-format](https://clang.llvm.org/docs/ClangFormat.html) was doing what it was doing. :frowning:

Some time ago we did find these extra braces with @stephenswat while looking at the code, but concluded that weirdly the compiler was still generating the same code here that it would do without the braces. :confused: So I didn't get to actually fixing the issue back then.

But since Minsi Chen's (whose GitHub ID I couldn't find unfortunately) static code analysis also pointed to this part in our code as having a bad smell, it was really time to finally fix it. :stuck_out_tongue: