### PR TITLE
SYCL Eigen Build Update, main branch (2023.02.27.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -83,3 +83,8 @@ traccc_add_library( traccc_core core TYPE SHARED
 target_link_libraries( traccc_core
   PUBLIC Eigen3::Eigen vecmem::core detray::core ActsCore
          traccc::Thrust traccc::algebra )
+
+# Prevent Eigen from getting confused when building code for a
+# CUDA or HIP backend with SYCL.
+target_compile_definitions( traccc_core
+  PUBLIC $<$<COMPILE_LANGUAGE:SYCL>:EIGEN_NO_CUDA EIGEN_NO_HIP> )

--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -38,8 +38,3 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
 target_link_libraries( traccc_sycl
   PUBLIC traccc::core detray::core detray::utils vecmem::core covfie::core
   PRIVATE traccc::device_common vecmem::sycl )
-
-# Prevent Eigen from getting confused when building code for a
-# CUDA or HIP backend.
-target_compile_definitions( traccc_sycl
-  PRIVATE EIGEN_NO_CUDA EIGEN_NO_HIP )

--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -19,15 +19,11 @@ traccc_add_executable( seeding_example_sycl "seeding_example_sycl.sycl"
    LINK_LIBRARIES traccc::options vecmem::core vecmem::sycl traccc::io
                   traccc::core traccc::device_common traccc::sycl
                   traccc::performance )
-target_compile_definitions( traccc_seeding_example_sycl
-   PUBLIC EIGEN_NO_CUDA EIGEN_NO_HIP )
 
 traccc_add_executable( seq_example_sycl "seq_example_sycl.sycl"
    LINK_LIBRARIES traccc::options vecmem::core vecmem::sycl traccc::io
                   traccc::core traccc::device_common traccc::sycl
                   traccc::performance )
-target_compile_definitions( traccc_seq_example_sycl
-   PUBLIC EIGEN_NO_CUDA EIGEN_NO_HIP )
 
 #
 # Set up the "throughput applications".
@@ -37,8 +33,6 @@ add_library( traccc_examples_sycl STATIC
    "full_chain_algorithm.sycl" )
 target_link_libraries( traccc_examples_sycl
    PUBLIC vecmem::core vecmem::sycl traccc::core traccc::device_common traccc::sycl )
-target_compile_definitions( traccc_examples_sycl
-   PUBLIC EIGEN_NO_CUDA EIGEN_NO_HIP )
 
 traccc_add_executable( throughput_st_sycl "throughput_st.cpp"
    LINK_LIBRARIES vecmem::core vecmem::sycl traccc::io traccc::performance


### PR DESCRIPTION
Centralised the "Eigen SYCL flags" on `traccc_core`. Instead of setting `EIGEN_NO_CUDA` and `EIGEN_NO_HIP` separately on every SYCL target that uses `traccc_core`, now the flags come automatically from that target itself.

This was triggered by yet another target requiring this flag.

```
[100%] Building SYCL object tests/sycl/CMakeFiles/traccc_test_sycl.dir/test_kalman_filter.sycl.o
In file included from /home/krasznaa/afs-projects/traccc/traccc/tests/sycl/test_kalman_filter.sycl:12:
In file included from /home/krasznaa/afs-projects/traccc/traccc/tests/common/tests/seed_generator.hpp:11:
In file included from /home/krasznaa/afs-projects/traccc/traccc/core/include/traccc/edm/track_parameters.hpp:11:
In file included from /home/krasznaa/afs-projects/traccc/traccc/core/include/traccc/definitions/common.hpp:11:
In file included from /home/krasznaa/afs-projects/traccc/traccc/core/include/traccc/definitions/primitives.hpp:22:
In file included from /home/krasznaa/ATLAS/projects/traccc/build-llvm/_deps/eigen3-src/Eigen/Core:171:
/home/krasznaa/ATLAS/projects/traccc/build-llvm/_deps/eigen3-src/Eigen/src/Core/MathFunctions.h:986:15: error: no member named 'isfinite' in the global namespace
    return (::isfinite)(x);
            ~~^
/home/krasznaa/ATLAS/projects/traccc/build-llvm/_deps/eigen3-src/Eigen/src/Core/MathFunctions.h:1001:15: error: no member named 'isinf' in the global namespace
    return (::isinf)(x);
            ~~^
/home/krasznaa/ATLAS/projects/traccc/build-llvm/_deps/eigen3-src/Eigen/src/Core/MathFunctions.h:1016:15: error: no member named 'isnan' in the global namespace
    return (::isnan)(x);
            ~~^
3 errors generated.
make[2]: *** [tests/sycl/CMakeFiles/traccc_test_sycl.dir/build.make:75: tests/sycl/CMakeFiles/traccc_test_sycl.dir/test_kalman_filter.sycl.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:4895: tests/sycl/CMakeFiles/traccc_test_sycl.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```

Instead of teaching the `traccc_test_sycl` target separately about the `EIGEN_NO_CUDA` and `EIGEN_NO_HIP` flags as well, it was finally time to centralise this setting...