### PR TITLE
Make cuda chain use asynchronous copies and kernel launches throughout

### DIFF
--- a/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/cuda/utils/stream.hpp"
 #include "traccc/edm/alt_seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
@@ -34,10 +35,14 @@ class seed_finding : public algorithm<alt_seed_collection_types::buffer(
     /// @param config is seed finder configuration parameters
     /// @param filter_config is seed filter configuration parameters
     /// @param sp_grid spacepoint grid
-    /// @param mr vecmem memory resource
+    /// @param mr The memory resource(s) to use in the algorithm
+    /// @param copy The copy object to use for copying data between device
+    ///             and host memory blocks
+    /// @param str The CUDA stream to perform the operations in
     seed_finding(const seedfinder_config& config,
                  const seedfilter_config& filter_config,
-                 const traccc::memory_resource& mr);
+                 const traccc::memory_resource& mr, vecmem::copy& copy,
+                 stream& str);
 
     /// Callable operator for the seed finding
     ///
@@ -53,7 +58,11 @@ class seed_finding : public algorithm<alt_seed_collection_types::buffer(
     seedfinder_config m_seedfinder_config;
     seedfilter_config m_seedfilter_config;
     traccc::memory_resource m_mr;
-    std::unique_ptr<vecmem::copy> m_copy;
+
+    /// The copy object to use
+    vecmem::copy& m_copy;
+    /// The CUDA stream to use
+    stream& m_stream;
 };
 
 }  // namespace traccc::cuda

--- a/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,7 @@
 // Library include(s).
 #include "traccc/cuda/seeding/seed_finding.hpp"
 #include "traccc/cuda/seeding/spacepoint_binning.hpp"
+#include "traccc/cuda/utils/stream.hpp"
 
 // Project include(s).
 #include "traccc/edm/alt_seed.hpp"
@@ -17,7 +18,7 @@
 #include "traccc/utils/algorithm.hpp"
 
 // VecMem include(s).
-#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/utils/copy.hpp>
 
 // traccc library include(s).
 #include "traccc/utils/memory_resource.hpp"
@@ -32,8 +33,13 @@ class seeding_algorithm : public algorithm<alt_seed_collection_types::buffer(
     /// Constructor for the seed finding algorithm
     ///
     /// @param mr The memory resource to use
+    /// @param mr The memory resource(s) to use in the algorithm
+    /// @param copy The copy object to use for copying data between device
+    ///             and host memory blocks
+    /// @param str The CUDA stream to perform the operations in
     ///
-    seeding_algorithm(const traccc::memory_resource& mr);
+    seeding_algorithm(const traccc::memory_resource& mr, vecmem::copy& copy,
+                      stream& str);
 
     /// Operator executing the algorithm.
     ///

--- a/device/cuda/include/traccc/cuda/seeding/spacepoint_binning.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/spacepoint_binning.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/cuda/utils/stream.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
 #include "traccc/seeding/detail/spacepoint_grid.hpp"
@@ -32,7 +33,8 @@ class spacepoint_binning
     /// Constructor for the algorithm
     spacepoint_binning(const seedfinder_config& config,
                        const spacepoint_grid_config& grid_config,
-                       const traccc::memory_resource& mr);
+                       const traccc::memory_resource& mr, vecmem::copy& copy,
+                       stream& str);
 
     /// Function executing the algorithm with a a view of spacepoints
     sp_grid_buffer operator()(const spacepoint_collection_types::const_view&
@@ -43,7 +45,11 @@ class spacepoint_binning
     seedfinder_config m_config;
     std::pair<sp_grid::axis_p0_type, sp_grid::axis_p1_type> m_axes;
     traccc::memory_resource m_mr;
-    std::unique_ptr<vecmem::copy> m_copy;
+
+    /// The copy object to use
+    vecmem::copy& m_copy;
+    /// The CUDA stream to use
+    stream& m_stream;
 
 };  // class spacepoint_binning
 

--- a/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "traccc/cuda/utils/stream.hpp"
 #include "traccc/edm/alt_seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/edm/track_parameters.hpp"
