### PR TITLE
Remove deprecated information from CPU seeding EDM

### DIFF
--- a/core/include/traccc/seeding/detail/doublet.hpp
+++ b/core/include/traccc/seeding/detail/doublet.hpp
@@ -21,10 +21,6 @@ struct doublet {
     sp_location sp1;
     // bottom (or top) spacepoint location in internal spacepoint container
     sp_location sp2;
-
-    // Position of the mid top doublets for this which share this spM
-    unsigned int m_mt_start_idx = 0;
-    unsigned int m_mt_end_idx = 0;
 };
 
 inline TRACCC_HOST_DEVICE bool operator==(const doublet& lhs,

--- a/core/include/traccc/seeding/detail/triplet.hpp
+++ b/core/include/traccc/seeding/detail/triplet.hpp
@@ -30,10 +30,6 @@ struct triplet {
     scalar weight;
     // z origin of triplet
     scalar z_vertex;
-
-    /// Position of the triplets which share this mb doublet
-    unsigned int triplets_mb_begin = 0;
-    unsigned int triplets_mb_end = 0;
 };
 
 inline TRACCC_HOST_DEVICE bool operator==(const triplet& lhs,


### PR DESCRIPTION
In #326 I forgot to remove some no longer needed information from the doublet & triplet core EDM given that it's now separated from that of the device.