### PR TITLE
Asynchronous Container Copies, main branch (2022.12.14.)

### DIFF
--- a/device/common/include/traccc/device/container_d2h_copy_alg.hpp
+++ b/device/common/include/traccc/device/container_d2h_copy_alg.hpp
@@ -40,7 +40,7 @@ class container_d2h_copy_alg
         const typename CONTAINER_TYPES::const_view&)>::output_type;
 
     /// Constructor with the needed resources
-    container_d2h_copy_alg(const memory_resource& mr, vecmem::copy& copy);
+    container_d2h_copy_alg(const memory_resource& mr, vecmem::copy& deviceCopy);
 
     /// Function executing the copy to the host
     virtual output_type operator()(input_type input) const override;
@@ -48,8 +48,10 @@ class container_d2h_copy_alg
     private:
     /// The memory resource(s) to use
     memory_resource m_mr;
-    /// The copy object to use
-    vecmem::copy& m_copy;
+    /// The D->H copy object to use
+    vecmem::copy& m_deviceCopy;
+    /// The H->H copy object to use
+    vecmem::copy m_hostCopy;
 
 };  // class container_d2h_copy_alg
 

--- a/device/common/include/traccc/device/container_h2d_copy_alg.hpp
+++ b/device/common/include/traccc/device/container_h2d_copy_alg.hpp
@@ -8,11 +8,13 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/utils/algorithm.hpp"
 #include "traccc/utils/memory_resource.hpp"
 
 // VecMem include(s).
 #include <vecmem/utils/copy.hpp>
