### PR TITLE
Replace FP64 by FP32 in gain matrix smoother

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
@@ -64,7 +64,7 @@ struct gain_matrix_smoother {
         const matrix_type<6, 6>& cur_filtered_cov = cur_filtered.covariance();
 
         // Regularization matrix for numerical stability
-        static constexpr double epsilon = 1e-13;
+        static constexpr scalar epsilon = 1e-13;
         const matrix_type<6, 6> regularization =
             matrix_operator().template identity<e_bound_size, e_bound_size>() *
             epsilon;


### PR DESCRIPTION
Courtesy of #336, this commit removes a use of double-precision floating point numbers and replaces it by a configurable scalar type as we prefer to do in traccc.