### PR TITLE
WIP: Change sycl chain to use async copying and an ordered queue

### DIFF
--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -37,12 +37,14 @@ class clusterization_algorithm
     /// Constructor for clusterization algorithm
     ///
     /// @param mr is a struct of memory resources (shared or host & device)
+    /// @param copy The copy object to use for copying data between device
+    ///             and host memory blocks
     /// @param queue is a wrapper for the for the sycl queue for kernel
     /// invocation
     /// @param target_cells_per_partition the average number of cells in each
     /// partition
     clusterization_algorithm(const traccc::memory_resource& mr,
-                             queue_wrapper queue,
+                             vecmem::copy& copy, queue_wrapper queue,
                              const unsigned short target_cells_per_partition);
 
     /// @param cells        a collection of cells
@@ -61,7 +63,7 @@ class clusterization_algorithm
 
     traccc::memory_resource m_mr;
     mutable queue_wrapper m_queue;
-    std::unique_ptr<vecmem::copy> m_copy;
+    vecmem::copy& m_copy;
 };
 
 }  // namespace traccc::sycl

--- a/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seed_finding.hpp
@@ -39,11 +39,14 @@ class seed_finding : public algorithm<alt_seed_collection_types::buffer(
     /// @param filter_config is seed filter configuration parameters
     /// @param mr       is a struct of memory resources (shared or
     /// host & device)
+    /// @param copy The copy object to use for copying data between device
+    ///             and host memory blocks
     /// @param queue    is a wrapper for the sycl queue for kernel
     /// invocation
     seed_finding(const seedfinder_config& config,
                  const seedfilter_config& filter_config,
-                 const traccc::memory_resource& mr, queue_wrapper queue);
+                 const traccc::memory_resource& mr, vecmem::copy& copy,
+                 queue_wrapper queue);
 
     /// Callable operator for the seed finding
     ///
@@ -61,7 +64,7 @@ class seed_finding : public algorithm<alt_seed_collection_types::buffer(
     seedfilter_config m_seedfilter_config;
     traccc::memory_resource m_mr;
     mutable queue_wrapper m_queue;
-    std::unique_ptr<vecmem::copy> m_copy;
+    vecmem::copy& m_copy;
 };
 
 }  // namespace traccc::sycl

--- a/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp
@@ -19,6 +19,7 @@
 
 // VecMem include(s).
 #include <vecmem/containers/data/vector_buffer.hpp>
+#include <vecmem/utils/copy.hpp>
 
 // traccc library include(s).
 #include "traccc/utils/memory_resource.hpp"
@@ -35,7 +36,7 @@ class seeding_algorithm : public algorithm<alt_seed_collection_types::buffer(
     /// @param mr is a struct of memory resources (shared or host & device)
     /// @param queue The SYCL queue to work with
     ///
-    seeding_algorithm(const traccc::memory_resource& mr,
+    seeding_algorithm(const traccc::memory_resource& mr, vecmem::copy& copy,
                       const queue_wrapper& queue);
 
     /// Operator executing the algorithm.

--- a/device/sycl/include/traccc/sycl/seeding/spacepoint_binning.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/spacepoint_binning.hpp
@@ -36,7 +36,8 @@ class spacepoint_binning
     /// Constructor for the algorithm
     spacepoint_binning(const seedfinder_config& config,
                        const spacepoint_grid_config& grid_config,
-                       const traccc::memory_resource& mr, queue_wrapper queue);
+                       const traccc::memory_resource& mr, vecmem::copy& copy,
+                       queue_wrapper queue);
 
     /// Function executing the algorithm with a a view of spacepoints
     sp_grid_buffer operator()(const spacepoint_collection_types::const_view&
@@ -48,7 +49,7 @@ class spacepoint_binning
     std::pair<sp_grid::axis_p0_type, sp_grid::axis_p1_type> m_axes;
     traccc::memory_resource m_mr;
     mutable queue_wrapper m_queue;
-    std::unique_ptr<vecmem::copy> m_copy;
+    vecmem::copy& m_copy;
 
 };  // class spacepoint_binning
 

--- a/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
@@ -37,10 +37,12 @@ struct track_params_estimation
     ///
     /// @param mr       is a struct of memory resources (shared or
     /// host & device)
+    /// @param copy The copy object to use for copying data between device
+    ///             and host memory blocks
     /// @param queue    is a wrapper for the sycl queue for kernel
     /// invocation
     track_params_estimation(const traccc::memory_resource& mr,
-                            queue_wrapper queue);
+                            vecmem::copy& copy, queue_wrapper queue);
 
     /// Callable operator for track_params_esitmation
     ///
@@ -56,7 +58,7 @@ struct track_params_estimation
     // Private member variables
     traccc::memory_resource m_mr;
     mutable queue_wrapper m_queue;
