### PR TITLE
Implement near-transparent layout-swappable arrays

### DIFF
--- a/core/include/traccc/utils/array_wrapper.hpp
+++ b/core/include/traccc/utils/array_wrapper.hpp
@@ -1,0 +1,238 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <traccc/definitions/qualifiers.hpp>
+#include <traccc/utils/functor.hpp>
+#include <type_traits>
+#include <utility>
+#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/memory/unique_ptr.hpp>
+
+namespace traccc {
+/**
+ * @brief Tuple of plain-old-data types.
+ *
+ * This is just a super-simple re-implementation of `std::tuple` that ensures
+ * that the type is trivially constructible.
+ */
+template <typename... Ts>
+struct pod {};
+
+template <>
+struct pod<> {};
+
+template <typename T, typename... Ts>
+struct pod<T, Ts...> {
+    static_assert(std::is_pod_v<T>, "Types in POD-tuple must each be POD.");
+
+    T v;
+    pod<Ts...> r;
+};
+
+/**
+ * @brief Get a given value from a POD tuple.
+ *
+ * @tparam I The index in the POD type to retrieve.
+ * @tparam Ts The types of the POD tuple.
+ *
+ * @param p A valid of the POD tuple type described by `Ts...`.
+ *
+ * @return A value of type `Ts[I]` as contained in `p`.
+ */
+template <std::size_t I, typename... Ts>
+constexpr auto& pod_get(pod<Ts...>& p) {
+    if constexpr (I == 0) {
+        return p.v;
+    } else {
+        return pod_get<I - 1>(p.r);
+    }
+}
+
+/**
+ * @brief An array wrapper that can swap between SoA and AoS layouts almost
+ * transparently.
+ *
+ * @tparam F The higher-order layout type, either `soa` or `aos`.
+ * @tparam T The struct type to embed in memory.
+ */
+template <template <typename...> typename F,
+          template <template <typename> typename> typename T>
+struct array_wrapper {
+    struct owner {
+        owner(vecmem::memory_resource& mr, std::size_t n) : data(mr, n) {}
+
+        typename details::functor::reapply<
+            F, typename T<details::functor::identity>::tuple_t>::type::owner
+            data;
+    };
+
+    struct handle {
+        using handle_t = typename details::functor::reapply<
+            F, typename T<details::functor::identity>::tuple_t>::type::handle;
+
+        handle(const owner& o) : data(o.data) {}
+
+        TRACCC_HOST_DEVICE std::size_t size() const { return data.size(); }
+
+        template <std::size_t I>
+        constexpr TRACCC_HOST_DEVICE auto& get(std::size_t i) {
+            return data.get<I>(i);
+        }
+
+        template <std::size_t I>
+        constexpr TRACCC_HOST_DEVICE auto get(std::size_t i) const {
+            return data.get<I>(i);
+        }
+
+        template <std::size_t... Ns>
+        constexpr TRACCC_HOST_DEVICE T<details::functor::identity>
+        _construct_helper_identity(std::index_sequence<Ns...>,
+                                   std::size_t i) const {
+            return T<details::functor::identity>{get<Ns>(i)...};
+        }
+
+        template <std::size_t... Ns>
+        constexpr TRACCC_HOST_DEVICE T<details::functor::reference>
+        _construct_helper_reference(std::index_sequence<Ns...>, std::size_t i) {
+            return T<details::functor::reference>{get<Ns>(i)...};
+        }
+
+        constexpr TRACCC_HOST_DEVICE T<details::functor::identity> operator[](
+            std::size_t i) const {
+            return _construct_helper_identity(
+                std::make_index_sequence<std::tuple_size_v<
+                    typename T<details::functor::identity>::tuple_t>>(),
+                i);
+        }
+
+        constexpr TRACCC_HOST_DEVICE T<details::functor::reference> operator[](
+            std::size_t i) {
+            return _construct_helper_reference(
+                std::make_index_sequence<std::tuple_size_v<
+                    typename T<details::functor::identity>::tuple_t>>(),
+                i);
+        }
+
+        handle_t data;
+    };
+};
+
+/**
+ * @brief Helper function to convert a list of unique pointers to raw pointers.
+ */
+template <std::size_t... Ns, typename... Ts>
+std::tuple<Ts*...> _get_ptrs(
+    std::index_sequence<Ns...>,
+    const std::tuple<vecmem::unique_alloc_ptr<Ts[]>...>& o) {
+    return {std::get<Ns>(o).get()...};
+}
+
+/**
+ * @brief A struct-of-arrays (SoA) layout scheme.
+ *
+ * Struct-of-arrays is a common approach in vectorized programming both on CPUs
+ * as well as CPUs. If only parts of the struct are accessed at the same time,
+ * an SoA layout may increase locality and allow for coalescing of accesses.
+ *
+ * @tparam Ts The types contained in the POD struct.
+ */
+template <typename... Ts>
+struct soa {
+    struct owner {
+        owner(vecmem::memory_resource& mr, std::size_t n)
+            : _size(n), _ptrs{vecmem::make_unique_alloc<Ts[]>(mr, n)...} {}
+
+        constexpr std::size_t size() const { return _size; }
+
+        const std::tuple<vecmem::unique_alloc_ptr<Ts[]>...>& pointers() const {
+            return _ptrs;
+        }
+
+        private:
+        std::size_t _size;
+        std::tuple<vecmem::unique_alloc_ptr<Ts[]>...> _ptrs;
+    };
+
+    struct handle {
+        private:
+        using tuple_t = std::tuple<Ts*...>;
+
+        public:
+        handle(const owner& o)
+            : _size(o.size()),
+              _ptrs(_get_ptrs(std::make_index_sequence<sizeof...(Ts)>(),
+                              o.pointers())) {}
+
+        constexpr TRACCC_HOST_DEVICE std::size_t size() const { return _size; }
+
+        template <std::size_t I>
+        constexpr TRACCC_HOST_DEVICE auto& get(std::size_t i) {
+            return std::get<I>(_ptrs)[i];
+        }
+
+        template <std::size_t I>
+        constexpr TRACCC_HOST_DEVICE const auto& get(std::size_t i) const {
+            return std::get<I>(_ptrs)[i];
+        }
+
+        private:
+        std::size_t _size;
+        std::tuple<Ts*...> _ptrs;
+    };
+};
+
+/**
+ * @brief An array-of-structs (Aos) layout scheme.
+ *
+ * Array-of-structs is the default layout scheme in C++. It is useful in cases
+ * where all elements of a struct need to be accessed simultaneously.
+ *
+ * @tparam Ts The types contained in the POD struct.
+ */
+template <typename... Ts>
+struct aos {
+    struct owner {
+        constexpr owner(vecmem::memory_resource& mr, std::size_t n)
+            : _size(n), _ptr{vecmem::make_unique_alloc<pod<Ts...>[]>(mr, n)} {}
+
+        constexpr std::size_t size() const { return _size; }
+
+        constexpr const vecmem::unique_alloc_ptr<pod<Ts...>[]>& pointer()
+            const { return _ptr; }
+
+        private : std::size_t _size;
+        vecmem::unique_alloc_ptr<pod<Ts...>[]> _ptr;
+    };
+
+    struct handle {
+        private:
+        using tuple_t = pod<Ts...>;
+
+        public:
+        constexpr handle(const owner& o)
+            : _size(o.size()), _ptr(o.pointer().get()) {}
+
+        constexpr TRACCC_HOST_DEVICE std::size_t size() const { return _size; }
+
+        template <std::size_t I>
+        constexpr TRACCC_HOST_DEVICE auto& get(std::size_t i) {
+            return pod_get<I>(_ptr[i]);
+        }
+
+        template <std::size_t I>
+        constexpr TRACCC_HOST_DEVICE const auto& get(std::size_t i) const {
+            return pod_get<I>(_ptr[i]);
+        }
+
+        private:
+        std::size_t _size;
+        tuple_t* _ptr;
+    };
+};
+}  // namespace traccc

--- a/core/include/traccc/utils/functor.hpp
+++ b/core/include/traccc/utils/functor.hpp
@@ -1,0 +1,44 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::details::functor {
+/**
+ * @brief The identity functor, such that `identity<T>` is equivalent to `T`.
+ */
+template <typename T>
+using identity = T;
+
+/**
+ * @brief The reference functor, such that `reference<T>` is equivalent to `T&`.
+ */
+template <typename T>
+using reference = T&;
+
+/**
+ * @brief The const reference functor, such that `const_reference<T>` is
+ * equivalent to `const T&`.
+ */
+template <typename T>
+using const_reference = const T&;
+
+/**
+ * @brief A natural transformation between two functors.
+ *
+ * Given two functors F1 and F2 as well as some types Ts... such that
+ * `F2<Ts...>` is a type, this produces `F1<Ts...>`.
+ */
+template <template <typename...> typename F, typename T>
+struct reapply {};
+
+template <template <typename...> typename F1,
+          template <typename...> typename F2, typename... Ts>
+struct reapply<F1, F2<Ts...>> {
+    using type = F1<Ts...>;
+};
+}  // namespace traccc::details::functor

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -32,6 +32,7 @@ traccc_add_test(
     test_kalman_filter.cpp
     test_thrust.cu
     test_sync.cu
+    test_array_wrapper.cu
 
     LINK_LIBRARIES
     CUDA::cudart

--- a/tests/cuda/test_array_wrapper.cu
+++ b/tests/cuda/test_array_wrapper.cu
@@ -1,0 +1,127 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <traccc/utils/array_wrapper.hpp>
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+
+template <template <typename> typename F>
+struct vector {
+    using tuple_t = std::tuple<uint32_t, uint32_t, uint32_t>;
+    F<uint32_t> x, y, z;
+};
+
+template <template <typename...> typename Layout>
+__global__ void testArrayWrapperKernel(
+    const typename traccc::array_wrapper<Layout, vector>::handle h,
+    uint32_t *total) {
+    __shared__ uint32_t block_total;
+
+    if (threadIdx.x == 0) {
+        block_total = 0;
+    }
+
+    __syncthreads();
+
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    uint32_t warp_total = h[tid].x;
+
+    for (int i = 16; i >= 1; i /= 2) {
+        warp_total += __shfl_xor_sync(0xffffffff, warp_total, i, 32);
+    }
+
+    if (threadIdx.x % 32 == 0) {
+        atomicAdd(&block_total, warp_total);
+    }
+
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        atomicAdd(total, block_total);
+    }
+}
+
+template <template <typename...> typename Layout>
+__global__ void fillWrapperKernel(
+    typename traccc::array_wrapper<Layout, vector>::handle h) {
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < h.size()) {
+        h[tid].x = 1u;
+        h[tid].y = 2u;
+        h[tid].z = 3u;
+    }
+}
+
+TEST(CUDAArrayWrapper, SoALayout) {
+    vecmem::cuda::device_memory_resource mr;
+
+    uint32_t n = 1024u * 1024u * 1024u;
+
+    traccc::array_wrapper<traccc::soa, vector>::owner o(mr, n);
+
+    fillWrapperKernel<traccc::soa><<<n / 1024u, 1024u>>>(
+        typename traccc::array_wrapper<traccc::soa, vector>::handle(o));
+
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    uint32_t host_result;
+    uint32_t *dev_result = nullptr;
+
+    ASSERT_EQ(cudaMalloc(&dev_result, sizeof(uint32_t)), cudaSuccess);
+    ASSERT_EQ(cudaMemset(&dev_result, sizeof(uint32_t), 0), cudaSuccess);
+
+    testArrayWrapperKernel<traccc::soa><<<n / 1024u, 1024u>>>(
+        typename traccc::array_wrapper<traccc::soa, vector>::handle(o),
+        dev_result);
+
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    ASSERT_EQ(cudaMemcpy(&host_result, dev_result, sizeof(uint32_t),
+                         cudaMemcpyDeviceToHost),
+              cudaSuccess);
+
+    ASSERT_EQ(host_result, n);
+}
+
+TEST(CUDAArrayWrapper, AoSLayout) {
+    vecmem::cuda::device_memory_resource mr;
+
+    uint32_t n = 1024u * 1024u * 1024u;
+
+    traccc::array_wrapper<traccc::aos, vector>::owner o(mr, n);
+
+    fillWrapperKernel<traccc::aos><<<n / 1024u, 1024u>>>(
+        typename traccc::array_wrapper<traccc::aos, vector>::handle(o));
+
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    uint32_t host_result;
+    uint32_t *dev_result = nullptr;
+
+    ASSERT_EQ(cudaMalloc(&dev_result, sizeof(uint32_t)), cudaSuccess);
+    ASSERT_EQ(cudaMemset(&dev_result, sizeof(uint32_t), 0), cudaSuccess);
+
+    testArrayWrapperKernel<traccc::aos><<<n / 1024u, 1024u>>>(
+        typename traccc::array_wrapper<traccc::aos, vector>::handle(o),
+        dev_result);
+
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    ASSERT_EQ(cudaMemcpy(&host_result, dev_result, sizeof(uint32_t),
+                         cudaMemcpyDeviceToHost),
+              cudaSuccess);
+
+    ASSERT_EQ(host_result, n);
+}


### PR DESCRIPTION
This code came to me in a dream.

We have recently been doing a lot of research into the viability of struct-of-array (SoA) and array-of-struct (AoS) layouts. This distinction is important in factorized computing on CPUs as well as on GPUs as it can impact locality and the ability for the processor to coalesce memory accesses. The problem is that swapping between these layouts requires a lot of programming effort, and I am _lazy_. Llama gives us some of this, but the programming API is in some ways inconvenient.

This is why I came up with this near transparent model for array wrappers which can be swapped between multiple layouts. Let us first consider a classical, C++-native array-of-structs layout. First, we define the struct:

```cpp
struct vector {
    float x;
    float y;
    float z;
};
```

We can then define an array of this type:

```cpp
vector array[100];
```

And then we can sum up the values inside of it:

```cpp
float acc = 0.f;
for (uint32_t i = 0; i < 100; ++i) {
    acc += array[i].x;
}
```

This works, but switching it to SoA is a pain in the rear. Let's consider what this looks like with the layout schemes implemented in this PR. We will first reclare our struct, in a slightly different fashion:

```cpp
template<template <typename> typename F>
struct vector {
    using tuple_t = std::tuple<float, float, float>;
    F<float> x;
    F<float> y;
    F<float> z;
}
```

It's not identical, but the structure is very similar. This is why I call it a near-transparent scheme. Then we create an array of this type (using some memory resource):

```cpp
using array_t = traccc::array_wrapper<soa, vector>;
array_t::owner owner(mr, 100);
array_t::hande array(owner);
```

And then we can access the data:

```cpp
float acc = 0.f;
for (uint32_t i = 0; i < 100; ++i) {
    acc += array[i].x;
}
```

All we now need to do to change this to an AoS layout is change the type declaration, such that:

```cpp
using array_t = traccc::array_wrapper<aos, vector>;
```

Notice the change from `soa` to `aos`. That's all that's necessary. Code using these structures should be 100% compatible, and able to read and write to the array without issue.

This PR also comes with a CUDA test that sums up the first element of one billion 3-vectors in an AoS and SoA layout. This serves to confirm functionality as well as the performance effects of this choice. On the A5000 in `pcadp04` the operation takes 18.0 milliseconds when using the SoA layout, and 27.2 milliseconds when using AoS: The SoA approach is 51% faster!