### PR TITLE
CMake Updates, main branch (2023.03.09.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -47,7 +47,7 @@ jobs:
       - name: Configure
         run: |
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
-          cmake -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DTRACCC_BUILD_${{ matrix.platform.name }}=TRUE -S ${GITHUB_WORKSPACE} -B build
+          cmake -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DTRACCC_BUILD_${{ matrix.platform.name }}=TRUE -DTRACCC_FAIL_ON_WARNINGS=TRUE -S ${GITHUB_WORKSPACE} -B build
       - name: Build
         run: |
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ set( CMAKE_CUDA_STANDARD 17 CACHE STRING "The (CUDA) C++ standard to use" )
 set( CMAKE_CUDA_EXTENSIONS FALSE CACHE BOOL "Disable (CUDA) C++ extensions" )
 set( CMAKE_SYCL_STANDARD 17 CACHE STRING "The (SYCL) C++ standard to use" )
 
+# Flag controlling whether warnings should make the build fail.
+option( TRACCC_FAIL_ON_WARNINGS
+   "Make the build fail on compiler/linker warnings" FALSE )
+
 # Standard CMake include(s).
 include( GNUInstallDirs )
 

--- a/cmake/traccc-compiler-options-cpp.cmake
+++ b/cmake/traccc-compiler-options-cpp.cmake
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -21,10 +21,12 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wextra" )
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wshadow" )
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wunused-local-typedefs" )
+   traccc_add_flag( CMAKE_CXX_FLAGS "-pedantic" )
 
-   # More rigorous tests for the Debug builds.
-   traccc_add_flag( CMAKE_CXX_FLAGS_DEBUG "-Werror" )
-   traccc_add_flag( CMAKE_CXX_FLAGS_DEBUG "-pedantic" )
+   # Fail on warnings, if asked for that behaviour.
+   if( TRACCC_FAIL_ON_WARNINGS )
+      traccc_add_flag( CMAKE_CXX_FLAGS "-Werror" )
+   endif()
 
 elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
 
@@ -33,7 +35,9 @@ elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
       "${CMAKE_CXX_FLAGS}" )
    traccc_add_flag( CMAKE_CXX_FLAGS "/W4" )
 
-   # More rigorous tests for the Debug builds.
-   traccc_add_flag( CMAKE_CXX_FLAGS_DEBUG "/WX" )
+   # Fail on warnings, if asked for that behaviour.
+   if( TRACCC_FAIL_ON_WARNINGS )
+      traccc_add_flag( CMAKE_CXX_FLAGS "/WX" )
+   endif()
 
 endif()

--- a/cmake/traccc-compiler-options-cuda.cmake
+++ b/cmake/traccc-compiler-options-cuda.cmake
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -35,10 +35,12 @@ traccc_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G" )
 # profilers have access to line data.
 traccc_add_flag( CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-lineinfo" )
 
-# More rigorous tests for the Debug builds.
-if( ( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "10.2" ) AND
-    ( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA" ) )
-   traccc_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-Werror all-warnings" )
-elseif( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "Clang" )
-   traccc_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-Werror" )
+# Fail on warnings, if asked for that behaviour.
+if( TRACCC_FAIL_ON_WARNINGS )
+   if( ( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "10.2" ) AND
+       ( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA" ) )
+      traccc_add_flag( CMAKE_CUDA_FLAGS "-Werror all-warnings" )
+   elseif( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "Clang" )
+      traccc_add_flag( CMAKE_CUDA_FLAGS "-Werror" )
+   endif()
 endif()

--- a/cmake/traccc-compiler-options-sycl.cmake
+++ b/cmake/traccc-compiler-options-sycl.cmake
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -16,10 +16,17 @@ foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
    traccc_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wunused-local-typedefs" )
 endforeach()
 
-# More rigorous tests for the Debug builds.
-traccc_add_flag( CMAKE_SYCL_FLAGS_DEBUG "-Werror" )
 if( NOT WIN32 )
-   traccc_add_flag( CMAKE_SYCL_FLAGS_DEBUG "-pedantic" )
+   foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
+      traccc_add_flag( CMAKE_SYCL_FLAGS_${mode} "-pedantic" )
+   endforeach()
+endif()
+
+# Fail on warnings, if asked for that behaviour.
+if( TRACCC_FAIL_ON_WARNINGS )
+   foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
+      traccc_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Werror" )
+   endforeach()
 endif()
 
 # Avoid issues coming from MSVC<->DPC++ argument differences.

--- a/cmake/traccc-functions.cmake
+++ b/cmake/traccc-functions.cmake
@@ -1,8 +1,11 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
+
+# DISCOVERY_TIMEOUT in gtest_discover_tests(...) requires at least CMake 3.10.
+cmake_minimum_required( VERSION 3.10 )
 
 # Guard against multiple includes.
 include_guard( GLOBAL )
@@ -117,7 +120,8 @@ function( traccc_add_test name )
    # CTest tests. All the while ensuring that they would find their data files.
    gtest_discover_tests( ${test_exe_name}
       PROPERTIES ENVIRONMENT
-                 TRACCC_TEST_DATA_DIR=${PROJECT_SOURCE_DIR}/data )
+                 TRACCC_TEST_DATA_DIR=${PROJECT_SOURCE_DIR}/data
+      DISCOVERY_TIMEOUT 20 )
 
 endfunction( traccc_add_test )
 


### PR DESCRIPTION
While working on #333, for which I needed to build the code in Debug mode on my laptop (while running on batteries), I ran into some issues.

First, just like I did in https://github.com/acts-project/vecmem/pull/210, I introduced a `TRACCC_FAIL_ON_WARNINGS` flag to control whether the `-Werror` (or equivalent) flag should be used in the build. Since it's been pretty impossible to build the SYCL code without warnings lately.

And I also ran into a very surprising build failure telling me that `traccc_test_sycl` "timed out". :confused: Apparently in power-saving mode my laptop was not able to tell CMake within 5 seconds what tests are built into that executable. :stuck_out_tongue: (This was happening very reliably while in power saving mode on battery power.) So I increased the timeout value a bit.