-    std::unique_ptr<vecmem::copy> m_copy;
+    vecmem::copy& m_copy;
 };
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -378,7 +378,7 @@ class ccl_kernel {
 }  // namespace kernels
 
 clusterization_algorithm::clusterization_algorithm(
-    const traccc::memory_resource& mr, queue_wrapper queue,
+    const traccc::memory_resource& mr, vecmem::copy& copy, queue_wrapper queue,
     const unsigned short target_cells_per_partition)
     : m_target_cells_per_partition(target_cells_per_partition),
       m_max_work_group_size(
@@ -386,14 +386,12 @@ clusterization_algorithm::clusterization_algorithm(
               .get_device()
               .get_info<::sycl::info::device::max_work_group_size>()),
       m_mr(mr),
-      m_queue(queue) {
+      m_queue(queue),
+      m_copy(copy) {
 
-    // Initialize m_copy ptr based on memory resources that were given
-    if (mr.host) {
-        m_copy = std::make_unique<vecmem::sycl::copy>(queue.queue());
-    } else {
-        m_copy = std::make_unique<vecmem::copy>();
-    }
+    // This algorithm should only be called using an ordered queue
+    assert(details::get_queue(queue).has_property(
+        ::sycl::property::queue::in_order()));
 }
 
 clusterization_algorithm::output_type clusterization_algorithm::operator()(
@@ -402,7 +400,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
 
     // Number of cells
     const alt_cell_collection_types::view::size_type num_cells =
-        m_copy->get_size(cells);
+        m_copy.get_size(cells);
 
     // Create result object for the CCL kernel with size overestimation
     alt_measurement_collection_types::buffer measurements_buffer(num_cells,
@@ -413,9 +411,8 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     // Counter for number of measurements
     vecmem::unique_alloc_ptr<unsigned int> num_measurements_device =
         vecmem::make_unique_alloc<unsigned int>(m_mr.main);
-    details::get_queue(m_queue)
-        .memset(num_measurements_device.get(), 0, sizeof(unsigned int))
-        .wait_and_throw();
+    details::get_queue(m_queue).memset(num_measurements_device.get(), 0,
+                                       sizeof(unsigned int));
 
     const unsigned short max_cells_per_partition =
         (m_target_cells_per_partition * MAX_CELLS_PER_THREAD +
@@ -445,10 +442,10 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     vecmem::data::vector_buffer<unsigned int> cell_links(num_cells, m_mr.main);
 
     // Run ccl kernel
-    details::get_queue(m_queue)
-        .submit([&ndrange, &cells, &modules, max_cells_per_partition,
-                 &target_cells_per_partition, &measurements_view, &cell_links,
-                 &num_measurements_device](::sycl::handler& h) {
+    details::get_queue(m_queue).submit(
+        [&ndrange, &cells, &modules, max_cells_per_partition,
+         &target_cells_per_partition, &measurements_view, &cell_links,
+         &num_measurements_device](::sycl::handler& h) {
             ::sycl::local_accessor<unsigned int> shared_uint(3, h);
             ::sycl::local_accessor<index_t> shared_idx(
                 2 * max_cells_per_partition, h);
@@ -459,8 +456,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
                              target_cells_per_partition, measurements_view,
                              num_measurements_device.get(), cell_links,
                              shared_uint, shared_idx));
-        })
-        .wait_and_throw();
+        });
 
     // Copy number of measurements to host
     unsigned int num_measurements_host;
@@ -479,18 +475,16 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
         num_measurements_host, m_max_work_group_size);
 
     // Run form spacepoints kernel, turning 2D measurements into 3D spacepoints
-    details::get_queue(m_queue)
-        .submit([&](::sycl::handler& h) {
-            h.parallel_for<kernels::form_spacepoints>(
-                spacepointsRange,
-                [measurements_view, modules, num_measurements_host,
-                 spacepoints_view](::sycl::nd_item<1> item) {
-                    device::form_spacepoints(
-                        item.get_global_linear_id(), measurements_view, modules,
-                        num_measurements_host, spacepoints_view);
-                });
-        })
-        .wait_and_throw();
+    details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+        h.parallel_for<kernels::form_spacepoints>(
+            spacepointsRange,
+            [measurements_view, modules, num_measurements_host,
+             spacepoints_view](::sycl::nd_item<1> item) {
+                device::form_spacepoints(
+                    item.get_global_linear_id(), measurements_view, modules,
+                    num_measurements_host, spacepoints_view);
+            });
+    });
 
     return {std::move(spacepoints_buffer), std::move(cell_links)};
 }

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -31,9 +31,6 @@
 #include "traccc/seeding/device/select_seeds.hpp"
 #include "traccc/seeding/device/update_triplet_weights.hpp"
 
