### PR TITLE
Add concurrency group for `build` CI jobs

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   builds:
     name: ${{ matrix.platform.name }}-${{ matrix.build }}


### PR DESCRIPTION
We currently build the entirety of the software whenever someone pushes to a branch that is linked to a PR. This is useful, but there are cases where development outpaces the rate at which the CI runs. In such cases, we run multiple CI jobs for the same PR at the same time, which occupies resources that could be spent elsewhere (thus making the CI run more slowly) and, not unimportantly, wastes electricity.

This commit adds the `build` CI jobs to a concurrency group that ensures that any running builds will be automatically cancelled if a new commit is pushed to an existing pull request.