### PR TITLE
Cleanup: Remove redundant calls to copying/getting size of buffers in seed finding.

### DIFF
--- a/device/common/include/traccc/seeding/device/make_doublet_buffers.hpp
+++ b/device/common/include/traccc/seeding/device/make_doublet_buffers.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -32,8 +32,8 @@ struct doublet_buffer_pair {
 /// This is a helper function to use for setting up the buffers that
 /// @c traccc::device::find_doublets would be able to fill.
 ///
-/// @param doublet_counter The doublet counter from
-///                        @c traccc::device::count_doublets
+/// @param mb_sizes the number of counted midBottom doublets
+/// @param mt_sizes the number of counted midTop doublets
 /// @param copy The object to use for accessing @c doublet_counter
 /// @param mr The memory resource for the buffer
 /// @param mr_host The (optional) host-accessible memory resource for the
@@ -41,8 +41,8 @@ struct doublet_buffer_pair {
 /// @return Buffers usable by @c traccc::device::find_doublets
 ///
 doublet_buffer_pair make_doublet_buffers(
-    const doublet_counter_container_types::const_view& doublet_counter,
-    vecmem::copy& copy, vecmem::memory_resource& mr,
-    vecmem::memory_resource* mr_host = nullptr);
+    const std::vector<unsigned int>& mb_sizes,
+    const std::vector<unsigned int>& mt_sizes, vecmem::copy& copy,
+    vecmem::memory_resource& mr, vecmem::memory_resource* mr_host = nullptr);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/make_triplet_buffer.hpp
+++ b/device/common/include/traccc/seeding/device/make_triplet_buffer.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -24,7 +24,7 @@ namespace traccc::device {
 /// This is a helper function to use for setting up the buffer that
 /// @c traccc::device::find_triplets would be able to fill.
 ///
-/// @param triplet_counter The triplet counter from
+/// @param triplet_sizes The number of counted triplets from
 ///                        @c traccc::device::count_triplets
 /// @param copy The object to use for accessing @c triplet_counter
 /// @param mr The memory resource for the buffer
@@ -33,8 +33,7 @@ namespace traccc::device {
 /// @return Buffer usable by @c traccc::device::find_triplets
 ///
 triplet_container_types::buffer make_triplet_buffer(
-    const triplet_counter_container_types::const_view& triplet_counter,
-    vecmem::copy& copy, vecmem::memory_resource& mr,
-    vecmem::memory_resource* mr_host = nullptr);
+    const std::vector<unsigned int>& triplet_sizes, vecmem::copy& copy,
+    vecmem::memory_resource& mr, vecmem::memory_resource* mr_host = nullptr);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/make_triplet_counter_buffer.hpp
+++ b/device/common/include/traccc/seeding/device/make_triplet_counter_buffer.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -33,7 +33,7 @@ namespace traccc::device {
 /// @return A buffer usable by @c traccc::device::count_triplets
 ///
 triplet_counter_container_types::buffer make_triplet_counter_buffer(
-    const std::vector<std::size_t>& mb_doublet_sizes, vecmem::copy& copy,
+    const std::vector<unsigned int>& mb_doublet_sizes, vecmem::copy& copy,
     vecmem::memory_resource& mr, vecmem::memory_resource* mr_host = nullptr);
 
 }  // namespace traccc::device

--- a/device/common/src/seeding/make_doublet_buffers.cpp
+++ b/device/common/src/seeding/make_doublet_buffers.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -17,25 +17,9 @@
 namespace traccc::device {
 
 doublet_buffer_pair make_doublet_buffers(
-    const doublet_counter_container_types::const_view& doublet_counter,
-    vecmem::copy& copy, vecmem::memory_resource& mr,
-    vecmem::memory_resource* mr_host) {
-
-    // Get the number of doublets per geometric bin.
-    vecmem::vector<device::doublet_counter_header> doublet_counts(
-        (mr_host != nullptr) ? mr_host : &mr);
-    copy(doublet_counter.headers, doublet_counts);
-
-    // Construct the size (vectors) for the buffers.
-    std::vector<std::size_t> mb_sizes(doublet_counts.size());
-    std::transform(
-        doublet_counts.begin(), doublet_counts.end(), mb_sizes.begin(),
-        [](const device::doublet_counter_header& dc) { return dc.m_nMidBot; });
-
-    std::vector<std::size_t> mt_sizes(doublet_counts.size());
-    std::transform(
-        doublet_counts.begin(), doublet_counts.end(), mt_sizes.begin(),
-        [](const device::doublet_counter_header& dc) { return dc.m_nMidTop; });
+    const std::vector<unsigned int>& mb_sizes,
+    const std::vector<unsigned int>& mt_sizes, vecmem::copy& copy,
+    vecmem::memory_resource& mr, vecmem::memory_resource* mr_host) {
 
     const doublet_container_types::buffer::header_vector::size_type mb_size =
         mb_sizes.size();

--- a/device/common/src/seeding/make_doublet_counter_buffer.cpp
+++ b/device/common/src/seeding/make_doublet_counter_buffer.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,9 +21,7 @@ device::doublet_counter_container_types::buffer make_doublet_counter_buffer(
     // Create the buffer object.
     device::doublet_counter_container_types::buffer buffer{
         {buffer_size, mr},
-        {std::vector<std::size_t>(buffer_size, 0),
-         std::vector<std::size_t>(grid_sizes.begin(), grid_sizes.end()), mr,
-         mr_host}};
+        {std::vector<unsigned int>(buffer_size, 0), grid_sizes, mr, mr_host}};
     copy.setup(buffer.headers);
     copy.setup(buffer.items);
 

--- a/device/common/src/seeding/make_triplet_buffer.cpp
+++ b/device/common/src/seeding/make_triplet_buffer.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -17,22 +17,8 @@
 namespace traccc::device {
 
 triplet_container_types::buffer make_triplet_buffer(
-    const triplet_counter_container_types::const_view& triplet_counter,
-    vecmem::copy& copy, vecmem::memory_resource& mr,
-    vecmem::memory_resource* mr_host) {
-
-    // Get the number of triplets per geometric bin.
-    vecmem::vector<device::triplet_counter_header> triplet_counts(
-        (mr_host != nullptr) ? mr_host : &mr);
-    copy(triplet_counter.headers, triplet_counts);
-
-    // Construct the size (vectors) for the buffers.
-    std::vector<std::size_t> triplet_sizes(triplet_counts.size());
-    std::transform(triplet_counts.begin(), triplet_counts.end(),
-                   triplet_sizes.begin(),
-                   [](const device::triplet_counter_header& tc) {
-                       return tc.m_nTriplets;
-                   });
+    const std::vector<unsigned int>& triplet_sizes, vecmem::copy& copy,
+    vecmem::memory_resource& mr, vecmem::memory_resource* mr_host) {
 
     const triplet_container_types::buffer::header_vector::size_type
         triplets_size = triplet_sizes.size();

--- a/device/common/src/seeding/make_triplet_counter_buffer.cpp
+++ b/device/common/src/seeding/make_triplet_counter_buffer.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,7 +11,7 @@
 namespace traccc::device {
 
 device::triplet_counter_container_types::buffer make_triplet_counter_buffer(
-    const std::vector<size_t>& mb_doublet_sizes, vecmem::copy& copy,
+    const std::vector<unsigned int>& mb_doublet_sizes, vecmem::copy& copy,
     vecmem::memory_resource& mr, vecmem::memory_resource* mr_host) {
 
     // Calculate the capacities for the buffer.
@@ -21,10 +21,8 @@ device::triplet_counter_container_types::buffer make_triplet_counter_buffer(
     // Create the buffer object.
     device::triplet_counter_container_types::buffer buffer{
         {buffer_size, mr},
-        {std::vector<std::size_t>(buffer_size, 0),
-         std::vector<std::size_t>(mb_doublet_sizes.begin(),
-                                  mb_doublet_sizes.end()),
-         mr, mr_host}};
+        {std::vector<unsigned int>(buffer_size, 0), mb_doublet_sizes, mr,
+         mr_host}};
     copy.setup(buffer.headers);
     copy.setup(buffer.items);
 

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -121,9 +121,19 @@ seed_finding::output_type seed_finding::operator()(
         m_mr.host ? m_mr.host : &(m_mr.main));
     (*m_copy)(doublet_counter_buffer.headers, doublet_counts);
 
+    std::vector<unsigned int> mb_buffer_sizes(doublet_counts.size());
+    std::transform(
+        doublet_counts.begin(), doublet_counts.end(), mb_buffer_sizes.begin(),
+        [](const device::doublet_counter_header& dc) { return dc.m_nMidBot; });
+
+    std::vector<unsigned int> mt_buffer_sizes(doublet_counts.size());
+    std::transform(
+        doublet_counts.begin(), doublet_counts.end(), mt_buffer_sizes.begin(),
+        [](const device::doublet_counter_header& dc) { return dc.m_nMidTop; });
+
     // Set up the doublet buffers.
     device::doublet_buffer_pair doublet_buffers = device::make_doublet_buffers(
-        doublet_counter_buffer, *m_copy, m_mr.main, m_mr.host);
+        mb_buffer_sizes, mt_buffer_sizes, *m_copy, m_mr.main, m_mr.host);
 
     // Create prefix sum buffer and its view
     vecmem::data::vector_buffer doublet_prefix_sum_buff =
@@ -153,11 +163,6 @@ seed_finding::output_type seed_finding::operator()(
                 });
         });
 
-    std::vector<std::size_t> mb_buffer_sizes(doublet_counts.size());
-    std::transform(
-        doublet_counts.begin(), doublet_counts.end(), mb_buffer_sizes.begin(),
-        [](const device::doublet_counter_header& dc) { return dc.m_nMidBot; });
-
     // Set up the triplet counter buffer and its view
     device::triplet_counter_container_types::buffer triplet_counter_buffer =
         device::make_triplet_counter_buffer(mb_buffer_sizes, *m_copy, m_mr.main,
@@ -168,8 +173,7 @@ seed_finding::output_type seed_finding::operator()(
 
     // Create prefix sum buffer and its view
     vecmem::data::vector_buffer mb_prefix_sum_buff = make_prefix_sum_buff(
-        m_copy->get_sizes(doublet_buffers.middleBottom.items), *m_copy, m_mr,
-        details::get_queue(m_queue));
+        mb_buffer_sizes, *m_copy, m_mr, details::get_queue(m_queue));
     vecmem::data::vector_view mb_prefix_sum_view = mb_prefix_sum_buff;
 
     // Calculate the range to run the triplet counting for.
@@ -195,9 +199,22 @@ seed_finding::output_type seed_finding::operator()(
         })
         .wait_and_throw();
 
+    // Get the number of triplets per geometric bin.
+    vecmem::vector<device::triplet_counter_header> triplet_counts(
+        m_mr.host ? m_mr.host : &(m_mr.main));
+    (*m_copy)(triplet_counter_buffer.headers, triplet_counts);
+
+    // Construct the size (vectors) for the buffers.
+    std::vector<unsigned int> triplet_sizes(triplet_counts.size());
+    std::transform(triplet_counts.begin(), triplet_counts.end(),
+                   triplet_sizes.begin(),
+                   [](const device::triplet_counter_header& tc) {
+                       return tc.m_nTriplets;
+                   });
+
     // Set up the triplet buffer and its view
     triplet_container_types::buffer triplet_buffer =
-        device::make_triplet_buffer(triplet_counter_buffer, *m_copy, m_mr.main,
+        device::make_triplet_buffer(triplet_sizes, *m_copy, m_mr.main,
                                     m_mr.host);
     triplet_container_types::view triplet_view = triplet_buffer;
 
@@ -230,9 +247,8 @@ seed_finding::output_type seed_finding::operator()(
         });
 
     // Create prefix sum buffer and its view
-    vecmem::data::vector_buffer triplet_prefix_sum_buff =
-        make_prefix_sum_buff(m_copy->get_sizes(triplet_buffer.items), *m_copy,
-                             m_mr, details::get_queue(m_queue));
+    vecmem::data::vector_buffer triplet_prefix_sum_buff = make_prefix_sum_buff(
+        triplet_sizes, *m_copy, m_mr, details::get_queue(m_queue));
     vecmem::data::vector_view triplet_prefix_sum_view = triplet_prefix_sum_buff;
 
     // Calculate the range to run the weight updating for
@@ -276,16 +292,9 @@ seed_finding::output_type seed_finding::operator()(
                 });
         });
 
-    // Take header of the triplet counter container buffer into host
-    vecmem::vector<device::triplet_counter_header> tcc_headers(
-        m_mr.host ? m_mr.host : &(m_mr.main));
-    (*m_copy)(triplet_counter_buffer.headers, tcc_headers);
-
     // Get the number of seeds (triplets)
-    unsigned int n_triplets = 0;
-    for (const auto& h : tcc_headers) {
-        n_triplets += h.m_nTriplets;
-    }
+    unsigned int n_triplets =
+        std::accumulate(triplet_sizes.begin(), triplet_sizes.end(), 0);
 
     // Create seed buffer object and its view
     alt_seed_collection_types::buffer seed_buffer(n_triplets, 0, m_mr.main);

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.22.0.tar.gz;URL_MD5;f074994adb7f9b13c67485df73e6c971"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.23.0.tar.gz;URL_MD5;e3d4c837f45332929296039bcb66f88b"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Depends on https://github.com/acts-project/vecmem/pull/220 

This cleans up our code by removing some redundant calls to `get_sizes()` and `copy` on buffers created in our seeding chain.