### PR TITLE
Log `target_cells_per_partition` in throughput measurements

### DIFF
--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -199,6 +199,7 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
                 << "," << mt_cfg.threads << "," << throughput_cfg.loaded_events
                 << "," << throughput_cfg.cold_run_events << ","
                 << throughput_cfg.processed_events << ","
+                << throughput_cfg.target_cells_per_partition << ","
                 << times.get_time("Warm-up processing").count() << ","
                 << times.get_time("Event processing").count() << std::endl;
         logFile.close();

--- a/examples/run/common/throughput_mt_alt.ipp
+++ b/examples/run/common/throughput_mt_alt.ipp
@@ -219,6 +219,7 @@ int throughput_mt_alt(std::string_view description, int argc, char* argv[],
                 << "," << mt_cfg.threads << "," << throughput_cfg.loaded_events
                 << "," << throughput_cfg.cold_run_events << ","
                 << throughput_cfg.processed_events << ","
+                << throughput_cfg.target_cells_per_partition << ","
                 << times.get_time("Warm-up processing").count() << ","
                 << times.get_time("Event processing").count() << std::endl;
         logFile.close();


### PR DESCRIPTION
In #341 I forgot to printout log this piece of information which could be useful in the future. 