-// VecMem include(s).
-#include "vecmem/utils/sycl/copy.hpp"
-
 namespace traccc::sycl {
 namespace kernels {
 
@@ -65,18 +62,16 @@ class select_seeds;
 seed_finding::seed_finding(const seedfinder_config& config,
                            const seedfilter_config& filter_config,
                            const traccc::memory_resource& mr,
-                           queue_wrapper queue)
+                           vecmem::copy& copy, queue_wrapper queue)
     : m_seedfinder_config(config.toInternalUnits()),
       m_seedfilter_config(filter_config.toInternalUnits()),
       m_mr(mr),
-      m_queue(queue) {
+      m_queue(queue),
+      m_copy(copy) {
 
-    // Initialize m_copy ptr based on memory resources that were given
-    if (mr.host) {
-        m_copy = std::make_unique<vecmem::sycl::copy>(queue.queue());
-    } else {
-        m_copy = std::make_unique<vecmem::copy>();
-    }
+    // This algorithm should only be called using an ordered queue
+    assert(details::get_queue(m_queue).has_property(
+        ::sycl::property::queue::in_order()));
 }
 
 seed_finding::output_type seed_finding::operator()(
@@ -84,18 +79,18 @@ seed_finding::output_type seed_finding::operator()(
     const sp_grid_const_view& g2_view) const {
 
     // Get the sizes from the grid view
-    auto grid_sizes = m_copy->get_sizes(g2_view._data_view);
+    auto grid_sizes = m_copy.get_sizes(g2_view._data_view);
 
     // Create prefix sum buffer and its view
     vecmem::data::vector_buffer sp_grid_prefix_sum_buff = make_prefix_sum_buff(
-        grid_sizes, *m_copy, m_mr, details::get_queue(m_queue));
+        grid_sizes, m_copy, m_mr, details::get_queue(m_queue));
     vecmem::data::vector_view<device::prefix_sum_element_t>
         sp_grid_prefix_sum_view = sp_grid_prefix_sum_buff;
 
     // Set up the doublet counter buffer.
     device::doublet_counter_collection_types::buffer doublet_counter_buffer = {
-        m_copy->get_size(sp_grid_prefix_sum_view), 0, m_mr.main};
-    m_copy->setup(doublet_counter_buffer);
+        m_copy.get_size(sp_grid_prefix_sum_view), 0, m_mr.main};
+    m_copy.setup(doublet_counter_buffer);
 
     // Counter for the total number of doublets and triplets
     vecmem::unique_alloc_ptr<device::seeding_global_counter>
@@ -103,36 +98,31 @@ seed_finding::output_type seed_finding::operator()(
             vecmem::make_unique_alloc<device::seeding_global_counter>(
                 m_mr.main);
 
-    details::get_queue(m_queue)
-        .memset(globalCounter_device.get(), 0,
-                sizeof(device::seeding_global_counter))
-        .wait_and_throw();
+    details::get_queue(m_queue).memset(globalCounter_device.get(), 0,
+                                       sizeof(device::seeding_global_counter));
 
     // Calculate the range to run the doublet counting for.
     static constexpr unsigned int doubletCountLocalSize = 32 * 2;
     auto doubletCountRange = traccc::sycl::calculate1DimNdRange(
-        m_copy->get_size(sp_grid_prefix_sum_view), doubletCountLocalSize);
+        m_copy.get_size(sp_grid_prefix_sum_view), doubletCountLocalSize);
 
     // Count the number of doublets that we need to produce.
     device::doublet_counter_collection_types::view doublet_counter_view =
         doublet_counter_buffer;
 
     auto aux_globalCounter = globalCounter_device.get();
-    details::get_queue(m_queue)
-        .submit([&](::sycl::handler& h) {
-            h.parallel_for<kernels::count_doublets>(
-                doubletCountRange,
-                [config = m_seedfinder_config, g2_view, sp_grid_prefix_sum_view,
-                 doublet_counter_view,
-                 aux_globalCounter](::sycl::nd_item<1> item) {
-                    device::count_doublets(item.get_global_linear_id(), config,
-                                           g2_view, sp_grid_prefix_sum_view,
-                                           doublet_counter_view,
-                                           (*aux_globalCounter).m_nMidBot,
-                                           (*aux_globalCounter).m_nMidTop);
-                });
-        })
-        .wait_and_throw();
+    details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+        h.parallel_for<kernels::count_doublets>(
+            doubletCountRange,
+            [config = m_seedfinder_config, g2_view, sp_grid_prefix_sum_view,
+             doublet_counter_view, aux_globalCounter](::sycl::nd_item<1> item) {
+                device::count_doublets(item.get_global_linear_id(), config,
+                                       g2_view, sp_grid_prefix_sum_view,
+                                       doublet_counter_view,
+                                       (*aux_globalCounter).m_nMidBot,
+                                       (*aux_globalCounter).m_nMidTop);
+            });
+    });
 
     // Get the summary values.
     device::seeding_global_counter globalCounter_host;
@@ -144,42 +134,41 @@ seed_finding::output_type seed_finding::operator()(
     // Set up the doublet buffers.
     device::device_doublet_collection_types::buffer doublet_buffer_mb = {
         globalCounter_host.m_nMidBot, m_mr.main};
-    m_copy->setup(doublet_buffer_mb);
+    m_copy.setup(doublet_buffer_mb);
     device::device_doublet_collection_types::buffer doublet_buffer_mt = {
         globalCounter_host.m_nMidTop, m_mr.main};
-    m_copy->setup(doublet_buffer_mt);
+    m_copy.setup(doublet_buffer_mt);
 
     // Calculate the range to run the doublet finding for.
     static constexpr unsigned int doubletFindLocalSize = 32 * 2;
     const unsigned int doublet_counter_buffer_size =
-        m_copy->get_size(doublet_counter_view);
+        m_copy.get_size(doublet_counter_view);
     auto doubletFindRange = traccc::sycl::calculate1DimNdRange(
         doublet_counter_buffer_size, doubletFindLocalSize);
 
     // Find all of the spacepoint doublets.
     device::device_doublet_collection_types::view mb_view = doublet_buffer_mb;
     device::device_doublet_collection_types::view mt_view = doublet_buffer_mt;
-    auto find_doublets_kernel =
-        details::get_queue(m_queue).submit([&](::sycl::handler& h) {
-            h.parallel_for<kernels::find_doublets>(
-                doubletFindRange,
-                [config = m_seedfinder_config, g2_view, doublet_counter_view,
-                 mb_view, mt_view](::sycl::nd_item<1> item) {
-                    device::find_doublets(item.get_global_linear_id(), config,
-                                          g2_view, doublet_counter_view,
-                                          mb_view, mt_view);
-                });
-        });
+    details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+        h.parallel_for<kernels::find_doublets>(
+            doubletFindRange,
+            [config = m_seedfinder_config, g2_view, doublet_counter_view,
+             mb_view, mt_view](::sycl::nd_item<1> item) {
+                device::find_doublets(item.get_global_linear_id(), config,
+                                      g2_view, doublet_counter_view, mb_view,
+                                      mt_view);
+            });
+    });
 
     // Set up the triplet counter buffers and their views
     device::triplet_counter_spM_collection_types::buffer
         triplet_counter_spM_buffer = {doublet_counter_buffer_size, m_mr.main};
-    m_copy->setup(triplet_counter_spM_buffer);
-    m_copy->memset(triplet_counter_spM_buffer, 0);
+    m_copy.setup(triplet_counter_spM_buffer);
+    m_copy.memset(triplet_counter_spM_buffer, 0);
     device::triplet_counter_collection_types::buffer
         triplet_counter_midBot_buffer = {globalCounter_host.m_nMidBot, 0,
                                          m_mr.main};
-    m_copy->setup(triplet_counter_midBot_buffer);
+    m_copy.setup(triplet_counter_midBot_buffer);
 
     device::triplet_counter_spM_collection_types::view
         triplet_counter_spM_view = triplet_counter_spM_buffer;
@@ -191,46 +180,36 @@ seed_finding::output_type seed_finding::operator()(
     auto tripletCountRange = traccc::sycl::calculate1DimNdRange(
         globalCounter_host.m_nMidBot, tripletCountLocalSize);
 
-    // Wait here for the find_doublets kernel to finish
-    find_doublets_kernel.wait_and_throw();
-
     // Count the number of triplets that we need to produce.
-    auto count_triplets_kernel =
-        details::get_queue(m_queue).submit([&](::sycl::handler& h) {
-            h.parallel_for<kernels::count_triplets>(
-                tripletCountRange,
-                [config = m_seedfinder_config, g2_view, doublet_counter_view,
-                 mb_view, mt_view, triplet_counter_spM_view,
-                 triplet_counter_midBot_view](::sycl::nd_item<1> item) {
-                    device::count_triplets(
-                        item.get_global_linear_id(), config, g2_view,
-                        doublet_counter_view, mb_view, mt_view,
-                        triplet_counter_spM_view, triplet_counter_midBot_view);
-                });
-        });
+    details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+        h.parallel_for<kernels::count_triplets>(
+            tripletCountRange,
+            [config = m_seedfinder_config, g2_view, doublet_counter_view,
+             mb_view, mt_view, triplet_counter_spM_view,
+             triplet_counter_midBot_view](::sycl::nd_item<1> item) {
+                device::count_triplets(item.get_global_linear_id(), config,
+                                       g2_view, doublet_counter_view, mb_view,
+                                       mt_view, triplet_counter_spM_view,
+                                       triplet_counter_midBot_view);
+            });
+    });
 
     // Calculate the range to run the triplet count reduction for.
     static constexpr unsigned int reduceTripletCountsLocalSize = 32 * 2;
     auto reduceTripletCountsRange = traccc::sycl::calculate1DimNdRange(
         doublet_counter_buffer_size, reduceTripletCountsLocalSize);
 
-    // Wait here for the count triplets kernel to finish
-    count_triplets_kernel.wait_and_throw();
-
     // Reduce the triplet counts per spM.
-    details::get_queue(m_queue)
-        .submit([&](::sycl::handler& h) {
-            h.parallel_for<kernels::reduce_triplet_counts>(
-                reduceTripletCountsRange,
-                [doublet_counter_view, triplet_counter_spM_view,
-                 aux_globalCounter](::sycl::nd_item<1> item) {
-                    device::reduce_triplet_counts(
-                        item.get_global_linear_id(), doublet_counter_view,
-                        triplet_counter_spM_view,
-                        (*aux_globalCounter).m_nTriplets);
-                });
-        })
-        .wait_and_throw();
+    details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+        h.parallel_for<kernels::reduce_triplet_counts>(
+            reduceTripletCountsRange,
+            [doublet_counter_view, triplet_counter_spM_view,
+             aux_globalCounter](::sycl::nd_item<1> item) {
+                device::reduce_triplet_counts(
+                    item.get_global_linear_id(), doublet_counter_view,
+                    triplet_counter_spM_view, (*aux_globalCounter).m_nTriplets);
+            });
+    });
 
     details::get_queue(m_queue)
         .memcpy(&globalCounter_host, globalCounter_device.get(),
@@ -240,39 +219,33 @@ seed_finding::output_type seed_finding::operator()(
     // Set up the triplet buffer and its view
     device::device_triplet_collection_types::buffer triplet_buffer = {
         globalCounter_host.m_nTriplets, m_mr.main};
-    m_copy->setup(triplet_buffer);
+    m_copy.setup(triplet_buffer);
     device::device_triplet_collection_types::view triplet_view = triplet_buffer;
 
     // Calculate the range to run the triplet finding for
     static constexpr unsigned int tripletFindLocalSize = 32 * 2;
     auto tripletFindRange = traccc::sycl::calculate1DimNdRange(
-        m_copy->get_size(triplet_counter_midBot_view), tripletFindLocalSize);
+        m_copy.get_size(triplet_counter_midBot_view), tripletFindLocalSize);
 
     // Find all of the spacepoint triplets.
-    auto find_triplets_kernel =
-        details::get_queue(m_queue).submit([&](::sycl::handler& h) {
-            h.parallel_for<kernels::find_triplets>(
-                tripletFindRange,
-                [config = m_seedfinder_config,
-                 filter_config = m_seedfilter_config, g2_view,
-                 doublet_counter_view, mt_view, triplet_counter_spM_view,
-                 triplet_counter_midBot_view,
-                 triplet_view](::sycl::nd_item<1> item) {
-                    device::find_triplets(
-                        item.get_global_linear_id(), config, filter_config,
-                        g2_view, doublet_counter_view, mt_view,
-                        triplet_counter_spM_view, triplet_counter_midBot_view,
-                        triplet_view);
-                });
-        });
+    details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+        h.parallel_for<kernels::find_triplets>(
+            tripletFindRange,
+            [config = m_seedfinder_config, filter_config = m_seedfilter_config,
+             g2_view, doublet_counter_view, mt_view, triplet_counter_spM_view,
+             triplet_counter_midBot_view,
+             triplet_view](::sycl::nd_item<1> item) {
+                device::find_triplets(
+                    item.get_global_linear_id(), config, filter_config, g2_view,
+                    doublet_counter_view, mt_view, triplet_counter_spM_view,
+                    triplet_counter_midBot_view, triplet_view);
+            });
+    });
 
     // Calculate the range to run the weight updating for
     static constexpr unsigned int weightUpdatingLocalSize = 32 * 2;
     auto weightUpdatingRange = traccc::sycl::calculate1DimNdRange(
         globalCounter_host.m_nTriplets, weightUpdatingLocalSize);
