### PR TITLE
SYCL Pinned Host Memory, main branch (2023.01.13.)

### DIFF
--- a/examples/run/sycl/throughput_mt.cpp
+++ b/examples/run/sycl/throughput_mt.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,11 +10,15 @@
 
 #include "full_chain_algorithm.hpp"
 
+// VecMem include(s).
+#include <vecmem/memory/sycl/host_memory_resource.hpp>
+
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
     static const bool use_host_caching = true;
-    return traccc::throughput_mt<traccc::sycl::full_chain_algorithm>(
+    return traccc::throughput_mt<traccc::sycl::full_chain_algorithm,
+                                 vecmem::sycl::host_memory_resource>(
         "Multi-threaded SYCL GPU throughput tests", argc, argv,
         use_host_caching);
 }


### PR DESCRIPTION
Switched to using pinned host memory with the SYCL throughput tests.

As I only realised yesterday, the SYCL algorithms are all already sort of / kind of asynchronous. Not really, memory copies are not executed asynchronously in them yet, but the kernels themselves are already only synchronized at the points with the CPU execution where they need to be.

So with this addition the SYCL throughput test becomes very competitive. :smile: The following is for this low pileup setup:

```
>>> Throughput options <<<
Input data format   : csv
Input directory     : tml_full/ttbar_mu20/
Detector geometry   : tml_detector/trackml-detector.csv
Digitization config : tml_detector/default-geometric-config-generic.json
Loaded event(s)     : 10
Cold run event(s)   : 10
Processed event(s)  : 10000
```

The CUDA and SYCL tests (with this update included) do the following (in events per second) on our RTX2060:

| Threads | 1 | 2 | 3 | 4 |
|--- | --- | --- | --- | --- |
| traccc_throughput_mt_cuda | 813.382 | 963.199 | 931.331 | 904.834 |
| traccc_throughput_mt_sycl | 764.659 | 1112.58 | 1310.76 | 1374.6 |

I.e. once the CUDA algorithms all start executing stuff asynchronously, we should really expect some nice performance uplift. :smile: