### PR TITLE
GPU Track Fitting

### DIFF
--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -54,6 +54,8 @@ struct track_state {
     using matrix_type =
         typename matrix_operator::template matrix_type<ROWS, COLS>;
 
+    track_state() = default;
+
     /// Construction with track candidate
     TRACCC_HOST_DEVICE
     track_state(const track_candidate& trk_cand)

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -47,9 +47,9 @@ struct gain_matrix_updater {
 
         // Some identity matrices
         // @Note: Make constexpr work
-        static const matrix_type<6, 6> I66 =
+        const matrix_type<6, 6> I66 =
             matrix_operator().template identity<e_bound_size, e_bound_size>();
-        static const matrix_type<2, 2> I22 =
+        const matrix_type<2, 2> I22 =
             matrix_operator().template identity<2, 2>();
 
         // projection matrix

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -87,8 +87,7 @@ struct kalman_actor : detray::actor {
         }
 
         // triggered only for sensitive surfaces
-        if (navigation.is_on_module() &&
-            navigation.current()->sf_id == detray::surface_id::e_sensitive) {
+        if (navigation.is_on_sensitive()) {
 
             auto& trk_state = actor_state();
 

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -35,6 +35,13 @@ struct kalman_actor : detray::actor {
             m_it = m_track_states.begin();
         }
 
+        /// Constructor with the vector of track states
+        TRACCC_HOST_DEVICE
+        state(const vector_t<track_state_type>& track_states)
+            : m_track_states(track_states) {
+            m_it = m_track_states.begin();
+        }
+
         /// @return the reference of track state pointed by the iterator
         TRACCC_HOST_DEVICE
         track_state_type& operator()() { return *m_it; }

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -32,6 +32,13 @@ class kalman_fitter {
     // scalar type
     using scalar_type = typename stepper_t::scalar_type;
 
+    // vector type
+    template <typename T>
+    using vector_type = typename navigator_t::template vector_type<T>;
+
+    // navigator candidate type
+    using intersection_type = typename navigator_t::intersection_type;
+
     // Kalman fitter configuration
     struct config {
         std::size_t n_iterations = 1;
@@ -50,7 +57,7 @@ class kalman_fitter {
     using aborter = detray::pathlimit_aborter;
     using transporter = detray::parameter_transporter<transform3_type>;
     using interactor = detray::pointwise_material_interactor<transform3_type>;
-    using fit_actor = traccc::kalman_actor<transform3_type, vecmem::vector>;
+    using fit_actor = traccc::kalman_actor<transform3_type, vector_type>;
     using resetter = detray::parameter_resetter<transform3_type>;
 
     using actor_chain_type =
@@ -64,6 +71,7 @@ class kalman_fitter {
     /// Constructor with a detector
     ///
     /// @param det the detector object
+    TRACCC_HOST_DEVICE
     kalman_fitter(const detector_type& det) : m_detector(det) {}
 
     /// Kalman fitter state
@@ -72,10 +80,19 @@ class kalman_fitter {
         /// State constructor
         ///
         /// @param track_states the vector of track states
-        state(vecmem::vector<track_state<transform3_type>>&& track_states)
+        TRACCC_HOST_DEVICE
+        state(vector_type<track_state<transform3_type>>&& track_states)
             : m_fit_actor_state(std::move(track_states)) {}
 
+        /// State constructor
+        ///
+        /// @param track_states the vector of track states
+        TRACCC_HOST_DEVICE
+        state(const vector_type<track_state<transform3_type>>& track_states)
+            : m_fit_actor_state(track_states) {}
+
         /// @return the actor chain state
+        TRACCC_HOST_DEVICE
         typename actor_chain_type::state operator()() {
             return std::tie(m_aborter_state, m_transporter_state,
                             m_interactor_state, m_fit_actor_state,
@@ -100,7 +117,9 @@ class kalman_fitter {
     /// @param seed_params seed track parameter
     /// @param fitter_state the state of kalman fitter
     template <typename seed_parameters_t>
-    void fit(const seed_parameters_t& seed_params, state& fitter_state) {
+    TRACCC_HOST_DEVICE void fit(
+        const seed_parameters_t& seed_params, state& fitter_state,
+        vector_type<intersection_type>&& nav_candidates = {}) {
 
         // Run the kalman filtering for a given number of iterations
         for (std::size_t i = 0; i < m_cfg.n_iterations; i++) {
@@ -109,7 +128,7 @@ class kalman_fitter {
             fitter_state.m_fit_actor_state.reset();
 
             if (i == 0) {
-                filter(seed_params, fitter_state);
+                filter(seed_params, fitter_state, std::move(nav_candidates));
             }
             // From the second iteration, seed parameter is the smoothed track
             // parameter at the first surface
@@ -117,7 +136,8 @@ class kalman_fitter {
                 const auto& new_seed_params =
                     fitter_state.m_fit_actor_state.m_track_states[0].smoothed();
 
-                filter(new_seed_params, fitter_state);
+                filter(new_seed_params, fitter_state,
+                       std::move(nav_candidates));
             }
         }
     }
@@ -129,7 +149,9 @@ class kalman_fitter {
     /// @param seed_params seed track parameter
     /// @param fitter_state the state of kalman fitter
     template <typename seed_parameters_t>
-    void filter(const seed_parameters_t& seed_params, state& fitter_state) {
+    TRACCC_HOST_DEVICE void filter(
+        const seed_parameters_t& seed_params, state& fitter_state,
+        vector_type<intersection_type>&& nav_candidates = {}) {
 
         // Create propagator
         propagator_type propagator({}, {});
@@ -139,7 +161,8 @@ class kalman_fitter {
 
         // Create propagator state
         typename propagator_type::state propagation(
-            seed_params, m_detector.get().get_bfield(), m_detector.get());
+            seed_params, m_detector.get_bfield(), m_detector,
+            std::move(nav_candidates));
 
         // Set overstep tolerance and stepper constraint
         propagation._stepping().set_overstep_tolerance(
@@ -163,6 +186,7 @@ class kalman_fitter {
     /// track and vertex fitting", R.Frühwirth, NIM A.
     ///
     /// @param fitter_state the state of kalman fitter
+    TRACCC_HOST_DEVICE
     void smooth(state& fitter_state) {
         auto& track_states = fitter_state.m_fit_actor_state.m_track_states;
 
@@ -177,16 +201,16 @@ class kalman_fitter {
         last.smoothed().set_vector(last.filtered().vector());
         last.smoothed().set_covariance(last.filtered().covariance());
 
-        const auto& mask_store = m_detector.get().mask_store();
+        const auto& mask_store = m_detector.mask_store();
 
-        for (typename vecmem::vector<
+        for (typename vector_type<
                  track_state<transform3_type>>::reverse_iterator it =
                  track_states.rbegin() + 1;
              it != track_states.rend(); ++it) {
 
             // Surface
             const auto& surface =
-                m_detector.get().surface_by_index(it->surface_link());
+                m_detector.surface_by_index(it->surface_link());
 
             // Run kalman smoother
             mask_store.template call<gain_matrix_smoother<transform3_type>>(
@@ -196,7 +220,7 @@ class kalman_fitter {
 
     private:
     // Detector object
-    std::reference_wrapper<detector_type> m_detector;
+    const detector_type& m_detector;
     // Configuration object
     config m_cfg;
 };

--- a/device/common/include/traccc/fitting/device/fit.hpp
+++ b/device/common/include/traccc/fitting/device/fit.hpp
@@ -1,0 +1,39 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/track_candidate.hpp"
+#include "traccc/edm/track_state.hpp"
+
+// System include(s).
+#include <cstddef>
+
+namespace traccc::device {
+
+/// Function used for fitting a track for a given track candidates
+///
+/// @param[in] globalIndex   The index of the current thread
+/// @param[in] det_data      Detector view object
+/// @param[in] nav_candidates_buffer Buffer for navigation candidate objects
+/// @param[in] track_candidates_view The input track candidates
+/// @param[out] track_states_view The output of fitted track states
+///
+template <typename fitter_t, typename detector_view_t>
+TRACCC_HOST_DEVICE inline void fit(
+    std::size_t globalIndex, detector_view_t det_data,
+    vecmem::data::jagged_vector_view<typename fitter_t::intersection_type>
+        nav_candidates_buffer,
+    track_candidate_container_types::const_view track_candidates_view,
+    track_state_container_types::view track_states_view);
+
+}  // namespace traccc::device
+
+// Include the implementation.
+#include "traccc/fitting/device/impl/fit.ipp"

--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -1,0 +1,55 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::device {
+
+template <typename fitter_t, typename detector_view_t>
+TRACCC_HOST_DEVICE inline void fit(
+    std::size_t globalIndex, detector_view_t det_data,
+    vecmem::data::jagged_vector_view<typename fitter_t::intersection_type>
+        nav_candidates_buffer,
+    track_candidate_container_types::const_view track_candidates_view,
+    track_state_container_types::view track_states_view) {
+
+    typename fitter_t::detector_type det(det_data);
+
+    vecmem::jagged_device_vector<typename fitter_t::intersection_type>
+        nav_candidates(nav_candidates_buffer);
+
+    track_candidate_container_types::const_device track_candidates(
+        track_candidates_view);
+
+    track_state_container_types::device track_states(track_states_view);
+
+    fitter_t fitter(det);
+
+    if (globalIndex >= track_states.size()) {
+        return;
+    }
+
+    // Track candidates per track
+    const auto& track_candidates_per_track =
+        track_candidates[globalIndex].items;
+
+    // Seed parameter
+    const auto& seed_param = track_candidates[globalIndex].header;
+
+    // Track states per track
+    auto track_states_per_track = track_states[globalIndex].items;
+
+    for (auto& cand : track_candidates_per_track) {
+        track_states_per_track.emplace_back(cand);
+    }
+
+    typename fitter_t::state fitter_state(track_states_per_track);
+
+    fitter.fit(seed_param, fitter_state, nav_candidates.at(globalIndex));
+}
+
+}  // namespace traccc::device

--- a/device/common/include/traccc/fitting/device/sync_kalman_fitter.hpp
+++ b/device/common/include/traccc/fitting/device/sync_kalman_fitter.hpp
@@ -1,0 +1,113 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/track_candidate.hpp"
+#include "traccc/edm/track_parameters.hpp"
+#include "traccc/edm/track_state.hpp"
+#include "traccc/fitting/kalman_filter/kalman_actor.hpp"
+
+// detray include(s).
+#include "detray/propagator/actor_chain.hpp"
+#include "detray/propagator/actors/aborters.hpp"
+#include "detray/propagator/actors/parameter_resetter.hpp"
+#include "detray/propagator/actors/parameter_transporter.hpp"
+#include "detray/propagator/actors/pointwise_material_interactor.hpp"
+#include "detray/propagator/propagator.hpp"
+
+namespace traccc::device {
+
+/// Kalman fitter algorithm to fit a single track
+template <typename stepper_t, typename navigator_t>
+class sync_kalman_fitter final
+    : public kalman_fitter_base<kalman_fitter, stepper_t, navigator_t> {
+
+    public:
+    using base_type = kalman_fitter_base<kalman_fitter, stepper_t, navigator_t>;
+    using base_type::base_type;
+
+    // vector type
+    template <typename T>
+    using vector_type = typename base_type::template vector_type<T>;
+
+    // navigator candidate type
+    using intersection_type = typename base_type::intersection_type;
+
+    // transform3 type
+    using transform3_type = typename base_type::transform3_type;
+
+    // Actor types
+    using aborter = detray::pathlimit_aborter;
+    using transporter = detray::parameter_transporter<transform3_type>;
+    using interactor = detray::pointwise_material_interactor<transform3_type>;
+    using fit_actor = traccc::kalman_actor<transform3_type, vector_type>;
+    using resetter = detray::parameter_resetter<transform3_type>;
+
+    using actor_chain_type =
+        detray::actor_chain<std::tuple, aborter, transporter, interactor,
+                            fit_actor, resetter>;
+
+    // Propagator type
+    using propagator_type =
+        detray::propagator<stepper_t, navigator_t, actor_chain_type>;
+
+    /// Kalman fitter state
+    struct state {
+
+        /// State constructor
+        ///
+        /// @param track_states the vector of track states
+        TRACCC_HOST_DEVICE
+        state(vector_type<track_state<transform3_type>>&& track_states)
+            : m_fit_actor_state(std::move(track_states)) {}
+
+        /// State constructor
+        ///
+        /// @param track_states the vector of track states
+        TRACCC_HOST_DEVICE
+        state(const vector_type<track_state<transform3_type>>& track_states)
+            : m_fit_actor_state(track_states) {}
+
+        /// @return the actor chain state
+        TRACCC_HOST_DEVICE
+        typename actor_chain_type::state operator()() {
+            return std::tie(m_aborter_state, m_transporter_state,
+                            m_interactor_state, m_fit_actor_state,
+                            m_resetter_state);
+        }
+
+        /// Individual actor states
+        typename aborter::state m_aborter_state{};
+        typename transporter::state m_transporter_state{};
+        typename interactor::state m_interactor_state{};
+        typename fit_actor::state m_fit_actor_state;
+        typename resetter::state m_resetter_state{};
+
+        /// Fitting result per track
+        fitter_info<transform3_type> m_fit_info;
+    };
+
+    /// Run the kalman fitter for an iteration
+    ///
+    /// @tparam seed_parameters_t the type of seed track parameter
+    ///
+    /// @param seed_params seed track parameter
+    /// @param fitter_state the state of kalman fitter
+    template <typename seed_parameters_t>
+    TRACCC_HOST_DEVICE void filter(
+        const seed_parameters_t& seed_params, state& fitter_state,
+        vector_type<intersection_type>&& nav_candidates = {}) {}
+
+    TRACCC_HOST_DEVICE void propagate(
+        typename propagator_type::state& propagation,
+        typename actor_chain_type::state&& actor_states);
+};
+
+}  // namespace traccc::device

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -41,9 +41,13 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   # Clusterization
   "include/traccc/cuda/clusterization/clusterization_algorithm.hpp"
   "src/clusterization/clusterization_algorithm.cu"
-)
+  # Fitting
+  "include/traccc/cuda/fitting/fitting_algorithm.hpp"
+  "src/fitting/fitting_algorithm.cu")
+  
 target_compile_options( traccc_cuda
   PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr> )
 target_link_libraries( traccc_cuda
-  PUBLIC traccc::core vecmem::core
+  PUBLIC traccc::core detray::core detray::utils vecmem::core covfie::core
   PRIVATE CUDA::cudart traccc::device_common vecmem::cuda )
+

--- a/device/cuda/include/traccc/cuda/fitting/fitting_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/fitting/fitting_algorithm.hpp
@@ -1,0 +1,55 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/edm/track_candidate.hpp"
+#include "traccc/edm/track_state.hpp"
+#include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/memory_resource.hpp"
+
+// VecMem include(s).
+#include <vecmem/utils/copy.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+
+// traccc library include(s).
+#include "traccc/utils/memory_resource.hpp"
+
+namespace traccc::cuda {
+
+/// Fitting algorithm for a set of tracks
+template <typename fitter_t>
+class fitting_algorithm
+    : public algorithm<track_state_container_types::buffer(
+          const typename fitter_t::detector_type::detector_view_type&,
+          const vecmem::data::jagged_vector_view<
+              typename fitter_t::intersection_type>&,
+          const typename track_candidate_container_types::const_view&)> {
+
+    public:
+    /// Constructor for the fitting algorithm
+    ///
+    /// @param mr The memory resource to use
+    fitting_algorithm(const traccc::memory_resource& mr);
+
+    /// Run the algorithm
+    track_state_container_types::buffer operator()(
+        const typename fitter_t::detector_type::detector_view_type& det_view,
+        const vecmem::data::jagged_vector_view<
+            typename fitter_t::intersection_type>& navigation_buffer,
+        const typename track_candidate_container_types::const_view&
+            track_candidates_view) const override;
+
+    private:
+    /// Memory resource used by the algorithm
+    traccc::memory_resource m_mr;
+    /// Copy object used by the algorithm
+    std::unique_ptr<vecmem::copy> m_copy;
+};
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/fitting/fitting_algorithm.cu
+++ b/device/cuda/src/fitting/fitting_algorithm.cu
@@ -1,0 +1,106 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/cuda/fitting/fitting_algorithm.hpp"
+#include "traccc/cuda/utils/definitions.hpp"
+#include "traccc/fitting/device/fit.hpp"
+#include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+
+// detray include(s).
+#include "detray/detectors/detector_metadata.hpp"
+#include "detray/propagator/rk_stepper.hpp"
+
+// System include(s).
+#include <vector>
+
+namespace traccc::cuda {
+
+namespace kernels {
+
+template <typename fitter_t, typename detector_view_t>
+__global__ void fit(
+    detector_view_t det_data,
+    vecmem::data::jagged_vector_view<typename fitter_t::intersection_type>
+        nav_candidates_buffer,
+    track_candidate_container_types::const_view track_candidates_view,
+    track_state_container_types::view track_states_view) {
+
+    int gid = threadIdx.x + blockIdx.x * blockDim.x;
+
+    device::fit<fitter_t>(gid, det_data, nav_candidates_buffer,
+                          track_candidates_view, track_states_view);
+}
+
+}  // namespace kernels
+
+template <typename fitter_t>
+fitting_algorithm<fitter_t>::fitting_algorithm(
+    const traccc::memory_resource& mr)
+    : m_mr(mr) {
+
+    // Initialize m_copy ptr based on memory resources that were given
+    if (mr.host) {
+        m_copy = std::make_unique<vecmem::cuda::copy>();
+    } else {
+        m_copy = std::make_unique<vecmem::copy>();
+    }
+};
+
+template <typename fitter_t>
+track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
+    const typename fitter_t::detector_type::detector_view_type& det_view,
+    const vecmem::data::jagged_vector_view<
+        typename fitter_t::intersection_type>& navigation_buffer,
+    const typename track_candidate_container_types::const_view&
+        track_candidates_view) const {
+
+    // Number of tracks
+    const track_candidate_container_types::const_device::header_vector::
+        size_type n_tracks = m_copy->get_size(track_candidates_view.headers);
+
+    // Get the sizes of the track candidates in each track
+    const std::vector<track_candidate_container_types::const_device::
+                          item_vector::value_type::size_type>
+        candidate_sizes = m_copy->get_sizes(track_candidates_view.items);
+
+    track_state_container_types::buffer track_states_buffer{
+        {n_tracks, m_mr.main},
+        {std::vector<std::size_t>(n_tracks),
+         std::vector<std::size_t>(candidate_sizes.begin(),
+                                  candidate_sizes.end()),
+         m_mr.main, m_mr.host}};
+
+    m_copy->setup(track_states_buffer.headers);
+    m_copy->setup(track_states_buffer.items);
+    m_copy->setup(navigation_buffer);
+
+    // Calculate the number of threads and thread blocks to run the track
+    // fitting
+    const unsigned int nThreads = WARP_SIZE * 2;
+    const unsigned int nBlocks = (n_tracks + nThreads - 1) / nThreads;
+
+    // Run the track fitting
+    kernels::fit<fitter_t><<<nBlocks, nThreads>>>(det_view, navigation_buffer,
+                                                  track_candidates_view,
+                                                  track_states_buffer);
+    return track_states_buffer;
+}
+
+// Explicit template instantiation
+using device_detector_type =
+    detray::detector<detray::detector_registry::telescope_detector,
+                     covfie::field_view, detray::device_container_types>;
+using rk_stepper_type = detray::rk_stepper<
+    covfie::field<device_detector_type::bfield_backend_type>::view_t,
+    transform3, detray::constrained_step<>>;
+using device_navigator_type = detray::navigator<const device_detector_type>;
+using device_fitter_type =
+    kalman_fitter<rk_stepper_type, device_navigator_type>;
+template class fitting_algorithm<device_fitter_type>;
+
+}  // namespace traccc::cuda

--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -15,6 +15,7 @@ enable_language( SYCL )
 traccc_add_library( traccc_sycl sycl TYPE SHARED
   # header files
   "include/traccc/sycl/clusterization/clusterization_algorithm.hpp"
+  "include/traccc/sycl/fitting/fitting_algorithm.hpp"
   "include/traccc/sycl/seeding/seeding_algorithm.hpp"
   "include/traccc/sycl/seeding/seed_finding.hpp"
   "include/traccc/sycl/seeding/spacepoint_binning.hpp"
@@ -24,6 +25,7 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
   "include/traccc/sycl/utils/make_prefix_sum_buff.hpp"
   # implementation files
   "src/clusterization/clusterization_algorithm.sycl"
+  "src/fitting/fitting_algorithm.sycl"
   "src/seeding/seed_finding.sycl"
   "src/seeding/seeding_algorithm.cpp"
   "src/seeding/spacepoint_binning.sycl"
@@ -34,7 +36,7 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
   "src/utils/calculate1DimNdRange.sycl"
   "src/utils/make_prefix_sum_buff.sycl" )
 target_link_libraries( traccc_sycl
-  PUBLIC vecmem::core traccc::core
+  PUBLIC traccc::core detray::core detray::utils vecmem::core covfie::core
   PRIVATE traccc::device_common vecmem::sycl )
 
 # Prevent Eigen from getting confused when building code for a

--- a/device/sycl/include/traccc/sycl/fitting/fitting_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/fitting/fitting_algorithm.hpp
@@ -1,0 +1,61 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// SYCL library include(s).
+#include "traccc/sycl/utils/queue_wrapper.hpp"
+
+// Project include(s).
+#include "traccc/edm/track_candidate.hpp"
+#include "traccc/edm/track_state.hpp"
+#include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/memory_resource.hpp"
+
+// VecMem include(s).
+#include <vecmem/utils/copy.hpp>
+#include <vecmem/utils/sycl/copy.hpp>
+
+// System include(s).
+#include <functional>
+
+namespace traccc::sycl {
+
+/// Fitting algorithm for a set of tracks
+template <typename fitter_t>
+class fitting_algorithm
+    : public algorithm<track_state_container_types::buffer(
+          const typename fitter_t::detector_type::detector_view_type&,
+          const vecmem::data::jagged_vector_view<
+              typename fitter_t::intersection_type>&,
+          const typename track_candidate_container_types::const_view&)> {
+
+    public:
+    /// Constructor for the fitting algorithm
+    ///
+    /// @param mr The memory resource to use
+    /// @param queue is a wrapper for the sycl queue for kernel invocation
+    fitting_algorithm(const traccc::memory_resource& mr, queue_wrapper queue);
+
+    /// Run the algorithm
+    track_state_container_types::buffer operator()(
+        const typename fitter_t::detector_type::detector_view_type& det_view,
+        const vecmem::data::jagged_vector_view<
+            typename fitter_t::intersection_type>& navigation_buffer,
+        const typename track_candidate_container_types::const_view&
+            track_candidates_view) const override;
+
+    private:
+    /// Memory resource used by the algorithm
+    traccc::memory_resource m_mr;
+    /// Queue wrapper
+    mutable queue_wrapper m_queue;
+    /// Copy object used by the algorithm
+    std::unique_ptr<vecmem::copy> m_copy;
+};
+
+}  // namespace traccc::sycl

--- a/device/sycl/src/fitting/fitting_algorithm.sycl
+++ b/device/sycl/src/fitting/fitting_algorithm.sycl
@@ -1,0 +1,111 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "../utils/get_queue.hpp"
+#include "traccc/fitting/device/fit.hpp"
+#include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+#include "traccc/sycl/fitting/fitting_algorithm.hpp"
+#include "traccc/sycl/utils/calculate1DimNdRange.hpp"
+
+// detray include(s).
+#include "detray/detectors/detector_metadata.hpp"
+#include "detray/propagator/rk_stepper.hpp"
+
+// System include(s).
+#include <vector>
+
+namespace traccc::sycl {
+
+namespace kernels {
+/// Class identifying the kernel running @c
+/// traccc::device::fit
+class fit;
+}  // namespace kernels
+
+template <typename fitter_t>
+fitting_algorithm<fitter_t>::fitting_algorithm(
+    const traccc::memory_resource& mr, queue_wrapper queue)
+    : m_mr(mr), m_queue(queue) {
+
+    // Initialize m_copy ptr based on memory resources that were given
+    if (mr.host) {
+        m_copy = std::make_unique<vecmem::sycl::copy>(queue.queue());
+    } else {
+        m_copy = std::make_unique<vecmem::copy>();
+    }
+}
+
+template <typename fitter_t>
+track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
+    const typename fitter_t::detector_type::detector_view_type& det_view,
+    const vecmem::data::jagged_vector_view<
+        typename fitter_t::intersection_type>& navigation_buffer,
+    const typename track_candidate_container_types::const_view&
+        track_candidates_view) const {
+
+    // Number of tracks
+    const track_candidate_container_types::const_device::header_vector::
+        size_type n_tracks = m_copy->get_size(track_candidates_view.headers);
+
+    // Get the sizes of the track candidates in each track
+    const std::vector<track_candidate_container_types::const_device::
+                          item_vector::value_type::size_type>
+        candidate_sizes = m_copy->get_sizes(track_candidates_view.items);
+
+    track_state_container_types::buffer track_states_buffer{
+        {n_tracks, m_mr.main},
+        {std::vector<std::size_t>(n_tracks),
+         std::vector<std::size_t>(candidate_sizes.begin(),
+                                  candidate_sizes.end()),
+         m_mr.main, m_mr.host}};
+
+    m_copy->setup(track_states_buffer.headers);
+    m_copy->setup(track_states_buffer.items);
+    m_copy->setup(navigation_buffer);
+
+    track_state_container_types::view track_states_view(track_states_buffer);
+
+    // -- localSize
+    // The dimension of workGroup (block) is the integer multiple of WARP_SIZE
+    // (=32)
+    unsigned int localSize = 64;
+
+    // 1 dim ND Range for the kernel
+    auto trackParamsNdRange =
+        traccc::sycl::calculate1DimNdRange(n_tracks, localSize);
+
+    details::get_queue(m_queue)
+        .submit([&](::sycl::handler& h) {
+            h.parallel_for<kernels::fit>(
+                trackParamsNdRange,
+                [det_view, navigation_buffer, track_candidates_view,
+                 track_states_view](::sycl::nd_item<1> item) {
+                    device::fit<fitter_t>(item.get_global_linear_id(), det_view,
+                                          navigation_buffer,
+                                          track_candidates_view,
+                                          track_states_view);
+                });
+        })
+        .wait_and_throw();
+
+    return track_states_buffer;
+}
+
+// Explicit template instantiation
+using device_detector_type =
+    detray::detector<detray::detector_registry::telescope_detector,
+                     covfie::field_view, detray::device_container_types>;
+using rk_stepper_type = detray::rk_stepper<
+    covfie::field<device_detector_type::bfield_backend_type>::view_t,
+    transform3, detray::constrained_step<>>;
+using device_navigator_type = detray::navigator<const device_detector_type>;
+using device_fitter_type =
+    kalman_fitter<rk_stepper_type, device_navigator_type>;
+template class fitting_algorithm<device_fitter_type>;
+
+}  // namespace traccc::sycl

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -87,8 +87,8 @@ int simulate(std::string output_directory, unsigned int events, scalar p0,
 
     boost::filesystem::create_directories(full_path);
 
-    auto sim =
-        detray::simulator(events, det, generator, meas_smearer, full_path);
+    auto sim = detray::simulator(events, det, std::move(generator),
+                                 meas_smearer, full_path);
     sim.run();
 
     return 1;

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.18.0.tar.gz;URL_MD5;f0bc0a6395759f548c19eacaf7bfa65d"
+   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.21.0.tar.gz;URL_MD5;cf7cecaf7045e0ec09b32934d256953b"
    CACHE STRING "Source for Detray, when built as part of this project" )
 
 mark_as_advanced( TRACCC_DETRAY_SOURCE )

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.17.0.tar.gz;URL_MD5;94f378bdd25591ddcbea1907603ea72f"
+   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.18.0.tar.gz;URL_MD5;f0bc0a6395759f548c19eacaf7bfa65d"
    CACHE STRING "Source for Detray, when built as part of this project" )
 
 mark_as_advanced( TRACCC_DETRAY_SOURCE )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,10 @@ if( TRACCC_BUILD_CUDA )
     add_subdirectory( cuda )
 endif()
 
+if( TRACCC_BUILD_SYCL )
+    add_subdirectory( sycl )
+endif()
+
 if( TRACCC_BUILD_KOKKOS )
     add_subdirectory( kokkos )
 endif()

--- a/tests/common/tests/kalman_fitting_test.hpp
+++ b/tests/common/tests/kalman_fitting_test.hpp
@@ -1,0 +1,97 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// detray include(s).
+#include "detray/detectors/detector_metadata.hpp"
+#include "detray/propagator/rk_stepper.hpp"
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+// ROOT include(s).
+#include <TF1.h>
+#include <TFile.h>
+
+namespace traccc {
+
+/// Kalman Fitting Test with Telescope Geometry
+///
+/// Tuple parameter made of (1) initial particle momentum and (2) initial phi
+class KalmanFittingTests
+    : public ::testing::TestWithParam<std::tuple<scalar, scalar>> {
+
+    public:
+    /// Type declarations
+    using host_detector_type =
+        detray::detector<detray::detector_registry::telescope_detector,
+                         covfie::field, detray::host_container_types>;
+    using device_detector_type =
+        detray::detector<detray::detector_registry::telescope_detector,
+                         covfie::field_view, detray::device_container_types>;
+
+    using b_field_t = typename host_detector_type::bfield_type;
+    using rk_stepper_type = detray::rk_stepper<b_field_t::view_t, transform3,
+                                               detray::constrained_step<>>;
+    using host_navigator_type = detray::navigator<const host_detector_type>;
+    using host_fitter_type =
+        kalman_fitter<rk_stepper_type, host_navigator_type>;
+    using device_navigator_type = detray::navigator<const device_detector_type>;
+    using device_fitter_type =
+        kalman_fitter<rk_stepper_type, device_navigator_type>;
+
+    /// Plane alignment direction (aligned to x-axis)
+    static const inline detray::detail::ray<transform3> traj{
+        {0, 0, 0}, 0, {1, 0, 0}, -1};
+    /// Position of planes (in mm unit)
+    static const inline std::vector<scalar> plane_positions = {
+        -10., 20., 40., 60., 80., 100., 120., 140, 160, 180., 200.};
+    /// B field value and its type
+    static constexpr vector3 B{2 * detray::unit<scalar>::T, 0, 0};
+    /// Plane material and thickness
+    static const inline detray::silicon_tml<scalar> mat = {};
+    static constexpr scalar thickness = 0.5 * detray::unit<scalar>::mm;
+
+    /// Standard deviations for seed track parameters
+    static constexpr std::array<scalar, e_bound_size> stddevs = {
+        0.03 * detray::unit<scalar>::mm,
+        0.03 * detray::unit<scalar>::mm,
+        0.017,
+        0.017,
+        0.001 / detray::unit<scalar>::GeV,
+        1 * detray::unit<scalar>::ns};
+
+    /// Verify that pull distribtion follows the normal distribution
+    ///
+    /// @param pull_dist the input histogram of pull values
+    void pull_value_test(TH1F* pull_dist) const {
+        TF1 gaus{"gaus", "gaus", -5, 5};
+        double fit_par[3];
+
+        // Set the mean seed to 0
+        gaus.SetParameters(1, 0.);
+        gaus.SetParLimits(1, -1., 1.);
+        // Set the standard deviation seed to 1
+        gaus.SetParameters(2, 1.0);
+        gaus.SetParLimits(2, 0.5, 2.);
+
+        auto res = pull_dist->Fit("gaus", "Q0S");
+
+        gaus.GetParameters(&fit_par[0]);
+
+        // Mean check
+        EXPECT_NEAR(fit_par[1], 0, 0.05)
+            << pull_dist->GetName() << " mean value error";
+
+        // Sigma check
+        EXPECT_NEAR(fit_par[2], 1, 0.1)
+            << pull_dist->GetName() << " sigma value error";
+    }
+};
+
+}  // namespace traccc

--- a/tests/common/tests/seed_generator.hpp
+++ b/tests/common/tests/seed_generator.hpp
@@ -44,9 +44,7 @@ struct seed_generator {
             auto& navigation = propagation._navigation;
 
             // Abort if the surface is sensitive
-            if (navigation.is_on_module() &&
-                navigation.current()->sf_id ==
-                    detray::surface_id::e_sensitive) {
+            if (navigation.is_on_sensitive()) {
                 propagation._heartbeat &= navigation.abort();
             }
         }

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -30,13 +30,17 @@ traccc_add_test(
     test_basic.cu
     test_cca.cpp
     test_copy_algs.cpp
+    test_kalman_filter.cpp
 
     LINK_LIBRARIES
     GTest::gtest
     vecmem::cuda
+    detray::core
+    detray::utils
     traccc::core
     traccc::device_common
     traccc::cuda
+    traccc::performance
     traccc::io
     traccc_tests_cuda_main
     traccc_tests_common

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -1,0 +1,28 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+include(traccc-compiler-options-sycl)
+
+enable_language(SYCL)
+
+traccc_add_test(
+    sycl
+
+    # Define the sources for the test.
+    test_kalman_filter.sycl
+
+    LINK_LIBRARIES
+    GTest::gtest_main
+    vecmem::sycl
+    detray::core
+    detray::utils
+    traccc::core
+    traccc::device_common
+    traccc::sycl
+    traccc::performance
+    traccc::io
+    traccc_tests_common
+)

--- a/tests/sycl/test_kalman_filter.sycl
+++ b/tests/sycl/test_kalman_filter.sycl
@@ -1,0 +1,187 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s)
+#include <CL/sycl.hpp>
+
+// Project include(s).
+#include "tests/seed_generator.hpp"
+#include "traccc/device/container_d2h_copy_alg.hpp"
+#include "traccc/device/container_h2d_copy_alg.hpp"
+#include "traccc/edm/track_state.hpp"
+#include "traccc/fitting/fitting_algorithm.hpp"
+#include "traccc/performance/details/is_same_object.hpp"
+#include "traccc/resolution/fitting_performance_writer.hpp"
+#include "traccc/sycl/fitting/fitting_algorithm.hpp"
+#include "traccc/utils/memory_resource.hpp"
+
+// Test include(s).
+#include "tests/kalman_fitting_test.hpp"
+
+// detray include(s).
+#include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/propagator/propagator.hpp"
+#include "detray/simulation/simulator.hpp"
+#include "detray/simulation/track_generators.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/memory/sycl/device_memory_resource.hpp>
+#include <vecmem/memory/sycl/shared_memory_resource.hpp>
+#include <vecmem/utils/sycl/copy.hpp>
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s).
+#include <climits>
+#include <exception>
+#include <iostream>
+
+using namespace traccc;
+
+// Simple asynchronous handler function
+auto handle_async_error = [](::sycl::exception_list elist) {
+    for (auto& e : elist) {
+        try {
+            std::rethrow_exception(e);
+        } catch (::sycl::exception& e) {
+            std::cout << "ASYNC EXCEPTION!!\n";
+            std::cout << e.what() << "\n";
+        }
+    }
+};
+
+// This defines the local frame test suite
+TEST_P(KalmanFittingTests, Run) {
+
+    // Test Parameters
+    const scalar p0 = std::get<0>(GetParam());
+    const scalar phi0 = std::get<1>(GetParam());
+
+    // Input path
+    const std::string full_path = "detray_simulation/telescope/kf_validation/" +
+                                  std::to_string(p0) + "_GeV_" +
+                                  std::to_string(phi0) + "_phi/";
+
+    traccc::fitting_performance_writer::config writer_cfg;
+    writer_cfg.file_path = "performance_track_fitting_" + std::to_string(p0) +
+                           "_GeV_" + std::to_string(phi0) + "_phi" + ".root";
+
+    traccc::fitting_performance_writer fit_performance_writer(writer_cfg);
+
+    /*****************************
+     * Build a telescope geometry
+     *****************************/
+
+    // Creating SYCL queue object
+    ::sycl::queue q(handle_async_error);
+    std::cout << "Running Seeding on device: "
+              << q.get_device().get_info<::sycl::info::device::name>() << "\n";
+
+    // Memory resources used by the application.
+    vecmem::host_memory_resource host_mr;
+    vecmem::sycl::device_memory_resource device_mr{&q};
+    traccc::memory_resource mr{device_mr, &host_mr};
+    vecmem::sycl::shared_memory_resource shared_mr;
+
+    host_detector_type host_det = create_telescope_detector(
+        shared_mr,
+        b_field_t(b_field_t::backend_t::configuration_t{B[0], B[1], B[2]}),
+        plane_positions, traj, std::numeric_limits<scalar>::infinity(),
+        std::numeric_limits<scalar>::infinity(), mat, thickness);
+
+    /***************
+     * Run fitting
+     ***************/
+
+    vecmem::sycl::copy copy{&q};
+
+    traccc::device::container_h2d_copy_alg<
+        traccc::track_candidate_container_types>
+        track_candidate_h2d{mr, copy};
+
+    traccc::device::container_d2h_copy_alg<traccc::track_state_container_types>
+        track_state_d2h{mr, copy};
+
+    // Seed generator
+    seed_generator<rk_stepper_type, host_navigator_type> sg(host_det, stddevs);
+
+    // Fitting algorithm object
+    traccc::sycl::fitting_algorithm<device_fitter_type> device_fitting(mr, &q);
+
+    std::size_t n_events = 100;
+
+    // Iterate over events
+    for (std::size_t i_evt = 0; i_evt < n_events; i_evt++) {
+        // Event map
+        traccc::event_map2 evt_map(i_evt, full_path, full_path, full_path);
+
+        // Truth Track Candidates
+        traccc::track_candidate_container_types::host track_candidates =
+            evt_map.generate_truth_candidates(sg, shared_mr);
+
+        // Instantiate cuda containers/collections
+        traccc::track_state_container_types::buffer track_states_sycl_buffer{
+            {{}, *(mr.host)}, {{}, *(mr.host), mr.host}};
+
+        // n_trakcs = 100
+        ASSERT_EQ(track_candidates.size(), 100);
+
+        // Detector view object
+        auto det_view = detray::get_data(host_det);
+
+        // Navigation buffer
+        auto navigation_buffer = detray::create_candidates_buffer(
+            host_det, track_candidates.size(), mr.main, mr.host);
+
+        // track candidates buffer
+        const traccc::track_candidate_container_types::buffer
+            track_candidates_sycl_buffer =
+                track_candidate_h2d(traccc::get_data(track_candidates));
+
+        // Run fitting
+        track_states_sycl_buffer = device_fitting(det_view, navigation_buffer,
+                                                  track_candidates_sycl_buffer);
+
+        traccc::track_state_container_types::host track_states_sycl =
+            track_state_d2h(track_states_sycl_buffer);
+
+        ASSERT_EQ(track_states_sycl.size(), 100);
+
+        const std::size_t n_tracks = track_states_sycl.size();
+
+        for (std::size_t i_trk = 0; i_trk < n_tracks; i_trk++) {
+            auto& device_states = track_states_sycl[i_trk].items;
+
+            fit_performance_writer.write(device_states, host_det, evt_map);
+        }
+    }
+
+    fit_performance_writer.finalize();
+
+    /********************
+     * Pull value test
+     ********************/
+
+    std::array<std::string, 5> pull_names{"pull_d0", "pull_z0", "pull_phi",
+                                          "pull_theta", "pull_qop"};
+
+    auto f = fit_performance_writer.get_file();
+
+    for (auto name : pull_names) {
+
+        auto pull_dist = (TH1F*)f->Get(name.c_str());
+        pull_value_test(pull_dist);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    KalmanFitValidation, KalmanFittingTests,
+    ::testing::Values(std::make_tuple(1 * detray::unit<scalar>::GeV, 0),
+                      std::make_tuple(10 * detray::unit<scalar>::GeV, 0),
+                      std::make_tuple(100 * detray::unit<scalar>::GeV, 0)));


### PR DESCRIPTION
The PR is still in WIP (and depends on #264). I didn't even generalize it for both CUDA and SYCL yet. 
But I want to get some advises in advance because I am stuck right now.
The main problem was that I was forced to implement the template classes in the source file:
For example, `traccc::cuda::fitting_algorithm` is declared in `traccc/device/cuda/include/traccc/cuda/fitting/fitting_algorithm.hpp` and implemented in `traccc/device/cuda/src/fitting/fitting_algorithm.cu`
Because `traccc::cuda::fitting_algorithm` is a template class, it was necessary to explicitly instantiate explicitly the class with specific template parameters :/ (See the code below)

```c++
// Explicit template instantiation
using host_detector_type =
    detray::detector<detray::detector_registry::telescope_detector,
                     covfie::field>;
using device_detector_type =
    detray::detector<detray::detector_registry::telescope_detector,
                     covfie::field_view, detray::device_container_types>;
using b_field_t = typename host_detector_type::bfield_type;
using rk_stepper_type = detray::rk_stepper<b_field_t::view_t, transform3,
                                           detray::constrained_step<>>;
using device_navigator_type = detray::navigator<const device_detector_type>;
using device_fitter_type =
    kalman_fitter<rk_stepper_type, device_navigator_type>;
template class fitting_algorithm<device_fitter_type, host_detector_type>;
```
 
Instantiating the classes for every detector class is definitely not I want to do. I wonder if there is a workaround for this ?
