### PR TITLE
Detray 0.22.0 Upgrade, main branch (2023.02.27.)

### DIFF
--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,7 +18,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.21.0.tar.gz;URL_MD5;cf7cecaf7045e0ec09b32934d256953b"
+   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.22.0.tar.gz;URL_MD5;2439c9f4ecc242974620901d61329174"
    CACHE STRING "Source for Detray, when built as part of this project" )
 
 mark_as_advanced( TRACCC_DETRAY_SOURCE )


### PR DESCRIPTION
Upgraded the project to [Detray 0.22.0](https://github.com/acts-project/detray/releases/tag/v0.22.0).

This is mainly to make the SYCL builds (for the Intel backend) work once again.