### PR TITLE
Data Update, main branch (2023.03.22.)

### DIFF
--- a/data/traccc_data_get_files.sh
+++ b/data/traccc_data_get_files.sh
@@ -27,7 +27,7 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v1"}
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v2"}
 TRACCC_WEB_DIRECTORY=${TRACCC_WEB_DIRECTORY:-"https://acts.web.cern.ch/traccc/data"}
 TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}
 TRACCC_CMAKE_EXECUTABLE=${TRACCC_CMAKE_EXECUTABLE:-cmake}
@@ -72,11 +72,11 @@ done
 cd "${TRACCC_DATA_DIRECTORY}"
 
 # Download the TGZ and MD5 files.
-"${TRACCC_CURL_EXECUTABLE}" --retry 5 --retry-connrefused --retry-delay 10 \
-   --output "${TRACCC_DATA_NAME}.tar.gz"                                   \
+"${TRACCC_CURL_EXECUTABLE}" --retry 5 --retry-delay 10 \
+   --output "${TRACCC_DATA_NAME}.tar.gz"               \
    "${TRACCC_WEB_DIRECTORY}/${TRACCC_DATA_NAME}.tar.gz"
-"${TRACCC_CURL_EXECUTABLE}" --retry 5 --retry-connrefused --retry-delay 10 \
-   --output "${TRACCC_DATA_NAME}.md5"                                      \
+"${TRACCC_CURL_EXECUTABLE}" --retry 5 --retry-delay 10 \
+   --output "${TRACCC_DATA_NAME}.md5"                  \
    "${TRACCC_WEB_DIRECTORY}/${TRACCC_DATA_NAME}.md5"
 
 # Verify that the download succeeded.

--- a/data/traccc_data_package_files.sh
+++ b/data/traccc_data_package_files.sh
@@ -27,7 +27,7 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v2"}
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v3"}
 TRACCC_DATA_DIRECTORY_NAMES=("cca_test" "detray_simulation" "single_module"
    "tml_detector" "tml_full" "tml_pixel_barrel" "tml_pixels" "two_modules")
 TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}


### PR DESCRIPTION
Updated to `v2` of the data files. (That were produced by @beomki-yeo. :wink:)

At the same time removed the `--retry-connrefused` flag from the `curl` download commands. The version of `curl` on [lxplus](https://abpcomputing.web.cern.ch/computing_resources/lxplus/) is just too old for that. :-( (Thanks for the report @Yhatoh!)

For prosperity, let me copy the commands here that Beomki posted on Mattermost, for how he produced the new files.

```
# Kalman filter validation
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/1_GeV_0_phi/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/10_GeV_0_phi/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/100_GeV_0_phi/

# Sparse Tracks
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:200:200 --gen-eta=0:0 --events=10000 --gen-nparticles=1 --output_directory=detray_simulation/telescope/sparse_tracks/single_tracks/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:200:200 --gen-eta=0:0 --events=10000 --gen-nparticles=2 --output_directory=detray_simulation/telescope/sparse_tracks/double_tracks/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:200:200 --gen-eta=0:0 --events=10000 --gen-nparticles=3 --output_directory=detray_simulation/telescope/sparse_tracks/triple_tracks/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:200:200 --gen-eta=0:0 --events=10000 --gen-nparticles=10 --output_directory=detray_simulation/telescope/sparse_tracks/decade_tracks/
```