@@ -30,7 +31,11 @@ struct track_params_estimation
     /// Constructor for track_params_estimation
     ///
     /// @param mr is the memory resource
-    track_params_estimation(const traccc::memory_resource& mr);
+    /// @param copy The copy object to use for copying data between device
+    ///             and host memory blocks
+    /// @param str The CUDA stream to perform the operations in
+    track_params_estimation(const traccc::memory_resource& mr,
+                            vecmem::copy& copy, stream& str);
 
     /// Callable operator for track_params_esitmation
     ///
@@ -45,8 +50,10 @@ struct track_params_estimation
     private:
     /// Memory resource used by the algorithm
     traccc::memory_resource m_mr;
-    /// Copy object used by the algorithm
-    std::unique_ptr<vecmem::copy> m_copy;
+    /// The copy object to use
+    vecmem::copy& m_copy;
+    /// The CUDA stream to use
+    stream& m_stream;
 };
 
 }  // namespace cuda

--- a/device/cuda/src/seeding/seeding_algorithm.cpp
+++ b/device/cuda/src/seeding/seeding_algorithm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -58,10 +58,12 @@ traccc::spacepoint_grid_config default_spacepoint_grid_config() {
 
 namespace traccc::cuda {
 
-seeding_algorithm::seeding_algorithm(const traccc::memory_resource& mr)
+seeding_algorithm::seeding_algorithm(const traccc::memory_resource& mr,
+                                     vecmem::copy& copy, stream& str)
     : m_spacepoint_binning(default_seedfinder_config(),
-                           default_spacepoint_grid_config(), mr),
-      m_seed_finding(default_seedfinder_config(), seedfilter_config(), mr) {}
+                           default_spacepoint_grid_config(), mr, copy, str),
+      m_seed_finding(default_seedfinder_config(), seedfilter_config(), mr, copy,
+                     str) {}
 
 seeding_algorithm::output_type seeding_algorithm::operator()(
     const spacepoint_collection_types::const_view& spacepoints_view) const {

--- a/device/cuda/src/seeding/spacepoint_binning.cu
+++ b/device/cuda/src/seeding/spacepoint_binning.cu
@@ -1,11 +1,12 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 // Local include(s).
+#include "../utils/utils.hpp"
 #include "traccc/cuda/seeding/spacepoint_binning.hpp"
 #include "traccc/cuda/utils/definitions.hpp"
 
@@ -45,33 +46,30 @@ __global__ void populate_grid(
 
 spacepoint_binning::spacepoint_binning(
     const seedfinder_config& config, const spacepoint_grid_config& grid_config,
-    const traccc::memory_resource& mr)
+    const traccc::memory_resource& mr, vecmem::copy& copy, stream& str)
     : m_config(config.toInternalUnits()),
       m_axes(get_axes(grid_config.toInternalUnits(),
                       (mr.host ? *(mr.host) : mr.main))),
-      m_mr(mr) {
-
-    // Initialize m_copy ptr based on memory resources that were given
-    if (mr.host) {
-        m_copy = std::make_unique<vecmem::cuda::copy>();
-    } else {
-        m_copy = std::make_unique<vecmem::copy>();
-    }
-}
+      m_mr(mr),
+      m_copy(copy),
+      m_stream(str) {}
 
 sp_grid_buffer spacepoint_binning::operator()(
     const spacepoint_collection_types::const_view& spacepoints_view) const {
 
+    // Get a convenience variable for the stream that we'll be using.
+    cudaStream_t stream = details::get_stream(m_stream);
+
     // Get the spacepoint sizes from the view
-    auto sp_size = m_copy->get_size(spacepoints_view);
+    auto sp_size = m_copy.get_size(spacepoints_view);
 
     // Set up the container that will be filled with the required capacities for
     // the spacepoint grid.
     const std::size_t grid_bins = m_axes.first.n_bins * m_axes.second.n_bins;
     vecmem::data::vector_buffer<unsigned int> grid_capacities_buff(grid_bins,
                                                                    m_mr.main);
-    m_copy->setup(grid_capacities_buff);
-    m_copy->memset(grid_capacities_buff, 0);
+    m_copy.setup(grid_capacities_buff);
+    m_copy.memset(grid_capacities_buff, 0);
     vecmem::data::vector_view<unsigned int> grid_capacities_view =
         grid_capacities_buff;
 
@@ -80,31 +78,31 @@ sp_grid_buffer spacepoint_binning::operator()(
     const unsigned int num_blocks = (sp_size + num_threads - 1) / num_threads;
 
     // Fill the grid capacity container.
-    kernels::count_grid_capacities<<<num_blocks, num_threads>>>(
+    kernels::count_grid_capacities<<<num_blocks, num_threads, 0, stream>>>(
         m_config, m_axes.first, m_axes.second, spacepoints_view,
         grid_capacities_view);
     CUDA_ERROR_CHECK(cudaGetLastError());
-    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
     // Copy grid capacities back to the host
     vecmem::vector<unsigned int> grid_capacities_host(m_mr.host ? m_mr.host
                                                                 : &(m_mr.main));
-    (*m_copy)(grid_capacities_buff, grid_capacities_host);
+    m_copy(grid_capacities_buff, grid_capacities_host);
 
+    m_stream.synchronize();
     // Create the grid buffer.
     sp_grid_buffer grid_buffer(
         m_axes.first, m_axes.second, std::vector<std::size_t>(grid_bins, 0),
         std::vector<std::size_t>(grid_capacities_host.begin(),
                                  grid_capacities_host.end()),
         m_mr.main, m_mr.host);
-    m_copy->setup(grid_buffer._buffer);
+    m_copy.setup(grid_buffer._buffer);
     sp_grid_view grid_view = grid_buffer;
 
     // Populate the grid.
-    kernels::populate_grid<<<num_blocks, num_threads>>>(
+    kernels::populate_grid<<<num_blocks, num_threads, 0, stream>>>(
         m_config, spacepoints_view, grid_view);
     CUDA_ERROR_CHECK(cudaGetLastError());
-    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+    m_stream.synchronize();
 
     // Return the freshly filled buffer.
     return grid_buffer;

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -1,13 +1,16 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
-// Project include(s).
+// Local include(s).
+#include "../utils/utils.hpp"
 #include "traccc/cuda/seeding/track_params_estimation.hpp"
 #include "traccc/cuda/utils/definitions.hpp"
+
+// Project include(s).
 #include "traccc/seeding/device/estimate_track_params.hpp"
 
 // VecMem include(s).
@@ -29,28 +32,23 @@ __global__ void estimate_track_params(
 }  // namespace kernels
 
 track_params_estimation::track_params_estimation(
-    const traccc::memory_resource& mr)
-    : m_mr(mr) {
-
-    // Initialize m_copy ptr based on memory resources that were given
-    if (mr.host) {
-        m_copy = std::make_unique<vecmem::cuda::copy>();
-    } else {
-        m_copy = std::make_unique<vecmem::copy>();
-    }
-}
+    const traccc::memory_resource& mr, vecmem::copy& copy, stream& str)
+    : m_mr(mr), m_copy(copy), m_stream(str) {}
 
 track_params_estimation::output_type track_params_estimation::operator()(
     const spacepoint_collection_types::const_view& spacepoints_view,
     const alt_seed_collection_types::const_view& seeds_view) const {
 
+    // Get a convenience variable for the stream that we'll be using.
+    cudaStream_t stream = details::get_stream(m_stream);
+
     // Get the size of the seeds view
-    const std::size_t seeds_size = m_copy->get_size(seeds_view);
+    const std::size_t seeds_size = m_copy.get_size(seeds_view);
 
     // Create device buffer for the parameters
     bound_track_parameters_collection_types::buffer params_buffer(seeds_size,
                                                                   m_mr.main);
-    m_copy->setup(params_buffer);
+    m_copy.setup(params_buffer);
 
     // Check if anything needs to be done.
     if (seeds_size == 0) {
@@ -67,12 +65,12 @@ track_params_estimation::output_type track_params_estimation::operator()(
     unsigned int num_blocks = (seeds_size + num_threads - 1) / num_threads;
 
     // run the kernel
-    kernels::estimate_track_params<<<num_blocks, num_threads>>>(
+    kernels::estimate_track_params<<<num_blocks, num_threads, 0, stream>>>(
         spacepoints_view, seeds_view, params_buffer);
 
     // cuda error check
     CUDA_ERROR_CHECK(cudaGetLastError());
-    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+    m_stream.synchronize();
 
     return params_buffer;
 }

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,9 +39,10 @@ full_chain_algorithm::full_chain_algorithm(
       m_target_cells_per_partition(target_cells_per_partition),
       m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
                        m_stream, m_target_cells_per_partition),
-      m_seeding(memory_resource{*m_cached_device_mr, &m_host_mr}),
+      m_seeding(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                m_stream),
       m_track_parameter_estimation(
-          memory_resource{*m_cached_device_mr, &m_host_mr}) {
+          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy, m_stream) {
 
     // Tell the user what device is being used.
     int device = 0;
@@ -63,9 +64,10 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
       m_target_cells_per_partition(parent.m_target_cells_per_partition),
       m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
                        m_stream, m_target_cells_per_partition),
-      m_seeding(memory_resource{*m_cached_device_mr, &m_host_mr}),
+      m_seeding(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                m_stream),
       m_track_parameter_estimation(
-          memory_resource{*m_cached_device_mr, &m_host_mr}) {}
+          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy, m_stream) {}
 
 full_chain_algorithm::~full_chain_algorithm() {
 

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -23,6 +23,7 @@
 // VecMem include(s).
 #include <vecmem/memory/cuda/device_memory_resource.hpp>
 #include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/utils/cuda/async_copy.hpp>
 #include <vecmem/utils/cuda/copy.hpp>
 
 // System include(s).
@@ -52,10 +53,13 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     traccc::seeding_algorithm sa(host_mr);
     traccc::track_params_estimation tp(host_mr);
 
-    vecmem::cuda::copy copy;
+    traccc::cuda::stream stream;
 
-    traccc::cuda::seeding_algorithm sa_cuda{mr};
-    traccc::cuda::track_params_estimation tp_cuda{mr};
+    vecmem::cuda::copy copy;
+    vecmem::cuda::async_copy async_copy{stream.cudaStream()};
+
+    traccc::cuda::seeding_algorithm sa_cuda{mr, async_copy, stream};
+    traccc::cuda::track_params_estimation tp_cuda{mr, async_copy, stream};
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -79,8 +79,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
     traccc::cuda::clusterization_algorithm ca_cuda(
         mr, async_copy, stream, common_opts.target_cells_per_partition);
-    traccc::cuda::seeding_algorithm sa_cuda(mr);
-    traccc::cuda::track_params_estimation tp_cuda(mr);
+    traccc::cuda::seeding_algorithm sa_cuda(mr, async_copy, stream);
+    traccc::cuda::track_params_estimation tp_cuda(mr, async_copy, stream);
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(


### PR DESCRIPTION
At the moment we can't *really* compare our multi-threaded CUDA vs SYCL performance as we weren't using the asynchronous capabilities of CUDA in most of the chain, where kernel launches and memory copies are happening synchronously.
This PR fixes that by passing a `cuda::queue` object to the `seeding_algorithm`. 

However, as @krasznaa pointed out, we still have a lot of synchronisation points between kernels (and copies) which could be eliminated. I will handle this in an upcoming PR both for CUDA and SYCL.

**Early** results are quite interesting, it seems that at low pile-up the native cuda algorithm significantly outperforms sycl, but at high pile-up the performance becomes essentially the same 
<img src="https://user-images.githubusercontent.com/108654433/225310303-85ba7942-9ec1-4710-9d89-7e6f4b0e7b3c.png" width=480>
<img src="https://user-images.githubusercontent.com/108654433/225310411-c18e5c7d-92ad-4262-85a4-4e8441bc53d4.png" width=480>
<img src="https://user-images.githubusercontent.com/108654433/225310446-330f5a6a-a2fa-4c0b-949f-2033ed3ca09b.png" width=480>
