### PR TITLE
Add a very simple pair type constructor

### DIFF
--- a/core/include/traccc/edm/details/container_base.hpp
+++ b/core/include/traccc/edm/details/container_base.hpp
@@ -10,12 +10,10 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/details/container_element.hpp"
+#include "traccc/types/pair.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
-
-// Thrust include(s).
-#include <thrust/pair.h>
 
 // System include(s).
 #include <cassert>
@@ -38,7 +36,7 @@ namespace traccc {
 template <typename header_t, typename item_t,
           template <typename> class vector_t,
           template <typename> class jagged_vector_t,
-          template <typename, typename> class pair_t = thrust::pair>
+          template <typename, typename> class pair_t = pair>
 class container_base {
     public:
     /// @name Type definitions

--- a/core/include/traccc/types/pair.hpp
+++ b/core/include/traccc/types/pair.hpp
@@ -1,0 +1,38 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <traccc/definitions/qualifiers.hpp>
+#include <type_traits>
+
+namespace traccc {
+/**
+ * @brief A simple pair type.
+ */
+template <typename T1, typename T2>
+struct pair {
+    public:
+    using first_type = T1;
+    using second_type = T2;
+
+    TRACCC_HOST_DEVICE constexpr pair() {}
+
+    TRACCC_HOST_DEVICE constexpr pair(const T1& _v1, const T2& _v2)
+        : first(_v1), second(_v2) {}
+
+    template <typename S1, typename S2,
+              std::enable_if_t<std::is_constructible_v<T1, const S1&> &&
+                                   std::is_constructible_v<T2, const S2&>,
+                               bool> = true>
+    TRACCC_HOST_DEVICE constexpr pair(const pair<S1, S2>& p)
+        : first(p.first), second(p.second) {}
+
+    T1 first;
+    T2 second;
+};
+}  // namespace traccc

--- a/device/common/include/traccc/device/fill_prefix_sum.hpp
+++ b/device/common/include/traccc/device/fill_prefix_sum.hpp
@@ -10,18 +10,16 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/container.hpp"
+#include "traccc/types/pair.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/utils/copy.hpp>
 
-// Thrust include(s).
-#include <thrust/pair.h>
-
 namespace traccc::device {
 
 /// Type for the individual elements in the prefix sum vector
-typedef thrust::pair<std::size_t, std::size_t> prefix_sum_element_t;
+typedef pair<std::size_t, std::size_t> prefix_sum_element_t;
 
 /// Convenience type definition for the return value of the helper function
 typedef vecmem::vector<prefix_sum_element_t> prefix_sum_t;


### PR DESCRIPTION
This negates the need for using Thrust unconditionally, as discussed in PR #354.