### PR TITLE
SYCL Throughput H->D Copy Fix, main branch (2023.01.11.)

### DIFF
--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -92,9 +92,14 @@ full_chain_algorithm::~full_chain_algorithm() {
 full_chain_algorithm::output_type full_chain_algorithm::operator()(
     const cell_container_types::host& cells) const {
 
+    // Copy the cells to the device.
+    cell_container_types::buffer hostCellBuffer;
+    cell_container_types::buffer deviceCellBuffer =
+        m_host2device(get_data(cells), hostCellBuffer);
+
     // Execute the algorithms.
     const clusterization_algorithm::output_type spacepoints =
-        m_clusterization(m_host2device(get_data(cells)));
+        m_clusterization(deviceCellBuffer);
     const track_params_estimation::output_type track_params =
         m_track_parameter_estimation(spacepoints, m_seeding(spacepoints));
 


### PR DESCRIPTION
Following up from #297, optimised the H->D cell copies for the SYCL throughput test as well. Which brought the performance of that executable back into the expected range.

```
[bash][atspot01]:build-x86_64_ubuntu2004_llvm_nvidia > ./bin/traccc_throughput_st_sycl --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_full/ttbar_mu20/ --processed_events=1000

Single-threaded SYCL GPU throughput tests

>>> Throughput options <<<
Input data format   : csv
Input directory     : tml_full/ttbar_mu20/
Detector geometry   : tml_detector/trackml-detector.csv
Digitization config : tml_detector/default-geometric-config-generic.json
Loaded event(s)     : 10
Cold run event(s)   : 10
Processed event(s)  : 1000

Using SYCL device: NVIDIA GeForce RTX 2060
Reconstructed track parameters: 1659433
Time totals:
                  File reading  821 ms
            Warm-up processing  29 ms
              Event processing  1493 ms
Throughput:
            Warm-up processing  2.95161 ms/event, 338.798 events/s
              Event processing  1.4933 ms/event, 669.659 events/s
[bash][atspot01]:build-x86_64_ubuntu2004_llvm_nvidia >
```