### PR TITLE
Add additional output information to clustering algorithm

### DIFF
--- a/device/common/include/traccc/clusterization/device/aggregate_cluster.hpp
+++ b/device/common/include/traccc/clusterization/device/aggregate_cluster.hpp
@@ -34,7 +34,8 @@ inline void aggregate_cluster(
     const cell_module_collection_types::const_device& modules,
     const vecmem::data::vector_view<unsigned short> f_view,
     const unsigned int start, const unsigned int end, const unsigned short cid,
-    alt_measurement& out);
+    alt_measurement& out, vecmem::data::vector_view<unsigned int> cell_links,
+    const unsigned int link);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -20,9 +20,11 @@ inline void aggregate_cluster(
     const cell_module_collection_types::const_device& modules,
     const vecmem::data::vector_view<unsigned short> f_view,
     const unsigned int start, const unsigned int end, const unsigned short cid,
-    alt_measurement& out) {
+    alt_measurement& out, vecmem::data::vector_view<unsigned int> cell_links,
+    const unsigned int link) {
 
     const vecmem::device_vector<unsigned short> f(f_view);
+    vecmem::device_vector<unsigned int> cell_links_device(cell_links);
 
     /*
      * Now, we iterate over all other cells to check if they belong
@@ -80,6 +82,8 @@ inline void aggregate_cluster(
                              weight * (diff[i]) * (cell_position[i] - mean[i]);
                 }
             }
+
+            cell_links_device.at(pos) = link;
         }
 
         /*

--- a/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
@@ -30,7 +30,8 @@ namespace traccc::cuda {
 /// algorithm, but also a pretty bad algorithm for a GPU.
 ///
 class clusterization_algorithm
-    : public algorithm<spacepoint_collection_types::buffer(
+    : public algorithm<std::pair<spacepoint_collection_types::buffer,
+                                 vecmem::data::vector_buffer<unsigned int>>(
           const alt_cell_collection_types::const_view&,
           const cell_module_collection_types::const_view&)> {
 
@@ -52,7 +53,8 @@ class clusterization_algorithm
     ///
     /// @param cells        a collection of cells
     /// @param modules      a collection of modules
-    /// @return a spacepoint collection (buffer)
+    /// @return a spacepoint collection (buffer) and a collection (buffer) of
+    /// links from cells to the spacepoints they belong to.
     output_type operator()(
         const alt_cell_collection_types::const_view& cells,
         const cell_module_collection_types::const_view& modules) const override;

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -28,7 +28,8 @@
 namespace traccc::sycl {
 
 class clusterization_algorithm
-    : public algorithm<spacepoint_collection_types::buffer(
+    : public algorithm<std::pair<spacepoint_collection_types::buffer,
+                                 vecmem::data::vector_buffer<unsigned int>>(
           const alt_cell_collection_types::const_view&,
           const cell_module_collection_types::const_view&)> {
 
@@ -46,7 +47,8 @@ class clusterization_algorithm
 
     /// @param cells        a collection of cells
     /// @param modules      a collection of modules
-    /// @return a spacepoint collection (buffer)
+    /// @return a spacepoint collection (buffer) and a collection (buffer) of
+    /// links from cells to the spacepoints they belong to.
     output_type operator()(
         const alt_cell_collection_types::const_view& cells,
         const cell_module_collection_types::const_view& modules) const override;

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -152,6 +152,7 @@ class ccl_kernel {
         const index_t target_cells_per_partition,
         alt_measurement_collection_types::view measurements,
         unsigned int* num_measurements,
+        vecmem::data::vector_view<unsigned int> cell_links,
         ::sycl::accessor<unsigned int, 1, ::sycl::access::mode::read_write,
                          ::sycl::access::target::local>
             shared_uint,
@@ -164,6 +165,7 @@ class ccl_kernel {
           m_target_cells_per_partition(target_cells_per_partition),
           measurements_view(measurements),
           m_measurement_count(num_measurements),
+          cell_links_view(cell_links),
           m_shared_uint(shared_uint),
           m_shared_idx(shared_idx) {}
 
@@ -365,7 +367,8 @@ class ccl_kernel {
 
                 device::aggregate_cluster(cells_device, modules_device, f_view,
                                           start, end, cid,
-                                          measurements_device[groupPos + id]);
+                                          measurements_device[groupPos + id],
+                                          cell_links_view, groupPos + id);
             }
         }
     }
@@ -377,6 +380,7 @@ class ccl_kernel {
     const unsigned short m_target_cells_per_partition;
     alt_measurement_collection_types::view measurements_view;
     unsigned int* m_measurement_count;
+    vecmem::data::vector_view<unsigned int> cell_links_view;
     ::sycl::accessor<unsigned int, 1, ::sycl::access::mode::read_write,
                      ::sycl::access::target::local>
         m_shared_uint;
@@ -451,10 +455,13 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
                .get_device()
                .get_info<::sycl::info::device::local_mem_size>());
 
+    // Create buffer for linking cells to their spacepoints.
+    vecmem::data::vector_buffer<unsigned int> cell_links(num_cells, m_mr.main);
+
     // Run ccl kernel
     details::get_queue(m_queue)
         .submit([&ndrange, &cells, &modules, max_cells_per_partition,
-                 &target_cells_per_partition, &measurements_view,
+                 &target_cells_per_partition, &measurements_view, &cell_links,
                  &num_measurements_device](::sycl::handler& h) {
             ::sycl::accessor<unsigned int, 1, ::sycl::access::mode::read_write,
                              ::sycl::access::target::local>
@@ -464,11 +471,11 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
                 shared_idx(2 * max_cells_per_partition, h);
 
             h.parallel_for<kernels::ccl_kernel>(
-                ndrange,
-                kernels::ccl_kernel(
-                    cells, modules, max_cells_per_partition,
-                    target_cells_per_partition, measurements_view,
-                    num_measurements_device.get(), shared_uint, shared_idx));
+                ndrange, kernels::ccl_kernel(
+                             cells, modules, max_cells_per_partition,
+                             target_cells_per_partition, measurements_view,
+                             num_measurements_device.get(), cell_links,
+                             shared_uint, shared_idx));
         })
         .wait_and_throw();
 
@@ -502,7 +509,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
         })
         .wait_and_throw();
 
-    return spacepoints_buffer;
+    return {std::move(spacepoints_buffer), std::move(cell_links)};
 }
 
 }  // namespace traccc::sycl

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -90,7 +90,8 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     const clusterization_algorithm::output_type spacepoints =
         m_clusterization(cells_buffer, modules_buffer);
     const track_params_estimation::output_type track_params =
-        m_track_parameter_estimation(spacepoints, m_seeding(spacepoints));
+        m_track_parameter_estimation(spacepoints.first,
+                                     m_seeding(spacepoints.first));
 
     // Get the final data back to the host.
     bound_track_parameters_collection_types::host result;

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -155,7 +155,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 traccc::performance::timer t("Clusterization (cuda)",
                                              elapsedTimes);
                 // Reconstruct it into spacepoints on the device.
-                spacepoints_cuda_buffer = ca_cuda(cells_buffer, modules_buffer);
+                spacepoints_cuda_buffer =
+                    ca_cuda(cells_buffer, modules_buffer).first;
                 stream.synchronize();
             }  // stop measuring clusterization cuda timer
 

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -107,7 +107,8 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     const clusterization_algorithm::output_type spacepoints =
         m_clusterization(cells_buffer, modules_buffer);
     const track_params_estimation::output_type track_params =
-        m_track_parameter_estimation(spacepoints, m_seeding(spacepoints));
+        m_track_parameter_estimation(spacepoints.first,
+                                     m_seeding(spacepoints.first));
 
     // Get the final data back to the host.
     bound_track_parameters_collection_types::host result;

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -180,7 +180,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 traccc::performance::timer t("Clusterization (sycl)",
                                              elapsedTimes);
                 // Reconstruct it into spacepoints on the device.
-                spacepoints_sycl_buffer = ca_sycl(cells_buffer, modules_buffer);
+                spacepoints_sycl_buffer =
+                    ca_sycl(cells_buffer, modules_buffer).first;
             }  // stop measuring clusterization sycl timer
 
             if (run_cpu) {


### PR DESCRIPTION
This PR adds additional output information to the clustering algorithm, which allows linking back from the created spacepoints down to the cells they were created from. This is currently not used for anything, but will be necessary for physics performance testing with the new EDM.