### PR TITLE
Remove headers from doublet and triplet containers.

### DIFF
--- a/core/include/traccc/seeding/detail/doublet.hpp
+++ b/core/include/traccc/seeding/detail/doublet.hpp
@@ -1,20 +1,19 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
+// Project include(s).
 #include "traccc/seeding/detail/singlet.hpp"
 
-namespace traccc {
+// System include(s).
+#include <variant>
 
-/// Header: the number of doublets per spacepoint bin
-struct doublet_per_bin {
-    unsigned int n_doublets = 0;
-};
+namespace traccc {
 
 /// Item: doublet of middle-bottom or middle-top
 struct doublet {
@@ -40,6 +39,6 @@ inline TRACCC_HOST_DEVICE bool operator==(const doublet& lhs,
 using doublet_collection_types = collection_types<doublet>;
 
 /// Declare all doublet container types
-using doublet_container_types = container_types<doublet_per_bin, doublet>;
+using doublet_container_types = container_types<std::monostate, doublet>;
 
 }  // namespace traccc

--- a/core/include/traccc/seeding/detail/triplet.hpp
+++ b/core/include/traccc/seeding/detail/triplet.hpp
@@ -1,21 +1,20 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
+// Project include(s).
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/seeding/detail/doublet.hpp"
 
-namespace traccc {
+// System include(s).
+#include <variant>
 
-/// Header: the number of triplets per spacepoint bin
-struct triplet_per_bin {
-    unsigned int n_triplets = 0;
-};
+namespace traccc {
 
 /// Item: triplets of middle-bottom-top
 struct triplet {
@@ -61,6 +60,6 @@ inline TRACCC_HOST_DEVICE bool operator<(const triplet& lhs,
 using triplet_collection_types = collection_types<triplet>;
 
 /// Declare all triplet container types
-using triplet_container_types = container_types<triplet_per_bin, triplet>;
+using triplet_container_types = container_types<std::monostate, triplet>;
 
 }  // namespace traccc

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -57,7 +57,6 @@ inline void count_triplets(
     // Get all spacepoints
     const const_sp_grid_device internal_sp_device(sp_view);
 
-    // Header of doublet: number of mid_top doublets per bin
     // Item of doublet: doublet objects per bin
     const vecmem::device_vector<const doublet> mid_top_doublets_per_bin =
         mid_top_doublet_device.get_items().at(bin_idx);

--- a/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
@@ -57,20 +57,9 @@ inline void find_doublets(
     doublet_collection_types::device mt_doublets_in_bin =
         mt_doublets.get_items().at(middle_sp_counter.m_spM.bin_idx);
 
-    // Atomic references for the doublet summary values for the bin of the
-    // middle spacepoint.
-    vecmem::device_atomic_ref<unsigned int> mb_doublet_count(
-        mb_doublets.get_headers()
-            .at(middle_sp_counter.m_spM.bin_idx)
-            .n_doublets);
-    vecmem::device_atomic_ref<unsigned int> mt_doublet_count(
-        mt_doublets.get_headers()
-            .at(middle_sp_counter.m_spM.bin_idx)
-            .n_doublets);
-
     // Get the spacepoint that we're evaluating in this thread, and treat that
     // as the "middle" spacepoint.
-    const internal_spacepoint<spacepoint>& middle_sp =
+    const internal_spacepoint<spacepoint> middle_sp =
         sp_grid.bin(middle_sp_counter.m_spM.bin_idx)
             .at(middle_sp_counter.m_spM.sp_idx);
 
@@ -149,7 +138,6 @@ inline void find_doublets(
                         {other_bin_idx, other_sp_idx},
                         mid_top_start_idx,
                         mid_top_end_idx};
-                    mb_doublet_count.fetch_add(1);
                 }
                 // Check if this spacepoint is a compatible "top" spacepoint to
                 // the thread's "middle" spacepoint.
@@ -166,7 +154,6 @@ inline void find_doublets(
                          static_cast<unsigned int>(
                              middle_sp_counter.m_spM.sp_idx)},
                         {other_bin_idx, other_sp_idx}};
-                    mt_doublet_count.fetch_add(1);
                 }
             }
         }

--- a/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
@@ -59,7 +59,6 @@ inline void find_triplets(
     const traccc::internal_spacepoint<traccc::spacepoint> spB =
         sp_grid.bin(spB_bin)[spB_idx];
 
-    // Header of doublet: number of mid_top doublets per bin
     // Item of doublet: doublet objects per bin
     const vecmem::device_vector<const doublet> mid_top_doublets_per_bin =
         mid_top_doublet_device.get_items().at(spM_bin);
@@ -109,11 +108,6 @@ inline void find_triplets(
         if (triplet_finding_helper::isCompatible(
                 spM, lb, lt, config, iSinTheta2, scatteringInRegion2, curvature,
                 impact_parameter)) {
-            // Atomic reference for the triplet summary value for the bin of the
-            // mid bottom doublet.
-            vecmem::device_atomic_ref<unsigned int> num_triplets_per_bin(
-                triplets.get_headers().at(spM_bin).n_triplets);
-            num_triplets_per_bin.fetch_add(1);
 
             // Add triplet to jagged vector
             triplets.get_items().at(spM_bin).at(posTriplets++) =

--- a/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
+++ b/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
@@ -84,12 +84,10 @@ inline void select_seeds(
     triplet_container_types::const_device triplet_device(triplet_view);
     alt_seed_collection_types::device seeds_device(seed_view);
 
-    // Header of triplet: number of triplets per bin
     // Item of triplet: triplet objects per bin
-    const unsigned int num_triplets_per_bin =
-        triplet_device.get_headers().at(bin_idx).n_triplets;
     const triplet_collection_types::const_device triplets_per_bin =
         triplet_device.get_items().at(bin_idx);
+    const unsigned int num_triplets_per_bin = triplets_per_bin.size();
 
     // Current work item = middle spacepoint
     const sp_location spM_loc =


### PR DESCRIPTION
We are storing redundant information on the headers of the doublet and triplet containers, and above all, spending valuable time in the `find doublets/triplets` kernels with atomic operations for filling these values, which are just equal to the size. As you might notice, we were already using `.size()` on almost all of our code, I only had to change a single call to a header.

This PR replaces the headers from the doublet/triplet container types with an empty type, `std::monostate`.