-
-    // Wait here for the find_triplets kernel to finish
-    find_triplets_kernel.wait_and_throw();
 
     // Check if device is capable of allocating sufficient local memory
     assert(sizeof(scalar) * m_seedfilter_config.compatSeedLimit *
@@ -282,43 +255,38 @@ seed_finding::output_type seed_finding::operator()(
                .get_info<::sycl::info::device::local_mem_size>());
 
     // Update the weight of all of the spacepoint triplets.
-    auto update_weights_kernel =
-        details::get_queue(m_queue).submit([&](::sycl::handler& h) {
-            // Array for temporary storage of triplet weights for comparing
-            // within kernel
-            ::sycl::local_accessor<scalar> local_mem(
-                m_seedfilter_config.compatSeedLimit * weightUpdatingLocalSize,
-                h);
+    details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+        // Array for temporary storage of triplet weights for comparing
+        // within kernel
+        ::sycl::local_accessor<scalar> local_mem(
+            m_seedfilter_config.compatSeedLimit * weightUpdatingLocalSize, h);
 
-            h.parallel_for<kernels::update_triplet_weights>(
-                weightUpdatingRange,
-                [filter_config = m_seedfilter_config, g2_view,
-                 triplet_counter_spM_view, triplet_counter_midBot_view,
-                 local_mem, triplet_view](::sycl::nd_item<1> item) {
-                    // Each thread uses compatSeedLimit elements of the array
-                    scalar* dataPos = &local_mem[item.get_local_id() *
-                                                 filter_config.compatSeedLimit];
+        h.parallel_for<kernels::update_triplet_weights>(
+            weightUpdatingRange,
+            [filter_config = m_seedfilter_config, g2_view,
+             triplet_counter_spM_view, triplet_counter_midBot_view, local_mem,
+             triplet_view](::sycl::nd_item<1> item) {
+                // Each thread uses compatSeedLimit elements of the array
+                scalar* dataPos = &local_mem[item.get_local_id() *
+                                             filter_config.compatSeedLimit];
 
-                    device::update_triplet_weights(
-                        item.get_global_linear_id(), filter_config, g2_view,
-                        triplet_counter_spM_view, triplet_counter_midBot_view,
-                        dataPos, triplet_view);
-                });
-        });
+                device::update_triplet_weights(
+                    item.get_global_linear_id(), filter_config, g2_view,
+                    triplet_counter_spM_view, triplet_counter_midBot_view,
+                    dataPos, triplet_view);
+            });
+    });
 
     // Create seed buffer object and its view
     alt_seed_collection_types::buffer seed_buffer(
         globalCounter_host.m_nTriplets, 0, m_mr.main);
-    m_copy->setup(seed_buffer);
+    m_copy.setup(seed_buffer);
     alt_seed_collection_types::view seed_view(seed_buffer);
 
     // Calculate the range to run the seed selecting for
     static constexpr unsigned int seedSelectingLocalSize = 32 * 2;
     auto seedSelectingRange = traccc::sycl::calculate1DimNdRange(
         doublet_counter_buffer_size, seedSelectingLocalSize);
-
-    // Wait here for the update_weights kernel to finish
-    update_weights_kernel.wait_and_throw();
 
     // Check if device is capable of allocating sufficient local memory
     assert(sizeof(triplet) * m_seedfilter_config.max_triplets_per_spM *
@@ -328,33 +296,30 @@ seed_finding::output_type seed_finding::operator()(
                .get_info<::sycl::info::device::local_mem_size>());
 
     // Create seeds out of selected triplets
-    details::get_queue(m_queue)
-        .submit([&](::sycl::handler& h) {
-            // Array for temporary storage of triplets for comparing within
-            // kernel
-            ::sycl::local_accessor<triplet> local_mem(
-                m_seedfilter_config.max_triplets_per_spM *
-                    seedSelectingLocalSize,
-                h);
+    details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+        // Array for temporary storage of triplets for comparing within
+        // kernel
+        ::sycl::local_accessor<triplet> local_mem(
+            m_seedfilter_config.max_triplets_per_spM * seedSelectingLocalSize,
+            h);
 
-            h.parallel_for<kernels::select_seeds>(
-                seedSelectingRange,
-                [filter_config = m_seedfilter_config, spacepoints_view, g2_view,
-                 triplet_counter_spM_view, triplet_counter_midBot_view,
-                 triplet_view, local_mem, seed_view](::sycl::nd_item<1> item) {
-                    // Each thread uses compatSeedLimit elements of the array
-                    triplet* dataPos =
-                        &local_mem[item.get_local_id() *
-                                   filter_config.max_triplets_per_spM];
+        h.parallel_for<kernels::select_seeds>(
+            seedSelectingRange,
+            [filter_config = m_seedfilter_config, spacepoints_view, g2_view,
+             triplet_counter_spM_view, triplet_counter_midBot_view,
+             triplet_view, local_mem, seed_view](::sycl::nd_item<1> item) {
+                // Each thread uses compatSeedLimit elements of the array
+                triplet* dataPos =
+                    &local_mem[item.get_local_id() *
+                               filter_config.max_triplets_per_spM];
 
-                    device::select_seeds(item.get_global_linear_id(),
-                                         filter_config, spacepoints_view,
-                                         g2_view, triplet_counter_spM_view,
-                                         triplet_counter_midBot_view,
-                                         triplet_view, dataPos, seed_view);
-                });
-        })
-        .wait_and_throw();
+                device::select_seeds(item.get_global_linear_id(), filter_config,
+                                     spacepoints_view, g2_view,
+                                     triplet_counter_spM_view,
+                                     triplet_counter_midBot_view, triplet_view,
+                                     dataPos, seed_view);
+            });
+    });
 
     return seed_buffer;
 }

