### PR TITLE
Fix launch error in CUDA CCA without cells

### DIFF
--- a/device/cuda/src/cca/component_connection.cu
+++ b/device/cuda/src/cca/component_connection.cu
@@ -771,9 +771,11 @@ component_connection::output_type component_connection::operator()(
      *
      * This step includes the measurement (hit) creation for each cluster.
      */
-    ccl_kernel<<<(total_cells / TARGET_CELLS_PER_PARTITION) +
-                     (total_cells % TARGET_CELLS_PER_PARTITION != 0 ? 1 : 0),
-                 THREADS_PER_BLOCK>>>(container, *mctnr, total_cells);
+    ccl_kernel<<<
+        std::max(1ul,
+                 (total_cells / TARGET_CELLS_PER_PARTITION) +
+                     (total_cells % TARGET_CELLS_PER_PARTITION != 0 ? 1 : 0)),
+        THREADS_PER_BLOCK>>>(container, *mctnr, total_cells);
 
     CUDA_ERROR_CHECK(cudaPeekAtLastError());
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());


### PR DESCRIPTION
Pull request #316 introduced a bug in the CUDA CCA algorithm where an empty input would lead to the code attempting to launch a CUDA kernel with a grid size of zero, which is illegal. This commit ensures that the grid size is always at least zero, thereby ensuring that the CUDA runtime does not run into problems.