### PR TITLE
Fix unused parameter in CCA code

### DIFF
--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -963,7 +963,7 @@ __global__ void partition_sorting_kernel(unsigned* out,
 }
 
 std::tuple<vecmem::unique_alloc_ptr<unsigned[]>, std::size_t> partition_gpu(
-    const cell_container_types::host& data, vecmem::memory_resource& mem,
+    const cell_container_types::host&, vecmem::memory_resource& mem,
     const details::cell_container cells) {
     /*
      * First, we allocate memory for our partitions, as well as memory for


### PR DESCRIPTION
Somehow, #309 introduced a CI error that caught an unused variable. This is odd, because the error was not caught by CI before. This commit fixes the error by removing (or rather, removing the name) for this parameter.