### PR TITLE
Intel iGPU Compatibility, main branch (2023.03.02.)

### DIFF
--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -54,6 +54,8 @@ class clusterization_algorithm
     private:
     /// The average number of cells in each partition
     unsigned short m_target_cells_per_partition;
+    /// The maximum number of threads in a work group
+    unsigned int m_max_work_group_size;
 
     traccc::memory_resource m_mr;
     mutable queue_wrapper m_queue;

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -391,6 +391,10 @@ clusterization_algorithm::clusterization_algorithm(
     const traccc::memory_resource& mr, queue_wrapper queue,
     const unsigned short target_cells_per_partition)
     : m_target_cells_per_partition(target_cells_per_partition),
+      m_max_work_group_size(
+          details::get_queue(queue)
+              .get_device()
+              .get_info<::sycl::info::device::max_work_group_size>()),
       m_mr(mr),
       m_queue(queue) {
 
@@ -481,9 +485,8 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
 
     // For the following kernel, we can now use whatever the desired number of
     // threads per block.
-    auto spacepointsLocalSize = 1024;
     auto spacepointsRange = traccc::sycl::calculate1DimNdRange(
-        num_measurements_host, spacepointsLocalSize);
+        num_measurements_host, m_max_work_group_size);
 
     // Run form spacepoints kernel, turning 2D measurements into 3D spacepoints
     details::get_queue(m_queue)


### PR DESCRIPTION
This is to fix the issue that I ran into while trying to run the latest code on an Intel iGPU.

```
[bash][atspot01]:build-llvm > ./bin/traccc_seq_example_sycl --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_full/ttbar_mu200/ --check_performance=1 --run_cpu=1 --events=5
Running ./bin/traccc_seq_example_sycl tml_detector/trackml-detector.csv tml_full/ttbar_mu200/ 5
Running Seeding on device: Intel(R) UHD Graphics 630 [0x3e98]
terminate called after throwing an instance of 'sycl::_V1::nd_range_error'
  what():  The number of work-items in each dimension of a work-group cannot exceed {256, 256, 256} for this device -54 (PI_ERROR_INVALID_WORK_GROUP_SIZE)
Aborted (core dumped)
[bash][atspot01]:build-llvm >
```

While 1024 is pretty much a rock solid number for CUDA devices, we should probably still get it using [cudaGetDeviceProperties(...)](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DEVICE.html#group__CUDART__DEVICE_1g1bf9d625a931d657e08db2b4391170f0) in the appropriate places. But I'd leave that to @guilhermeAlmeida1. :wink: