### PR TITLE
Thrust System Includes, main branch (2023.03.22.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,13 @@ set( TRACCC_THRUST_OPTIONS "" CACHE STRING
    "Extra options for configuring how Thrust should be used" )
 mark_as_advanced( TRACCC_THRUST_OPTIONS )
 thrust_create_target( traccc::Thrust ${TRACCC_THRUST_OPTIONS} )
+# Make sure that Thrust/CUB headers are treated as system headers.
+get_target_property( _thrustIncludeDir Thrust::Thrust INTERFACE_INCLUDE_DIRECTORIES )
+get_target_property( _cubIncludeDir CUB::CUB INTERFACE_INCLUDE_DIRECTORIES )
+target_include_directories( traccc::Thrust
+   SYSTEM INTERFACE ${_thrustIncludeDir} ${_cubIncludeDir} )
+unset( _thrustIncludeDir )
+unset( _cubIncludeDir )
 
 # Set up TBB.
 option( TRACCC_SETUP_TBB


### PR DESCRIPTION
This is meant as a replacement for #354.

The `traccc::Thrust` target is sort of a virtual target that the Thrust CMake code sets up on top of the low-level / real targets (`Thrust::Thrust`, `CUB::CUB`). So one needs to get the `INTERFACE_INCLUDE_DIRECTORIES` properties from those "real" targets, and then add them as system include directories on `traccc::Thrust`. (It's a long story why one should not actually try to modify `Thrust::Thrust` and `CUB::CUB` themselves...)