### PR TITLE
Throughput Host Cache Fix, main branch (2022.12.14.)

### DIFF
--- a/examples/run/common/throughput_mt.hpp
+++ b/examples/run/common/throughput_mt.hpp
@@ -22,11 +22,14 @@ namespace traccc {
 /// @param description A short description of the application
 /// @param argc The count of command line arguments (from @c main(...))
 /// @param argv The command line arguments (from @c main(...))
+/// @param use_host_caching Flag specifying whether host-side memory caching
+///                         should be used
 /// @return The value to be returned from @c main(...)
 ///
 template <typename FULL_CHAIN_ALG,
           typename HOST_MR = vecmem::host_memory_resource>
-int throughput_mt(std::string_view description, int argc, char* argv[]);
+int throughput_mt(std::string_view description, int argc, char* argv[],
+                  bool use_host_caching = false);
 
 }  // namespace traccc
 

--- a/examples/run/common/throughput_st.hpp
+++ b/examples/run/common/throughput_st.hpp
@@ -22,11 +22,14 @@ namespace traccc {
 /// @param description A short description of the application
 /// @param argc The count of command line arguments (from @c main(...))
 /// @param argv The command line arguments (from @c main(...))
+/// @param use_host_caching Flag specifying whether host-side memory caching
+///                         should be used
 /// @return The value to be returned from @c main(...)
 ///
 template <typename FULL_CHAIN_ALG,
           typename HOST_MR = vecmem::host_memory_resource>
-int throughput_st(std::string_view description, int argc, char* argv[]);
+int throughput_st(std::string_view description, int argc, char* argv[],
+                  bool use_host_caching = false);
 
 }  // namespace traccc
 

--- a/examples/run/cuda/throughput_mt.cpp
+++ b/examples/run/cuda/throughput_mt.cpp
@@ -16,7 +16,9 @@
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
+    static const bool use_host_caching = true;
     return traccc::throughput_mt<traccc::cuda::full_chain_algorithm,
                                  vecmem::cuda::host_memory_resource>(
-        "Multi-threaded CUDA GPU throughput tests", argc, argv);
+        "Multi-threaded CUDA GPU throughput tests", argc, argv,
+        use_host_caching);
 }

--- a/examples/run/cuda/throughput_st.cpp
+++ b/examples/run/cuda/throughput_st.cpp
@@ -16,7 +16,9 @@
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
+    static const bool use_host_caching = true;
     return traccc::throughput_st<traccc::cuda::full_chain_algorithm,
                                  vecmem::cuda::host_memory_resource>(
-        "Single-threaded CUDA GPU throughput tests", argc, argv);
+        "Single-threaded CUDA GPU throughput tests", argc, argv,
+        use_host_caching);
 }

--- a/examples/run/sycl/throughput_mt.cpp
+++ b/examples/run/sycl/throughput_mt.cpp
@@ -13,6 +13,8 @@
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
+    static const bool use_host_caching = true;
     return traccc::throughput_mt<traccc::sycl::full_chain_algorithm>(
-        "Multi-threaded SYCL GPU throughput tests", argc, argv);
+        "Multi-threaded SYCL GPU throughput tests", argc, argv,
+        use_host_caching);
 }

--- a/examples/run/sycl/throughput_st.cpp
+++ b/examples/run/sycl/throughput_st.cpp
@@ -13,6 +13,8 @@
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
+    static const bool use_host_caching = true;
     return traccc::throughput_st<traccc::sycl::full_chain_algorithm>(
-        "Single-threaded SYCL GPU throughput tests", argc, argv);
+        "Single-threaded SYCL GPU throughput tests", argc, argv,
+        use_host_caching);
 }


### PR DESCRIPTION
Turned off host-side memory caching for the CPU throughput tests. Did so by making the host-side caching configurable. And not enabling it for the CPU tests.

While trying to make some fresh throughput tests to compare MT CPU performance with MT GPU performance, I had to realise that #292 did quite the number on the performance of `traccc_throughput_st` and `traccc_throughput_mt` (the CPU-only single/multi-threaded tests). These tests do a **lot** of host memory allocations/de-allocations. Which [vecmem::binary_page_memory_resource](https://github.com/acts-project/vecmem/blob/main/core/include/vecmem/memory/binary_page_memory_resource.hpp) is just not designed to handle well.

With this I'm now back to competitive throughput numbers with the CPU-only algorithms.