### PR TITLE
Implement warp ballot sync with indexing in CUDA

### DIFF
--- a/device/cuda/src/utils/sync.cuh
+++ b/device/cuda/src/utils/sync.cuh
@@ -1,0 +1,55 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::cuda {
+/**
+ * @brief Calculate the index of the current thread in the set of threads in
+ * the warp for which a predicate evaluates to true.
+ *
+ * @param predicate The predicate to evaluate.
+ * @param mask The thread mask to sync.
+ *
+ * @returns The tuple (T, I), where T is the total number of threads in the
+ * warp for which the provided predicate was true, and where I is a unique,
+ * consecutive index in the set of threads for which this was true.
+ *
+ * @example If a predicate P evaluates as `[T, F, F, T]` in a 4-lane warp, the
+ * call to `warp_indexed_ballot_sync(P)` will evaluate to the values
+ * `[(2, 0), (2, ?), (2, ?), (2, 1)]` where `?` indicates an undefined value.
+ *
+ * @warning The value of T is always well-defined, the value if I is only
+ * well-defined if the given predicate was true for the given thread.
+ *
+ * @note As with all CUDA synchronization barriers, exited threads are treated
+ * as having implicitly reached the barrier to avoid deadlock situations.
+ *
+ * @note This function forces thread synchronization.
+ */
+__device__ __forceinline__ std::pair<uint32_t, uint32_t>
+warp_indexed_ballot_sync(bool predicate, uint32_t mask = 0xFFFFFFFFu) {
+    uint32_t vote = __ballot_sync(mask, predicate);
+
+    /*
+     * The total number of threads which return true is simply the population
+     * count of the voting result, which is to say the number of true bits in
+     * its binary expansion.
+     */
+    uint32_t tot = __popc(vote);
+
+    /*
+     * The index is the population count of the vote mask, but only for bits
+     * with an index lower than the current thread index. Thus, we shift a bit
+     * mask over the voting result, nulling any bits that are _higher_ than
+     * the thread index!
+     */
+    uint32_t idx = __popc(vote & ~(0xFFFFFFFFu << (threadIdx.x % warpSize)));
+
+    return {tot, idx};
+}
+}  // namespace traccc::cuda

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -32,6 +32,7 @@ traccc_add_test(
     test_copy_algs.cpp
     test_kalman_filter.cpp
     test_thrust.cu
+    test_sync.cu
 
     LINK_LIBRARIES
     GTest::gtest

--- a/tests/cuda/test_sync.cu
+++ b/tests/cuda/test_sync.cu
@@ -1,0 +1,97 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../device/cuda/src/utils/sync.cuh"
+
+__global__ void testWarpIndexedBallotSyncBasicKernel(uint32_t *vts,
+                                                     uint32_t *vis) {
+    auto [vt, vi] =
+        traccc::cuda::warp_indexed_ballot_sync(threadIdx.x % 2 == 0);
+
+    vts[threadIdx.x] = vt;
+    vis[threadIdx.x] = vi;
+}
+
+__global__ void testWarpIndexedBallotSyncWithExitKernel(uint32_t *vts,
+                                                        uint32_t *vis) {
+    if (threadIdx.x < 16) {
+        return;
+    }
+
+    auto [vt, vi] =
+        traccc::cuda::warp_indexed_ballot_sync(threadIdx.x % 2 == 0);
+
+    vts[threadIdx.x] = vt;
+    vis[threadIdx.x] = vi;
+}
+
+TEST(CUDASync, WarpIndexedBallotSyncBasic) {
+    uint32_t *dev_vt = nullptr, *dev_vi = nullptr;
+    uint32_t host_vt[32], host_vi[32];
+
+    ASSERT_EQ(cudaMalloc(&dev_vt, 32u * sizeof(uint32_t)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&dev_vi, 32u * sizeof(uint32_t)), cudaSuccess);
+    ASSERT_NE(dev_vt, nullptr);
+    ASSERT_NE(dev_vi, nullptr);
+
+    testWarpIndexedBallotSyncBasicKernel<<<1, 32u>>>(dev_vt, dev_vi);
+
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+
+    ASSERT_EQ(cudaMemcpy(host_vt, dev_vt, 32u * sizeof(uint32_t),
+                         cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(host_vi, dev_vi, 32u * sizeof(uint32_t),
+                         cudaMemcpyDeviceToHost),
+              cudaSuccess);
+
+    for (uint32_t i = 0; i < 32u; ++i) {
+        ASSERT_EQ(host_vt[i], 16u);
+    }
+
+    for (uint32_t i = 0; i < 16u; ++i) {
+        ASSERT_EQ(host_vi[i * 2], i);
+    }
+
+    ASSERT_EQ(cudaFree(dev_vt), cudaSuccess);
+    ASSERT_EQ(cudaFree(dev_vi), cudaSuccess);
+}
+
+TEST(CUDASync, WarpIndexedBallotSyncWithExit) {
+    uint32_t *dev_vt = nullptr, *dev_vi = nullptr;
+    uint32_t host_vt[32], host_vi[32];
+
+    ASSERT_EQ(cudaMalloc(&dev_vt, 32u * sizeof(uint32_t)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&dev_vi, 32u * sizeof(uint32_t)), cudaSuccess);
+    ASSERT_NE(dev_vt, nullptr);
+    ASSERT_NE(dev_vi, nullptr);
+
+    testWarpIndexedBallotSyncWithExitKernel<<<1, 32u>>>(dev_vt, dev_vi);
+
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+
+    ASSERT_EQ(cudaMemcpy(host_vt, dev_vt, 32u * sizeof(uint32_t),
+                         cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(host_vi, dev_vi, 32u * sizeof(uint32_t),
+                         cudaMemcpyDeviceToHost),
+              cudaSuccess);
+
+    for (uint32_t i = 16; i < 32u; ++i) {
+        ASSERT_EQ(host_vt[i], 8u);
+    }
+
+    for (uint32_t i = 0; i < 8u; ++i) {
+        ASSERT_EQ(host_vi[i * 2 + 16], i);
+    }
+
+    ASSERT_EQ(cudaFree(dev_vt), cudaSuccess);
+    ASSERT_EQ(cudaFree(dev_vi), cudaSuccess);
+}


### PR DESCRIPTION
It suffices to say that inter-thread communication is an important feature in GPGPU computing. One particularly common operation is to count the number of threads for which some predicate evaluates to true (for example, that predicate can determine whether to write something to global memory). This is commonly done using shared memory, but this is not necessary. CUDA provides ballot synchronization primitives, but this does not give you the index of the current thread in the set of threads that evaluate a predicate to true. This commit adds a new utility function which adds this functionality. Given a predicate, this function synchronizes a warp and returns a unique, consecutive index of the current thread in the set of threads for which the predicate is true.