--- a/device/sycl/src/seeding/seeding_algorithm.cpp
+++ b/device/sycl/src/seeding/seeding_algorithm.cpp
@@ -59,10 +59,11 @@ traccc::spacepoint_grid_config default_spacepoint_grid_config() {
 namespace traccc::sycl {
 
 seeding_algorithm::seeding_algorithm(const traccc::memory_resource& mr,
+                                     vecmem::copy& copy,
                                      const queue_wrapper& queue)
     : m_spacepoint_binning(default_seedfinder_config(),
-                           default_spacepoint_grid_config(), mr, queue),
-      m_seed_finding(default_seedfinder_config(), seedfilter_config(), mr,
+                           default_spacepoint_grid_config(), mr, copy, queue),
+      m_seed_finding(default_seedfinder_config(), seedfilter_config(), mr, copy,
                      queue) {}
 
 seeding_algorithm::output_type seeding_algorithm::operator()(

--- a/device/sycl/src/seeding/spacepoint_binning.sycl
+++ b/device/sycl/src/seeding/spacepoint_binning.sycl
@@ -16,9 +16,6 @@
 #include "traccc/seeding/device/count_grid_capacities.hpp"
 #include "traccc/seeding/device/populate_grid.hpp"
 
-// VecMem include(s).
-#include <vecmem/utils/sycl/copy.hpp>
-
 // SYCL include(s).
 #include <CL/sycl.hpp>
 
@@ -36,34 +33,32 @@ class populate_grid;
 
 spacepoint_binning::spacepoint_binning(
     const seedfinder_config& config, const spacepoint_grid_config& grid_config,
-    const traccc::memory_resource& mr, queue_wrapper queue)
+    const traccc::memory_resource& mr, vecmem::copy& copy, queue_wrapper queue)
     : m_config(config.toInternalUnits()),
       m_axes(get_axes(grid_config.toInternalUnits(),
                       (mr.host ? *(mr.host) : mr.main))),
       m_mr(mr),
-      m_queue(queue) {
+      m_queue(queue),
+      m_copy(copy) {
 
-    // Initialize m_copy ptr based on memory resources that were given
-    if (mr.host) {
-        m_copy = std::make_unique<vecmem::sycl::copy>(queue.queue());
-    } else {
-        m_copy = std::make_unique<vecmem::copy>();
-    }
+    // This algorithm should only be called using an ordered queue
+    assert(details::get_queue(m_queue).has_property(
+        ::sycl::property::queue::in_order()));
 }
 
 sp_grid_buffer spacepoint_binning::operator()(
     const spacepoint_collection_types::const_view& spacepoints_view) const {
 
     // Get the spacepoint sizes from the view
-    auto sp_size = m_copy->get_size(spacepoints_view);
+    auto sp_size = m_copy.get_size(spacepoints_view);
 
     // Set up the container that will be filled with the required capacities for
     // the spacepoint grid.
     const std::size_t grid_bins = m_axes.first.n_bins * m_axes.second.n_bins;
     vecmem::data::vector_buffer<unsigned int> grid_capacities_buff(grid_bins,
                                                                    m_mr.main);
-    m_copy->setup(grid_capacities_buff);
-    m_copy->memset(grid_capacities_buff, 0);
+    m_copy.setup(grid_capacities_buff);
+    m_copy.memset(grid_capacities_buff, 0);
     vecmem::data::vector_view<unsigned int> grid_capacities_view =
         grid_capacities_buff;
 
@@ -72,24 +67,22 @@ sp_grid_buffer spacepoint_binning::operator()(
     auto range = traccc::sycl::calculate1DimNdRange(sp_size, localSize);
 
     // Fill the grid capacity container.
-    details::get_queue(m_queue)
-        .submit([&](::sycl::handler& h) {
-            h.parallel_for<kernels::count_grid_capacities>(
-                range, [config = m_config, phi_axis = m_axes.first,
-                        z_axis = m_axes.second, spacepoints = spacepoints_view,
-                        grid_capacities =
-                            grid_capacities_view](::sycl::nd_item<1> item) {
-                    device::count_grid_capacities(item.get_global_linear_id(),
-                                                  config, phi_axis, z_axis,
-                                                  spacepoints, grid_capacities);
-                });
-        })
-        .wait_and_throw();
+    details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+        h.parallel_for<kernels::count_grid_capacities>(
+            range,
+            [config = m_config, phi_axis = m_axes.first, z_axis = m_axes.second,
+             spacepoints = spacepoints_view,
+             grid_capacities = grid_capacities_view](::sycl::nd_item<1> item) {
+                device::count_grid_capacities(item.get_global_linear_id(),
+                                              config, phi_axis, z_axis,
+                                              spacepoints, grid_capacities);
+            });
+    });
 
     // Copy grid capacities back to the host
     vecmem::vector<unsigned int> grid_capacities_host(m_mr.host ? m_mr.host
                                                                 : &(m_mr.main));
-    (*m_copy)(grid_capacities_buff, grid_capacities_host);
+    m_copy(grid_capacities_buff, grid_capacities_host)->wait();
 
     // Create the grid buffer and its view
     sp_grid_buffer grid_buffer(
@@ -97,20 +90,18 @@ sp_grid_buffer spacepoint_binning::operator()(
         std::vector<std::size_t>(grid_capacities_host.begin(),
                                  grid_capacities_host.end()),
         m_mr.main, m_mr.host);
-    m_copy->setup(grid_buffer._buffer);
+    m_copy.setup(grid_buffer._buffer);
     sp_grid_view grid_view = grid_buffer;
 
     // Populate the grid.
-    details::get_queue(m_queue)
-        .submit([&](::sycl::handler& h) {
-            h.parallel_for<kernels::populate_grid>(
-                range, [config = m_config, spacepoints = spacepoints_view,
-                        grid = grid_view](::sycl::nd_item<1> item) {
-                    device::populate_grid(item.get_global_linear_id(), config,
-                                          spacepoints, grid);
-                });
-        })
-        .wait_and_throw();
+    details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+        h.parallel_for<kernels::populate_grid>(
+            range, [config = m_config, spacepoints = spacepoints_view,
+                    grid = grid_view](::sycl::nd_item<1> item) {
+                device::populate_grid(item.get_global_linear_id(), config,
+                                      spacepoints, grid);
+            });
+    });
 
     // Return the freshly filled buffer.
     return grid_buffer;

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -25,15 +25,12 @@ class estimate_track_params;
 }  // namespace kernels
 
 track_params_estimation::track_params_estimation(
-    const traccc::memory_resource& mr, queue_wrapper queue)
-    : m_mr(mr), m_queue(queue) {
+    const traccc::memory_resource& mr, vecmem::copy& copy, queue_wrapper queue)
+    : m_mr(mr), m_queue(queue), m_copy(copy) {
 
-    // Initialize m_copy ptr based on memory resources that were given
-    if (mr.host) {
-        m_copy = std::make_unique<vecmem::sycl::copy>(queue.queue());
-    } else {
-        m_copy = std::make_unique<vecmem::copy>();
-    }
+    // This algorithm should only be called using an ordered queue
+    assert(details::get_queue(m_queue).has_property(
+        ::sycl::property::queue::in_order()));
 }
 
 track_params_estimation::output_type track_params_estimation::operator()(
@@ -41,12 +38,12 @@ track_params_estimation::output_type track_params_estimation::operator()(
     const alt_seed_collection_types::const_view& seeds_view) const {
 
     // Get the size of the seeds view
-    auto seeds_size = m_copy->get_size(seeds_view);
+    auto seeds_size = m_copy.get_size(seeds_view);
 
     // Create device buffer for the parameters
     bound_track_parameters_collection_types::buffer params_buffer(seeds_size,
                                                                   m_mr.main);
-    m_copy->setup(params_buffer);
+    m_copy.setup(params_buffer);
 
     // Check if anything needs to be done.
     if (seeds_size == 0) {
@@ -64,17 +61,15 @@ track_params_estimation::output_type track_params_estimation::operator()(
     auto trackParamsNdRange =
         traccc::sycl::calculate1DimNdRange(seeds_size, localSize);
 
-    details::get_queue(m_queue)
-        .submit([&](::sycl::handler& h) {
-            h.parallel_for<kernels::estimate_track_params>(
-                trackParamsNdRange, [spacepoints_view, seeds_view,
-                                     params_view](::sycl::nd_item<1> item) {
-                    device::estimate_track_params(item.get_global_linear_id(),
-                                                  spacepoints_view, seeds_view,
-                                                  params_view);
-                });
-        })
-        .wait_and_throw();
+    details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+        h.parallel_for<kernels::estimate_track_params>(
+            trackParamsNdRange, [spacepoints_view, seeds_view,
+                                 params_view](::sycl::nd_item<1> item) {
+                device::estimate_track_params(item.get_global_linear_id(),
+                                              spacepoints_view, seeds_view,
+                                              params_view);
+            });
+    });
 
     return params_buffer;
 }

--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -18,7 +18,7 @@
 #include <vecmem/memory/binary_page_memory_resource.hpp>
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/memory/sycl/device_memory_resource.hpp>
-#include <vecmem/utils/sycl/copy.hpp>
+#include <vecmem/utils/sycl/async_copy.hpp>
 
 // System include(s).
 #include <memory>
@@ -81,7 +81,7 @@ class full_chain_algorithm
     /// Device caching memory resource
     std::unique_ptr<vecmem::binary_page_memory_resource> m_cached_device_mr;
     /// Memory copy object
-    mutable std::unique_ptr<vecmem::sycl::copy> m_copy;
+    mutable vecmem::sycl::async_copy m_copy;
 
     /// @name Sub-algorithms used by this full-chain algorithm
     /// @{

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -43,20 +43,21 @@ struct full_chain_algorithm_data {
 full_chain_algorithm::full_chain_algorithm(
     vecmem::memory_resource& host_mr,
     const unsigned short target_cells_per_partition)
-    : m_data(new details::full_chain_algorithm_data{{::handle_async_error}}),
+    : m_data(new details::full_chain_algorithm_data{
+          {::handle_async_error, ::sycl::property::queue::in_order()}}),
       m_host_mr(host_mr),
       m_device_mr(std::make_unique<vecmem::sycl::device_memory_resource>(
           &(m_data->m_queue))),
       m_cached_device_mr(
           std::make_unique<vecmem::binary_page_memory_resource>(*m_device_mr)),
-      m_copy(std::make_unique<vecmem::sycl::copy>(&(m_data->m_queue))),
+      m_copy(&(m_data->m_queue)),
       m_target_cells_per_partition(target_cells_per_partition),
-      m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr},
+      m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
                        &(m_data->m_queue), m_target_cells_per_partition),
-      m_seeding(memory_resource{*m_cached_device_mr, &m_host_mr},
+      m_seeding(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
                 &(m_data->m_queue)),
       m_track_parameter_estimation(
-          memory_resource{*m_cached_device_mr, &m_host_mr},
+          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
           &(m_data->m_queue)) {
 
     // Tell the user what device is being used.
@@ -67,27 +68,27 @@ full_chain_algorithm::full_chain_algorithm(
 }
 
 full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
-    : m_data(new details::full_chain_algorithm_data{{::handle_async_error}}),
+    : m_data(new details::full_chain_algorithm_data{
+          {::handle_async_error, ::sycl::property::queue::in_order()}}),
       m_host_mr(parent.m_host_mr),
       m_device_mr(std::make_unique<vecmem::sycl::device_memory_resource>(
           &(m_data->m_queue))),
       m_cached_device_mr(
           std::make_unique<vecmem::binary_page_memory_resource>(*m_device_mr)),
-      m_copy(std::make_unique<vecmem::sycl::copy>(&(m_data->m_queue))),
+      m_copy(&(m_data->m_queue)),
       m_target_cells_per_partition(parent.m_target_cells_per_partition),
-      m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr},
+      m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
                        &(m_data->m_queue), m_target_cells_per_partition),
-      m_seeding(memory_resource{*m_cached_device_mr, &m_host_mr},
+      m_seeding(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
                 &(m_data->m_queue)),
       m_track_parameter_estimation(
-          memory_resource{*m_cached_device_mr, &m_host_mr},
+          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
           &(m_data->m_queue)) {}
 
 full_chain_algorithm::~full_chain_algorithm() {
     // Need to ensure that objects would be deleted in the correct order.
     m_cached_device_mr.reset();
     m_device_mr.reset();
-    m_copy.reset();
     delete m_data;
 }
 
@@ -98,10 +99,10 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     // Create device copy of input collections
     alt_cell_collection_types::buffer cells_buffer(cells.size(),
                                                    *m_cached_device_mr);
-    (*m_copy)(vecmem::get_data(cells), cells_buffer);
+    (m_copy)(vecmem::get_data(cells), cells_buffer);
     cell_module_collection_types::buffer modules_buffer(modules.size(),
                                                         *m_cached_device_mr);
-    (*m_copy)(vecmem::get_data(modules), modules_buffer);
+    (m_copy)(vecmem::get_data(modules), modules_buffer);
 
     // Execute the algorithms.
     const clusterization_algorithm::output_type spacepoints =
@@ -112,7 +113,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
 
     // Get the final data back to the host.
     bound_track_parameters_collection_types::host result;
-    (*m_copy)(track_params, result);
+    (m_copy)(track_params, result)->wait();
 
     // Return the host container.
     return result;

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -32,7 +32,7 @@
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
 #include <vecmem/memory/sycl/device_memory_resource.hpp>
-#include <vecmem/utils/sycl/copy.hpp>
+#include <vecmem/utils/sycl/async_copy.hpp>
 
 // System include(s).
 #include <exception>
@@ -54,7 +54,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     uint64_t n_seeds_sycl = 0;
 
     // Creating sycl queue object
-    ::sycl::queue q;
+    ::sycl::queue q(::sycl::property::queue::in_order());
     std::cout << "Running on device: "
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
@@ -66,10 +66,10 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     traccc::seeding_algorithm sa(host_mr);
     traccc::track_params_estimation tp(host_mr);
 
-    vecmem::sycl::copy copy{&q};
+    vecmem::sycl::async_copy copy{&q};
 
-    traccc::sycl::seeding_algorithm sa_sycl{mr, &q};
-    traccc::sycl::track_params_estimation tp_sycl{mr, &q};
+    traccc::sycl::seeding_algorithm sa_sycl{mr, copy, &q};
+    traccc::sycl::track_params_estimation tp_sycl{mr, copy, &q};
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -39,7 +39,7 @@
 #include <vecmem/memory/sycl/device_memory_resource.hpp>
 #include <vecmem/memory/sycl/host_memory_resource.hpp>
 #include <vecmem/memory/sycl/shared_memory_resource.hpp>
-#include <vecmem/utils/sycl/copy.hpp>
+#include <vecmem/utils/sycl/async_copy.hpp>
 
 // Project include(s).
 #include "traccc/utils/memory_resource.hpp"
@@ -85,7 +85,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     uint64_t n_seeds_sycl = 0;
 
     // Creating SYCL queue object
-    ::sycl::queue q(handle_async_error);
+    ::sycl::queue q(handle_async_error, ::sycl::property::queue::in_order());
     std::cout << "Running Seeding on device: "
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
@@ -99,12 +99,12 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     traccc::seeding_algorithm sa(host_mr);
     traccc::track_params_estimation tp(host_mr);
 
-    vecmem::sycl::copy copy{&q};
+    vecmem::sycl::async_copy copy{&q};
 
     traccc::sycl::clusterization_algorithm ca_sycl(
-        mr, &q, common_opts.target_cells_per_partition);
-    traccc::sycl::seeding_algorithm sa_sycl(mr, &q);
-    traccc::sycl::track_params_estimation tp_sycl(mr, &q);
+        mr, copy, &q, common_opts.target_cells_per_partition);
+    traccc::sycl::seeding_algorithm sa_sycl(mr, copy, &q);
+    traccc::sycl::track_params_estimation tp_sycl(mr, copy, &q);
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(


### PR DESCRIPTION
This PR moves towards further asynchronising kernel launches and memory copies in our algorithmic chains.
* `vecmem::sycl::copy` is replaced with `vecmem::sycl::async_copy`.
* `sycl::queue` is constructed with [`::sycl::property::queue::in_order`](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:queue-properties). This allows removing all the synchronisation points in between kernels, only requiring them after device-to-host copies.

Keeping this as a draft as I don't really understand the results right now... Somehow multi-threaded performance becomes worse, and that shouldn't really happen.

PS: a big chunk of the changed LOCs in this PR right now come from the formatting, not so actual changes to the code.