### PR TITLE
Remove redundant information from counter headers

### DIFF
--- a/device/common/include/traccc/edm/device/doublet_counter.hpp
+++ b/device/common/include/traccc/edm/device/doublet_counter.hpp
@@ -20,10 +20,6 @@ namespace traccc::device {
 ///
 struct doublet_counter_header {
 
-    /// The total number of middle spacepoints in a given geometric bin for
-    /// which a compatible bottom- or top-doublet was found.
-    unsigned int m_nSpM = 0;
-
     /// The total number of middle-bottom spacepoint doublets in a given
     /// geometric bin.
     unsigned int m_nMidBot = 0;

--- a/device/common/include/traccc/edm/device/triplet_counter.hpp
+++ b/device/common/include/traccc/edm/device/triplet_counter.hpp
@@ -20,10 +20,6 @@ namespace traccc::device {
 ///
 struct triplet_counter_header {
 
-    /// The total number of middle-bottom spacepoint doublets in a given
-    /// geometric bin.
-    unsigned int m_nMidBot = 0;
-
     /// The total number of Triplets in a given geometric bin
     unsigned int m_nTriplets = 0;
 

--- a/device/common/include/traccc/seeding/device/impl/count_doublets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_doublets.ipp
@@ -114,8 +114,6 @@ inline void count_doublets(
         // Increment the summary values in the header object.
         doublet_counter_header& header =
             doublet_counter.get_headers().at(middle_sp_idx.first);
-        vecmem::device_atomic_ref<unsigned int> nSpM(header.m_nSpM);
-        nSpM.fetch_add(1);
         vecmem::device_atomic_ref<unsigned int> nMidBot(header.m_nMidBot);
         const unsigned int posBot = nMidBot.fetch_add(n_mb_cand);
         vecmem::device_atomic_ref<unsigned int> nMidTop(header.m_nMidTop);

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -122,8 +122,6 @@ inline void count_triplets(
     if (num_triplets_per_mb > 0) {
         triplet_counter_header& header =
             triplet_counter.get_headers().at(bin_idx);
-        vecmem::device_atomic_ref<unsigned int> nMidBot(header.m_nMidBot);
-        nMidBot.fetch_add(1);
         vecmem::device_atomic_ref<unsigned int> nTriplets(header.m_nTriplets);
         const unsigned int posTriplets =
             nTriplets.fetch_add(num_triplets_per_mb);


### PR DESCRIPTION
I could've seen this earlier when looking at #319 but I noticed just now there's more pointless information in our device EDM we can just get rid of. 