### PR TITLE
Add option to log multi-threaded results to output file

### DIFF
--- a/examples/options/include/traccc/options/throughput_options.hpp
+++ b/examples/options/include/traccc/options/throughput_options.hpp
@@ -46,6 +46,9 @@ struct throughput_options {
     /// them in the performance measurements
     std::size_t cold_run_events = 10;
 
+    /// Output log file
+    std::string log_file;
+
     /// Constructor on top of a common @c program_options object
     ///
     /// @param desc The program options to add to

--- a/examples/options/src/options/throughput_options.cpp
+++ b/examples/options/src/options/throughput_options.cpp
@@ -43,6 +43,10 @@ throughput_options::throughput_options(po::options_description& desc) {
     desc.add_options()("cold_run_events",
                        po::value<std::size_t>()->default_value(10),
                        "Number of events to run 'cold'");
+    desc.add_options()(
+        "log_file",
+        po::value<std::string>()->default_value(
+            "\0", "File where result logs will be printed (in append mode)."));
 }
 
 void throughput_options::read(const po::variables_map& vm) {
@@ -69,6 +73,7 @@ void throughput_options::read(const po::variables_map& vm) {
     loaded_events = vm["loaded_events"].as<std::size_t>();
     processed_events = vm["processed_events"].as<std::size_t>();
     cold_run_events = vm["cold_run_events"].as<std::size_t>();
+    log_file = vm["log_file"].as<std::string>();
 }
 
 std::ostream& operator<<(std::ostream& out, const throughput_options& opt) {
@@ -83,7 +88,8 @@ std::ostream& operator<<(std::ostream& out, const throughput_options& opt) {
         << "\n"
         << "Loaded event(s)            : " << opt.loaded_events << "\n"
         << "Cold run event(s)          : " << opt.cold_run_events << "\n"
-        << "Processed event(s)         : " << opt.processed_events;
+        << "Processed event(s)         : " << opt.processed_events << "\n"
+        << "Log_file                   : " << opt.log_file;
     return out;
 }
 

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -32,6 +32,7 @@
 #include <atomic>
 #include <cstdlib>
 #include <ctime>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -189,6 +190,19 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
               << performance::throughput{throughput_cfg.processed_events, times,
                                          "Event processing"}
               << std::endl;
+
+    // Print results to log file
+    if (throughput_cfg.log_file != "\0") {
+        std::ofstream logFile;
+        logFile.open(throughput_cfg.log_file, std::fstream::app);
+        logFile << "\"" << throughput_cfg.input_directory << "\""
+                << "," << mt_cfg.threads << "," << throughput_cfg.loaded_events
+                << "," << throughput_cfg.cold_run_events << ","
+                << throughput_cfg.processed_events << ","
+                << times.get_time("Warm-up processing").count() << ","
+                << times.get_time("Event processing").count() << std::endl;
+        logFile.close();
+    }
 
     // Return gracefully.
     return 0;

--- a/examples/run/common/throughput_mt_alt.ipp
+++ b/examples/run/common/throughput_mt_alt.ipp
@@ -37,6 +37,7 @@
 #include <atomic>
 #include <cstdlib>
 #include <ctime>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -209,6 +210,19 @@ int throughput_mt_alt(std::string_view description, int argc, char* argv[],
               << performance::throughput{throughput_cfg.processed_events, times,
                                          "Event processing"}
               << std::endl;
+
+    // Print results to log file
+    if (throughput_cfg.log_file != "\0") {
+        std::ofstream logFile;
+        logFile.open(throughput_cfg.log_file, std::fstream::app);
+        logFile << "\"" << throughput_cfg.input_directory << "\""
+                << "," << mt_cfg.threads << "," << throughput_cfg.loaded_events
+                << "," << throughput_cfg.cold_run_events << ","
+                << throughput_cfg.processed_events << ","
+                << times.get_time("Warm-up processing").count() << ","
+                << times.get_time("Event processing").count() << std::endl;
+        logFile.close();
+    }
 
     // Return gracefully.
     return 0;


### PR DESCRIPTION
This makes running performance tests through a wide range of input options simpler, by easily being incorporated with any given script which runs the desired options (various mu values, number of threads, etc.) and printing it all to a csv-compatible file.