### PR TITLE
Seeding FP64 Cleanup, main branch (2023.03.08.)

### DIFF
--- a/core/include/traccc/seeding/doublet_finding_helper.hpp
+++ b/core/include/traccc/seeding/doublet_finding_helper.hpp
@@ -112,7 +112,8 @@ lin_circle doublet_finding_helper::transform_coordinates(
     scalar x = deltaX * cosPhiM + deltaY * sinPhiM;
     scalar y = deltaY * cosPhiM - deltaX * sinPhiM;
     // 1/(length of M -> SP)
-    scalar iDeltaR2 = 1. / (deltaX * deltaX + deltaY * deltaY);
+    scalar iDeltaR2 =
+        static_cast<scalar>(1.) / (deltaX * deltaX + deltaY * deltaY);
     scalar iDeltaR = std::sqrt(iDeltaR2);
     // cot_theta = (deltaZ/deltaR)
     scalar cot_theta = deltaZ * iDeltaR;

--- a/core/include/traccc/seeding/triplet_finding_helper.hpp
+++ b/core/include/traccc/seeding/triplet_finding_helper.hpp
@@ -41,10 +41,11 @@ bool triplet_finding_helper::isCompatible(
     const lin_circle& lt, const seedfinder_config& config,
     const scalar& iSinTheta2, const scalar& scatteringInRegion2,
     scalar& curvature, scalar& impact_parameter) {
+
     // add errors of spB-spM and spM-spT pairs and add the correlation term
     // for errors on spM
     scalar error2 = lt.Er() + lb.Er() +
-                    2 *
+                    static_cast<scalar>(2.f) *
                         (lb.cotTheta() * lt.cotTheta() * spM.varianceR() +
                          spM.varianceZ()) *
                         lb.iDeltaR() * lt.iDeltaR();
@@ -60,8 +61,8 @@ bool triplet_finding_helper::isCompatible(
         deltaCotTheta = std::abs(deltaCotTheta);
         // if deltaTheta larger than the scattering for the lower pT cut, skip
         error = std::sqrt(error2);
-        dCotThetaMinusError2 =
-            deltaCotTheta2 + error2 - 2 * deltaCotTheta * error;
+        dCotThetaMinusError2 = deltaCotTheta2 + error2 -
+                               static_cast<scalar>(2.) * deltaCotTheta * error;
         // avoid taking root of scatteringInRegion
         // if left side of ">" is positive, both sides of unequality can be
         // squared
@@ -73,14 +74,14 @@ bool triplet_finding_helper::isCompatible(
 
     // protects against division by 0
     scalar dU = lt.U() - lb.U();
-    if (dU == 0.) {
+    if (dU == static_cast<scalar>(0.)) {
         return false;
     }
 
     // A and B are evaluated as a function of the circumference parameters
     // x_0 and y_0
     scalar A = (lt.V() - lb.V()) / dU;
-    scalar S2 = 1. + A * A;
+    scalar S2 = static_cast<scalar>(1.) + A * A;
     scalar B = lb.V() - A * lb.U();
     scalar B2 = B * B;
     // sqrt(S2)/B = 2 * helixradius
@@ -92,10 +93,12 @@ bool triplet_finding_helper::isCompatible(
     // 1/helixradius: (B/sqrt(S2))*2 (we leave everything squared)
     scalar iHelixDiameter2 = B2 / S2;
     // calculate scattering for p(T) calculated from seed curvature
-    scalar pT2scatter = 4 * iHelixDiameter2 * config.pT2perRadius;
+    scalar pT2scatter =
+        static_cast<scalar>(4.) * iHelixDiameter2 * config.pT2perRadius;
     // if pT > maxPtScattering, calculate allowed scattering angle using
     // maxPtScattering instead of pt.
-    scalar pT = config.pTPerHelixRadius * std::sqrt(S2 / B2) / 2.;
+    scalar pT =
+        config.pTPerHelixRadius * std::sqrt(S2 / B2) / static_cast<scalar>(2.);
     if (pT > config.maxPtScattering) {
         scalar pTscatter = config.highland / config.maxPtScattering;
         pT2scatter = pTscatter * pTscatter;
@@ -104,7 +107,7 @@ bool triplet_finding_helper::isCompatible(
     // from rad to deltaCotTheta
     scalar p2scatter = pT2scatter * iSinTheta2;
     // if deltaTheta larger than allowed scattering for calculated pT, skip
-    if ((deltaCotTheta2 - error2 > 0) &&
+    if ((deltaCotTheta2 - error2 > static_cast<scalar>(0.)) &&
         (dCotThetaMinusError2 >
          p2scatter * config.sigmaScattering * config.sigmaScattering)) {
         return false;

--- a/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -80,7 +80,7 @@ inline void count_triplets(
 
     // Calculate some physical quantities required for triplet compatibility
     // check
-    scalar iSinTheta2 = 1 + lb.cotTheta() * lb.cotTheta();
+    scalar iSinTheta2 = static_cast<scalar>(1.) + lb.cotTheta() * lb.cotTheta();
     scalar scatteringInRegion2 = config.maxScatteringAngle2 * iSinTheta2;
     scatteringInRegion2 *= config.sigmaScattering * config.sigmaScattering;
 


### PR DESCRIPTION
It's been a hot minute since I would've tried to run the code on the integrated GPU of my laptop. Which quickly lead to:

```
Running ./bin/traccc_seeding_example_sycl tml_detector/trackml-detector.csv tml_full/ttbar_mu200/ 1
Running on device: Intel(R) Graphics [0x46a6]
terminate called after throwing an instance of 'sycl::_V1::exception'
  what():  Required aspect fp64 is not supported on the device
Aborted (core dumped)
```

After quite some detective work, I had to make these changes to make the seed finding work without FP64 operations.

Clusterization may, and kalman fitting definitely still contains some FP64 operations. But I'll open different PRs for those.