### PR TITLE
SYCL Eigen Fix, main branch (2023.01.20.)

### DIFF
--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -37,5 +37,7 @@ target_link_libraries( traccc_sycl
   PUBLIC vecmem::core traccc::core
   PRIVATE traccc::device_common vecmem::sycl )
 
-# Prevent Eigen from getting confused when building code for a HIP backend.
-target_compile_definitions( traccc_sycl PRIVATE EIGEN_NO_CUDA )
+# Prevent Eigen from getting confused when building code for a
+# CUDA or HIP backend.
+target_compile_definitions( traccc_sycl
+  PRIVATE EIGEN_NO_CUDA EIGEN_NO_HIP )

--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -19,11 +19,15 @@ traccc_add_executable( seeding_example_sycl "seeding_example_sycl.sycl"
    LINK_LIBRARIES traccc::options vecmem::core vecmem::sycl traccc::io
                   traccc::core traccc::device_common traccc::sycl
                   traccc::performance )
+target_compile_definitions( traccc_seeding_example_sycl
+   PUBLIC EIGEN_NO_CUDA EIGEN_NO_HIP )
 
 traccc_add_executable( seq_example_sycl "seq_example_sycl.sycl"
    LINK_LIBRARIES traccc::options vecmem::core vecmem::sycl traccc::io
                   traccc::core traccc::device_common traccc::sycl
                   traccc::performance )
+target_compile_definitions( traccc_seq_example_sycl
+   PUBLIC EIGEN_NO_CUDA EIGEN_NO_HIP )
 
 #
 # Set up the "throughput applications".
@@ -33,6 +37,8 @@ add_library( traccc_examples_sycl STATIC
    "full_chain_algorithm.sycl" )
 target_link_libraries( traccc_examples_sycl
    PUBLIC vecmem::core vecmem::sycl traccc::core traccc::device_common traccc::sycl )
+target_compile_definitions( traccc_examples_sycl
+   PUBLIC EIGEN_NO_CUDA EIGEN_NO_HIP )
 
 traccc_add_executable( throughput_st_sycl "throughput_st.cpp"
    LINK_LIBRARIES vecmem::core vecmem::sycl traccc::io traccc::performance


### PR DESCRIPTION
Made the SYCL compilation use `-DEIGEN_NO_CUDA` and `-DEIGEN_NO_HIP`.

The first one was already used by `traccc_sycl`, but when building the code for an AMD backend with the Intel compiler, we ended up needing `EIGEN_NO_HIP` not only on `traccc_sycl`, but also on the example executables.

The compilation problem, without the fix, was like this:

```
[ 92%] Building SYCL object examples/run/sycl/CMakeFiles/traccc_seeding_example_sycl.dir/seeding_example_sycl.sycl.o
warning: linking module '/mnt/hdd1/software/intel/clang-2022-09/x86_64-centos9-gcc11-opt/lib/clang/16.0.0/../../clc/remangled-l64-signed_char.libspirv-nvptx64--nvidiacl.bc': Linking two modules of different target triples: '/mnt/hdd1/software/intel/clang-2022-09/x86_64-centos9-gcc11-opt/lib/clang/16.0.0/../../clc/remangled-l64-signed_char.libspirv-nvptx64--nvidiacl.bc' is 'nvptx64-unknown-nvidiacl' whereas '/afs/cern.ch/user/k/krasznaa/work/projects/traccc/traccc/examples/run/sycl/seeding_example_sycl.sycl' is 'nvptx64-nvidia-cuda'
 [-Wlinker-warnings]
1 warning generated.
In file included from /afs/cern.ch/user/k/krasznaa/work/projects/traccc/traccc/examples/run/sycl/seeding_example_sycl.sycl:13:
In file included from /afs/cern.ch/user/k/krasznaa/work/projects/traccc/traccc/core/include/traccc/seeding/seeding_algorithm.hpp:11:
In file included from /afs/cern.ch/user/k/krasznaa/work/projects/traccc/traccc/core/include/traccc/edm/seed.hpp:11:
In file included from /afs/cern.ch/user/k/krasznaa/work/projects/traccc/traccc/core/include/traccc/edm/spacepoint.hpp:11:
In file included from /afs/cern.ch/user/k/krasznaa/work/projects/traccc/traccc/core/include/traccc/definitions/common.hpp:11:
In file included from /afs/cern.ch/user/k/krasznaa/work/projects/traccc/traccc/core/include/traccc/definitions/primitives.hpp:22:
In file included from /mnt/hdd1/krasznaa/projects/traccc/build_local/_deps/eigen3-src/Eigen/Core:162:
/mnt/hdd1/krasznaa/projects/traccc/build_local/_deps/eigen3-src/Eigen/src/Core/util/Meta.h:19:12: fatal error: 'math_constants.h' file not found
  #include <math_constants.h>
           ^~~~~~~~~~~~~~~~~~
1 error generated.
```

And now with this fix included, I can do:

```
[bash][pcadp04]:build_local > ./bin/traccc_throughput_st_sycl --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_full/ttbar_mu200/ --processed_events=1000

Single-threaded SYCL GPU throughput tests

>>> Throughput options <<<
Input data format   : csv
Input directory     : tml_full/ttbar_mu200/
Detector geometry   : tml_detector/trackml-detector.csv
Digitization config : tml_detector/default-geometric-config-generic.json
Loaded event(s)     : 10
Cold run event(s)   : 10
Processed event(s)  : 1000

Using SYCL device: AMD Radeon RX 6700 XT
Reconstructed track parameters: 16094512
Time totals:
                  File reading  6097 ms
            Warm-up processing  114 ms
              Event processing  8231 ms
Throughput:
            Warm-up processing  11.4571 ms/event, 87.282 events/s
              Event processing  8.232 ms/event, 121.477 events/s
[bash][pcadp04]:build_local >
```

:grin: (This one is mostly here for @guilhermeAlmeida1's benefit. :stuck_out_tongue:)

Though building fat binaries for both the CUDA and HIP SYCL backends at the same time doesn't work at the moment unfortunately. :frowning:

```
[bash][pcadp04]:build_local > ./bin/traccc_throughput_st_sycl --help
traccc_throughput_st_sycl: /mnt/hdd1/krasznaa/projects/intel/llvm/sycl/source/detail/program_manager/program_manager.cpp:1203: void sycl::_V1::detail::ProgramManager::addImages(pi_device_binaries): Assertion `KSIdMap[EntriesIt->name] == KSIdIt->second && "Kernel sets are not disjoint"' failed.
Aborted (core dumped)
[bash][pcadp04]:build_local >
```

Something to follow up with the Intel developers...