+
+// System include(s).
+#include <type_traits>
 
 namespace traccc::device {
 
@@ -29,28 +31,38 @@ namespace traccc::device {
 /// @tparam CONTAINER_TYPES One of the "container types" traits
 ///
 template <typename CONTAINER_TYPES>
-class container_h2d_copy_alg
-    : public algorithm<typename CONTAINER_TYPES::buffer(
-          const typename CONTAINER_TYPES::const_view&)> {
+class container_h2d_copy_alg {
 
     public:
     /// Helper type declaration for the input type
     typedef const typename CONTAINER_TYPES::const_view& input_type;
-    /// Help the compiler understand what @c output_type is
-    using output_type = typename algorithm<typename CONTAINER_TYPES::buffer(
-        const typename CONTAINER_TYPES::const_view&)>::output_type;
+    /// Helper type declaration for the output type
+    typedef typename CONTAINER_TYPES::buffer output_type;
 
     /// Constructor with the needed resources
-    container_h2d_copy_alg(const memory_resource& mr, vecmem::copy& copy);
+    container_h2d_copy_alg(const memory_resource& mr, vecmem::copy& deviceCopy);
 
-    /// Function executing the copy to the device
-    virtual output_type operator()(input_type input) const override;
+    /// Function executing a simple copy to the device
+    output_type operator()(input_type input) const;
+    /// Function executing an optimised copy to the device
+    output_type operator()(input_type input,
+                           typename CONTAINER_TYPES::buffer& hostBuffer) const;
 
     private:
+    /// Size type for the handled container's header vector
+    using header_size_type =
+        const typename std::remove_reference<typename std::remove_cv<
+            input_type>::type>::type::header_vector::size_type;
+
+    /// Helper function calculating the size(s) of the input container
+    std::vector<std::size_t> get_sizes(input_type input) const;
+
     /// The memory resource(s) to use
     memory_resource m_mr;
-    /// The copy object to use
-    vecmem::copy& m_copy;
+    /// The H->D copy object to use
+    vecmem::copy& m_deviceCopy;
+    /// The H->H copy object to use
+    vecmem::copy m_hostCopy;
 
 };  // class container_h2d_copy_alg
 

--- a/device/common/include/traccc/device/impl/container_d2h_copy_alg.ipp
+++ b/device/common/include/traccc/device/impl/container_d2h_copy_alg.ipp
@@ -7,32 +7,64 @@
 
 #pragma once
 
+// System include(s).
+#include <algorithm>
+#include <cassert>
+#include <type_traits>
+#include <vector>
+
 namespace traccc::device {
 
 template <typename CONTAINER_TYPES>
 container_d2h_copy_alg<CONTAINER_TYPES>::container_d2h_copy_alg(
-    const memory_resource& mr, vecmem::copy& copy)
-    : m_mr(mr), m_copy(copy) {}
+    const memory_resource& mr, vecmem::copy& deviceCopy)
+    : m_mr(mr), m_deviceCopy(deviceCopy) {}
 
 template <typename CONTAINER_TYPES>
 typename container_d2h_copy_alg<CONTAINER_TYPES>::output_type
 container_d2h_copy_alg<CONTAINER_TYPES>::operator()(input_type input) const {
 
+    // A sanity check.
+    assert(input.headers.size() == input.items.size());
+
     // Decide what memory resource to use for the host container.
-    vecmem::memory_resource* mr = m_mr.host ? m_mr.host : &(m_mr.main);
+    vecmem::memory_resource* host_mr =
+        (m_mr.host != nullptr) ? m_mr.host : &(m_mr.main);
+
+    // Create a temporary buffer that will receive the device memory.
+    const typename std::remove_reference<typename std::remove_cv<
+        input_type>::type>::type::header_vector::size_type size =
+        input.headers.size();
+    std::vector<std::size_t> capacities(size, 0);
+    std::transform(input.items.host_ptr(), input.items.host_ptr() + size,
+                   capacities.begin(),
+                   [](const auto& view) { return view.capacity(); });
+    typename CONTAINER_TYPES::buffer hostBuffer{{size, *host_mr},
+                                                {capacities, *host_mr}};
+    m_hostCopy.setup(hostBuffer.headers);
+    m_hostCopy.setup(hostBuffer.items);
+
+    // Copy the device container into this temporary host buffer.
+    vecmem::copy::event_type header_event = m_deviceCopy(
+        input.headers, hostBuffer.headers, vecmem::copy::type::device_to_host);
+    vecmem::copy::event_type item_event = m_deviceCopy(
+        input.items, hostBuffer.items, vecmem::copy::type::device_to_host);
 
     // Create the result object, giving it the appropriate memory resource for
     // all of its elements.
-    output_type result{input.items.size(), mr};
+    output_type result{size, host_mr};
     for (std::size_t i = 0; i < result.size(); ++i) {
         result[i].items =
-            typename CONTAINER_TYPES::host::item_vector::value_type{mr};
+            typename CONTAINER_TYPES::host::item_vector::value_type{host_mr};
     }
 
-    // Perform the copy.
-    m_copy(input.headers, result.get_headers(),
-           vecmem::copy::type::device_to_host);
-    m_copy(input.items, result.get_items(), vecmem::copy::type::device_to_host);
+    // Wait for the D->H copies to finish.
+    header_event->wait();
+    item_event->wait();
+
+    // Perform the H->H copy.
+    m_hostCopy(hostBuffer.headers, result.get_headers())->wait();
+    m_hostCopy(hostBuffer.items, result.get_items())->wait();
 
     // Return the host object.
     return result;

--- a/device/common/include/traccc/device/impl/container_h2d_copy_alg.ipp
+++ b/device/common/include/traccc/device/impl/container_h2d_copy_alg.ipp
@@ -10,42 +10,89 @@
 // System include(s).
 #include <algorithm>
 #include <cassert>
-#include <type_traits>
 
 namespace traccc::device {
 
 template <typename CONTAINER_TYPES>
 container_h2d_copy_alg<CONTAINER_TYPES>::container_h2d_copy_alg(
-    const memory_resource& mr, vecmem::copy& copy)
-    : m_mr(mr), m_copy(copy) {}
+    const memory_resource& mr, vecmem::copy& deviceCopy)
+    : m_mr(mr), m_deviceCopy(deviceCopy), m_hostCopy() {}
 
 template <typename CONTAINER_TYPES>
 typename container_h2d_copy_alg<CONTAINER_TYPES>::output_type
 container_h2d_copy_alg<CONTAINER_TYPES>::operator()(input_type input) const {
 
+    // Get the sizes of the jagged vector.
+    const std::vector<std::size_t> sizes = get_sizes(input);
+
+    // Create the output buffer with the correct sizes.
+    output_type result{{static_cast<header_size_type>(sizes.size()), m_mr.main},
+                       {sizes, m_mr.main, m_mr.host}};
+    m_deviceCopy.setup(result.headers);
+    m_deviceCopy.setup(result.items);
+
+    // Copy data straight into it.
+    m_deviceCopy(input.headers, result.headers,
+                 vecmem::copy::type::host_to_device);
+    m_deviceCopy(input.items, result.items, vecmem::copy::type::host_to_device);
+
+    // Return the created buffer.
+    return result;
+}
+
+template <typename CONTAINER_TYPES>
+typename container_h2d_copy_alg<CONTAINER_TYPES>::output_type
+container_h2d_copy_alg<CONTAINER_TYPES>::operator()(
+    input_type input, typename CONTAINER_TYPES::buffer& hostBuffer) const {
+
+    // Get the sizes of the jagged vector.
+    const std::vector<std::size_t> sizes = get_sizes(input);
+    const header_size_type size = static_cast<header_size_type>(sizes.size());
+
+    // Decide what memory resource to use for the host container.
+    vecmem::memory_resource* host_mr =
+        (m_mr.host != nullptr) ? m_mr.host : &(m_mr.main);
+
+    // Create/set the host buffer.
+    hostBuffer =
+        typename CONTAINER_TYPES::buffer{{size, *host_mr}, {sizes, *host_mr}};
+    m_hostCopy.setup(hostBuffer.headers);
+    m_hostCopy.setup(hostBuffer.items);
+
+    // Copy the data into the host buffer.
+    m_hostCopy(input.headers, hostBuffer.headers);
+    m_hostCopy(input.items, hostBuffer.items);
+
+    // Create the output buffer with the correct sizes.
+    output_type result{{size, m_mr.main}, {sizes, m_mr.main, m_mr.host}};
+    m_deviceCopy.setup(result.headers);
+    m_deviceCopy.setup(result.items);
+
+    // Copy data from the host buffer into the device/result buffer.
+    m_deviceCopy(hostBuffer.headers, result.headers,
+                 vecmem::copy::type::host_to_device);
+    m_deviceCopy(hostBuffer.items, result.items,
+                 vecmem::copy::type::host_to_device);
+
+    // Return the created buffer.
+    return result;
+}
+
+template <typename CONTAINER_TYPES>
+std::vector<std::size_t> container_h2d_copy_alg<CONTAINER_TYPES>::get_sizes(
+    input_type input) const {
+
     // Get the sizes of the jagged vector. Remember that the input comes from
     // host accessible memory. (Using the vecmem::copy object is not a good idea
     // in this case.)
     assert(input.headers.size() == input.items.size());
-    const typename std::remove_reference<typename std::remove_cv<
-        input_type>::type>::type::header_vector::size_type size =
-        input.headers.size();
-    std::vector<std::size_t> sizes(size, 0);
+    std::vector<std::size_t> sizes(input.headers.size(), 0);
     const typename CONTAINER_TYPES::const_device device(input);
     std::transform(device.get_items().begin(), device.get_items().end(),
                    sizes.begin(), [](const auto& vec) { return vec.size(); });
 
-    // Create the output buffer with the correct sizes.
-    output_type result{{size, m_mr.main}, {sizes, m_mr.main, m_mr.host}};
-
-    // Set it up, and copy data into it.
-    m_copy.setup(result.headers);
-    m_copy.setup(result.items);
-    m_copy(input.headers, result.headers, vecmem::copy::type::host_to_device);
-    m_copy(input.items, result.items, vecmem::copy::type::host_to_device);
-
-    // Return the created buffer.
-    return result;
+    // Return the sizes.
+    return sizes;
 }
 
 }  // namespace traccc::device

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.21.0.tar.gz;URL_MD5;ab361d4ca2b26f673956e81f2cdd4c56"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.22.0.tar.gz;URL_MD5;f074994adb7f9b13c67485df73e6c971"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
As I noted in #292, the cell H->D copies were done synchronously in the code so far. This PR makes those copies asynchronous in the CUDA throughput tests.

This required a few updates in [vecmem](https://github.com/acts-project/vecmem), so the PR updates the build to [vecmem-2.22.0](https://github.com/acts-project/vecmem/releases/tag/v0.22.0).

The MT throughput with CUDA increases just a little with this update. But the **very** promising thing is that in my latest profiles I observed quite a few things running in parallel. :smile:

![image](https://user-images.githubusercontent.com/30694331/207640485-bd6414e9-1b3a-4c9a-b76b-c470bda44fc8.png)

Note how a couple of kernels manage to run in parallel as well! So I have some renewed hopes for what we may get once we make all of the algorithms run asynchronously. :wink: