### PR TITLE
Add Particle Generation Options

### DIFF
--- a/examples/options/CMakeLists.txt
+++ b/examples/options/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,6 +10,8 @@ traccc_add_library( traccc_options options TYPE SHARED
   "include/traccc/options/common_options.hpp"
   "include/traccc/options/handle_argument_errors.hpp"
   "include/traccc/options/mt_options.hpp"
+  "include/traccc/options/options.hpp"
+  "include/traccc/options/particle_gen_options.hpp"
   "include/traccc/options/seeding_input_options.hpp"
   "include/traccc/options/full_tracking_input_options.hpp"   
   "include/traccc/options/throughput_options.hpp"

--- a/examples/options/include/traccc/options/options.hpp
+++ b/examples/options/include/traccc/options/options.hpp
@@ -1,0 +1,103 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Boost include(s).
+#include <boost/algorithm/string.hpp>
+
+// System include(s).
+#include <array>
+#include <iosfwd>
+#include <istream>
+#include <optional>
+#include <ostream>
+#include <vector>
+
+namespace traccc {
+
+namespace {
+constexpr char s_separator = ':';
+}
+
+/// A fixed number of real values as one user option.
+///
+/// @note Implemented as a subclass so it is distinct from `std::array`
+///   and we can provide overloads in the same namespace.
+template <typename scalar_t, size_t kSize>
+class Reals : public std::array<scalar_t, kSize> {};
+
+namespace detail {
+
+template <typename value_t, typename converter_t>
+void parse_variable(std::istream& is, std::vector<value_t>& values,
+                    converter_t&& convert) {
+    values.clear();
+
+    std::string buf;
+    is >> buf;
+    std::vector<std::string> stringValues;
+    boost::split(stringValues, buf,
+                 boost::is_any_of(std::string(&s_separator)));
+    for (const std::string& stringValue : stringValues) {
+        values.push_back(convert(stringValue));
+    }
+}
+
+template <typename value_t, typename converter_t>
+void parse_fixed(std::istream& is, size_t size, value_t* values,
+                 converter_t&& convert) {
+    // reserve space for the expected number of values
+    std::vector<value_t> tmp(size, 0);
+    parse_variable(is, tmp, std::forward<converter_t>(convert));
+    if (tmp.size() < size) {
+        throw std::invalid_argument(
+            "Not enough values for fixed-size user option, expected " +
+            std::to_string(size) + " received " + std::to_string(tmp.size()));
+    }
+    if (size < tmp.size()) {
+        throw std::invalid_argument(
+            "Too many values for fixed-size user option, expected " +
+            std::to_string(size) + " received " + std::to_string(tmp.size()));
+    }
+    std::copy(tmp.begin(), tmp.end(), values);
+}
+
+}  // namespace detail
+
+/// Extract a fixed number of doubles from an input of the form 'x:y:z'.
+///
+/// @note If the values would be separated by whitespace, negative values
+///   and additional command line both start with `-` and would be
+///   undistinguishable.
+template <typename scalar_t, size_t kSize>
+inline std::istream& operator>>(std::istream& is,
+                                Reals<scalar_t, kSize>& values) {
+    detail::parse_fixed(is, kSize, values.data(),
+                        [](const std::string& s) { return std::stod(s); });
+
+    return is;
+}
+
+/// Print a fixed number of doubles as `x:y:z`.
+template <typename scalar_t, size_t kSize>
+inline std::ostream& operator<<(std::ostream& os,
+                                const Reals<scalar_t, kSize>& values) {
+
+    const auto data = values.data();
+
+    for (size_t i = 0; i < kSize; ++i) {
+        if (0u < i) {
+            os << s_separator;
+        }
+        os << data[i];
+    }
+
+    return os;
+}
+
+}  // namespace traccc

--- a/examples/options/include/traccc/options/particle_gen_options.hpp
+++ b/examples/options/include/traccc/options/particle_gen_options.hpp
@@ -1,0 +1,72 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/options/options.hpp"
+
+// Boost
+#include <boost/program_options.hpp>
+
+namespace traccc {
+
+namespace po = boost::program_options;
+
+template <typename scalar_t>
+struct particle_gen_options {
+    unsigned int gen_nparticles{1};
+    Reals<scalar_t, 3> vertex{0., 0., 0.};
+    Reals<scalar_t, 3> vertex_stddev{0., 0., 0.};
+    Reals<scalar_t, 2> mom_range{1., 1.};
+    Reals<scalar_t, 2> phi_range{0., 0.};
+    Reals<scalar_t, 2> theta_range{0., 0.};
+
+    particle_gen_options(po::options_description& desc) {
+        desc.add_options()("gen-nparticles",
+                           po::value<unsigned int>()->default_value(1),
+                           "The number of particles to generate per event");
+        desc.add_options()(
+            "gen-vertex-xyz-mm",
+            po::value<Reals<scalar_t, 3>>()->value_name("X:Y:Z")->default_value(
+                {{0.f, 0.f, 0.f}}),
+            "Vertex [mm]");
+        desc.add_options()(
+            "gen-vertex-xyz-std-mm",
+            po::value<Reals<scalar_t, 3>>()->value_name("X:Y:Z")->default_value(
+                {{0.f, 0.f, 0.f}}),
+            "Standard deviation of the vertex [mm]");
+        desc.add_options()("gen-mom-gev",
+                           po::value<Reals<scalar_t, 2>>()
+                               ->value_name("MIN:MAX")
+                               ->default_value({1.f, 1.f}),
+                           "Range of momentum [GeV]");
+        desc.add_options()("gen-phi-degree",
+                           po::value<Reals<scalar_t, 2>>()
+                               ->value_name("MIN:MAX")
+                               ->default_value({0.f, 0.f}),
+                           "Range of phi [Degree]");
+        desc.add_options()("gen-eta",
+                           po::value<Reals<scalar_t, 2>>()
+                               ->value_name("MIN:MAX")
+                               ->default_value({0.f, 0.f}),
+                           "Range of eta");
+    }
+    void read(const po::variables_map& vm) {
+        gen_nparticles = vm["gen-nparticles"].as<unsigned int>();
+        vertex = vm["gen-vertex-xyz-mm"].as<Reals<scalar_t, 3>>();
+        vertex_stddev = vm["gen-vertex-xyz-std-mm"].as<Reals<scalar_t, 3>>();
+        mom_range = vm["gen-mom-gev"].as<Reals<scalar_t, 2>>();
+        phi_range = vm["gen-phi-degree"].as<Reals<scalar_t, 2>>();
+        const auto eta_range = vm["gen-eta"].as<Reals<scalar_t, 2>>();
+        // TODO: remove the conversion here...
+        theta_range = {2 * std::atan(std::exp(-eta_range[0])),
+                       2 * std::atan(std::exp(-eta_range[1]))};
+    }
+};
+
+}  // namespace traccc


### PR DESCRIPTION
This PR adds particle generation options (e.g., eta and phi range) for simulation. The detray track generator type is also changed from `uniform_track_generator` to `random_track_generator`

Update:
Options for the momentum range and vertex standard deviation are added 