### PR TITLE
Clusterization FP64 Cleanup, main branch (2023.03.09.)

### DIFF
--- a/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
+++ b/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -112,8 +112,9 @@ TRACCC_HOST_DEVICE inline void fill_measurement(
         m.variance[1] = var[1] / totalWeight;
         // plus pitch^2 / 12
         const auto pitch = module.pixel.get_pitch();
-        m.variance = m.variance +
-                     point2{pitch[0] * pitch[0] / 12, pitch[1] * pitch[1] / 12};
+        m.variance =
+            m.variance + point2{pitch[0] * pitch[0] / static_cast<scalar>(12.),
+                                pitch[1] * pitch[1] / static_cast<scalar>(12.)};
         // @todo add variance estimation
 
         measurements[module_link].header = module;

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -32,7 +32,7 @@ inline void aggregate_cluster(
      * because no cell is ever a child of a cluster owned by a cell
      * with a higher ID.
      */
-    float totalWeight = 0.;
+    scalar totalWeight = 0.;
     point2 mean{0., 0.}, var{0., 0.};
     const auto module_link = cells[cid + start].module_link;
     const cell_module this_module = modules.at(module_link);
@@ -94,12 +94,13 @@ inline void aggregate_cluster(
             break;
         }
     }
-    if (totalWeight > 0.) {
+    if (totalWeight > static_cast<scalar>(0.)) {
         for (char i = 0; i < 2; ++i) {
             var[i] /= totalWeight;
         }
         const auto pitch = this_module.pixel.get_pitch();
-        var = var + point2{pitch[0] * pitch[0] / 12, pitch[1] * pitch[1] / 12};
+        var = var + point2{pitch[0] * pitch[0] / static_cast<scalar>(12.),
+                           pitch[1] * pitch[1] / static_cast<scalar>(12.)};
     }
 
     /*


### PR DESCRIPTION
As a sibling to #333, this PR makes the entire chain in `traccc_seq_example_sycl` able to run on my laptop's integrated GPU. :wink:

We should also hunt down the FP64 operations in the CUDA code at one point. As SYCL might gain an unfair advantage. :stuck_out_tongue: