### PR TITLE
Data Directory Re-Design, main branch (2023.03.20.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -39,13 +39,13 @@ jobs:
         shell: bash
     steps:
       - name: Dependencies
-        run: apt-get install -y git-lfs
+        run: apt-get install -y git-lfs wget
       - uses: actions/checkout@v2
         with:
           submodules: true
           lfs: true
-      - name: Unpack data files
-        run: data/extract_files.sh
+      - name: Download data files
+        run: data/traccc_data_get_files.sh
       - name: Configure
         run: |
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "data"]
-	path = data
-	url = https://gitlab.cern.ch/acts/traccc-data.git

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ flowchart LR
     linkStyle 24 stroke: brown;
 ```
 
-## Requirements and dependencies 
+## Requirements and dependencies
 
 ### OS & compilers:
 
@@ -178,12 +178,6 @@ and toolchains that are currently known to work (last updated 2022/01/24):
 | Build | OS | gcc | cuda | comment |
 | --- | --- | --- | --- | --- |
 | CUDA | Ubuntu 20.04   | 9.3.0 | 11.5 | runs on CI |
-
-### Data directory
-
-The `data` directory is a submodule hosted as `git lfs` on `https://gitlab.cern.ch/acts/traccc-data`.
-After cloning the submodule, you need to run the script `extract_files.sh`, that is located
-in the submodule checkout. It will unpack the `tar.gz` files which contain the test data.
 
 ### Prerequisites
 
@@ -211,7 +205,7 @@ cmake --build <build_directory> <options>
 
 ### Build options
 
-| Option | Description | 
+| Option | Description |
 | --- | --- |
 | TRACCC_BUILD_CUDA  | Build the CUDA sources included in traccc |
 | TRACCC_BUILD_SYCL  | Build the SYCL sources included in traccc |
@@ -230,7 +224,7 @@ cmake --build <build_directory> <options>
 ### cpu reconstruction chain
 
 ```sh
-<build_directory>/bin/traccc_seq_example --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_pixels/ --events=10 
+<build_directory>/bin/traccc_seq_example --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_pixels/ --events=10
 ```
 
 ### cuda reconstruction chain

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,15 @@
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+#
+cca_test/
+detray_simulation/
+single_module/
+tml_detector/
+tml_full/
+tml_pixel_barrel/
+tml_pixels/
+two_modules/
+*.tar.gz
+*.md5

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,16 @@
+# Data Directory
+
+This subdirectory is what normally holds the data files used by the tests
+and examples.
+
+To download the "default version" of the files (corresponding to the version
+of the code in the repository), just execute
+
+```
+./traccc_data_get_files.sh
+```
+
+without any additional arguments.
+
+To produce a new tarball of data files, use the `traccc_data_package_files.sh`
+script.

--- a/data/traccc_data_get_files.sh
+++ b/data/traccc_data_get_files.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+#
+# Script downloading the traccc data file(s) through HTTPS, and unpacking them.
+#
+
+# Stop on errors.
+set -e
+set -o pipefail
+
+# Function printing the usage information for the script.
+usage() {
+   echo "Script downloading/unpacking data TGZ/MD5 files"
+   echo ""
+   echo "Usage: traccc_data_get_files.sh [options]"
+   echo ""
+   echo "Options:"
+   echo "  -f <filename>        Name of the data file, without its extension"
+   echo "  -d <webDirectory>    Directory holding the data and MD5 files"
+   echo "  -o <dataDirectory>   Main data directory"
+   echo "  -c <cmakeExecutable> CMake executable to use in the script"
+   echo "  -w <curlExecutable>  CUrl executable to use in the script"
+   echo ""
+}
+
+# Default script arguments.
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v1"}
+TRACCC_WEB_DIRECTORY=${TRACCC_WEB_DIRECTORY:-"https://acts.web.cern.ch/traccc/data"}
+TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}
+TRACCC_CMAKE_EXECUTABLE=${TRACCC_CMAKE_EXECUTABLE:-cmake}
+TRACCC_CURL_EXECUTABLE=${TRACCC_CURL_EXECUTABLE:-curl}
+
+# Parse the command line argument(s).
+while getopts ":f:d:o:c:wh" opt; do
+   case $opt in
+      f)
+         TRACCC_DATA_NAME=$OPTARG
+         ;;
+      d)
+         TRACCC_WEB_DIRECTORY=$OPTARG
+         ;;
+      o)
+         TRACCC_DATA_DIRECTORY=$OPTARG
+         ;;
+      c)
+         TRACCC_CMAKE_EXECUTABLE=$OPTARG
+         ;;
+      w)
+         TRACCC_CURL_EXECUTABLE=$OPTARG
+         ;;
+      h)
+         usage
+         exit 0
+         ;;
+      :)
+         echo "Argument -$OPTARG requires a parameter!"
+         usage
+         exit 1
+         ;;
+      ?)
+         echo "Unknown argument: -$OPTARG"
+         usage
+         exit 1
+         ;;
+   esac
+done
+
+# Go into the target directory.
+cd "${TRACCC_DATA_DIRECTORY}"
+
+# Download the TGZ and MD5 files.
+"${TRACCC_CURL_EXECUTABLE}" --retry 5 --retry-connrefused --retry-delay 10 \
+   --output "${TRACCC_DATA_NAME}.tar.gz"                                   \
+   "${TRACCC_WEB_DIRECTORY}/${TRACCC_DATA_NAME}.tar.gz"
+"${TRACCC_CURL_EXECUTABLE}" --retry 5 --retry-connrefused --retry-delay 10 \
+   --output "${TRACCC_DATA_NAME}.md5"                                      \
+   "${TRACCC_WEB_DIRECTORY}/${TRACCC_DATA_NAME}.md5"
+
+# Verify that the download succeeded.
+"${TRACCC_CMAKE_EXECUTABLE}" -E md5sum "${TRACCC_DATA_NAME}.tar.gz" > \
+   "${TRACCC_DATA_NAME}.md5-test"
+"${TRACCC_CMAKE_EXECUTABLE}" -E compare_files "${TRACCC_DATA_NAME}.md5" \
+   "${TRACCC_DATA_NAME}.md5-test"
+
+# Extract the data files.
+"${TRACCC_CMAKE_EXECUTABLE}" -E tar xf "${TRACCC_DATA_NAME}.tar.gz"
+
+# Clean up.
+"${TRACCC_CMAKE_EXECUTABLE}" -E remove "${TRACCC_DATA_NAME}.tar.gz" \
+   "${TRACCC_DATA_NAME}.md5" "${TRACCC_DATA_NAME}.md5-test"
+
+# Leave the user with a message.
+"${TRACCC_CMAKE_EXECUTABLE}" -E echo \
+   "Files from ${TRACCC_DATA_NAME} unpacked under '${TRACCC_DATA_DIRECTORY}'"

--- a/data/traccc_data_package_files.sh
+++ b/data/traccc_data_package_files.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+#
+# Script generating TGZ/MD5 files that could then be uploaded to the ACTS web
+# service.
+#
+
+# Stop on errors.
+set -e
+set -o pipefail
+
+# Function printing the usage information for the script.
+usage() {
+   echo "Script generating data TGZ/MD5 files"
+   echo ""
+   echo "Usage: traccc_data_package_files.sh [options]"
+   echo ""
+   echo "Options:"
+   echo "  -o <outputName>      Set the name of the output file(s)"
+   echo "  -i <inputDirectory>  Additional input directory to pick up"
+   echo "  -d <dataDirectory>   Main data directory"
+   echo "  -c <cmakeExecutable> CMake executable to use in the script"
+   echo ""
+}
+
+# Default script arguments.
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v2"}
+TRACCC_DATA_DIRECTORY_NAMES=("cca_test" "detray_simulation" "single_module"
+   "tml_detector" "tml_full" "tml_pixel_barrel" "tml_pixels" "two_modules")
+TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}
+TRACCC_CMAKE_EXECUTABLE=${TRACCC_CMAKE_EXECUTABLE:-cmake}
+
+# Parse the command line argument(s).
+while getopts ":o:i:d:ch" opt; do
+   case $opt in
+      o)
+         TRACCC_DATA_NAME=$OPTARG
+         ;;
+      i)
+         TRACCC_DATA_DIRECTORY_NAMES+=($OPTARG)
+         ;;
+      d)
+         TRACCC_DATA_DIRECTORY=$OPTARG
+         ;;
+      c)
+         TRACCC_CMAKE_EXECUTABLE=$OPTARG
+         ;;
+      h)
+         usage
+         exit 0
+         ;;
+      :)
+         echo "Argument -$OPTARG requires a parameter!"
+         usage
+         exit 1
+         ;;
+      ?)
+         echo "Unknown argument: -$OPTARG"
+         usage
+         exit 1
+         ;;
+   esac
+done
+
+# Go into the source directory.
+cd "${TRACCC_DATA_DIRECTORY}"
+
+# Compress the directories.
+"${TRACCC_CMAKE_EXECUTABLE}" -E tar czf "${TRACCC_DATA_NAME}.tar.gz" \
+   ${TRACCC_DATA_DIRECTORY_NAMES[@]}
+
+# Generate an MD5 file.
+"${TRACCC_CMAKE_EXECUTABLE}" -E md5sum "${TRACCC_DATA_NAME}.tar.gz" > \
+   "${TRACCC_DATA_NAME}.md5"
+
+# Leave the user with a message.
+"${TRACCC_CMAKE_EXECUTABLE}" -E echo \
+   "Generated files '${TRACCC_DATA_NAME}.tar.gz' and '${TRACCC_DATA_NAME}.md5'"


### PR DESCRIPTION
After the latest round of issues with https://gitlab.cern.ch/acts/traccc-data, this is an alternative proposal for how the project could get the data files that it needs.

The current version of the files were packaged in the "V1 files" under https://acts.web.cern.ch/traccc/data/. Which could be created and downloaded with the 2 scripts included in this PR.

The scripts themselves are pretty bare bones. But they should do the trick in such a basic setup as well. Note for instance that the retry setup for the downloads with `wget` was absolutely necessary. Apparently all CI jobs starting the download at once is pretty heavy traffic for the webserver. :confused: (If we get yelled at for this as well, I'll get **very** upset.) Also note that the error messages are not all super user friendly. For instance in case of a download error, you would get something like:

```
--2023-03-20 18:25:27--  https://acts.web.cern.ch/traccc/data//traccc-data-v1.tar.gz
Resolving acts.web.cern.ch (acts.web.cern.ch)... 2001:1458:d00:62::100:2e8, 2001:1458:d00:16::41d, 2001:1458:d00:19::12e, ...
Connecting to acts.web.cern.ch (acts.web.cern.ch)|2001:1458:d00:62::100:2e8|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 856290640 (817M) [application/x-gzip]
Saving to: ‘traccc-data-v1.tar.gz’

traccc-data-v1.tar.gz                    100%[===============================================================================>] 816.62M  58.9MB/s    in 14s     

2023-03-20 18:25:41 (56.7 MB/s) - ‘traccc-data-v1.tar.gz’ saved [856290640/856290640]

--2023-03-20 18:25:41--  https://acts.web.cern.ch/traccc/data//traccc-data-v1.md5
Resolving acts.web.cern.ch (acts.web.cern.ch)... 2001:1458:d00:62::100:2e8, 2001:1458:d00:16::41d, 2001:1458:d00:19::12e, ...
Connecting to acts.web.cern.ch (acts.web.cern.ch)|2001:1458:d00:62::100:2e8|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 60
Saving to: ‘traccc-data-v1.md5’

traccc-data-v1.md5                       100%[===============================================================================>]      60  --.-KB/s    in 0s      

2023-03-20 18:25:46 (19.6 MB/s) - ‘traccc-data-v1.md5’ saved [60/60]

Files "traccc-data-v1.md5" to "traccc-data-v1.md5-test" are different.
```

But again, making this better did not seem to be important enough... :thinking:

Note that in the CI setup I couldn't remove the installation of git-lfs yet. Since the CI for this PR still needs to get the HEAD of the main branch first as it seems, before switching to my branch. But once/if this all goes into the main branch, we'll be able to remove the installation of git-lfs from the CI recipe.