### PR TITLE
Change CPU clustering to use flat (alt) edm

### DIFF
--- a/core/include/traccc/clusterization/clusterization_algorithm.hpp
+++ b/core/include/traccc/clusterization/clusterization_algorithm.hpp
@@ -10,8 +10,8 @@
 // Library include(s).
 #include "traccc/clusterization/component_connection.hpp"
 #include "traccc/clusterization/measurement_creation.hpp"
-#include "traccc/edm/cell.hpp"
-#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/alt_cell.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 #include "traccc/utils/algorithm.hpp"
 
 // VecMem include(s).
@@ -28,8 +28,9 @@ namespace traccc {
 /// module from the cells of the modules.
 ///
 class clusterization_algorithm
-    : public algorithm<measurement_container_types::host(
-          const cell_container_types::host&)> {
+    : public algorithm<alt_measurement_collection_types::host(
+          const alt_cell_collection_types::host&,
+          const cell_module_collection_types::host&)> {
 
     public:
     /// Clusterization algorithm constructor
@@ -41,10 +42,12 @@ class clusterization_algorithm
     /// Construct measurements for each detector module
     ///
     /// @param cells The cells for every detector module in the event
+    /// @param modules A collection of detector modules
     /// @return The measurements reconstructed for every detector module
     ///
     output_type operator()(
-        const cell_container_types::host& cells) const override;
+        const alt_cell_collection_types::host& cells,
+        const cell_module_collection_types::host& modules) const override;
 
     private:
     /// @name Sub-algorithms used by this algorithm

--- a/core/include/traccc/clusterization/component_connection.hpp
+++ b/core/include/traccc/clusterization/component_connection.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/cell.hpp"
+#include "traccc/edm/alt_cell.hpp"
 #include "traccc/edm/cluster.hpp"
 #include "traccc/utils/algorithm.hpp"
 
@@ -31,7 +31,7 @@ namespace traccc {
 /// implementation internally.
 ///
 class component_connection : public algorithm<cluster_container_types::host(
-                                 const cell_container_types::host&)> {
+                                 const alt_cell_collection_types::host&)> {
 
     public:
     /// Constructor for component_connection
@@ -45,15 +45,13 @@ class component_connection : public algorithm<cluster_container_types::host(
     /// Callable operator for the connected component, based on one single
     /// module
     ///
-    /// @param cells are the input cells into the connected component, they are
-    ///              per module and unordered
-    /// @param module The description of the module that the cells belong to
+    /// @param cells Collection of input cells sorted by module
     ///
     /// c++20 piping interface:
     /// @return a cluster collection
     ///
     output_type operator()(
-        const cell_container_types::host& cells) const override;
+        const alt_cell_collection_types::host& cells) const override;
 
     /// @}
 

--- a/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
+++ b/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
@@ -10,9 +10,9 @@
 // Project include(s).
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
-#include "traccc/edm/cell.hpp"
+#include "traccc/edm/alt_cell.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 #include "traccc/edm/cluster.hpp"
-#include "traccc/edm/measurement.hpp"
 
 namespace traccc::detail {
 
@@ -25,10 +25,11 @@ inline scalar signal_cell_modelling(scalar signal_in,
 
 /// Function for pixel segmentation
 TRACCC_HOST_DEVICE
-inline vector2 position_from_cell(const cell& c, const cell_module& module) {
+inline vector2 position_from_cell(const alt_cell& cell,
+                                  const cell_module& module) {
     // Retrieve the specific values based on module idx
-    return {module.pixel.min_center_x + c.channel0 * module.pixel.pitch_x,
-            module.pixel.min_center_y + c.channel1 * module.pixel.pitch_y};
+    return {module.pixel.min_center_x + cell.c.channel0 * module.pixel.pitch_x,
+            module.pixel.min_center_y + cell.c.channel1 * module.pixel.pitch_y};
 }
 
 /// Function used for calculating the properties of the cluster during
@@ -42,21 +43,21 @@ inline vector2 position_from_cell(const cell& c, const cell_module& module) {
 /// @param[out] totalWeight The total weight of the cluster/measurement
 ///
 template <typename cell_collection_t>
-TRACCC_HOST_DEVICE inline void calc_cluster_properties(
+TRACCC_HOST inline void calc_cluster_properties(
     const cell_collection_t& cluster, const cell_module& module, point2& mean,
     point2& var, scalar& totalWeight) {
 
     // Loop over the cells of the cluster.
-    for (const cell& cell : cluster) {
+    for (const alt_cell& cell : cluster) {
 
         // Translate the cell readout value into a weight.
-        const scalar weight = signal_cell_modelling(cell.activation, module);
+        const scalar weight = signal_cell_modelling(cell.c.activation, module);
 
         // Only consider cells over a minimum threshold.
         if (weight > module.threshold) {
 
             // Update all output properties with this cell.
-            totalWeight += cell.activation;
+            totalWeight += cell.c.activation;
             const point2 cell_position = position_from_cell(cell, module);
             const point2 prev = mean;
             const point2 diff = cell_position - prev;
@@ -73,18 +74,16 @@ TRACCC_HOST_DEVICE inline void calc_cluster_properties(
 /// Function used for calculating the properties of the cluster during
 /// measurement creation
 ///
-/// @param[out] measurements is the measurement container where the measurement
+/// @param[out] measurements is the measurement collection where the measurement
 /// object will be filled
 /// @param[in] cluster is the input cell vector
 /// @param[in] module is the cell module where the cluster belongs to
-/// @param[in] module_link is the module index of the cell container
-/// @param[in] cluster_link is the cluster index of the cluster container
+/// @param[in] module_link is the module index
 ///
-template <typename measurement_container_t, typename cell_collection_t>
-TRACCC_HOST_DEVICE inline void fill_measurement(
-    measurement_container_t& measurements, const cell_collection_t& cluster,
-    const cell_module& module, const std::size_t module_link,
-    const std::size_t cl_link) {
+TRACCC_HOST void fill_measurement(
+    alt_measurement_collection_types::host& measurements,
+    const alt_cell_collection_types::host& cluster, const cell_module& module,
+    const unsigned int module_link) {
 
     // To calculate the mean and variance with high numerical stability
     // we use a weighted variant of Welford's algorithm. This is a
@@ -102,9 +101,8 @@ TRACCC_HOST_DEVICE inline void fill_measurement(
     detail::calc_cluster_properties(cluster, module, mean, var, totalWeight);
 
     if (totalWeight > 0.) {
-        measurement m;
-        // cluster link
-        m.cluster_link = cl_link;
+        alt_measurement m;
+        m.module_link = module_link;
         // normalize the cell position
         m.local = mean;
         // normalize the variance
@@ -117,8 +115,7 @@ TRACCC_HOST_DEVICE inline void fill_measurement(
                                 pitch[1] * pitch[1] / static_cast<scalar>(12.)};
         // @todo add variance estimation
 
-        measurements[module_link].header = module;
-        measurements[module_link].items.push_back(std::move(m));
+        measurements.push_back(std::move(m));
     }
 }
 

--- a/core/include/traccc/clusterization/measurement_creation.hpp
+++ b/core/include/traccc/clusterization/measurement_creation.hpp
@@ -8,9 +8,9 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/cell.hpp"
+#include "traccc/edm/alt_cell.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 #include "traccc/edm/cluster.hpp"
-#include "traccc/edm/measurement.hpp"
 #include "traccc/utils/algorithm.hpp"
 
 // VecMem include(s).
@@ -27,9 +27,10 @@ namespace traccc {
 /// for all of the clusters that were identified in that one detector
 /// module.
 ///
-class measurement_creation : public algorithm<measurement_container_types::host(
-                                 const cell_container_types::host &,
-                                 const cluster_container_types::host &)> {
+class measurement_creation
+    : public algorithm<alt_measurement_collection_types::host(
+          const cluster_container_types::host &,
+          const cell_module_collection_types::host &)> {
 
     public:
     /// Measurement_creation algorithm constructor
@@ -41,17 +42,17 @@ class measurement_creation : public algorithm<measurement_container_types::host(
     /// Callable operator for the connected component, based on one single
     /// module
     ///
-    /// @param clusters are the input cells into the connected component, they
-    /// are
-    ///              per module and unordered
+    /// @param clusters Container of cells. Each subvector of cells corresponds
+    /// to a cluster
+    /// @param modules Collection of detector modules the clusters link to.
     ///
     /// C++20 piping interface
     ///
     /// @return a measurement collection - usually same size or sometime
     /// slightly smaller than the input
     output_type operator()(
-        const cell_container_types::host &cells,
-        const cluster_container_types::host &clusters) const override;
+        const cluster_container_types::host &clusters,
+        const cell_module_collection_types::host &modules) const override;
 
     private:
     /// The memory resource used by the algorithm

--- a/core/include/traccc/clusterization/spacepoint_formation.hpp
+++ b/core/include/traccc/clusterization/spacepoint_formation.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/utils/algorithm.hpp"
 
@@ -25,8 +25,9 @@ namespace traccc {
 /// This algorithm performs the local-to-global transformation of the 2D
 /// measurements made on every detector module, into 3D spacepoint coordinates.
 ///
-class spacepoint_formation : public algorithm<spacepoint_container_types::host(
-                                 const measurement_container_types::host&)> {
+class spacepoint_formation : public algorithm<spacepoint_collection_types::host(
+                                 const alt_measurement_collection_types::host&,
+                                 const cell_module_collection_types::host&)> {
 
     public:
     /// Constructor for spacepoint_formation
@@ -38,12 +39,14 @@ class spacepoint_formation : public algorithm<spacepoint_container_types::host(
     /// Callable operator for the space point formation, based on one single
     /// module
     ///
-    /// @param measurements are the input measurements
+    /// @param measurements A collection of measurements
+    /// @param modules A collection of modules the measurements link to
     /// @return A spacepoint container, with one spacepoint for every
     ///         measurement
     ///
     output_type operator()(
-        const measurement_container_types::host& measurements) const override;
+        const alt_measurement_collection_types::host& measurements,
+        const cell_module_collection_types::host& modules) const override;
 
     private:
     std::reference_wrapper<vecmem::memory_resource> m_mr;

--- a/core/include/traccc/edm/alt_cell.hpp
+++ b/core/include/traccc/edm/alt_cell.hpp
@@ -28,12 +28,29 @@ struct alt_cell {
 /// Declare all cell collection types
 using alt_cell_collection_types = collection_types<alt_cell>;
 
-/// Type definition for the reading of cells into a vector of alt_cells and a
-/// vector of modules. The alt_cells hold a link to a position in the modules'
-/// vector.
-struct alt_cell_reader_output_t {
-    alt_cell_collection_types::host cells;
-    cell_module_collection_types::host modules;
-};
+TRACCC_HOST_DEVICE
+inline bool operator<(const alt_cell& lhs, const alt_cell& rhs) {
+
+    if (lhs.module_link != rhs.module_link) {
+        return lhs.module_link < rhs.module_link;
+    } else if (lhs.c.channel0 != rhs.c.channel0) {
+        return (lhs.c.channel0 < rhs.c.channel0);
+    } else if (lhs.c.channel1 != rhs.c.channel1) {
+        return (lhs.c.channel1 < rhs.c.channel1);
+    } else {
+        return lhs.c.activation < rhs.c.activation;
+    }
+}
+
+/// Equality operator for cells
+TRACCC_HOST_DEVICE
+inline bool operator==(const alt_cell& lhs, const alt_cell& rhs) {
+
+    return ((lhs.module_link == rhs.module_link) &&
+            (lhs.c.channel0 == rhs.c.channel0) &&
+            (lhs.c.channel1 == rhs.c.channel1) &&
+            (std::abs(lhs.c.activation - rhs.c.activation) < float_epsilon) &&
+            (std::abs(lhs.c.time - rhs.c.time) < float_epsilon));
+}
 
 }  // namespace traccc

--- a/core/include/traccc/edm/alt_measurement.hpp
+++ b/core/include/traccc/edm/alt_measurement.hpp
@@ -27,8 +27,32 @@ struct alt_measurement {
     variance2 variance{0., 0.};
 
     using link_type = cell_module_collection_types::view::size_type;
-    link_type module_link;
+    link_type module_link = 0;
 };
+
+/// Comparison / ordering operator for measurements
+TRACCC_HOST_DEVICE
+inline bool operator<(const alt_measurement& lhs, const alt_measurement& rhs) {
+
+    if (lhs.module_link != rhs.module_link) {
+        return lhs.module_link < rhs.module_link;
+    } else if (std::abs(lhs.local[0] - rhs.local[0]) > float_epsilon) {
+        return (lhs.local[0] < rhs.local[0]);
+    } else {
+        return (lhs.local[1] < rhs.local[1]);
+    }
+}
+
+/// Equality operator for measurements
+TRACCC_HOST_DEVICE
+inline bool operator==(const alt_measurement& lhs, const alt_measurement& rhs) {
+
+    return ((lhs.module_link == rhs.module_link) &&
+            (std::abs(lhs.local[0] - rhs.local[0]) < float_epsilon) &&
+            (std::abs(lhs.local[1] - rhs.local[1]) < float_epsilon) &&
+            (std::abs(lhs.variance[0] - rhs.variance[0]) < float_epsilon) &&
+            (std::abs(lhs.variance[1] - rhs.variance[1]) < float_epsilon));
+}
 
 /// Declare all alt measurement collection types
 using alt_measurement_collection_types = collection_types<alt_measurement>;

--- a/core/include/traccc/edm/alt_seed.hpp
+++ b/core/include/traccc/edm/alt_seed.hpp
@@ -26,7 +26,7 @@ struct alt_seed {
     scalar z_vertex;
 
     TRACCC_HOST_DEVICE
-    std::array<measurement, 3> get_measurements(
+    std::array<alt_measurement, 3> get_measurements(
         const spacepoint_collection_types::const_view& spacepoints_view) const {
         const spacepoint_collection_types::const_device spacepoints(
             spacepoints_view);

--- a/core/include/traccc/edm/cluster.hpp
+++ b/core/include/traccc/edm/cluster.hpp
@@ -9,16 +9,17 @@
 
 // Library include(s).
 #include "traccc/definitions/primitives.hpp"
-#include "traccc/edm/cell.hpp"
+#include "traccc/edm/alt_cell.hpp"
 #include "traccc/edm/container.hpp"
 #include "traccc/geometry/pixel_data.hpp"
 
 // System include(s).
 #include <cstddef>
+#include <variant>
 
 namespace traccc {
 
 /// Declare all cluster container types
-using cluster_container_types = container_types<std::size_t, cell>;
+using cluster_container_types = container_types<std::monostate, alt_cell>;
 
 }  // namespace traccc

--- a/core/include/traccc/edm/internal_spacepoint.hpp
+++ b/core/include/traccc/edm/internal_spacepoint.hpp
@@ -23,16 +23,8 @@ namespace traccc {
 template <typename spacepoint_t>
 struct internal_spacepoint {
 
-    // FIXME: geometry_id is hard-coded here
-    using spacepoint_container_type = host_container<geometry_id, spacepoint_t>;
-    using link_type = typename spacepoint_container_type::link_type;
-
+    using link_type = typename collection_types<spacepoint_t>::host::size_type;
     link_type m_link;
-
-    /// TODO: This is a *VERY* temporary variable which will be removed asap.
-    /// only here while transitioning from the jagged to non-jagged
-    /// clusterization and prevent even more code duplication
-    unsigned int m_link_alt;
 
     scalar m_x;
     scalar m_y;
@@ -42,23 +34,10 @@ struct internal_spacepoint {
 
     internal_spacepoint() = default;
 
-    template <typename spacepoint_container_t>
-    TRACCC_HOST_DEVICE internal_spacepoint(
-        const spacepoint_container_t& sp_container, const link_type& sp_link,
-        const vector2& offsetXY)
-        : m_link(sp_link) {
-        const spacepoint_t& sp = sp_container.at(sp_link);
-        m_x = sp.global[0] - offsetXY[0];
-        m_y = sp.global[1] - offsetXY[1];
-        m_z = sp.global[2];
-        m_r = algebra::math::sqrt(m_x * m_x + m_y * m_y);
-        m_phi = algebra::math::atan2(m_y, m_x);
-    }
-
     TRACCC_HOST_DEVICE internal_spacepoint(const spacepoint_t& sp,
-                                           const unsigned int sp_link,
+                                           const link_type sp_link,
                                            const vector2& offsetXY)
-        : m_link_alt(sp_link) {
+        : m_link(sp_link) {
         m_x = sp.global[0] - offsetXY[0];
         m_y = sp.global[1] - offsetXY[1];
         m_z = sp.global[2];
@@ -79,8 +58,7 @@ struct internal_spacepoint {
     TRACCC_HOST_DEVICE
     static inline internal_spacepoint<spacepoint_t> invalid_value() {
 
-        link_type l = {detray::detail::invalid_value<decltype(l.first)>(),
-                       detray::detail::invalid_value<decltype(l.second)>()};
+        link_type l = detray::detail::invalid_value<link_type>();
 
         return internal_spacepoint<spacepoint_t>({std::move(l)});
     }

--- a/core/include/traccc/edm/seed.hpp
+++ b/core/include/traccc/edm/seed.hpp
@@ -23,40 +23,7 @@ struct seed {
 
     scalar weight;
     scalar z_vertex;
-
-    TRACCC_HOST_DEVICE
-    std::array<measurement, 3> get_measurements(
-        const spacepoint_container_types::const_view& spacepoints_view) const {
-        const spacepoint_container_types::const_device spacepoints(
-            spacepoints_view);
-        return {spacepoints.at(spB_link).meas, spacepoints.at(spM_link).meas,
-                spacepoints.at(spT_link).meas};
-    }
-
-    TRACCC_HOST_DEVICE
-    std::array<spacepoint, 3> get_spacepoints(
-        const spacepoint_container_types::const_view& spacepoints_view) const {
-        const spacepoint_container_types::const_device spacepoints(
-            spacepoints_view);
-        return {spacepoints.at(spB_link), spacepoints.at(spM_link),
-                spacepoints.at(spT_link)};
-    }
 };
-
-template <typename seed_collection_t, typename spacepoint_container_t>
-TRACCC_HOST std::vector<std::array<spacepoint, 3>> get_spacepoint_vector(
-    const seed_collection_t& seeds, const spacepoint_container_t& container) {
-
-    std::vector<std::array<spacepoint, 3>> result;
-    result.reserve(seeds.size());
-
-    std::transform(seeds.cbegin(), seeds.cend(), std::back_inserter(result),
-                   [&](const seed& value) {
-                       return value.get_spacepoints(get_data(container));
-                   });
-
-    return result;
-}
 
 /// Declare all seed collection types
 using seed_collection_types = collection_types<seed>;

--- a/core/include/traccc/edm/spacepoint.hpp
+++ b/core/include/traccc/edm/spacepoint.hpp
@@ -11,8 +11,8 @@
 #include "traccc/definitions/common.hpp"
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 #include "traccc/edm/container.hpp"
-#include "traccc/edm/measurement.hpp"
 
 // System include(s).
 #include <cmath>
@@ -29,7 +29,7 @@ struct spacepoint {
     /// The global position of the spacepoint in 3D space
     point3 global{0., 0., 0.};
     /// The local measurement of the spacepoint on the detector surface
-    measurement meas;
+    alt_measurement meas;
 
     TRACCC_HOST_DEVICE
     const scalar& x() const { return global[0]; }

--- a/core/include/traccc/seeding/seed_filtering.hpp
+++ b/core/include/traccc/seeding/seed_filtering.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/seed.hpp"
+#include "traccc/edm/alt_seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
 #include "traccc/seeding/detail/spacepoint_grid.hpp"
@@ -25,16 +25,16 @@ class seed_filtering {
 
     /// Callable operator for the seed filtering
     ///
-    /// @param isp_container is internal spacepoint container
+    /// @param isp_collection is internal spacepoint collection
     /// @param triplets is the vector of triplets per middle spacepoint
     ///
     /// void interface
     ///
     /// @return seeds are the vector of seeds where the new compatible seeds are
     /// added
-    void operator()(const spacepoint_container_types::host& sp_container,
+    void operator()(const spacepoint_collection_types::host& sp_collection,
                     const sp_grid& g2, triplet_collection_types::host& triplets,
-                    seed_collection_types::host& seeds) const;
+                    alt_seed_collection_types::host& seeds) const;
 
     private:
     /// Seed filter configuration

--- a/core/include/traccc/seeding/seed_finding.hpp
+++ b/core/include/traccc/seeding/seed_finding.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/edm/seed.hpp"
+#include "traccc/edm/alt_seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
 #include "traccc/seeding/detail/spacepoint_grid.hpp"
@@ -21,8 +21,8 @@ namespace traccc {
 
 /// Seed finding
 class seed_finding
-    : public algorithm<seed_collection_types::host(
-          const spacepoint_container_types::host&, const sp_grid&)> {
+    : public algorithm<alt_seed_collection_types::host(
+          const spacepoint_collection_types::host&, const sp_grid&)> {
 
     public:
     /// Constructor for the seed finding
@@ -35,12 +35,13 @@ class seed_finding
 
     /// Callable operator for the seed finding
     ///
-    /// @param sp_container All spacepoints in the event
+    /// @param sp_collection All spacepoints in the event
     /// @param g2 The same spacepoints arranged in a 2D Phi-Z grid
     /// @return seed_collection is the vector of seeds per event
     ///
-    output_type operator()(const spacepoint_container_types::host& sp_container,
-                           const sp_grid& g2) const override;
+    output_type operator()(
+        const spacepoint_collection_types::host& sp_collection,
+        const sp_grid& g2) const override;
 
     private:
     /// Algorithm performing the mid bottom doublet finding

--- a/core/include/traccc/seeding/seeding_algorithm.hpp
+++ b/core/include/traccc/seeding/seeding_algorithm.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/seed.hpp"
+#include "traccc/edm/alt_seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/seeding/seed_finding.hpp"
 #include "traccc/seeding/spacepoint_binning.hpp"
@@ -20,8 +20,8 @@
 namespace traccc {
 
 /// Main algorithm for performing the track seeding on the CPU
-class seeding_algorithm : public algorithm<seed_collection_types::host(
-                              const spacepoint_container_types::host&)> {
+class seeding_algorithm : public algorithm<alt_seed_collection_types::host(
+                              const spacepoint_collection_types::host&)> {
 
     public:
     /// Constructor for the seed finding algorithm
@@ -36,7 +36,7 @@ class seeding_algorithm : public algorithm<seed_collection_types::host(
     /// @return The track seeds reconstructed from the spacepoints
     ///
     output_type operator()(
-        const spacepoint_container_types::host& spacepoints) const override;
+        const spacepoint_collection_types::host& spacepoints) const override;
 
     private:
     /// Sub-algorithm performing the spacepoint binning

--- a/core/include/traccc/seeding/spacepoint_binning.hpp
+++ b/core/include/traccc/seeding/spacepoint_binning.hpp
@@ -20,7 +20,7 @@ namespace traccc {
 
 /// spacepoint binning
 class spacepoint_binning
-    : public algorithm<sp_grid(const spacepoint_container_types::host&)> {
+    : public algorithm<sp_grid(const spacepoint_collection_types::host&)> {
 
     public:
     /// Constructor for the spacepoint binning
@@ -35,11 +35,11 @@ class spacepoint_binning
 
     /// Operator executing the algorithm
     ///
-    /// @param sp_container All of the spacepoints of the event
+    /// @param sp_collection All of the spacepoints of the event
     /// @return The spacepoints arranged in a Phi-Z grid
     ///
     output_type operator()(
-        const spacepoint_container_types::host& sp_container) const override;
+        const spacepoint_collection_types::host& sp_collection) const override;
 
     private:
     seedfinder_config m_config;

--- a/core/include/traccc/seeding/spacepoint_binning_helper.hpp
+++ b/core/include/traccc/seeding/spacepoint_binning_helper.hpp
@@ -126,20 +126,4 @@ inline TRACCC_HOST_DEVICE size_t is_valid_sp(const seedfinder_config& config,
     return detray::detail::invalid_value<size_t>();
 }
 
-template <typename spacepoint_container_t,
-          template <typename> class jagged_vector_type>
-inline TRACCC_HOST_DEVICE void fill_radius_bins(
-    const seedfinder_config& config, const spacepoint_container_t& sp_container,
-    const sp_location sp_loc, jagged_vector_type<sp_location>& r_bins) {
-
-    const spacepoint& sp =
-        sp_container.get_items()[sp_loc.bin_idx][sp_loc.sp_idx];
-
-    auto r_index = is_valid_sp(config, sp);
-
-    if (r_index != detray::detail::invalid_value<size_t>()) {
-        r_bins[r_index].push_back(sp_loc);
-    }
-}
-
 }  // namespace traccc

--- a/core/include/traccc/seeding/track_params_estimation.hpp
+++ b/core/include/traccc/seeding/track_params_estimation.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/seed.hpp"
+#include "traccc/edm/alt_seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/utils/algorithm.hpp"
@@ -27,8 +27,8 @@ namespace traccc {
 ///
 class track_params_estimation
     : public algorithm<bound_track_parameters_collection_types::host(
-          const spacepoint_container_types::host&,
-          const seed_collection_types::host&)> {
+          const spacepoint_collection_types::host&,
+          const alt_seed_collection_types::host&)> {
 
     public:
     /// Constructor for track_params_estimation
@@ -43,8 +43,8 @@ class track_params_estimation
     /// @return A vector of bound track parameters
     ///
     output_type operator()(
-        const spacepoint_container_types::host& spacepoints,
-        const seed_collection_types::host& seeds) const override;
+        const spacepoint_collection_types::host& spacepoints,
+        const alt_seed_collection_types::host& seeds) const override;
 
     private:
     /// The memory resource to use in the algorithm

--- a/core/include/traccc/seeding/track_params_estimation_helper.hpp
+++ b/core/include/traccc/seeding/track_params_estimation_helper.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/seed.hpp"
+#include "traccc/edm/alt_seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/edm/track_parameters.hpp"
 
@@ -37,16 +37,16 @@ inline TRACCC_HOST_DEVICE vector2 uv_transform(const scalar& x,
 /// @param seed is the input seed
 /// @param bfield is the magnetic field
 /// @param mass is the mass of particle
-template <typename spacepoint_container_t, typename seed_t>
+template <typename spacepoint_collection_t>
 inline TRACCC_HOST_DEVICE bound_vector seed_to_bound_vector(
-    const spacepoint_container_t& sp_container, const seed_t& seed,
+    const spacepoint_collection_t& sp_collection, const alt_seed& seed,
     const vector3& bfield, const scalar mass) {
 
     bound_vector params;
 
-    const auto& spB = sp_container.at(seed.spB_link);
-    const auto& spM = sp_container.at(seed.spM_link);
-    const auto& spT = sp_container.at(seed.spT_link);
+    const auto& spB = sp_collection.at(seed.spB_link);
+    const auto& spM = sp_collection.at(seed.spM_link);
+    const auto& spT = sp_collection.at(seed.spT_link);
 
     darray<vector3, 3> sp_global_positions;
     sp_global_positions[0] = spB.global;

--- a/core/src/clusterization/clusterization_algorithm.cpp
+++ b/core/src/clusterization/clusterization_algorithm.cpp
@@ -14,9 +14,10 @@ clusterization_algorithm::clusterization_algorithm(vecmem::memory_resource& mr)
     : m_cc(mr), m_mc(mr), m_mr(mr) {}
 
 clusterization_algorithm::output_type clusterization_algorithm::operator()(
-    const cell_container_types::host& cells) const {
+    const alt_cell_collection_types::host& cells,
+    const cell_module_collection_types::host& modules) const {
 
-    return m_mc(cells, m_cc(cells));
+    return m_mc(m_cc(cells), modules);
 }
 
 }  // namespace traccc

--- a/core/src/clusterization/component_connection.cpp
+++ b/core/src/clusterization/component_connection.cpp
@@ -17,45 +17,20 @@
 namespace traccc {
 
 component_connection::output_type component_connection::operator()(
-    const cell_container_types::host& cells) const {
+    const alt_cell_collection_types::host& cells) const {
 
-    std::vector<std::size_t> num_clusters(cells.size(), 0);
-    std::vector<std::vector<unsigned int>> CCL_indices(cells.size());
+    unsigned int num_clusters = 0;
+    std::vector<unsigned int> CCL_indices(cells.size());
 
-    for (std::size_t i = 0; i < cells.size(); i++) {
-        const auto& cells_per_module = cells.get_items()[i];
-
-        CCL_indices[i] = std::vector<unsigned int>(cells_per_module.size());
-
-        // Run SparseCCL to fill CCL indices
-        num_clusters[i] = detail::sparse_ccl(cells_per_module, CCL_indices[i]);
-    }
-
-    // Get total number of clusters
-    const std::size_t N =
-        std::accumulate(num_clusters.begin(), num_clusters.end(), 0);
+    // Run SparseCCL to fill CCL indices
+    num_clusters = detail::sparse_ccl(cells, CCL_indices);
 
     // Create the result container.
-    output_type result(N, &(m_mr.get()));
+    output_type result(num_clusters, &(m_mr.get()));
 
-    std::size_t stack = 0;
-    for (std::size_t i = 0; i < cells.size(); i++) {
-
-        auto& cells_per_module = cells.get_items()[i];
-
-        // Fill the module link
-        std::fill(result.get_headers().begin() + stack,
-                  result.get_headers().begin() + stack + num_clusters[i], i);
-
-        // Full the cluster cells
-        for (std::size_t j = 0; j < CCL_indices[i].size(); j++) {
-
-            auto cindex = static_cast<unsigned int>(CCL_indices[i][j] - 1);
-
-            result.get_items()[stack + cindex].push_back(cells_per_module[j]);
-        }
-
-        stack += num_clusters[i];
+    // Add cells to their clusters
+    for (std::size_t i = 0; i < CCL_indices.size(); ++i) {
+        result.get_items()[CCL_indices[i]].push_back(cells[i]);
     }
 
     return result;

--- a/core/src/seeding/seed_filtering.cpp
+++ b/core/src/seeding/seed_filtering.cpp
@@ -16,11 +16,11 @@ seed_filtering::seed_filtering(const seedfilter_config& config)
     : m_filter_config(config) {}
 
 void seed_filtering::operator()(
-    const spacepoint_container_types::host& sp_container, const sp_grid& g2,
+    const spacepoint_collection_types::host& sp_collection, const sp_grid& g2,
     triplet_collection_types::host& triplets,
-    seed_collection_types::host& seeds) const {
+    alt_seed_collection_types::host& seeds) const {
 
-    seed_collection_types::host seeds_per_spM;
+    alt_seed_collection_types::host seeds_per_spM;
 
     for (triplet& triplet : triplets) {
         // bottom
@@ -49,16 +49,16 @@ void seed_filtering::operator()(
 
     // sort seeds based on their weights
     std::sort(seeds_per_spM.begin(), seeds_per_spM.end(),
-              [&](seed& seed1, seed& seed2) {
+              [&](alt_seed& seed1, alt_seed& seed2) {
                   if (seed1.weight != seed2.weight) {
                       return seed1.weight > seed2.weight;
                   } else {
                       scalar seed1_sum = 0;
                       scalar seed2_sum = 0;
-                      auto& spB1 = sp_container.at(seed1.spB_link);
-                      auto& spT1 = sp_container.at(seed1.spT_link);
-                      auto& spB2 = sp_container.at(seed2.spB_link);
-                      auto& spT2 = sp_container.at(seed2.spT_link);
+                      auto& spB1 = sp_collection.at(seed1.spB_link);
+                      auto& spT1 = sp_collection.at(seed1.spT_link);
+                      auto& spB2 = sp_collection.at(seed2.spB_link);
+                      auto& spT2 = sp_collection.at(seed2.spT_link);
 
                       seed1_sum += pow(spB1.y(), 2) + pow(spB1.z(), 2);
                       seed1_sum += pow(spT1.y(), 2) + pow(spT1.z(), 2);
@@ -69,7 +69,7 @@ void seed_filtering::operator()(
                   }
               });
 
-    seed_collection_types::host new_seeds;
+    alt_seed_collection_types::host new_seeds;
     if (seeds_per_spM.size() > 1) {
         new_seeds.push_back(seeds_per_spM[0]);
 
@@ -78,7 +78,7 @@ void seed_filtering::operator()(
         // don't cut first element
         for (size_t i = 1; i < itLength; i++) {
             if (seed_selecting_helper::cut_per_middle_sp(
-                    m_filter_config, sp_container, seeds_per_spM[i],
+                    m_filter_config, sp_collection, seeds_per_spM[i],
                     seeds_per_spM[i].weight)) {
                 new_seeds.push_back(std::move(seeds_per_spM[i]));
             }

--- a/core/src/seeding/seed_finding.cpp
+++ b/core/src/seeding/seed_finding.cpp
@@ -18,7 +18,7 @@ seed_finding::seed_finding(const seedfinder_config& finder_config,
       m_seed_filtering(filter_config.toInternalUnits()) {}
 
 seed_finding::output_type seed_finding::operator()(
-    const spacepoint_container_types::host& sp_container,
+    const spacepoint_collection_types::host& sp_collection,
     const sp_grid& g2) const {
 
     // Run the algorithm
@@ -62,7 +62,7 @@ seed_finding::output_type seed_finding::operator()(
             }
 
             // seed filtering
-            m_seed_filtering(sp_container, g2, triplets_per_spM, seeds);
+            m_seed_filtering(sp_collection, g2, triplets_per_spM, seeds);
         }
     }
 

--- a/core/src/seeding/seeding_algorithm.cpp
+++ b/core/src/seeding/seeding_algorithm.cpp
@@ -63,7 +63,7 @@ seeding_algorithm::seeding_algorithm(vecmem::memory_resource& mr)
       m_seed_finding(default_seedfinder_config(), seedfilter_config()) {}
 
 seeding_algorithm::output_type seeding_algorithm::operator()(
-    const spacepoint_container_types::host& spacepoints) const {
+    const spacepoint_collection_types::host& spacepoints) const {
 
     return m_seed_finding(spacepoints, m_spacepoint_binning(spacepoints));
 }

--- a/core/src/seeding/spacepoint_binning.cpp
+++ b/core/src/seeding/spacepoint_binning.cpp
@@ -22,34 +22,24 @@ spacepoint_binning::spacepoint_binning(
       m_mr(mr) {}
 
 spacepoint_binning::output_type spacepoint_binning::operator()(
-    const spacepoint_container_types::host& sp_container) const {
+    const spacepoint_collection_types::host& sp_collection) const {
 
     output_type g2(m_axes.first, m_axes.second, m_mr.get());
 
-    djagged_vector<sp_location> rbins(m_config.get_num_rbins());
+    auto& phi_axis = g2.axis_p0();
+    auto& z_axis = g2.axis_p1();
 
-    for (unsigned int i = 0; i < sp_container.size(); i++) {
-        for (unsigned int j = 0; j < sp_container.get_items()[i].size(); j++) {
-            sp_location sp_loc{i, j};
-            fill_radius_bins<spacepoint_container_types::host, djagged_vector>(
-                m_config, sp_container, sp_loc, rbins);
+    for (unsigned int i = 0; i < sp_collection.size(); i++) {
+        const spacepoint& sp = sp_collection[i];
+        internal_spacepoint<spacepoint> isp(sp, i, m_config.beamPos);
+
+        if (is_valid_sp(m_config, sp) !=
+            detray::detail::invalid_value<size_t>()) {
+            const std::size_t bin_index =
+                phi_axis.bin(isp.phi()) + phi_axis.bins() * z_axis.bin(isp.z());
+            g2.bin(bin_index).push_back(std::move(isp));
         }
     }
-
-    // fill rbins into grid such that each grid bin is sorted in r
-    // space points with delta r < rbin size can be out of order
-    for (auto& rbin : rbins) {
-        for (auto& sp_loc : rbin) {
-
-            auto isp = internal_spacepoint<spacepoint>(
-                sp_container, {sp_loc.bin_idx, sp_loc.sp_idx},
-                m_config.beamPos);
-
-            point2 sp_position = {isp.phi(), isp.z()};
-            g2.populate(sp_position, std::move(isp));
-        }
-    }
-
     return g2;
 }
 

--- a/core/src/seeding/track_params_estimation.cpp
+++ b/core/src/seeding/track_params_estimation.cpp
@@ -16,8 +16,8 @@ track_params_estimation::track_params_estimation(vecmem::memory_resource& mr)
     : m_mr(mr) {}
 
 track_params_estimation::output_type track_params_estimation::operator()(
-    const spacepoint_container_types::host& spacepoints,
-    const seed_collection_types::host& seeds) const {
+    const spacepoint_collection_types::host& spacepoints,
+    const alt_seed_collection_types::host& seeds) const {
 
     output_type result(&m_mr.get());
 

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -53,7 +53,7 @@ inline void aggregate_cluster(
             break;
         }
 
-        const cell this_cell = cells[pos].c;
+        const alt_cell this_cell = cells[pos];
 
         /*
          * If the value of this cell is equal to our, that means it
@@ -62,15 +62,15 @@ inline void aggregate_cluster(
          */
         if (f[j] == cid) {
 
-            if (this_cell.channel1 > maxChannel1) {
-                maxChannel1 = this_cell.channel1;
+            if (this_cell.c.channel1 > maxChannel1) {
+                maxChannel1 = this_cell.c.channel1;
             }
 
             const float weight = traccc::detail::signal_cell_modelling(
-                this_cell.activation, this_module);
+                this_cell.c.activation, this_module);
 
             if (weight > this_module.threshold) {
-                totalWeight += this_cell.activation;
+                totalWeight += this_cell.c.activation;
                 const point2 cell_position =
                     traccc::detail::position_from_cell(this_cell, this_module);
                 const point2 prev = mean;
@@ -90,7 +90,7 @@ inline void aggregate_cluster(
          * Terminate the process earlier if we have reached a cell sufficiently
          * far away from the cluster in the dominant axis.
          */
-        if (this_cell.channel1 > maxChannel1 + 1) {
+        if (this_cell.c.channel1 > maxChannel1 + 1) {
             break;
         }
     }

--- a/device/common/include/traccc/clusterization/device/impl/form_spacepoints.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/form_spacepoints.ipp
@@ -41,7 +41,7 @@ inline void form_spacepoints(
     point3 global = mod.placement.point_to_global(local_3d);
 
     // Fill the result object with this spacepoint
-    spacepoints_device[globalIndex] = {global, {meas.local, meas.variance, 0}};
+    spacepoints_device[globalIndex] = {global, meas};
 }
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
+++ b/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
@@ -162,14 +162,10 @@ inline void select_seeds(
                 const internal_spacepoint<spacepoint>& ispT2 =
                     internal_sp_device.bin(rhs.sp3.bin_idx)[rhs.sp3.sp_idx];
 
-                const spacepoint& spB1 =
-                    spacepoints_device.at(ispB1.m_link_alt);
-                const spacepoint& spT1 =
-                    spacepoints_device.at(ispT1.m_link_alt);
-                const spacepoint& spB2 =
-                    spacepoints_device.at(ispB2.m_link_alt);
-                const spacepoint& spT2 =
-                    spacepoints_device.at(ispT2.m_link_alt);
+                const spacepoint& spB1 = spacepoints_device.at(ispB1.m_link);
+                const spacepoint& spT1 = spacepoints_device.at(ispT1.m_link);
+                const spacepoint& spB2 = spacepoints_device.at(ispB2.m_link);
+                const spacepoint& spT2 = spacepoints_device.at(ispT2.m_link);
 
                 constexpr scalar exp = 2;
                 seed1_sum += std::pow(spB1.y(), exp) + std::pow(spB1.z(), exp);
@@ -199,8 +195,8 @@ inline void select_seeds(
             break;
         }
 
-        alt_seed aSeed({spB.m_link_alt, spM.m_link_alt, spT.m_link_alt,
-                        aTriplet.weight, aTriplet.z_vertex});
+        alt_seed aSeed({spB.m_link, spM.m_link, spT.m_link, aTriplet.weight,
+                        aTriplet.z_vertex});
 
         // check if it is a good triplet
         if (seed_selecting_helper::cut_per_middle_sp(

--- a/device/cuda/include/traccc/cuda/cca/component_connection.hpp
+++ b/device/cuda/include/traccc/cuda/cca/component_connection.hpp
@@ -8,13 +8,14 @@
 
 #pragma once
 
-#include "traccc/edm/cell.hpp"
-#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/alt_cell.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 #include "traccc/utils/algorithm.hpp"
 
 namespace traccc::cuda {
-struct component_connection : algorithm<measurement_container_types::host(
-                                  const cell_container_types::host& cells)> {
-    output_type operator()(const cell_container_types::host& cells) const;
+struct component_connection
+    : algorithm<alt_measurement_collection_types::host(
+          const alt_cell_collection_types::host& data)> {
+    output_type operator()(const alt_cell_collection_types::host& data) const;
 };
 }  // namespace traccc::cuda

--- a/examples/io/create_binaries.cpp
+++ b/examples/io/create_binaries.cpp
@@ -6,11 +6,11 @@
  */
 
 // Project include(s).
-#include "traccc/io/read_cells.hpp"
+#include "traccc/io/read_cells_alt.hpp"
 #include "traccc/io/read_digitization_config.hpp"
 #include "traccc/io/read_geometry.hpp"
 #include "traccc/io/read_measurements.hpp"
-#include "traccc/io/read_spacepoints.hpp"
+#include "traccc/io/read_spacepoints_alt.hpp"
 #include "traccc/io/write.hpp"
 #include "traccc/options/common_options.hpp"
 #include "traccc/options/handle_argument_errors.hpp"
@@ -38,36 +38,37 @@ int create_binaries(const std::string& detector_file,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Read the cells from the relevant event file
-        traccc::cell_container_types::host cells_csv = traccc::io::read_cells(
+        auto cells_csv = traccc::io::read_cells_alt(
             event, common_opts.input_directory, common_opts.input_data_format,
             &surface_transforms, &digi_cfg, &host_mr);
 
         // Write binary file
         traccc::io::write(event, common_opts.input_directory,
                           traccc::data_format::binary,
-                          traccc::get_data(cells_csv));
+                          vecmem::get_data(cells_csv.cells),
+                          vecmem::get_data(cells_csv.modules));
 
         // Read the hits from the relevant event file
-        traccc::spacepoint_container_types::host spacepoints_csv =
-            traccc::io::read_spacepoints(
-                event, common_opts.input_directory, surface_transforms,
-                common_opts.input_data_format, &host_mr);
+        auto spacepoints_csv = traccc::io::read_spacepoints_alt(
+            event, common_opts.input_directory, surface_transforms,
+            common_opts.input_data_format, &host_mr);
 
         // Write binary file
         traccc::io::write(event, common_opts.input_directory,
                           traccc::data_format::binary,
-                          traccc::get_data(spacepoints_csv));
+                          vecmem::get_data(spacepoints_csv.spacepoints),
+                          vecmem::get_data(spacepoints_csv.modules));
 
         // Read the measurements from the relevant event file
-        traccc::measurement_container_types::host measurements_csv =
-            traccc::io::read_measurements(event, common_opts.input_directory,
-                                          common_opts.input_data_format,
-                                          &host_mr);
+        auto measurements_csv = traccc::io::read_measurements(
+            event, common_opts.input_directory, common_opts.input_data_format,
+            &host_mr);
 
         // Write binary file
         traccc::io::write(event, common_opts.input_directory,
                           traccc::data_format::binary,
-                          traccc::get_data(measurements_csv));
+                          vecmem::get_data(measurements_csv.measurements),
+                          vecmem::get_data(measurements_csv.modules));
     }
 
     return 0;

--- a/examples/run/common/throughput_mt_alt.hpp
+++ b/examples/run/common/throughput_mt_alt.hpp
@@ -29,7 +29,7 @@ namespace traccc {
 template <typename FULL_CHAIN_ALG,
           typename HOST_MR = vecmem::host_memory_resource>
 int throughput_mt_alt(std::string_view description, int argc, char* argv[],
-                      bool use_host_caching);
+                      bool use_host_caching = false);
 
 }  // namespace traccc
 

--- a/examples/run/common/throughput_st_alt.hpp
+++ b/examples/run/common/throughput_st_alt.hpp
@@ -29,7 +29,7 @@ namespace traccc {
 template <typename FULL_CHAIN_ALG,
           typename HOST_MR = vecmem::host_memory_resource>
 int throughput_st_alt(std::string_view description, int argc, char* argv[],
-                      bool use_host_caching);
+                      bool use_host_caching = false);
 
 }  // namespace traccc
 

--- a/examples/run/cpu/ccl_example.cpp
+++ b/examples/run/cpu/ccl_example.cpp
@@ -8,8 +8,8 @@
 
 // Project include(s).
 #include "traccc/clusterization/component_connection.hpp"
-#include "traccc/edm/cell.hpp"
-#include "traccc/io/read_cells.hpp"
+#include "traccc/edm/alt_cell.hpp"
+#include "traccc/io/read_cells_alt.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -29,7 +29,7 @@ double delta_ms(std::chrono::high_resolution_clock::time_point s,
 }
 }  // namespace
 
-void print_statistics(const traccc::cell_container_types::host& data) {
+void print_statistics(const traccc::alt_cell_collection_types::host& data) {
     static std::vector<std::size_t> bins_edges = {
         0,   1,   2,    3,    4,    6,    8,    11,   16,
         23,  32,  45,   64,   91,   128,  181,  256,  362,
@@ -39,15 +39,21 @@ void print_statistics(const traccc::cell_container_types::host& data) {
 
     std::vector<std::size_t> bins(bins_edges.size());
 
+    unsigned int last = std::numeric_limits<unsigned int>::max();
+    std::size_t count = 0;
     for (std::size_t i = 0; i < data.size(); ++i) {
-        std::size_t count = data.at(i).items.size();
-
-        for (std::size_t j = 0; j < bins_edges.size(); ++j) {
-            if (count >= bins_edges[j] &&
-                (j + 1 >= bins_edges.size() || count < bins_edges[j + 1])) {
-                ++bins[j];
-                break;
+        if (last == data.at(i).module_link) {
+            count++;
+        } else {
+            for (std::size_t j = 0; j < bins_edges.size(); ++j) {
+                if (count >= bins_edges[j] &&
+                    (j + 1 >= bins_edges.size() || count < bins_edges[j + 1])) {
+                    ++bins[j];
+                    break;
+                }
             }
+            count = 1;
+            last = data.at(i).module_link;
         }
     }
 
@@ -78,7 +84,7 @@ void print_statistics(const traccc::cell_container_types::host& data) {
 }
 
 void run_on_event(traccc::component_connection& cc,
-                  traccc::cell_container_types::host& data) {
+                  traccc::alt_cell_collection_types::host& data) {
     traccc::cluster_container_types::host clusters = cc(data);
 }
 
@@ -99,8 +105,8 @@ int main(int argc, char* argv[]) {
 
     auto time_read_start = std::chrono::high_resolution_clock::now();
 
-    traccc::cell_container_types::host data =
-        traccc::io::read_cells(event_file);
+    traccc::alt_cell_collection_types::host data =
+        traccc::io::read_cells_alt(event_file).cells;
 
     auto time_read_end = std::chrono::high_resolution_clock::now();
 

--- a/examples/run/cpu/full_chain_algorithm.cpp
+++ b/examples/run/cpu/full_chain_algorithm.cpp
@@ -10,17 +10,19 @@
 
 namespace traccc {
 
-full_chain_algorithm::full_chain_algorithm(vecmem::memory_resource& mr)
+full_chain_algorithm::full_chain_algorithm(vecmem::memory_resource& mr,
+                                           unsigned int)
     : m_clusterization(mr),
       m_spacepoint_formation(mr),
       m_seeding(mr),
       m_track_parameter_estimation(mr) {}
 
 full_chain_algorithm::output_type full_chain_algorithm::operator()(
-    const cell_container_types::host& cells) const {
+    const alt_cell_collection_types::host& cells,
+    const cell_module_collection_types::host& modules) const {
 
     const spacepoint_formation::output_type spacepoints =
-        m_spacepoint_formation(m_clusterization(cells));
+        m_spacepoint_formation(m_clusterization(cells, modules), modules);
     return m_track_parameter_estimation(spacepoints, m_seeding(spacepoints));
 }
 

--- a/examples/run/cpu/full_chain_algorithm.hpp
+++ b/examples/run/cpu/full_chain_algorithm.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "traccc/clusterization/clusterization_algorithm.hpp"
 #include "traccc/clusterization/spacepoint_formation.hpp"
+#include "traccc/edm/alt_cell.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
 #include "traccc/utils/algorithm.hpp"
@@ -25,15 +26,19 @@ namespace traccc {
 ///
 class full_chain_algorithm
     : public algorithm<bound_track_parameters_collection_types::host(
-          const cell_container_types::host&)> {
+          const alt_cell_collection_types::host&,
+          const cell_module_collection_types::host&)> {
 
     public:
     /// Algorithm constructor
     ///
     /// @param mr The memory resource to use for the intermediate and result
     ///           objects
+    /// @param dummy This is not used anywhere. Allows templating CPU/Device
+    /// algorithm.
     ///
-    full_chain_algorithm(vecmem::memory_resource& mr);
+
+    full_chain_algorithm(vecmem::memory_resource& mr, unsigned int dummy);
 
     /// Reconstruct track parameters in the entire detector
     ///
@@ -41,7 +46,8 @@ class full_chain_algorithm
     /// @return The track parameters reconstructed
     ///
     output_type operator()(
-        const cell_container_types::host& cells) const override;
+        const alt_cell_collection_types::host& cells,
+        const cell_module_collection_types::host& modules) const override;
 
     private:
     /// @name Sub-algorithms used by this full-chain algorithm

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -7,7 +7,7 @@
 
 // io
 #include "traccc/io/read_geometry.hpp"
-#include "traccc/io/read_spacepoints.hpp"
+#include "traccc/io/read_spacepoints_alt.hpp"
 
 // algorithms
 #include "traccc/seeding/seeding_algorithm.hpp"
@@ -57,10 +57,11 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Read the hits from the relevant event file
-        traccc::spacepoint_container_types::host spacepoints_per_event =
-            traccc::io::read_spacepoints(
-                event, common_opts.input_directory, surface_transforms,
-                common_opts.input_data_format, &host_mr);
+        auto readOut = traccc::io::read_spacepoints_alt(
+            event, common_opts.input_directory, surface_transforms,
+            common_opts.input_data_format, &host_mr);
+        traccc::spacepoint_collection_types::host& spacepoints_per_event =
+            readOut.spacepoints;
 
         /*----------------
              Seeding
@@ -72,7 +73,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
              Statistics
           ---------------*/
 
-        n_spacepoints += spacepoints_per_event.total_size();
+        n_spacepoints += spacepoints_per_event.size();
         n_seeds += seeds.size();
 
         /*------------
@@ -84,7 +85,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
                                       common_opts.input_directory,
                                       common_opts.input_directory, host_mr);
             sd_performance_writer.write("CPU", vecmem::get_data(seeds),
-                                        traccc::get_data(spacepoints_per_event),
+                                        vecmem::get_data(spacepoints_per_event),
                                         evt_map);
         }
     }

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -6,7 +6,7 @@
  */
 
 // io
-#include "traccc/io/read_cells.hpp"
+#include "traccc/io/read_cells_alt.hpp"
 #include "traccc/io/read_digitization_config.hpp"
 #include "traccc/io/read_geometry.hpp"
 
@@ -71,22 +71,26 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Read the cells from the relevant event file
-        traccc::cell_container_types::host cells_per_event =
-            traccc::io::read_cells(event, common_opts.input_directory,
-                                   common_opts.input_data_format,
-                                   &surface_transforms, &digi_cfg, &host_mr);
+        auto readOut = traccc::io::read_cells_alt(
+            event, common_opts.input_directory, common_opts.input_data_format,
+            &surface_transforms, &digi_cfg, &host_mr);
+        traccc::alt_cell_collection_types::host& cells_per_event =
+            readOut.cells;
+        traccc::cell_module_collection_types::host& modules_per_event =
+            readOut.modules;
 
         /*-------------------
             Clusterization
           -------------------*/
 
-        auto measurements_per_event = ca(cells_per_event);
+        auto measurements_per_event = ca(cells_per_event, modules_per_event);
 
         /*------------------------
             Spacepoint formation
           ------------------------*/
 
-        auto spacepoints_per_event = sf(measurements_per_event);
+        auto spacepoints_per_event =
+            sf(measurements_per_event, modules_per_event);
 
         /*-----------------------
           Seeding algorithm
@@ -104,10 +108,10 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
           Statistics
           ----------------------------*/
 
-        n_modules += cells_per_event.size();
-        n_cells += cells_per_event.total_size();
-        n_measurements += measurements_per_event.total_size();
-        n_spacepoints += spacepoints_per_event.total_size();
+        n_modules += modules_per_event.size();
+        n_cells += cells_per_event.size();
+        n_measurements += measurements_per_event.size();
+        n_spacepoints += spacepoints_per_event.size();
         n_seeds += seeds.size();
 
         /*------------
@@ -121,7 +125,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 common_opts.input_directory, host_mr);
 
             sd_performance_writer.write("CPU", vecmem::get_data(seeds),
-                                        traccc::get_data(spacepoints_per_event),
+                                        vecmem::get_data(spacepoints_per_event),
                                         evt_map);
         }
     }

--- a/examples/run/cpu/throughput_mt.cpp
+++ b/examples/run/cpu/throughput_mt.cpp
@@ -6,13 +6,12 @@
  */
 
 // Local include(s).
-#include "../common/throughput_mt.hpp"
-
+#include "../common/throughput_mt_alt.hpp"
 #include "full_chain_algorithm.hpp"
 
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
-    return traccc::throughput_mt<traccc::full_chain_algorithm>(
+    return traccc::throughput_mt_alt<traccc::full_chain_algorithm>(
         "Multi-threaded host-only throughput tests", argc, argv);
 }

--- a/examples/run/cpu/throughput_st.cpp
+++ b/examples/run/cpu/throughput_st.cpp
@@ -6,13 +6,12 @@
  */
 
 // Local include(s).
-#include "../common/throughput_st.hpp"
-
+#include "../common/throughput_st_alt.hpp"
 #include "full_chain_algorithm.hpp"
 
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
-    return traccc::throughput_st<traccc::full_chain_algorithm>(
+    return traccc::throughput_st_alt<traccc::full_chain_algorithm>(
         "Single-threaded host-only throughput tests", argc, argv);
 }

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -13,7 +13,6 @@
 #include "traccc/cuda/seeding/track_params_estimation.hpp"
 #include "traccc/cuda/utils/stream.hpp"
 #include "traccc/efficiency/seeding_performance_writer.hpp"
-#include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_cells_alt.hpp"
 #include "traccc/io/read_digitization_config.hpp"
 #include "traccc/io/read_geometry.hpp"
@@ -52,7 +51,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
     // Output stats
     uint64_t n_cells = 0;
-    uint64_t n_alt_cells = 0;
     uint64_t n_modules = 0;
     // uint64_t n_clusters = 0;
     uint64_t n_measurements = 0;
@@ -97,8 +95,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Instantiate host containers/collections
-        traccc::cell_container_types::host cells_per_event;
-        traccc::alt_cell_reader_output_t alt_read_out_per_event;
+        traccc::io::cell_reader_output alt_read_out_per_event;
         traccc::clusterization_algorithm::output_type measurements_per_event;
         traccc::spacepoint_formation::output_type spacepoints_per_event;
         traccc::seeding_algorithm::output_type seeds;
@@ -115,18 +112,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         {
             traccc::performance::timer wall_t("Wall time", elapsedTimes);
 
-            if (run_cpu) {
-                traccc::performance::timer t("File reading  (cpu)",
-                                             elapsedTimes);
-                // Read the cells from the relevant event file into host memory.
-                cells_per_event = traccc::io::read_cells(
-                    event, common_opts.input_directory,
-                    common_opts.input_data_format, &surface_transforms,
-                    &digi_cfg, &cuda_host_mr);
-            }  // stop measuring file reading timer
-
             {
-                traccc::performance::timer t("Alt File reading  (cpu)",
+                traccc::performance::timer t("File reading  (cpu)",
                                              elapsedTimes);
                 // Read the cells from the relevant event file into host memory.
                 alt_read_out_per_event = traccc::io::read_cells_alt(
@@ -169,7 +156,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 {
                     traccc::performance::timer t("Clusterization  (cpu)",
                                                  elapsedTimes);
-                    measurements_per_event = ca(cells_per_event);
+                    measurements_per_event =
+                        ca(alt_cells_per_event, modules_per_event);
                 }  // stop measuring clusterization cpu timer
 
                 /*---------------------------------
@@ -179,7 +167,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 {
                     traccc::performance::timer t("Spacepoint formation  (cpu)",
                                                  elapsedTimes);
-                    spacepoints_per_event = sf(measurements_per_event);
+                    spacepoints_per_event =
+                        sf(measurements_per_event, modules_per_event);
                 }  // stop measuring spacepoint formation cpu timer
             }
 
@@ -242,21 +231,19 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
             // Show which event we are currently presenting the results for.
             std::cout << "===>>> Event " << event << " <<<===" << std::endl;
 
-            /// TODO:
             // Compare the spacepoints made on the host and on the device.
-            /* traccc::container_comparator<traccc::geometry_id,
-                                         traccc::spacepoint>
+            traccc::collection_comparator<traccc::spacepoint>
                 compare_spacepoints{"spacepoints"};
-            compare_spacepoints(traccc::get_data(spacepoints_per_event),
-                                traccc::get_data(spacepoints_per_event_cuda));
+            compare_spacepoints(vecmem::get_data(spacepoints_per_event),
+                                vecmem::get_data(spacepoints_per_event_cuda));
 
             // Compare the seeds made on the host and on the device
-            traccc::collection_comparator<traccc::seed> compare_seeds{
-                "seeds", traccc::details::comparator_factory<traccc::seed>{
-                             traccc::get_data(spacepoints_per_event),
-                             traccc::get_data(spacepoints_per_event_cuda)}};
+            traccc::collection_comparator<traccc::alt_seed> compare_seeds{
+                "seeds", traccc::details::comparator_factory<traccc::alt_seed>{
+                             vecmem::get_data(spacepoints_per_event),
+                             vecmem::get_data(spacepoints_per_event_cuda)}};
             compare_seeds(vecmem::get_data(seeds),
-                          vecmem::get_data(seeds_cuda)); */
+                          vecmem::get_data(seeds_cuda));
 
             // Compare the track parameters made on the host and on the device.
             traccc::collection_comparator<traccc::bound_track_parameters>
@@ -265,47 +252,41 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                                      vecmem::get_data(params_cuda));
 
             /// Statistics
-            n_modules += cells_per_event.size();
-            n_cells += cells_per_event.total_size();
-            n_alt_cells += alt_read_out_per_event.cells.size();
-            n_measurements += measurements_per_event.total_size();
-            n_spacepoints += spacepoints_per_event.total_size();
+            n_modules += alt_read_out_per_event.modules.size();
+            n_cells += alt_read_out_per_event.cells.size();
+            n_measurements += measurements_per_event.size();
+            n_spacepoints += spacepoints_per_event.size();
             n_spacepoints_cuda += spacepoints_per_event_cuda.size();
             n_seeds_cuda += seeds_cuda.size();
             n_seeds += seeds.size();
         }
-        /// TODO:
-        /* if (i_cfg.check_performance) {
+        if (i_cfg.check_performance) {
 
             traccc::event_map evt_map(
-                event, i_cfg.detector_file,
-                i_cfg.digitization_config_file,
+                event, i_cfg.detector_file, i_cfg.digitization_config_file,
                 common_opts.input_directory, common_opts.input_directory,
                 common_opts.input_directory, host_mr);
-            sd_performance_writer.write("CUDA", seeds_cuda,
-                                        spacepoints_per_event_cuda,
-                                        evt_map);
+            sd_performance_writer.write(
+                "CUDA", vecmem::get_data(seeds_cuda),
+                vecmem::get_data(spacepoints_per_event_cuda), evt_map);
 
             if (run_cpu) {
-                sd_performance_writer.write("CPU", seeds,
-                spacepoints_per_event,
-                                            evt_map);
+                sd_performance_writer.write(
+                    "CPU", vecmem::get_data(seeds),
+                    vecmem::get_data(spacepoints_per_event), evt_map);
             }
-        } */
+        }
     }
 
-    /* if (i_cfg.check_performance) {
+    if (i_cfg.check_performance) {
         sd_performance_writer.finalize();
-    } */
+    }
 
     std::cout << "==> Statistics ... " << std::endl;
     std::cout << "- read    " << n_spacepoints << " spacepoints from "
               << n_modules << " modules" << std::endl;
-    std::cout << "- created        " << n_cells << " cells           "
-              << std::endl;
-    std::cout << "- created        " << n_alt_cells << " alt cells"
-              << std::endl;
-    std::cout << "- created        " << n_measurements << " meaurements     "
+    std::cout << "- created        " << n_cells << " cells" << std::endl;
+    std::cout << "- created        " << n_measurements << " measurements     "
               << std::endl;
     std::cout << "- created        " << n_spacepoints << " spacepoints     "
               << std::endl;

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -104,8 +104,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     for (unsigned int event = common_opts.skip;
          event < common_opts.events + common_opts.skip; ++event) {
 
-        traccc::spacepoint_container_types::host spacepoints_per_event;
-        traccc::spacepoint_collection_types::host alt_spacepoints_per_event;
+        traccc::io::spacepoint_reader_output reader_output;
         traccc::seeding_algorithm::output_type seeds;
         traccc::track_params_estimation::output_type params;
 
@@ -115,29 +114,22 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
             /*-----------------
             hit file reading
             -----------------*/
-            if (run_cpu) {
+            {
                 traccc::performance::timer t("Hit reading  (cpu)",
                                              elapsedTimes);
                 // Read the hits from the relevant event file
-                spacepoints_per_event = traccc::io::read_spacepoints(
+                reader_output = traccc::io::read_spacepoints_alt(
                     event, common_opts.input_directory, surface_transforms,
                     common_opts.input_data_format, &host_mr);
             }  // stop measuring hit reading timer
 
-            {
-                traccc::performance::timer t("Alt hit reading  (cpu)",
-                                             elapsedTimes);
-                // Read the hits from the relevant event file
-                alt_spacepoints_per_event = traccc::io::read_spacepoints_alt(
-                    event, common_opts.input_directory, surface_transforms,
-                    common_opts.input_data_format, &host_mr);
-            }  // stop measuring hit reading timer
+            traccc::spacepoint_collection_types::host& spacepoints_per_event =
+                reader_output.spacepoints;
 
             {  // Spacepoin binning for kokkos
                 traccc::performance::timer t("Spacepoint binning (kokkos)",
                                              elapsedTimes);
-                m_spacepoint_binning(
-                    vecmem::get_data(alt_spacepoints_per_event));
+                m_spacepoint_binning(vecmem::get_data(spacepoints_per_event));
             }
 
             /*----------------------------

--- a/examples/run/openmp/io_dec_par_example.cpp
+++ b/examples/run/openmp/io_dec_par_example.cpp
@@ -8,9 +8,10 @@
 // Project include(s).
 #include "traccc/clusterization/clusterization_algorithm.hpp"
 #include "traccc/clusterization/spacepoint_formation.hpp"
-#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/alt_cell.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
-#include "traccc/io/demonstrator_edm.hpp"
+#include "traccc/io/demonstrator_alt_edm.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -29,8 +30,8 @@
 
 namespace po = boost::program_options;
 
-traccc::demonstrator_result run(traccc::demonstrator_input input_data,
-                                vecmem::host_memory_resource resource) {
+traccc::alt_demonstrator_result run(traccc::alt_demonstrator_input input_data,
+                                    vecmem::host_memory_resource resource) {
 
     // Algorithms
     traccc::clusterization_algorithm ca(resource);
@@ -44,38 +45,42 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data,
 
     auto startAlgorithms = std::chrono::system_clock::now();
 
-    traccc::demonstrator_result aggregated_results(input_data.size(),
-                                                   &resource);
+    traccc::alt_demonstrator_result aggregated_results(input_data.size(),
+                                                       &resource);
 
 #pragma omp parallel for reduction (+:n_modules, n_cells, n_measurements, n_spacepoints)
     for (size_t event = 0; event < input_data.size(); ++event) {
-        traccc::cell_container_types::host cells_per_event =
-            input_data.operator[](event);
+        traccc::alt_cell_collection_types::host& cells_per_event =
+            input_data.operator[](event).cells;
+
+        traccc::cell_module_collection_types::host& modules_per_event =
+            input_data.operator[](event).modules;
 
         /*-------------------
             Clusterization
           -------------------*/
 
-        auto measurements_per_event = ca(cells_per_event);
+        auto measurements_per_event = ca(cells_per_event, modules_per_event);
 
         /*------------------------
             Spacepoint formation
           ------------------------*/
 
-        auto spacepoints_per_event = sf(measurements_per_event);
+        auto spacepoints_per_event =
+            sf(measurements_per_event, modules_per_event);
 
         /*----------------------------
           Statistics
           ----------------------------*/
 
-        n_modules += cells_per_event.size();
-        n_cells += cells_per_event.total_size();
-        n_measurements += measurements_per_event.total_size();
-        n_spacepoints += spacepoints_per_event.total_size();
+        n_modules += modules_per_event.size();
+        n_cells += cells_per_event.size();
+        n_measurements += measurements_per_event.size();
+        n_spacepoints += spacepoints_per_event.size();
 
 #pragma omp critical
         aggregated_results[event] =
-            traccc::result({measurements_per_event, spacepoints_per_event});
+            traccc::alt_result({measurements_per_event, spacepoints_per_event});
     }
 
     auto endAlgorithms = std::chrono::system_clock::now();
@@ -94,7 +99,7 @@ traccc::demonstrator_result run(traccc::demonstrator_input input_data,
 }
 
 // The main routine
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
 
     // Set up the program options.
     po::options_description desc("Allowed options");
@@ -119,7 +124,7 @@ int main(int argc, char *argv[]) {
     // Handle any and all errors.
     try {
         po::notify(vm);
-    } catch (const std::exception &ex) {
+    } catch (const std::exception& ex) {
         std::cerr << "Couldn't interpret command line options because of:\n\n"
                   << ex.what() << "\n\n"
                   << desc << std::endl;

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -8,12 +8,12 @@
 // Project include(s).
 #include "traccc/clusterization/clusterization_algorithm.hpp"
 #include "traccc/clusterization/spacepoint_formation.hpp"
-#include "traccc/edm/cell.hpp"
+#include "traccc/edm/alt_cell.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 #include "traccc/edm/cluster.hpp"
-#include "traccc/edm/measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/geometry/pixel_data.hpp"
-#include "traccc/io/read_cells.hpp"
+#include "traccc/io/read_cells_alt.hpp"
 #include "traccc/io/read_digitization_config.hpp"
 #include "traccc/io/read_geometry.hpp"
 
@@ -63,30 +63,35 @@ int par_run(const std::string &detector_file,
     for (unsigned int event = 0; event < events; ++event) {
 
         // Read the cells from the relevant event file
-        traccc::cell_container_types::host cells_per_event =
-            traccc::io::read_cells(event, cells_dir, traccc::data_format::csv,
-                                   &surface_transforms, &digi_cfg, &resource);
+        auto readOut = traccc::io::read_cells_alt(
+            event, cells_dir, traccc::data_format::csv, &surface_transforms,
+            &digi_cfg, &resource);
+        traccc::alt_cell_collection_types::host &cells_per_event =
+            readOut.cells;
+        traccc::cell_module_collection_types::host &modules_per_event =
+            readOut.modules;
 
         /*-------------------
             Clusterization
           -------------------*/
 
-        auto measurements_per_event = ca(cells_per_event);
+        auto measurements_per_event = ca(cells_per_event, modules_per_event);
 
         /*------------------------
             Spacepoint formation
           ------------------------*/
 
-        auto spacepoints_per_event = sf(measurements_per_event);
+        auto spacepoints_per_event =
+            sf(measurements_per_event, modules_per_event);
 
         /*----------------------------
           Statistics
           ----------------------------*/
 
-        n_modules += cells_per_event.size();
-        n_cells += cells_per_event.total_size();
-        n_measurements += measurements_per_event.total_size();
-        n_spacepoints += spacepoints_per_event.total_size();
+        n_modules += modules_per_event.size();
+        n_cells += cells_per_event.size();
+        n_measurements += measurements_per_event.size();
+        n_spacepoints += spacepoints_per_event.size();
     }
 
 #pragma omp critical

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -86,8 +86,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Instantiate host containers/collections
-        traccc::spacepoint_container_types::host spacepoints_per_event;
-        traccc::spacepoint_collection_types::host alt_spacepoints_per_event;
+        traccc::io::spacepoint_reader_output reader_output;
         traccc::seeding_algorithm::output_type seeds;
         traccc::track_params_estimation::output_type params;
 
@@ -104,25 +103,18 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
               hit file reading
               -----------------*/
 
-            if (run_cpu) {
+            {
                 traccc::performance::timer t("Hit reading  (cpu)",
                                              elapsedTimes);
                 // Read the hits from the relevant event file
-                spacepoints_per_event = traccc::io::read_spacepoints(
-                    event, common_opts.input_directory, surface_transforms,
-                    common_opts.input_data_format, &host_mr);
-            }  // stop measuring hit reading timer
-
-            {
-                traccc::performance::timer t("Alt hit reading  (cpu)",
-                                             elapsedTimes);
-                // Read the hits from the relevant event file
-                alt_spacepoints_per_event = traccc::io::read_spacepoints_alt(
+                reader_output = traccc::io::read_spacepoints_alt(
                     event, common_opts.input_directory, surface_transforms,
                     common_opts.input_data_format, &host_mr);
 
             }  // stop measuring hit reading timer
 
+            const traccc::spacepoint_collection_types::host&
+                spacepoints_per_event = reader_output.spacepoints;
             /*----------------------------
                  Seeding algorithm
               ----------------------------*/
@@ -131,8 +123,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
 
             // Copy the spacepoint data to the device.
             traccc::spacepoint_collection_types::buffer spacepoints_sycl_buffer(
-                alt_spacepoints_per_event.size(), mr.main);
-            copy(vecmem::get_data(alt_spacepoints_per_event),
+                spacepoints_per_event.size(), mr.main);
+            copy(vecmem::get_data(spacepoints_per_event),
                  spacepoints_sycl_buffer);
 
             {
@@ -180,17 +172,17 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         copy(seeds_sycl_buffer, seeds_sycl);
         copy(params_sycl_buffer, params_sycl);
 
-        if (run_cpu) {
+        if (run_cpu && i_cfg.check_performance) {
             // Show which event we are currently presenting the results for.
             std::cout << "===>>> Event " << event << " <<<===" << std::endl;
 
             // Compare the seeds made on the host and on the device
-            /* traccc::collection_comparator<traccc::seed> compare_seeds{
-                "seeds", traccc::details::comparator_factory<traccc::seed>{
-                             traccc::get_data(spacepoints_per_event),
-                             traccc::get_data(spacepoints_per_event)}};
+            traccc::collection_comparator<traccc::alt_seed> compare_seeds{
+                "seeds", traccc::details::comparator_factory<traccc::alt_seed>{
+                             vecmem::get_data(reader_output.spacepoints),
+                             vecmem::get_data(reader_output.spacepoints)}};
             compare_seeds(vecmem::get_data(seeds),
-                          vecmem::get_data(seeds_sycl)); */
+                          vecmem::get_data(seeds_sycl));
 
             // Compare the track parameters made on the host and on the device.
             traccc::collection_comparator<traccc::bound_track_parameters>
@@ -203,7 +195,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
              Statistics
           ---------------*/
 
-        n_spacepoints += spacepoints_per_event.size();
+        n_spacepoints += reader_output.spacepoints.size();
         n_seeds_sycl += seeds_sycl.size();
         n_seeds += seeds.size();
 
@@ -211,22 +203,24 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
           Writer
           ------------*/
 
-        /* if (i_cfg.check_performance) {
+        if (i_cfg.check_performance) {
             traccc::event_map evt_map(event, i_cfg.detector_file,
                                       common_opts.input_directory,
                                       common_opts.input_directory, host_mr);
-            sd_performance_writer.write("SYCL", seeds_sycl,
-                                        spacepoints_per_event, evt_map);
+            sd_performance_writer.write(
+                "SYCL", vecmem::get_data(seeds_sycl),
+                vecmem::get_data(reader_output.spacepoints), evt_map);
             if (run_cpu) {
-                sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
-                                            evt_map);
+                sd_performance_writer.write(
+                    "CPU", vecmem::get_data(seeds),
+                    vecmem::get_data(reader_output.spacepoints), evt_map);
             }
-        } */
+        }
     }
 
-    /* if (i_cfg.check_performance) {
+    if (i_cfg.check_performance) {
         sd_performance_writer.finalize();
-    } */
+    }
 
     std::cout << "==> Statistics ... " << std::endl;
     std::cout << "- read    " << n_spacepoints << " spacepoints from "

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -9,7 +9,6 @@
 #include <CL/sycl.hpp>
 
 // io
-#include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_cells_alt.hpp"
 #include "traccc/io/read_digitization_config.hpp"
 #include "traccc/io/read_geometry.hpp"
@@ -75,7 +74,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
     // Output stats
     uint64_t n_cells = 0;
-    uint64_t n_alt_cells = 0;
     uint64_t n_modules = 0;
     // uint64_t n_clusters = 0;
     uint64_t n_measurements = 0;
@@ -121,8 +119,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Instantiate host containers/collections
-        traccc::cell_container_types::host cells_per_event;
-        traccc::alt_cell_reader_output_t alt_read_out_per_event;
+        traccc::io::cell_reader_output alt_read_out_per_event;
         traccc::clusterization_algorithm::output_type measurements_per_event;
         traccc::spacepoint_formation::output_type spacepoints_per_event;
         traccc::seeding_algorithm::output_type seeds;
@@ -139,18 +136,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         {
             traccc::performance::timer wall_t("Wall time", elapsedTimes);
 
-            if (run_cpu) {
-                traccc::performance::timer t("File reading  (cpu)",
-                                             elapsedTimes);
-                // Read the cells from the relevant event file into host memory.
-                cells_per_event = traccc::io::read_cells(
-                    event, common_opts.input_directory,
-                    common_opts.input_data_format, &surface_transforms,
-                    &digi_cfg, &host_mr);
-            }  // stop measuring file reading timer
-
             {
-                traccc::performance::timer t("Alt File reading  (cpu)",
+                traccc::performance::timer t("File reading  (cpu)",
                                              elapsedTimes);
                 // Read the cells from the relevant event file into host memory.
                 alt_read_out_per_event = traccc::io::read_cells_alt(
@@ -193,7 +180,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 {
                     traccc::performance::timer t("Clusterization  (cpu)",
                                                  elapsedTimes);
-                    measurements_per_event = ca(cells_per_event);
+                    measurements_per_event =
+                        ca(alt_cells_per_event, modules_per_event);
                 }
 
                 /*---------------------------------
@@ -203,7 +191,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 {
                     traccc::performance::timer t("Spacepoint formation  (cpu)",
                                                  elapsedTimes);
-                    spacepoints_per_event = sf(measurements_per_event);
+                    spacepoints_per_event =
+                        sf(measurements_per_event, modules_per_event);
                 }
             }
 
@@ -264,21 +253,19 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
             // Show which event we are currently presenting the results for.
             std::cout << "===>>> Event " << event << " <<<===" << std::endl;
 
-            /// TODO:
             // Compare the spacepoints made on the host and on the device.
-            /* traccc::container_comparator<traccc::geometry_id,
-                                         traccc::spacepoint>
+            traccc::collection_comparator<traccc::spacepoint>
                 compare_spacepoints{"spacepoints"};
-            compare_spacepoints(traccc::get_data(spacepoints_per_event),
-                                traccc::get_data(spacepoints_per_event_sycl));
+            compare_spacepoints(vecmem::get_data(spacepoints_per_event),
+                                vecmem::get_data(spacepoints_per_event_sycl));
 
             // Compare the seeds made on the host and on the device
-            traccc::collection_comparator<traccc::seed> compare_seeds{
-                "seeds", traccc::details::comparator_factory<traccc::seed>{
-                             traccc::get_data(spacepoints_per_event),
-                             traccc::get_data(spacepoints_per_event_sycl)}};
+            traccc::collection_comparator<traccc::alt_seed> compare_seeds{
+                "seeds", traccc::details::comparator_factory<traccc::alt_seed>{
+                             vecmem::get_data(spacepoints_per_event),
+                             vecmem::get_data(spacepoints_per_event_sycl)}};
             compare_seeds(vecmem::get_data(seeds),
-                          vecmem::get_data(seeds_sycl)); */
+                          vecmem::get_data(seeds_sycl));
 
             // Compare the track parameters made on the host and on the device.
             traccc::collection_comparator<traccc::bound_track_parameters>
@@ -287,42 +274,41 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                                      vecmem::get_data(params_sycl));
 
             /// Statistics
-            n_modules += cells_per_event.size();
-            n_cells += cells_per_event.total_size();
-            n_alt_cells += alt_read_out_per_event.cells.size();
-            n_measurements += measurements_per_event.total_size();
-            n_spacepoints += spacepoints_per_event.total_size();
+            n_modules += alt_read_out_per_event.modules.size();
+            n_cells += alt_read_out_per_event.cells.size();
+            n_measurements += measurements_per_event.size();
+            n_spacepoints += spacepoints_per_event.size();
             n_spacepoints_sycl += spacepoints_per_event_sycl.size();
             n_seeds_sycl += seeds_sycl.size();
             n_seeds += seeds.size();
         }
-        /// TODO:
-        /* if (i_cfg.check_performance) {
+
+        if (i_cfg.check_performance) {
 
             traccc::event_map evt_map(
                 event, i_cfg.detector_file, i_cfg.digitization_config_file,
                 common_opts.input_directory, common_opts.input_directory,
                 common_opts.input_directory, host_mr);
-            sd_performance_writer.write("SYCL", seeds_sycl,
-                                        spacepoints_per_event_sycl, evt_map);
+            sd_performance_writer.write(
+                "SYCL", vecmem::get_data(seeds_sycl),
+                vecmem::get_data(spacepoints_per_event_sycl), evt_map);
 
             if (run_cpu) {
-                sd_performance_writer.write("CPU", seeds, spacepoints_per_event,
-                                            evt_map);
+                sd_performance_writer.write(
+                    "CPU", vecmem::get_data(seeds),
+                    vecmem::get_data(spacepoints_per_event), evt_map);
             }
-        } */
+        }
     }
 
-    /* if (i_cfg.check_performance) {
+    if (i_cfg.check_performance) {
         sd_performance_writer.finalize();
-    } */
+    }
 
     std::cout << "==> Statistics ... " << std::endl;
     std::cout << "- read    " << n_spacepoints << " spacepoints from "
               << n_modules << " modules" << std::endl;
     std::cout << "- created        " << n_cells << " cells           "
-              << std::endl;
-    std::cout << "- created        " << n_alt_cells << " alt cells"
               << std::endl;
     std::cout << "- created        " << n_measurements << " measurements     "
               << std::endl;

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -28,6 +28,7 @@ traccc_add_library( traccc_io io TYPE SHARED
   "include/traccc/io/write.hpp"
   "include/traccc/io/utils.hpp"
   "include/traccc/io/details/read_surfaces.hpp"
+  "include/traccc/io/reader_edm.hpp"
   # Implementation
   "src/data_format.cpp"
   "src/event_map2.cpp"

--- a/io/include/traccc/io/demonstrator_alt_edm.hpp
+++ b/io/include/traccc/io/demonstrator_alt_edm.hpp
@@ -9,13 +9,14 @@
 
 #include "traccc/edm/alt_cell.hpp"
 #include "traccc/edm/spacepoint.hpp"
+#include "traccc/io/reader_edm.hpp"
 
 namespace traccc {
 struct alt_result {
-    measurement_container_types::host measurements;
-    spacepoint_container_types::host spacepoints;
+    alt_measurement_collection_types::host measurements;
+    spacepoint_collection_types::host spacepoints;
 };
 
-using alt_demonstrator_input = vecmem::vector<alt_cell_reader_output_t>;
+using alt_demonstrator_input = vecmem::vector<io::cell_reader_output>;
 using alt_demonstrator_result = vecmem::vector<alt_result>;
 }  // namespace traccc

--- a/io/include/traccc/io/mapper.hpp
+++ b/io/include/traccc/io/mapper.hpp
@@ -8,8 +8,8 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/edm/cell.hpp"
-#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/alt_cell.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 #include "traccc/edm/particle.hpp"
 #include "traccc/edm/spacepoint.hpp"
 
@@ -26,34 +26,40 @@ using particle_id = uint64_t;
 using particle_map = std::map<particle_id, particle>;
 using hit_particle_map = std::map<spacepoint, particle>;
 using hit_map = std::map<hit_id, spacepoint>;
-using hit_cell_map = std::map<spacepoint, std::vector<cell>>;
-using cell_particle_map = std::map<cell, particle>;
-using measurement_cell_map = std::map<measurement, vecmem::vector<cell>>;
+using hit_cell_map = std::map<spacepoint, std::vector<alt_cell>>;
+using geoId_link_map = std::map<geometry_id, unsigned int>;
+using cell_particle_map = std::map<alt_cell, particle>;
+using measurement_cell_map =
+    std::map<alt_measurement, vecmem::vector<alt_cell>>;
 using measurement_particle_map =
-    std::map<measurement, std::map<particle, uint64_t>>;
+    std::map<alt_measurement, std::map<particle, uint64_t>>;
 
 particle_map generate_particle_map(std::size_t event,
                                    const std::string& particle_dir);
 
-hit_particle_map generate_hit_particle_map(std::size_t event,
-                                           const std::string& hits_dir,
-                                           const std::string& particle_dir);
+hit_particle_map generate_hit_particle_map(
+    std::size_t event, const std::string& hits_dir,
+    const std::string& particle_dir,
+    const geoId_link_map& link_map = geoId_link_map());
 
 hit_map generate_hit_map(std::size_t event, const std::string& hits_dir);
 
-hit_cell_map generate_hit_cell_map(std::size_t event,
-                                   const std::string& cells_dir,
-                                   const std::string& hits_dir);
+hit_cell_map generate_hit_cell_map(
+    std::size_t event, const std::string& cells_dir,
+    const std::string& hits_dir,
+    const geoId_link_map& link_map = geoId_link_map());
 
-cell_particle_map generate_cell_particle_map(std::size_t event,
-                                             const std::string& cells_dir,
-                                             const std::string& hits_dir,
-                                             const std::string& particle_dir);
+cell_particle_map generate_cell_particle_map(
+    std::size_t event, const std::string& cells_dir,
+    const std::string& hits_dir, const std::string& particle_dir,
+    const geoId_link_map& link_map = geoId_link_map());
 
-measurement_cell_map generate_measurement_cell_map(
-    std::size_t event, const std::string& detector_file,
-    const std::string& digi_config_file, const std::string& cells_dir,
-    vecmem::memory_resource& resource);
+std::tuple<measurement_cell_map, cell_module_collection_types::host>
+generate_measurement_cell_map(std::size_t event,
+                              const std::string& detector_file,
+                              const std::string& digi_config_file,
+                              const std::string& cells_dir,
+                              vecmem::memory_resource& resource);
 
 measurement_particle_map generate_measurement_particle_map(
     std::size_t event, const std::string& detector_file,

--- a/io/include/traccc/io/read_cells_alt.hpp
+++ b/io/include/traccc/io/read_cells_alt.hpp
@@ -9,6 +9,7 @@
 
 // Local include(s).
 #include "traccc/io/data_format.hpp"
+#include "traccc/io/reader_edm.hpp"
 
 // Project include(s).
 #include "traccc/edm/alt_cell.hpp"
@@ -37,11 +38,11 @@ namespace traccc::io {
 /// @param mr The memory resource to create the host collection with
 /// @return A alt_cell (host) collection & a cell_module collection
 ///
-alt_cell_reader_output_t read_cells_alt(
-    std::size_t event, std::string_view directory,
-    data_format format = data_format::csv, const geometry *geom = nullptr,
-    const digitization_config *dconfig = nullptr,
-    vecmem::memory_resource *mr = nullptr);
+cell_reader_output read_cells_alt(std::size_t event, std::string_view directory,
+                                  data_format format = data_format::csv,
+                                  const geometry *geom = nullptr,
+                                  const digitization_config *dconfig = nullptr,
+                                  vecmem::memory_resource *mr = nullptr);
 
 /// Read cell data into memory
 ///
@@ -54,10 +55,10 @@ alt_cell_reader_output_t read_cells_alt(
 /// @param mr The memory resource to create the host collection with
 /// @return A alt_cell (host) collection & a cell_module collection
 ///
-alt_cell_reader_output_t read_cells_alt(
-    std::string_view filename, data_format format = data_format::csv,
-    const geometry *geom = nullptr,
-    const digitization_config *dconfig = nullptr,
-    vecmem::memory_resource *mr = nullptr);
+cell_reader_output read_cells_alt(std::string_view filename,
+                                  data_format format = data_format::csv,
+                                  const geometry *geom = nullptr,
+                                  const digitization_config *dconfig = nullptr,
+                                  vecmem::memory_resource *mr = nullptr);
 
 }  // namespace traccc::io

--- a/io/include/traccc/io/read_measurements.hpp
+++ b/io/include/traccc/io/read_measurements.hpp
@@ -12,6 +12,7 @@
 
 // Project include(s).
 #include "traccc/edm/measurement.hpp"
+#include "traccc/io/reader_edm.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
@@ -33,7 +34,7 @@ namespace traccc::io {
 /// @param mr The memory resource to create the host container with
 /// @return A cell (host) container
 ///
-measurement_container_types::host read_measurements(
+measurement_reader_output read_measurements(
     std::size_t event, std::string_view directory,
     data_format format = data_format::csv,
     vecmem::memory_resource *mr = nullptr);
@@ -47,7 +48,7 @@ measurement_container_types::host read_measurements(
 /// @param mr The memory resource to create the host container with
 /// @return A cell (host) container
 ///
-measurement_container_types::host read_measurements(
+measurement_reader_output read_measurements(
     std::string_view filename, data_format format = data_format::csv,
     vecmem::memory_resource *mr = nullptr);
 

--- a/io/include/traccc/io/read_spacepoints_alt.hpp
+++ b/io/include/traccc/io/read_spacepoints_alt.hpp
@@ -9,6 +9,7 @@
 
 // Local include(s).
 #include "traccc/io/data_format.hpp"
+#include "traccc/io/reader_edm.hpp"
 
 // Project include(s).
 #include "traccc/edm/spacepoint.hpp"
@@ -35,7 +36,7 @@ namespace traccc::io {
 /// @param mr The memory resource to create the host collection with
 /// @return A cell (host) collection
 ///
-spacepoint_collection_types::host read_spacepoints_alt(
+spacepoint_reader_output read_spacepoints_alt(
     std::size_t event, std::string_view directory, const geometry &geom,
     data_format format = data_format::csv,
     vecmem::memory_resource *mr = nullptr);
@@ -50,7 +51,7 @@ spacepoint_collection_types::host read_spacepoints_alt(
 /// @param mr The memory resource to create the host collection with
 /// @return A cell (host) collection
 ///
-spacepoint_collection_types::host read_spacepoints_alt(
+spacepoint_reader_output read_spacepoints_alt(
     std::string_view filename, const geometry &geom,
     data_format format = data_format::csv,
     vecmem::memory_resource *mr = nullptr);

--- a/io/include/traccc/io/reader_edm.hpp
+++ b/io/include/traccc/io/reader_edm.hpp
@@ -1,0 +1,40 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/edm/alt_cell.hpp"
+#include "traccc/edm/alt_measurement.hpp"
+#include "traccc/edm/spacepoint.hpp"
+
+namespace traccc::io {
+
+/// Type definition for the reading of cells into a vector of alt_cells and a
+/// vector of modules. The alt_cells hold a link to a position in the modules'
+/// vector.
+struct cell_reader_output {
+    alt_cell_collection_types::host cells;
+    cell_module_collection_types::host modules;
+};
+
+/// Type definition for the reading of measurements into a vector of
+/// alt_measurements and a vector of modules. The alt_measurements hold a link
+/// to a position in the modules' vector.
+struct measurement_reader_output {
+    alt_measurement_collection_types::host measurements;
+    cell_module_collection_types::host modules;
+};
+
+/// Type definition for the reading of spacepoints into a vector of spacepoitns
+/// and a vector of modules. Each spacepoint holds a link to a position in the
+/// modules' vector.
+struct spacepoint_reader_output {
+    spacepoint_collection_types::host spacepoints;
+    cell_module_collection_types::host modules;
+};
+
+}  // namespace traccc::io

--- a/io/include/traccc/io/write.hpp
+++ b/io/include/traccc/io/write.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/edm/cell.hpp"
+#include "traccc/edm/alt_cell.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/io/data_format.hpp"
 
@@ -23,32 +23,38 @@ namespace traccc::io {
 /// @param event is the event index
 /// @param directory is the directory for the output cell file
 /// @param format is the data format (e.g. csv or binary) of output file
-/// @param cells is the cell container to write
+/// @param cells is the cell collection to write
+/// @param modules is the module collection to write
 ///
 void write(std::size_t event, std::string_view directory,
            traccc::data_format format,
-           traccc::cell_container_types::const_view cells);
+           traccc::alt_cell_collection_types::const_view cells,
+           traccc::cell_module_collection_types::const_view modules);
 
 /// Function for hit file writing
 ///
 /// @param event is the event index
 /// @param directory is the directory for the output spacepoint file
 /// @param format is the data format (e.g. csv or binary) of output file
-/// @param spacepoints is the spacepoint container to write
+/// @param spacepoints is the spacepoint collection to write
+/// @param modules is the module collection to write
 ///
 void write(std::size_t event, std::string_view directory,
            traccc::data_format format,
-           spacepoint_container_types::const_view spacepoints);
+           spacepoint_collection_types::const_view spacepoints,
+           traccc::cell_module_collection_types::const_view modules);
 
 /// Function for measurement file writing
 ///
 /// @param event is the event index
 /// @param directory is the directory for the output measurement file
 /// @param format is the data format (e.g. csv or binary) of output file
-/// @param measurements is the measurement container to write
+/// @param measurements is the measurement collection to write
+/// @param modules is the module collection to write
 ///
 void write(std::size_t event, std::string_view directory,
            traccc::data_format format,
-           measurement_container_types::const_view measurements);
+           alt_measurement_collection_types::const_view measurements,
+           traccc::cell_module_collection_types::const_view modules);
 
 }  // namespace traccc::io

--- a/io/src/csv/read_cells_alt.cpp
+++ b/io/src/csv/read_cells_alt.cpp
@@ -75,10 +75,10 @@ traccc::cell_module get_module(traccc::io::csv::cell c,
 
 namespace traccc::io::csv {
 
-alt_cell_reader_output_t read_cells_alt(std::string_view filename,
-                                        const geometry* geom,
-                                        const digitization_config* dconfig,
-                                        vecmem::memory_resource* mr) {
+cell_reader_output read_cells_alt(std::string_view filename,
+                                  const geometry* geom,
+                                  const digitization_config* dconfig,
+                                  vecmem::memory_resource* mr) {
 
     // Construct the cell reader object.
     auto reader = make_cell_reader(filename);
@@ -86,7 +86,13 @@ alt_cell_reader_output_t read_cells_alt(std::string_view filename,
     // Create cell counter vector.
     std::vector<unsigned int> cellCounts;
     cellCounts.reserve(5000);
-    cell_module_collection_types::host result_modules(0, mr);
+
+    cell_module_collection_types::host result_modules;
+    if (mr != nullptr) {
+        result_modules = cell_module_collection_types::host{0, mr};
+    } else {
+        result_modules = cell_module_collection_types::host(0);
+    }
     result_modules.reserve(5000);
 
     // Create a cell collection, which holds on to a flat list of all the cells
@@ -126,7 +132,12 @@ alt_cell_reader_output_t read_cells_alt(std::string_view filename,
     const unsigned int totalCells = allCells.size();
 
     // Construct the result collection.
-    alt_cell_collection_types::host result_cells{totalCells, mr};
+    alt_cell_collection_types::host result_cells;
+    if (mr != nullptr) {
+        result_cells = alt_cell_collection_types::host{totalCells, mr};
+    } else {
+        result_cells = alt_cell_collection_types::host(totalCells);
+    }
 
     // Member "-1" of the prefix sum vector
     unsigned int nCellsZero = 0;
@@ -144,6 +155,9 @@ alt_cell_reader_output_t read_cells_alt(std::string_view filename,
                      .module_link = counterPos};
     }
 
+    if (cellCounts.size() == 0) {
+        return {result_cells, result_modules};
+    }
     /* This is might look a bit overcomplicated, and could be made simpler by
      * having a copy of the prefix sum vector before incrementing its value when
      * filling the vector. however this seems more efficient, but requires

--- a/io/src/csv/read_cells_alt.hpp
+++ b/io/src/csv/read_cells_alt.hpp
@@ -11,6 +11,7 @@
 #include "traccc/edm/alt_cell.hpp"
 #include "traccc/geometry/digitization_config.hpp"
 #include "traccc/geometry/geometry.hpp"
+#include "traccc/io/reader_edm.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
@@ -28,9 +29,9 @@ namespace traccc::io::csv {
 /// @param mr The memory resource to create the host collection with
 /// @return A alt_cell (host) collection & a cell_module collection
 ///
-alt_cell_reader_output_t read_cells_alt(
-    std::string_view filename, const geometry* geom = nullptr,
-    const digitization_config* dconfig = nullptr,
-    vecmem::memory_resource* mr = nullptr);
+cell_reader_output read_cells_alt(std::string_view filename,
+                                  const geometry* geom = nullptr,
+                                  const digitization_config* dconfig = nullptr,
+                                  vecmem::memory_resource* mr = nullptr);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_measurements.hpp
+++ b/io/src/csv/read_measurements.hpp
@@ -8,7 +8,8 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/alt_measurement.hpp"
+#include "traccc/io/reader_edm.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
@@ -24,7 +25,7 @@ namespace traccc::io::csv {
 /// @param mr The memory resource to create the host container with
 /// @return A measurement (host) container
 ///
-measurement_container_types::host read_measurements(
+measurement_reader_output read_measurements(
     std::string_view filename, vecmem::memory_resource* mr = nullptr);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_spacepoints_alt.hpp
+++ b/io/src/csv/read_spacepoints_alt.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/geometry/geometry.hpp"
+#include "traccc/io/reader_edm.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
@@ -26,7 +27,7 @@ namespace traccc::io::csv {
 /// @param mr The memory resource to create the host collection with
 /// @return A spacepoint (host) collection
 ///
-spacepoint_collection_types::host read_spacepoints_alt(
+spacepoint_reader_output read_spacepoints_alt(
     std::string_view filename, const geometry& geom,
     vecmem::memory_resource* mr = nullptr);
 

--- a/io/src/mapper.cpp
+++ b/io/src/mapper.cpp
@@ -12,10 +12,10 @@
 #include "csv/make_hit_reader.hpp"
 #include "csv/make_measurement_hit_id_reader.hpp"
 #include "csv/make_particle_reader.hpp"
-#include "traccc/io/read_cells.hpp"
+#include "traccc/io/read_cells_alt.hpp"
 #include "traccc/io/read_digitization_config.hpp"
 #include "traccc/io/read_geometry.hpp"
-#include "traccc/io/read_spacepoints.hpp"
+#include "traccc/io/read_spacepoints_alt.hpp"
 #include "traccc/io/utils.hpp"
 
 // Project include(s).
@@ -54,7 +54,8 @@ particle_map generate_particle_map(std::size_t event,
 
 hit_particle_map generate_hit_particle_map(std::size_t event,
                                            const std::string& hits_dir,
-                                           const std::string& particle_dir) {
+                                           const std::string& particle_dir,
+                                           const geoId_link_map& link_map) {
     hit_particle_map result;
 
     auto pmap = generate_particle_map(event, particle_dir);
@@ -71,6 +72,14 @@ hit_particle_map generate_hit_particle_map(std::size_t event,
 
         spacepoint sp;
         sp.global = {iohit.tx, iohit.ty, iohit.tz};
+
+        unsigned int link = 0;
+        auto it = link_map.find(iohit.geometry_id);
+        if (it != link_map.end()) {
+            link = (*it).second;
+        }
+
+        sp.meas.module_link = link;
 
         particle ptc = pmap[iohit.particle_id];
 
@@ -124,7 +133,8 @@ hit_map generate_hit_map(std::size_t event, const std::string& hits_dir) {
 
 hit_cell_map generate_hit_cell_map(std::size_t event,
                                    const std::string& cells_dir,
-                                   const std::string& hits_dir) {
+                                   const std::string& hits_dir,
+                                   const geoId_link_map& link_map) {
 
     hit_cell_map result;
 
@@ -139,23 +149,30 @@ hit_cell_map generate_hit_cell_map(std::size_t event,
     io::csv::cell iocell;
 
     while (creader.read(iocell)) {
-        result[hmap[iocell.hit_id]].push_back(cell{
-            iocell.channel0, iocell.channel1, iocell.value, iocell.timestamp});
+        unsigned int link = 0;
+        auto it = link_map.find(iocell.geometry_id);
+        if (it != link_map.end()) {
+            link = (*it).second;
+        }
+        result[hmap[iocell.hit_id]].push_back(alt_cell{
+            {iocell.channel0, iocell.channel1, iocell.value, iocell.timestamp},
+            link});
     }
-
     return result;
 }
 
 cell_particle_map generate_cell_particle_map(std::size_t event,
                                              const std::string& cells_dir,
                                              const std::string& hits_dir,
-                                             const std::string& particle_dir) {
+                                             const std::string& particle_dir,
+                                             const geoId_link_map& link_map) {
 
     cell_particle_map result;
 
-    auto h_p_map = generate_hit_particle_map(event, hits_dir, particle_dir);
+    auto h_p_map =
+        generate_hit_particle_map(event, hits_dir, particle_dir, link_map);
 
-    auto h_c_map = generate_hit_cell_map(event, cells_dir, hits_dir);
+    auto h_c_map = generate_hit_cell_map(event, cells_dir, hits_dir, link_map);
 
     for (auto const& [hit, ptc] : h_p_map) {
         auto& cells = h_c_map[hit];
@@ -168,10 +185,12 @@ cell_particle_map generate_cell_particle_map(std::size_t event,
     return result;
 }
 
-measurement_cell_map generate_measurement_cell_map(
-    std::size_t event, const std::string& detector_file,
-    const std::string& digi_config_file, const std::string& cells_dir,
-    vecmem::memory_resource& resource) {
+std::tuple<measurement_cell_map, cell_module_collection_types::host>
+generate_measurement_cell_map(std::size_t event,
+                              const std::string& detector_file,
+                              const std::string& digi_config_file,
+                              const std::string& cells_dir,
+                              vecmem::memory_resource& resource) {
 
     measurement_cell_map result;
 
@@ -186,25 +205,23 @@ measurement_cell_map generate_measurement_cell_map(
     auto digi_cfg = io::read_digitization_config(digi_config_file);
 
     // Read the cells from the relevant event file
-    cell_container_types::host cells_per_event =
-        io::read_cells(event, cells_dir, traccc::data_format::csv,
-                       &surface_transforms, &digi_cfg, &resource);
+    auto readOut =
+        io::read_cells_alt(event, cells_dir, traccc::data_format::csv,
+                           &surface_transforms, &digi_cfg, &resource);
+    alt_cell_collection_types::host& cells_per_event = readOut.cells;
+    cell_module_collection_types::host& modules_per_event = readOut.modules;
 
     auto clusters_per_event = cc(cells_per_event);
-    auto measurements_per_event = mc(cells_per_event, clusters_per_event);
+    auto measurements_per_event = mc(clusters_per_event, modules_per_event);
 
-    for (std::size_t i = 0; i < measurements_per_event.size(); ++i) {
-        const auto& measurements = measurements_per_event.get_items()[i];
+    assert(measurements_per_event.size() == clusters_per_event.size());
+    for (unsigned int i = 0; i < measurements_per_event.size(); ++i) {
+        const auto& clus = clusters_per_event.get_items()[i];
 
-        for (const auto& meas : measurements) {
-            const auto& clus =
-                clusters_per_event.get_items()[meas.cluster_link];
-
-            result[meas] = clus;
-        }
+        result[measurements_per_event[i]] = clus;
     }
 
-    return result;
+    return {result, modules_per_event};
 }
 
 measurement_particle_map generate_measurement_particle_map(
@@ -215,13 +232,22 @@ measurement_particle_map generate_measurement_particle_map(
 
     measurement_particle_map result;
 
-    // generate cell particle map
-    auto c_p_map =
-        generate_cell_particle_map(event, cells_dir, hits_dir, particle_dir);
-
     // generate measurement cell map
-    auto m_c_map = generate_measurement_cell_map(
+    auto gen_m_c_map = generate_measurement_cell_map(
         event, detector_file, digi_config_file, cells_dir, resource);
+    auto& m_c_map = std::get<0>(gen_m_c_map);
+    auto& modules = std::get<1>(gen_m_c_map);
+
+    // generate geometry_id link map
+    geoId_link_map link_map;
+
+    for (unsigned int i = 0; i < modules.size(); ++i) {
+        link_map[modules[i].module] = i;
+    }
+
+    // generate cell particle map
+    auto c_p_map = generate_cell_particle_map(event, cells_dir, hits_dir,
+                                              particle_dir, link_map);
 
     for (auto const& [meas, cells] : m_c_map) {
         for (const auto& c : cells) {
@@ -239,28 +265,34 @@ measurement_particle_map generate_measurement_particle_map(
 
     measurement_particle_map result;
 
-    auto h_p_map = generate_hit_particle_map(event, hits_dir, particle_dir);
-
     // Read the surface transforms
     auto surface_transforms = io::read_geometry(detector_file);
 
     // Read the spacepoints from the relevant event file
-    spacepoint_container_types::host spacepoints_per_event =
-        io::read_spacepoints(event, hits_dir, surface_transforms,
-                             traccc::data_format::csv, &resource);
+    auto readOut =
+        io::read_spacepoints_alt(event, hits_dir, surface_transforms,
+                                 traccc::data_format::csv, &resource);
+    spacepoint_collection_types::host& spacepoints_per_event =
+        readOut.spacepoints;
+    cell_module_collection_types::host& modules = readOut.modules;
 
-    for (std::size_t i = 0; i < spacepoints_per_event.size(); ++i) {
-        const auto& spacepoints_per_module = spacepoints_per_event.at(i).items;
+    geoId_link_map link_map;
 
-        for (const auto& hit : spacepoints_per_module) {
-            const auto& meas = hit.meas;
+    for (unsigned int i = 0; i < modules.size(); ++i) {
+        link_map[modules[i].module] = i;
+    }
 
-            spacepoint new_hit;
-            new_hit.global = hit.global;
+    auto h_p_map =
+        generate_hit_particle_map(event, hits_dir, particle_dir, link_map);
 
-            const auto& ptc = h_p_map[new_hit];
-            result[meas][ptc]++;
-        }
+    for (const auto& hit : spacepoints_per_event) {
+        const auto& meas = hit.meas;
+
+        spacepoint new_hit;
+        new_hit.global = hit.global;
+
+        const auto& ptc = h_p_map[new_hit];
+        result[meas][ptc]++;
     }
 
     return result;

--- a/io/src/read_binary.hpp
+++ b/io/src/read_binary.hpp
@@ -66,4 +66,35 @@ container_t read_binary_container(std::string_view filename,
     return result;
 }
 
+/// Function for reading a collection from a binary file
+///
+/// @param filename The full input filename
+/// @param mr Is the memory resource to create the result collection with
+///
+template <typename collection_t>
+collection_t read_binary_collection(std::string_view filename,
+                                    vecmem::memory_resource* mr = nullptr) {
+
+    // Make sure that the chosen types work.
+    static_assert(std::is_standard_layout_v<typename collection_t::value_type>,
+                  "Collection item type must be standard layout.");
+
+    // Open the input file.
+    std::ifstream in_file(filename.data(), std::ios::binary);
+
+    // Read the size of the header vector.
+    std::size_t size;
+    in_file.read(reinterpret_cast<char*>(&size), sizeof(std::size_t));
+
+    // Create the result collection, and set it to the correct size.
+    collection_t result(size, mr);
+
+    // Read the items into memory.
+    in_file.read(reinterpret_cast<char*>(result.data()),
+                 size * sizeof(typename collection_t::value_type));
+
+    // Return the newly created container.
+    return result;
+}
+
 }  // namespace traccc::io::details

--- a/io/src/read_cells_alt.cpp
+++ b/io/src/read_cells_alt.cpp
@@ -14,28 +14,38 @@
 
 namespace traccc::io {
 
-alt_cell_reader_output_t read_cells_alt(std::size_t event,
-                                        std::string_view directory,
-                                        data_format format,
-                                        const geometry* geom,
-                                        const digitization_config* dconfig,
-                                        vecmem::memory_resource* mr) {
+cell_reader_output read_cells_alt(std::size_t event, std::string_view directory,
+                                  data_format format, const geometry* geom,
+                                  const digitization_config* dconfig,
+                                  vecmem::memory_resource* mr) {
 
     switch (format) {
         case data_format::csv:
             return read_cells_alt(data_directory() + directory.data() +
                                       get_event_filename(event, "-cells.csv"),
                                   format, geom, dconfig, mr);
+        case data_format::binary: {
+            auto cells = details::read_binary_collection<
+                alt_cell_collection_types::host>(
+                data_directory() + directory.data() +
+                    get_event_filename(event, "-cells.dat"),
+                mr);
+            auto modules = details::read_binary_collection<
+                cell_module_collection_types::host>(
+                data_directory() + directory.data() +
+                    get_event_filename(event, "-modules.dat"),
+                mr);
+            return {std::move(cells), std::move(modules)};
+        }
         default:
             throw std::invalid_argument("Unsupported data format");
     }
 }
 
-alt_cell_reader_output_t read_cells_alt(std::string_view filename,
-                                        data_format format,
-                                        const geometry* geom,
-                                        const digitization_config* dconfig,
-                                        vecmem::memory_resource* mr) {
+cell_reader_output read_cells_alt(std::string_view filename, data_format format,
+                                  const geometry* geom,
+                                  const digitization_config* dconfig,
+                                  vecmem::memory_resource* mr) {
 
     switch (format) {
         case data_format::csv:

--- a/io/src/read_measurements.cpp
+++ b/io/src/read_measurements.cpp
@@ -14,9 +14,10 @@
 
 namespace traccc::io {
 
-measurement_container_types::host read_measurements(
-    std::size_t event, std::string_view directory, data_format format,
-    vecmem::memory_resource* mr) {
+measurement_reader_output read_measurements(std::size_t event,
+                                            std::string_view directory,
+                                            data_format format,
+                                            vecmem::memory_resource* mr) {
 
     switch (format) {
         case data_format::csv:
@@ -24,26 +25,31 @@ measurement_container_types::host read_measurements(
                 data_directory() + directory.data() +
                     get_event_filename(event, "-measurements.csv"),
                 format, mr);
-        case data_format::binary:
-            return read_measurements(
+        case data_format::binary: {
+            auto measurements = details::read_binary_collection<
+                alt_measurement_collection_types::host>(
                 data_directory() + directory.data() +
                     get_event_filename(event, "-measurements.dat"),
-                format, mr);
+                mr);
+            auto modules = details::read_binary_collection<
+                cell_module_collection_types::host>(
+                data_directory() + directory.data() +
+                    get_event_filename(event, "-modules.dat"),
+                mr);
+            return {std::move(measurements), std::move(modules)};
+        }
         default:
             throw std::invalid_argument("Unsupported data format");
     }
 }
 
-measurement_container_types::host read_measurements(
-    std::string_view filename, data_format format,
-    vecmem::memory_resource* mr) {
+measurement_reader_output read_measurements(std::string_view filename,
+                                            data_format format,
+                                            vecmem::memory_resource* mr) {
 
     switch (format) {
         case data_format::csv:
             return csv::read_measurements(filename, mr);
-        case data_format::binary:
-            return details::read_binary_container<
-                measurement_container_types::host>(filename, mr);
         default:
             throw std::invalid_argument("Unsupported data format");
     }

--- a/io/src/read_spacepoints_alt.cpp
+++ b/io/src/read_spacepoints_alt.cpp
@@ -14,9 +14,11 @@
 
 namespace traccc::io {
 
-spacepoint_collection_types::host read_spacepoints_alt(
-    std::size_t event, std::string_view directory, const geometry& geom,
-    data_format format, vecmem::memory_resource* mr) {
+spacepoint_reader_output read_spacepoints_alt(std::size_t event,
+                                              std::string_view directory,
+                                              const geometry& geom,
+                                              data_format format,
+                                              vecmem::memory_resource* mr) {
 
     switch (format) {
         case data_format::csv:
@@ -24,14 +26,28 @@ spacepoint_collection_types::host read_spacepoints_alt(
                 data_directory() + directory.data() +
                     get_event_filename(event, "-hits.csv"),
                 geom, format, mr);
+        case data_format::binary: {
+            auto hits = details::read_binary_collection<
+                spacepoint_collection_types::host>(
+                data_directory() + directory.data() +
+                    get_event_filename(event, "-hits.dat"),
+                mr);
+            auto modules = details::read_binary_collection<
+                cell_module_collection_types::host>(
+                data_directory() + directory.data() +
+                    get_event_filename(event, "-modules.dat"),
+                mr);
+            return {std::move(hits), std::move(modules)};
+        }
         default:
             throw std::invalid_argument("Unsupported data format");
     }
 }
 
-spacepoint_collection_types::host read_spacepoints_alt(
-    std::string_view filename, const geometry& geom, data_format format,
-    vecmem::memory_resource* mr) {
+spacepoint_reader_output read_spacepoints_alt(std::string_view filename,
+                                              const geometry& geom,
+                                              data_format format,
+                                              vecmem::memory_resource* mr) {
 
     switch (format) {
         case data_format::csv:

--- a/io/src/write.cpp
+++ b/io/src/write.cpp
@@ -15,14 +15,19 @@ namespace traccc::io {
 
 void write(std::size_t event, std::string_view directory,
            traccc::data_format format,
-           traccc::cell_container_types::const_view cells) {
+           traccc::alt_cell_collection_types::const_view cells,
+           traccc::cell_module_collection_types::const_view modules) {
 
     switch (format) {
         case data_format::binary:
-            details::write_binary_container(
+            details::write_binary_collection(
                 data_directory() + directory.data() +
                     get_event_filename(event, "-cells.dat"),
-                traccc::cell_container_types::const_device{cells});
+                traccc::alt_cell_collection_types::const_device{cells});
+            details::write_binary_collection(
+                data_directory() + directory.data() +
+                    get_event_filename(event, "-modules.dat"),
+                traccc::cell_module_collection_types::const_device{modules});
             break;
         default:
             throw std::invalid_argument("Unsupported data format");
@@ -31,14 +36,19 @@ void write(std::size_t event, std::string_view directory,
 
 void write(std::size_t event, std::string_view directory,
            traccc::data_format format,
-           spacepoint_container_types::const_view spacepoints) {
+           spacepoint_collection_types::const_view spacepoints,
+           cell_module_collection_types::const_view modules) {
 
     switch (format) {
         case data_format::binary:
-            details::write_binary_container(
+            details::write_binary_collection(
                 data_directory() + directory.data() +
                     get_event_filename(event, "-hits.dat"),
-                traccc::spacepoint_container_types::const_device{spacepoints});
+                traccc::spacepoint_collection_types::const_device{spacepoints});
+            details::write_binary_collection(
+                data_directory() + directory.data() +
+                    get_event_filename(event, "-modules.dat"),
+                traccc::cell_module_collection_types::const_device{modules});
             break;
         default:
             throw std::invalid_argument("Unsupported data format");
@@ -47,15 +57,20 @@ void write(std::size_t event, std::string_view directory,
 
 void write(std::size_t event, std::string_view directory,
            traccc::data_format format,
-           measurement_container_types::const_view measurements) {
+           alt_measurement_collection_types::const_view measurements,
+           traccc::cell_module_collection_types::const_view modules) {
 
     switch (format) {
         case data_format::binary:
-            details::write_binary_container(
+            details::write_binary_collection(
                 data_directory() + directory.data() +
                     get_event_filename(event, "-measurements.dat"),
-                traccc::measurement_container_types::const_device{
+                traccc::alt_measurement_collection_types::const_device{
                     measurements});
+            details::write_binary_collection(
+                data_directory() + directory.data() +
+                    get_event_filename(event, "-modules.dat"),
+                traccc::cell_module_collection_types::const_device{modules});
             break;
         default:
             throw std::invalid_argument("Unsupported data format");

--- a/io/src/write_binary.hpp
+++ b/io/src/write_binary.hpp
@@ -62,4 +62,29 @@ void write_binary_container(std::string_view filename,
     }
 }
 
+/// Function for writing a collection into a binary file
+///
+/// @param filename is the output filename which includes the path
+/// @param collection is the traccc collection to write
+///
+template <typename collection_t>
+void write_binary_collection(std::string_view filename,
+                             const collection_t& collection) {
+
+    // Make sure that the chosen types work.
+    static_assert(std::is_standard_layout_v<typename collection_t::value_type>,
+                  "Collection item type must have standard layout.");
+
+    // Open the output file.
+    std::ofstream out_file(filename.data(), std::ios::binary);
+
+    // Write the size of the vector.
+    const std::size_t size = collection.size();
+    out_file.write(reinterpret_cast<const char*>(&size), sizeof(std::size_t));
+
+    // Write the items.
+    out_file.write(reinterpret_cast<const char*>(collection.data()),
+                   size * sizeof(typename collection_t::value_type));
+}
+
 }  // namespace traccc::io::details

--- a/performance/include/traccc/efficiency/seeding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/seeding_performance_writer.hpp
@@ -11,7 +11,7 @@
 #include "traccc/utils/helpers.hpp"
 
 // Project include(s).
-#include "traccc/edm/seed.hpp"
+#include "traccc/edm/alt_seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/io/event_map.hpp"
 
@@ -63,8 +63,8 @@ class seeding_performance_writer {
     void add_cache(std::string_view name);
 
     void write(std::string_view name,
-               const seed_collection_types::const_view& seeds_view,
-               const spacepoint_container_types::const_view& spacepoints_view,
+               const alt_seed_collection_types::const_view& seeds_view,
+               const spacepoint_collection_types::const_view& spacepoints_view,
                const event_map& evt_map);
 
     void finalize();

--- a/performance/include/traccc/performance/impl/is_same_measurement.ipp
+++ b/performance/include/traccc/performance/impl/is_same_measurement.ipp
@@ -8,27 +8,27 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 
 namespace traccc::details {
 
 /// @c traccc::is_same_object specialisation for @c traccc::measurement
 template <>
-class is_same_object<measurement> {
+class is_same_object<alt_measurement> {
 
     public:
     /// Constructor with a reference object, and an allowed uncertainty
-    is_same_object(const measurement& ref, scalar unc = float_epsilon);
+    is_same_object(const alt_measurement& ref, scalar unc = float_epsilon);
 
     /// Specialised implementation for @c traccc::measurement
-    bool operator()(const measurement& obj) const;
+    bool operator()(const alt_measurement& obj) const;
 
     private:
     /// The reference object
-    std::reference_wrapper<const measurement> m_ref;
+    std::reference_wrapper<const alt_measurement> m_ref;
     /// The uncertainty
     scalar m_unc;
 
-};  // class is_same_object<measurement>
+};  // class is_same_object<alt_measurement>
 
 }  // namespace traccc::details

--- a/performance/include/traccc/performance/impl/is_same_seed.ipp
+++ b/performance/include/traccc/performance/impl/is_same_seed.ipp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Library include(s).
-#include "traccc/edm/seed.hpp"
+#include "traccc/edm/alt_seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
 
 // System include(s).
@@ -18,26 +18,26 @@ namespace traccc::details {
 
 /// @c traccc::is_same_object specialisation for @c traccc::seed
 template <>
-class is_same_object<seed> {
+class is_same_object<alt_seed> {
 
     public:
     /// Constructor with all necessary arguments
     is_same_object(
-        const spacepoint_container_types::const_view& ref_spacepoints,
-        const spacepoint_container_types::const_view& test_spacepoints,
-        const seed& ref, scalar unc = float_epsilon);
+        const spacepoint_collection_types::const_view& ref_spacepoints,
+        const spacepoint_collection_types::const_view& test_spacepoints,
+        const alt_seed& ref, scalar unc = float_epsilon);
 
     /// Specialised implementation for @c traccc::seed
-    bool operator()(const seed& obj) const;
+    bool operator()(const alt_seed& obj) const;
 
     private:
     /// Spacepoints for the reference object
     const std::array<spacepoint, 3> m_ref_spacepoints;
     /// Spacepoint container for the test seeds
-    const spacepoint_container_types::const_view m_spacepoints;
+    const spacepoint_collection_types::const_view m_spacepoints;
 
     /// The reference object
-    std::reference_wrapper<const seed> m_ref;
+    std::reference_wrapper<const alt_seed> m_ref;
     /// The uncertainty
     scalar m_unc;
 

--- a/performance/include/traccc/performance/impl/seed_comparator_factory.ipp
+++ b/performance/include/traccc/performance/impl/seed_comparator_factory.ipp
@@ -8,30 +8,30 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/edm/seed.hpp"
+#include "traccc/edm/alt_seed.hpp"
 #include "traccc/edm/spacepoint.hpp"
 
 namespace traccc::details {
 
 /// @c traccc::details::comparator_factory specialisation for @c traccc::seed
 template <>
-class comparator_factory<seed> {
+class comparator_factory<alt_seed> {
 
     public:
     /// Constructor with all necessary arguments
     comparator_factory(
-        const spacepoint_container_types::const_view& ref_spacepoints,
-        const spacepoint_container_types::const_view& test_spacepoints);
+        const spacepoint_collection_types::const_view& ref_spacepoints,
+        const spacepoint_collection_types::const_view& test_spacepoints);
 
     /// Instantiate an instance of a comparator object
-    is_same_object<seed> make_comparator(const seed& ref,
-                                         scalar unc = float_epsilon) const;
+    is_same_object<alt_seed> make_comparator(const alt_seed& ref,
+                                             scalar unc = float_epsilon) const;
 
     private:
     /// Spacepoint container for the reference seeds
-    const spacepoint_container_types::const_view m_ref_spacepoints;
+    const spacepoint_collection_types::const_view m_ref_spacepoints;
     /// Spacepoint container for the test seeds
-    const spacepoint_container_types::const_view m_test_spacepoints;
+    const spacepoint_collection_types::const_view m_test_spacepoints;
 
 };  // class comparator_factory
 

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -63,15 +63,16 @@ void seeding_performance_writer::add_cache(std::string_view name) {
 }
 
 void seeding_performance_writer::write(
-    std::string_view name, const seed_collection_types::const_view& seeds_view,
-    const spacepoint_container_types::const_view& spacepoints_view,
+    std::string_view name,
+    const alt_seed_collection_types::const_view& seeds_view,
+    const spacepoint_collection_types::const_view& spacepoints_view,
     const event_map& evt_map) {
 
     std::map<particle_id, std::size_t> match_counter;
 
     // Iterate over the seeds.
-    seed_collection_types::const_device seeds(seeds_view);
-    for (const seed& sd : seeds) {
+    alt_seed_collection_types::const_device seeds(seeds_view);
+    for (const alt_seed& sd : seeds) {
 
         // Check which particle matches this seed.
         std::vector<particle_hit_count> particle_hit_counts =

--- a/performance/src/efficiency/track_classification.hpp
+++ b/performance/src/efficiency/track_classification.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include "traccc/edm/particle.hpp"
-#include "traccc/edm/seed.hpp"
 #include "traccc/io/mapper.hpp"
 
 namespace traccc {
@@ -35,13 +34,17 @@ inline bool operator<(const particle_hit_count& lhs,
 
 template <template <typename, std::size_t> class array_t, std::size_t N>
 std::vector<particle_hit_count> identify_contributing_particles(
-    const array_t<measurement, N>& measurements,
+    const array_t<alt_measurement, N>& measurements,
     const measurement_particle_map& m_p_map) {
 
     std::vector<particle_hit_count> result;
 
     for (const auto& meas : measurements) {
-        const auto& ptcs = m_p_map.find(meas)->second;
+        const auto mp_it = m_p_map.find(meas);
+        if (mp_it == m_p_map.end()) {
+            continue;
+        }
+        const auto& ptcs = mp_it->second;
 
         for (auto const& [ptc, count] : ptcs) {
             auto it = std::find(result.begin(), result.end(), ptc);

--- a/performance/src/performance/details/comparator_factory.cpp
+++ b/performance/src/performance/details/comparator_factory.cpp
@@ -13,17 +13,17 @@ namespace traccc::details {
 /// @name Implementation for @c traccc::details::comparator_factory<seed>
 /// @{
 
-comparator_factory<seed>::comparator_factory(
-    const spacepoint_container_types::const_view& ref_spacepoints,
-    const spacepoint_container_types::const_view& test_spacepoints)
+comparator_factory<alt_seed>::comparator_factory(
+    const spacepoint_collection_types::const_view& ref_spacepoints,
+    const spacepoint_collection_types::const_view& test_spacepoints)
     : m_ref_spacepoints(ref_spacepoints),
       m_test_spacepoints(test_spacepoints) {}
 
-is_same_object<seed> comparator_factory<seed>::make_comparator(
-    const seed& ref, scalar unc) const {
+is_same_object<alt_seed> comparator_factory<alt_seed>::make_comparator(
+    const alt_seed& ref, scalar unc) const {
 
-    return is_same_object<seed>(m_ref_spacepoints, m_test_spacepoints, ref,
-                                unc);
+    return is_same_object<alt_seed>(m_ref_spacepoints, m_test_spacepoints, ref,
+                                    unc);
 }
 
 /// @}

--- a/performance/src/performance/details/is_same_object.cpp
+++ b/performance/src/performance/details/is_same_object.cpp
@@ -16,15 +16,18 @@ namespace traccc::details {
 /// @name Implementation for @c traccc::details::is_same_object<measurement>
 /// @{
 
-is_same_object<measurement>::is_same_object(const measurement& ref, scalar unc)
+is_same_object<alt_measurement>::is_same_object(const alt_measurement& ref,
+                                                scalar unc)
     : m_ref(ref), m_unc(unc) {}
 
-bool is_same_object<measurement>::operator()(const measurement& obj) const {
+bool is_same_object<alt_measurement>::operator()(
+    const alt_measurement& obj) const {
 
     return (is_same_scalar(obj.local[0], m_ref.get().local[0], m_unc) &&
             is_same_scalar(obj.local[1], m_ref.get().local[1], m_unc) &&
             is_same_scalar(obj.variance[0], m_ref.get().variance[0], m_unc) &&
-            is_same_scalar(obj.variance[1], m_ref.get().variance[1], m_unc));
+            is_same_scalar(obj.variance[1], m_ref.get().variance[1], m_unc) &&
+            obj.module_link == m_ref.get().module_link);
 }
 
 /// @}
@@ -32,16 +35,16 @@ bool is_same_object<measurement>::operator()(const measurement& obj) const {
 /// @name Implementation for @c traccc::details::is_same_object<seed>
 /// @{
 
-is_same_object<seed>::is_same_object(
-    const spacepoint_container_types::const_view& ref_spacepoints,
-    const spacepoint_container_types::const_view& test_spacepoints,
-    const seed& ref, scalar unc)
+is_same_object<alt_seed>::is_same_object(
+    const spacepoint_collection_types::const_view& ref_spacepoints,
+    const spacepoint_collection_types::const_view& test_spacepoints,
+    const alt_seed& ref, scalar unc)
     : m_ref_spacepoints(ref.get_spacepoints(ref_spacepoints)),
       m_spacepoints(test_spacepoints),
       m_ref(ref),
       m_unc(unc) {}
 
-bool is_same_object<seed>::operator()(const seed& obj) const {
+bool is_same_object<alt_seed>::operator()(const alt_seed& obj) const {
 
     // Extract the spacepoints belonging to the tested seed.
     std::array<spacepoint, 3> test_spacepoints =
@@ -71,7 +74,7 @@ bool is_same_object<spacepoint>::operator()(const spacepoint& obj) const {
     return (is_same_scalar(obj.x(), m_ref.get().x(), m_unc) &&
             is_same_scalar(obj.y(), m_ref.get().y(), m_unc) &&
             is_same_scalar(obj.z(), m_ref.get().z(), m_unc) &&
-            is_same_object<measurement>(m_ref.get().meas, m_unc)(obj.meas));
+            is_same_object<alt_measurement>(m_ref.get().meas, m_unc)(obj.meas));
 }
 
 /// @}

--- a/tests/common/tests/cca_test.hpp
+++ b/tests/common/tests/cca_test.hpp
@@ -9,10 +9,10 @@
 
 // Project include(s).
 #include "traccc/definitions/primitives.hpp"
-#include "traccc/edm/cell.hpp"
+#include "traccc/edm/alt_cell.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 #include "traccc/edm/cluster.hpp"
-#include "traccc/edm/measurement.hpp"
-#include "traccc/io/read_cells.hpp"
+#include "traccc/io/read_cells_alt.hpp"
 
 // Test include(s).
 #include "tests/data_test.hpp"
@@ -31,8 +31,9 @@
 #include <functional>
 
 using cca_function_t = std::function<
-    std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>>(
-        const traccc::cell_container_types::host &)>;
+    std::map<traccc::geometry_id, vecmem::vector<traccc::alt_measurement>>(
+        const traccc::alt_cell_collection_types::host &,
+        const traccc::cell_module_collection_types::host &)>;
 
 class ConnectedComponentAnalysisTests
     : public traccc::tests::data_test,
@@ -91,15 +92,16 @@ class ConnectedComponentAnalysisTests
         std::string file_truth =
             get_datafile("cca_test/" + file_prefix + "_truth.csv");
 
-        traccc::cell_container_types::host data =
-            traccc::io::read_cells(file_hits);
+        auto data = traccc::io::read_cells_alt(file_hits);
+        traccc::alt_cell_collection_types::host &cells = data.cells;
+        traccc::cell_module_collection_types::host &modules = data.modules;
 
-        for (std::size_t i = 0; i < data.size(); i++) {
-            data.at(i).header.pixel = traccc::pixel_data{0, 0, 1, 1};
+        for (std::size_t i = 0; i < modules.size(); i++) {
+            modules.at(i).pixel = traccc::pixel_data{0, 0, 1, 1};
         }
 
-        std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>>
-            result = f(data);
+        std::map<traccc::geometry_id, vecmem::vector<traccc::alt_measurement>>
+            result = f(cells, modules);
 
         std::size_t total_truth = 0, total_found = 0;
 
@@ -113,7 +115,7 @@ class ConnectedComponentAnalysisTests
         while (truth_reader.read(io_truth)) {
             ASSERT_TRUE(result.find(io_truth.geometry_id) != result.end());
 
-            const vecmem::vector<traccc::measurement> &meas =
+            const vecmem::vector<traccc::alt_measurement> &meas =
                 result.at(io_truth.geometry_id);
 
             traccc::scalar tol = std::max(
@@ -121,7 +123,7 @@ class ConnectedComponentAnalysisTests
 
             auto match = std::find_if(
                 meas.begin(), meas.end(),
-                [&io_truth, tol](const traccc::measurement &i) {
+                [&io_truth, tol](const traccc::alt_measurement &i) {
                     return std::abs(i.local[0] - io_truth.channel0) < tol &&
                            std::abs(i.local[1] - io_truth.channel1) < tol;
                 });

--- a/tests/cpu/seq_single_module.cpp
+++ b/tests/cpu/seq_single_module.cpp
@@ -9,9 +9,9 @@
 #include "traccc/clusterization/component_connection.hpp"
 #include "traccc/clusterization/measurement_creation.hpp"
 #include "traccc/clusterization/spacepoint_formation.hpp"
-#include "traccc/edm/cell.hpp"
+#include "traccc/edm/alt_cell.hpp"
+#include "traccc/edm/alt_measurement.hpp"
 #include "traccc/edm/cluster.hpp"
-#include "traccc/edm/measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/geometry/pixel_data.hpp"
 
@@ -30,25 +30,24 @@ TEST(algorithms, seq_single_module) {
     traccc::measurement_creation mc(resource);
 
     /// Following [DOI: 10.1109/DASIP48288.2019.9049184]
-    traccc::cell_collection_types::host cells_per_module = {{{1, 0, 1., 0.},
-                                                             {8, 4, 2., 0.},
-                                                             {10, 4, 3., 0.},
-                                                             {9, 5, 4., 0.},
-                                                             {10, 5, 5., 0},
-                                                             {12, 12, 6, 0},
-                                                             {3, 13, 7, 0},
-                                                             {11, 13, 8, 0},
-                                                             {4, 14, 9, 0}},
-                                                            &resource};
+    traccc::alt_cell_collection_types::host cells = {{{{1, 0, 1., 0.}, 0},
+                                                      {{8, 4, 2., 0.}, 0},
+                                                      {{10, 4, 3., 0.}, 0},
+                                                      {{9, 5, 4., 0.}, 0},
+                                                      {{10, 5, 5., 0}, 0},
+                                                      {{12, 12, 6, 0}, 0},
+                                                      {{3, 13, 7, 0}, 0},
+                                                      {{11, 13, 8, 0}, 0},
+                                                      {{4, 14, 9, 0}, 0}},
+                                                     &resource};
     traccc::cell_module module;
-
-    traccc::cell_container_types::host cells;
-    cells.push_back(module, cells_per_module);
+    traccc::cell_module_collection_types::host modules(&resource);
+    modules.push_back(module);
 
     auto clusters = cc(cells);
     EXPECT_EQ(clusters.size(), 4u);
 
-    auto measurements = mc(cells, clusters);
+    auto measurements = mc(clusters, modules);
 
-    EXPECT_EQ(measurements.at(0).items.size(), 4u);
+    EXPECT_EQ(measurements.size(), 4u);
 }

--- a/tests/cpu/test_cca.cpp
+++ b/tests/cpu/test_cca.cpp
@@ -8,7 +8,7 @@
 // Project include(s).
 #include "traccc/clusterization/clusterization_algorithm.hpp"
 #include "traccc/definitions/primitives.hpp"
-#include "traccc/edm/cell.hpp"
+#include "traccc/edm/alt_cell.hpp"
 #include "traccc/edm/cluster.hpp"
 
 // Test include(s).
@@ -27,16 +27,20 @@ namespace {
 vecmem::host_memory_resource resource;
 traccc::clusterization_algorithm ca(resource);
 
-cca_function_t f = [](const traccc::cell_container_types::host &data) {
-    std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>> result;
+cca_function_t f =
+    [](const traccc::alt_cell_collection_types::host& cells,
+       const traccc::cell_module_collection_types::host& modules) {
+        std::map<traccc::geometry_id, vecmem::vector<traccc::alt_measurement>>
+            result;
 
-    auto measurements = ca(data);
-    for (std::size_t i = 0; i < measurements.size(); i++) {
-        result[measurements.at(i).header.module] = measurements.at(i).items;
-    }
+        auto measurements = ca(cells, modules);
+        for (std::size_t i = 0; i < measurements.size(); i++) {
+            result[modules.at(measurements.at(i).module_link).module].push_back(
+                measurements.at(i));
+        }
 
-    return result;
-};
+        return result;
+    };
 }  // namespace
 
 TEST_P(ConnectedComponentAnalysisTests, Run) {

--- a/tests/cpu/test_clusterization_resolution.cpp
+++ b/tests/cpu/test_clusterization_resolution.cpp
@@ -8,10 +8,10 @@
 // Project include(s).
 #include "traccc/clusterization/clusterization_algorithm.hpp"
 #include "traccc/clusterization/spacepoint_formation.hpp"
-#include "traccc/io/read_cells.hpp"
+#include "traccc/io/read_cells_alt.hpp"
 #include "traccc/io/read_digitization_config.hpp"
 #include "traccc/io/read_geometry.hpp"
-#include "traccc/io/read_spacepoints.hpp"
+#include "traccc/io/read_spacepoints_alt.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -45,50 +45,45 @@ TEST_P(SurfaceBinningTests, Run) {
     traccc::spacepoint_formation sf(host_mr);
 
     // Read the cells from the relevant event file
-    traccc::cell_container_types::host cells_truth =
-        traccc::io::read_cells(event, data_dir, traccc::data_format::csv,
-                               &surface_transforms, &digi_cfg, &host_mr);
+    auto readOut =
+        traccc::io::read_cells_alt(event, data_dir, traccc::data_format::csv,
+                                   &surface_transforms, &digi_cfg, &host_mr);
+
+    const traccc::alt_cell_collection_types::host& cells_truth = readOut.cells;
+    const traccc::cell_module_collection_types::host& modules = readOut.modules;
 
     // Get Reconstructed Spacepoints
-    auto measurements_recon = ca(cells_truth);
-    auto spacepoints_recon = sf(measurements_recon);
+    auto measurements_recon = ca(cells_truth, modules);
+    auto spacepoints_recon = sf(measurements_recon, modules);
 
     // Read the hits from the relevant event file
-    traccc::spacepoint_container_types::host spacepoints_truth =
-        traccc::io::read_spacepoints(event, data_dir, surface_transforms,
-                                     traccc::data_format::csv, &host_mr);
+    auto sp_readOut =
+        traccc::io::read_spacepoints_alt(event, data_dir, surface_transforms,
+                                         traccc::data_format::csv, &host_mr);
+
+    const traccc::spacepoint_collection_types::host& spacepoints_truth =
+        sp_readOut.spacepoints;
+    const traccc::cell_module_collection_types::host& modules_2 =
+        sp_readOut.modules;
 
     // Check the size of spacepoints
     EXPECT_TRUE(spacepoints_recon.size() > 0);
     EXPECT_EQ(spacepoints_recon.size(), spacepoints_truth.size());
-    EXPECT_TRUE(spacepoints_recon.total_size() > 0);
-    EXPECT_EQ(spacepoints_recon.total_size(), spacepoints_truth.total_size());
 
     for (std::size_t i = 0; i < spacepoints_recon.size(); i++) {
-        EXPECT_EQ(spacepoints_recon.at(i).header,
-                  spacepoints_truth.at(i).header);
 
-        // Get the spacepoint vectors
-        traccc::spacepoint_collection_types::host& sp_collection_recon =
-            spacepoints_recon[i].items;
+        const auto& sp_recon = spacepoints_recon[i];
+        const auto& sp_truth = spacepoints_truth[i];
 
-        traccc::spacepoint_collection_types::host& sp_collection_truth =
-            spacepoints_truth[i].items;
+        // Check that the spacepoints belong to the same module
+        EXPECT_EQ(modules.at(sp_recon.meas.module_link).module,
+                  modules_2.at(sp_truth.meas.module_link).module);
 
-        EXPECT_EQ(sp_collection_recon.size(), sp_collection_truth.size());
-
-        // Iterate over each spacepoint
-        for (std::size_t j = 0; j < sp_collection_recon.size(); j++) {
-            const auto& sp_recon = sp_collection_recon[j];
-            const auto& sp_truth = sp_collection_truth[j];
-
-            // Make sure that the difference in spacepoint position is less than
-            // 1%
-            EXPECT_TRUE(
-                traccc::getter::norm(sp_recon.global - sp_truth.global) /
-                    traccc::getter::norm(sp_recon.global) <
-                0.01);
-        }
+        // Make sure that the difference in spacepoint position is less than
+        // 1%
+        EXPECT_TRUE(traccc::getter::norm(sp_recon.global - sp_truth.global) /
+                        traccc::getter::norm(sp_recon.global) <
+                    0.01);
     }
 }
 

--- a/tests/cuda/test_cca.cpp
+++ b/tests/cuda/test_cca.cpp
@@ -15,23 +15,21 @@
 namespace {
 traccc::cuda::component_connection cc;
 
-cca_function_t f = [](const traccc::cell_container_types::host &data) {
-    std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>> result;
+cca_function_t f =
+    [](const traccc::alt_cell_collection_types::host& cells,
+       const traccc::cell_module_collection_types::host& modules) {
+        std::map<traccc::geometry_id, vecmem::vector<traccc::alt_measurement>>
+            result;
 
-    traccc::measurement_container_types::host mss = cc(data);
+        auto measurements = cc(cells);
 
-    for (std::size_t i = 0; i < mss.size(); ++i) {
-        vecmem::vector<traccc::measurement> msv;
-
-        for (std::size_t j = 0; j < mss.at(i).items.size(); ++j) {
-            msv.push_back(mss.at(i).items.at(j));
+        for (std::size_t i = 0; i < measurements.size(); i++) {
+            result[modules.at(measurements.at(i).module_link).module].push_back(
+                measurements.at(i));
         }
 
-        result.emplace(mss.at(i).header.module, std::move(msv));
-    }
-
-    return result;
-};
+        return result;
+    };
 }  // namespace
 
 TEST_P(ConnectedComponentAnalysisTests, Run) {

--- a/tests/io/test_binary.cpp
+++ b/tests/io/test_binary.cpp
@@ -6,11 +6,11 @@
  */
 
 // Project include(s).
-#include "traccc/io/read_cells.hpp"
+#include "traccc/io/read_cells_alt.hpp"
 #include "traccc/io/read_digitization_config.hpp"
 #include "traccc/io/read_geometry.hpp"
 #include "traccc/io/read_measurements.hpp"
-#include "traccc/io/read_spacepoints.hpp"
+#include "traccc/io/read_spacepoints_alt.hpp"
 #include "traccc/io/utils.hpp"
 #include "traccc/io/write.hpp"
 
@@ -43,18 +43,26 @@ TEST(io_binary, cell) {
         "tml_detector/default-geometric-config-generic.json");
 
     // Read csv file
-    traccc::cell_container_types::host cells_csv =
-        traccc::io::read_cells(event, cells_directory, traccc::data_format::csv,
-                               &surface_transforms, &digi_cfg, &host_mr);
+    auto reader_csv = traccc::io::read_cells_alt(
+        event, cells_directory, traccc::data_format::csv, &surface_transforms,
+        &digi_cfg, &host_mr);
+    const traccc::alt_cell_collection_types::host& cells_csv = reader_csv.cells;
+    const traccc::cell_module_collection_types::host& modules_csv =
+        reader_csv.modules;
 
     // Write binary file
     traccc::io::write(event, cells_directory, traccc::data_format::binary,
-                      traccc::get_data(cells_csv));
+                      vecmem::get_data(cells_csv),
+                      vecmem::get_data(modules_csv));
 
     // Read binary file
-    traccc::cell_container_types::host cells_binary = traccc::io::read_cells(
+    auto reader_binary = traccc::io::read_cells_alt(
         event, cells_directory, traccc::data_format::binary,
         &surface_transforms, &digi_cfg, &host_mr);
+    const traccc::alt_cell_collection_types::host& cells_binary =
+        reader_binary.cells;
+    const traccc::cell_module_collection_types::host& modules_binary =
+        reader_binary.modules;
 
     // Delete binary file
     std::string io_cells_file =
@@ -64,30 +72,27 @@ TEST(io_binary, cell) {
 
     ASSERT_TRUE(!std::ifstream(io_cells_file));
 
-    // Check header size
+    std::string io_modules_file =
+        traccc::io::data_directory() + cells_directory +
+        traccc::io::get_event_filename(event, "-modules.dat");
+    std::remove(io_modules_file.c_str());
+
+    ASSERT_TRUE(!std::ifstream(io_modules_file));
+
+    // Check cells size
     ASSERT_TRUE(cells_csv.size() > 0);
     ASSERT_EQ(cells_csv.size(), cells_binary.size());
 
-    auto& headers_csv = cells_csv.get_headers();
-    auto& headers_bin = cells_binary.get_headers();
+    // Check modules size
+    ASSERT_TRUE(modules_csv.size() > 0);
+    ASSERT_EQ(modules_csv.size(), modules_binary.size());
 
     for (std::size_t i = 0; i < cells_csv.size(); i++) {
-
-        // Check header content
-        ASSERT_EQ(headers_csv[i].module, headers_bin[i].module);
-        ASSERT_EQ(headers_csv[i].placement, headers_bin[i].placement);
-
-        auto& items_csv = cells_csv.get_items()[i];
-        auto& items_bin = cells_binary.get_items()[i];
-
-        // Check item size
-        ASSERT_TRUE(items_csv.size() > 0);
-        ASSERT_EQ(items_csv.size(), items_bin.size());
-
-        // Check item contents
-        for (std::size_t j = 0; j < items_csv.size(); j++) {
-            ASSERT_EQ(items_csv[j], items_bin[j]);
-        }
+        ASSERT_EQ(cells_csv[i], cells_binary[i]);
+    }
+    for (std::size_t i = 0; i < modules_csv.size(); i++) {
+        ASSERT_EQ(modules_csv[i].module, modules_binary[i].module);
+        ASSERT_EQ(modules_csv[i].placement, modules_binary[i].placement);
     }
 }
 
@@ -106,18 +111,27 @@ TEST(io_binary, spacepoint) {
         traccc::io::read_geometry("tml_detector/trackml-detector.csv");
 
     // Read csv file
-    traccc::spacepoint_container_types::host spacepoints_csv =
-        traccc::io::read_spacepoints(event, hits_directory, surface_transforms,
-                                     traccc::data_format::csv, &host_mr);
+    auto reader_csv = traccc::io::read_spacepoints_alt(
+        event, hits_directory, surface_transforms, traccc::data_format::csv,
+        &host_mr);
+    const traccc::spacepoint_collection_types::host& spacepoints_csv =
+        reader_csv.spacepoints;
+    const traccc::cell_module_collection_types::host& modules_csv =
+        reader_csv.modules;
 
-    // Write binary file
+    // // Write binary file
     traccc::io::write(event, hits_directory, traccc::data_format::binary,
-                      traccc::get_data(spacepoints_csv));
+                      vecmem::get_data(spacepoints_csv),
+                      vecmem::get_data(modules_csv));
 
     // Read binary file
-    traccc::spacepoint_container_types::host spacepoints_binary =
-        traccc::io::read_spacepoints(event, hits_directory, surface_transforms,
-                                     traccc::data_format::binary, &host_mr);
+    auto reader_binary = traccc::io::read_spacepoints_alt(
+        event, hits_directory, surface_transforms, traccc::data_format::binary,
+        &host_mr);
+    const traccc::spacepoint_collection_types::host& spacepoints_binary =
+        reader_binary.spacepoints;
+    const traccc::cell_module_collection_types::host& modules_binary =
+        reader_binary.modules;
 
     // Delete binary file
     std::string io_spacepoints_file =
@@ -127,35 +141,31 @@ TEST(io_binary, spacepoint) {
 
     ASSERT_TRUE(!std::ifstream(io_spacepoints_file));
 
-    // Check header size
+    std::string io_modules_file =
+        traccc::io::data_directory() + hits_directory +
+        traccc::io::get_event_filename(event, "-modules.dat");
+    std::remove(io_modules_file.c_str());
+
+    ASSERT_TRUE(!std::ifstream(io_modules_file));
+
+    // Check spacepoints size
     ASSERT_TRUE(spacepoints_csv.size() > 0);
     ASSERT_EQ(spacepoints_csv.size(), spacepoints_binary.size());
 
-    auto& headers_csv = spacepoints_csv.get_headers();
-    auto& headers_bin = spacepoints_binary.get_headers();
+    // Check modules size
+    ASSERT_TRUE(modules_csv.size() > 0);
+    ASSERT_EQ(modules_csv.size(), modules_binary.size());
 
     for (std::size_t i = 0; i < spacepoints_csv.size(); i++) {
-
-        // Check header content
-        ASSERT_EQ(headers_csv[i], headers_bin[i]);
-
-        auto& items_csv = spacepoints_csv.get_items()[i];
-        auto& items_bin = spacepoints_binary.get_items()[i];
-
-        // Check item size
-        ASSERT_TRUE(items_csv.size() > 0);
-        ASSERT_EQ(items_csv.size(), items_bin.size());
-
-        // Check item contents
-        for (std::size_t j = 0; j < items_csv.size(); j++) {
-            ASSERT_EQ(items_csv[j], items_bin[j]);
-        }
+        ASSERT_EQ(spacepoints_csv[i], spacepoints_binary[i]);
+    }
+    for (std::size_t i = 0; i < modules_csv.size(); i++) {
+        ASSERT_EQ(modules_csv[i], modules_binary[i]);
     }
 }
 
 // This defines the local frame test suite for binary measurement container
 TEST(io_binary, measurement) {
-
     // Set event configuration
     const std::size_t event = 0;
     const std::string measurements_directory = "tml_full/ttbar_mu200/";
@@ -164,19 +174,25 @@ TEST(io_binary, measurement) {
     vecmem::host_memory_resource host_mr;
 
     // Read csv file
-    traccc::measurement_container_types::host measurements_csv =
-        traccc::io::read_measurements(event, measurements_directory,
-                                      traccc::data_format::csv, &host_mr);
+    auto reader_csv = traccc::io::read_measurements(
+        event, measurements_directory, traccc::data_format::csv, &host_mr);
+    const traccc::alt_measurement_collection_types::host& measurements_csv =
+        reader_csv.measurements;
+    const traccc::cell_module_collection_types::host& modules_csv =
+        reader_csv.modules;
 
     // Write binary file
-    traccc::io::write(event, measurements_directory,
-                      traccc::data_format::binary,
-                      traccc::get_data(measurements_csv));
+    traccc::io::write(
+        event, measurements_directory, traccc::data_format::binary,
+        vecmem::get_data(measurements_csv), vecmem::get_data(modules_csv));
 
     // Read binary file
-    traccc::measurement_container_types::host measurements_binary =
-        traccc::io::read_measurements(event, measurements_directory,
-                                      traccc::data_format::binary, &host_mr);
+    auto reader_binary = traccc::io::read_measurements(
+        event, measurements_directory, traccc::data_format::binary, &host_mr);
+    const traccc::alt_measurement_collection_types::host& measurements_binary =
+        reader_binary.measurements;
+    const traccc::cell_module_collection_types::host& modules_binary =
+        reader_binary.modules;
 
     // Delete binary file
     std::string io_measurements_file =
@@ -186,28 +202,25 @@ TEST(io_binary, measurement) {
 
     ASSERT_TRUE(!std::ifstream(io_measurements_file));
 
+    std::string io_modules_file =
+        traccc::io::data_directory() + measurements_directory +
+        traccc::io::get_event_filename(event, "-modules.dat");
+    std::remove(io_modules_file.c_str());
+
+    ASSERT_TRUE(!std::ifstream(io_modules_file));
+
     // Check header size
     ASSERT_TRUE(measurements_csv.size() > 0);
     ASSERT_EQ(measurements_csv.size(), measurements_binary.size());
 
-    auto& headers_csv = measurements_csv.get_headers();
-    auto& headers_bin = measurements_binary.get_headers();
+    // Check modules size
+    ASSERT_TRUE(modules_csv.size() > 0);
+    ASSERT_EQ(modules_csv.size(), modules_binary.size());
 
     for (std::size_t i = 0; i < measurements_csv.size(); i++) {
-
-        // Check header content
-        ASSERT_EQ(headers_csv[i], headers_bin[i]);
-
-        auto& items_csv = measurements_csv.get_items()[i];
-        auto& items_bin = measurements_binary.get_items()[i];
-
-        // Check item size
-        ASSERT_TRUE(items_csv.size() > 0);
-        ASSERT_EQ(items_csv.size(), items_bin.size());
-
-        // Check item contents
-        for (std::size_t j = 0; j < items_csv.size(); j++) {
-            ASSERT_EQ(items_csv[j], items_bin[j]);
-        }
+        ASSERT_EQ(measurements_csv[i], measurements_binary[i]);
+    }
+    for (std::size_t i = 0; i < modules_csv.size(); i++) {
+        ASSERT_EQ(modules_csv[i].module, modules_binary[i].module);
     }
 }

--- a/tests/io/test_csv.cpp
+++ b/tests/io/test_csv.cpp
@@ -13,7 +13,7 @@
 #include "traccc/io/read_geometry.hpp"
 #include "traccc/io/read_measurements.hpp"
 #include "traccc/io/read_particles.hpp"
-#include "traccc/io/read_spacepoints.hpp"
+#include "traccc/io/read_spacepoints_alt.hpp"
 
 // Test include(s).
 #include "tests/data_test.hpp"
@@ -97,10 +97,9 @@ TEST_F(io, csv_read_cells_alt) {
                                &surface_transforms, &digi_cfg, &host_mr);
 
     // Read csv file to collection of cells + collection of modules
-    traccc::alt_cell_reader_output_t alt_cells_modules_csv =
-        traccc::io::read_cells_alt(event, cells_directory,
-                                   traccc::data_format::csv,
-                                   &surface_transforms, &digi_cfg, &host_mr);
+    auto alt_cells_modules_csv = traccc::io::read_cells_alt(
+        event, cells_directory, traccc::data_format::csv, &surface_transforms,
+        &digi_cfg, &host_mr);
 
     const traccc::alt_cell_collection_types::host& alt_cells_csv =
         alt_cells_modules_csv.cells;
@@ -150,32 +149,24 @@ TEST_F(io, csv_read_tml_single_muon) {
         traccc::io::read_geometry("tml_detector/trackml-detector.csv");
 
     // Read the hits from the relevant event file
-    traccc::spacepoint_container_types::host spacepoints_per_event =
-        traccc::io::read_spacepoints(0, "tml_full/single_muon/",
-                                     surface_transforms,
-                                     traccc::data_format::csv, &resource);
+    auto spacepoints_per_event = traccc::io::read_spacepoints_alt(
+        0, "tml_full/single_muon/", surface_transforms,
+        traccc::data_format::csv, &resource);
 
     // Read the measurements from the relevant event file
-    traccc::measurement_container_types::host measurements_per_event =
-        traccc::io::read_measurements(0, "tml_full/single_muon/",
-                                      traccc::data_format::csv, &resource);
+    auto measurements_per_event = traccc::io::read_measurements(
+        0, "tml_full/single_muon/", traccc::data_format::csv, &resource);
 
     // Read the particles from the relevant event file
     traccc::particle_collection_types::host particles_per_event =
         traccc::io::read_particles(0, "tml_full/single_muon/",
                                    traccc::data_format::csv, &resource);
 
-    const auto sp_header_size = spacepoints_per_event.size();
-    const auto ms_header_size = measurements_per_event.size();
-    ASSERT_EQ(sp_header_size, 11u);
-    ASSERT_EQ(ms_header_size, 11u);
+    ASSERT_EQ(spacepoints_per_event.modules.size(), 11u);
+    ASSERT_EQ(measurements_per_event.modules.size(), 11u);
 
-    for (std::size_t i = 0; i < sp_header_size; i++) {
-        ASSERT_EQ(spacepoints_per_event[i].items.size(), 1u);
-    }
-    for (std::size_t i = 0; i < ms_header_size; i++) {
-        ASSERT_EQ(measurements_per_event[i].items.size(), 1u);
-    }
+    ASSERT_EQ(spacepoints_per_event.spacepoints.size(), 11u);
+    ASSERT_EQ(measurements_per_event.measurements.size(), 11u);
 
     ASSERT_EQ(particles_per_event.size(), 1u);
 }

--- a/tests/io/test_mapper.cpp
+++ b/tests/io/test_mapper.cpp
@@ -92,10 +92,12 @@ TEST(mappper, hit_map) {
     auto h_map = traccc::generate_hit_map(event, hits_dir);
 
     EXPECT_EQ(h_map.size(), 3);
-
-    h_map[0].global = traccc::point3{39.2037048, 0.352969825, -1502.5};
-    h_map[1].global = traccc::point3{-269.925323, 419.792511, -480.266479};
-    h_map[2].global = traccc::point3{-878.646667, -10.9199247, 2952.5};
+    traccc::point3 p0{39.2037048, 0.352969825, -1502.5};
+    traccc::point3 p1{31.5048428, 5.16000509, -1502.5};
+    traccc::point3 p2{90.4015808, 0.7420941, -1502.5};
+    EXPECT_EQ(h_map[0].global, p0);
+    EXPECT_EQ(h_map[1].global, p1);
+    EXPECT_EQ(h_map[2].global, p2);
 }
 
 // Test generate_hit_cell_map function
@@ -113,21 +115,21 @@ TEST(mappper, hit_cell_map) {
     traccc::spacepoint sp2;
     sp2.global = traccc::point3{90.4015808, 0.7420941, -1502.5};
 
-    std::vector<traccc::cell> cells0;
-    cells0.push_back({1, 0, 0.0041470062, 0});
-    cells0.push_back({0, 1, 0.00306466641, 0});
-    cells0.push_back({1, 1, 0.00868905429, 0});
+    std::vector<traccc::alt_cell> cells0;
+    cells0.push_back({{1, 0, 0.0041470062, 0}, 0});
+    cells0.push_back({{0, 1, 0.00306466641, 0}, 0});
+    cells0.push_back({{1, 1, 0.00868905429, 0}, 0});
 
-    std::vector<traccc::cell> cells1;
-    cells1.push_back({1, 1, 0.00886478275, 0});
-    cells1.push_back({1, 2, 0.00580428448, 0});
-    cells1.push_back({2, 1, 0.0016894876, 0});
-    cells1.push_back({2, 2, 0.00199076766, 0});
+    std::vector<traccc::alt_cell> cells1;
+    cells1.push_back({{1, 1, 0.00886478275, 0}, 0});
+    cells1.push_back({{1, 2, 0.00580428448, 0}, 0});
+    cells1.push_back({{2, 1, 0.0016894876, 0}, 0});
+    cells1.push_back({{2, 2, 0.00199076766, 0}, 0});
 
-    std::vector<traccc::cell> cells2;
-    cells2.push_back({5, 5, 0.00632160669, 0});
-    cells2.push_back({5, 6, 0.00911649223, 0});
-    cells2.push_back({5, 7, 0.00518329488, 0});
+    std::vector<traccc::alt_cell> cells2;
+    cells2.push_back({{5, 5, 0.00632160669, 0}, 0});
+    cells2.push_back({{5, 6, 0.00911649223, 0}, 0});
+    cells2.push_back({{5, 7, 0.00518329488, 0}, 0});
 
     EXPECT_EQ(h_c_map[sp0], cells0);
     EXPECT_EQ(h_c_map[sp1], cells1);
@@ -140,17 +142,16 @@ TEST(mappper, cell_particle_map) {
     auto c_p_map = traccc::generate_cell_particle_map(event, cells_dir,
                                                       hits_dir, particles_dir);
 
-    std::vector<traccc::cell> cells;
-    traccc::cell cell0{1, 0, 0.0041470062, 0};
-    traccc::cell cell1{0, 1, 0.00306466641, 0};
-    traccc::cell cell2{1, 1, 0.00868905429, 0};
-    traccc::cell cell3{1, 1, 0.00886478275, 0};
-    traccc::cell cell4{1, 2, 0.00580428448, 0};
-    traccc::cell cell5{2, 1, 0.0016894876, 0};
-    traccc::cell cell6{2, 2, 0.00199076766, 0};
-    traccc::cell cell7{5, 5, 0.00632160669, 0};
-    traccc::cell cell8{5, 6, 0.00911649223, 0};
-    traccc::cell cell9{5, 7, 0.00518329488, 0};
+    traccc::alt_cell cell0{{1, 0, 0.0041470062, 0}, 0};
+    traccc::alt_cell cell1{{0, 1, 0.00306466641, 0}, 0};
+    traccc::alt_cell cell2{{1, 1, 0.00868905429, 0}, 0};
+    traccc::alt_cell cell3{{1, 1, 0.00886478275, 0}, 0};
+    traccc::alt_cell cell4{{1, 2, 0.00580428448, 0}, 0};
+    traccc::alt_cell cell5{{2, 1, 0.0016894876, 0}, 0};
+    traccc::alt_cell cell6{{2, 2, 0.00199076766, 0}, 0};
+    traccc::alt_cell cell7{{5, 5, 0.00632160669, 0}, 0};
+    traccc::alt_cell cell8{{5, 6, 0.00911649223, 0}, 0};
+    traccc::alt_cell cell9{{5, 7, 0.00518329488, 0}, 0};
 
     EXPECT_EQ(c_p_map[cell0].particle_id, 4503599644147712);
     EXPECT_EQ(c_p_map[cell1].particle_id, 4503599644147712);
@@ -167,8 +168,8 @@ TEST(mappper, cell_particle_map) {
 // Test generate_measurement_cell_map function
 TEST(mappper, measurement_cell_map) {
 
-    auto compare_cells = [](vecmem::vector<traccc::cell>& cells1,
-                            vecmem::vector<traccc::cell>& cells2) {
+    auto compare_cells = [](vecmem::vector<traccc::alt_cell>& cells1,
+                            vecmem::vector<traccc::alt_cell>& cells2) {
         std::sort(cells1.begin(), cells1.end());
         std::sort(cells2.begin(), cells2.end());
 
@@ -177,22 +178,23 @@ TEST(mappper, measurement_cell_map) {
 
     vecmem::host_memory_resource resource;
 
-    auto m_c_map = traccc::generate_measurement_cell_map(
+    auto m_c_map_pair = traccc::generate_measurement_cell_map(
         event, detector_file, digi_config_file, cells_dir, resource);
+    auto m_c_map = std::get<0>(m_c_map_pair);
 
-    vecmem::vector<traccc::cell> cells0;
-    cells0.push_back({1, 0, 0.0041470062, 0});
-    cells0.push_back({0, 1, 0.00306466641, 0});
-    cells0.push_back({1, 1, 0.00868905429, 0});
-    cells0.push_back({1, 1, 0.00886478275, 0});
-    cells0.push_back({1, 2, 0.00580428448, 0});
-    cells0.push_back({2, 1, 0.0016894876, 0});
-    cells0.push_back({2, 2, 0.00199076766, 0});
+    vecmem::vector<traccc::alt_cell> cells0;
+    cells0.push_back({{1, 0, 0.0041470062, 0}, 0});
+    cells0.push_back({{0, 1, 0.00306466641, 0}, 0});
+    cells0.push_back({{1, 1, 0.00868905429, 0}, 0});
+    cells0.push_back({{1, 1, 0.00886478275, 0}, 0});
+    cells0.push_back({{1, 2, 0.00580428448, 0}, 0});
+    cells0.push_back({{2, 1, 0.0016894876, 0}, 0});
+    cells0.push_back({{2, 2, 0.00199076766, 0}, 0});
 
-    vecmem::vector<traccc::cell> cells1;
-    cells1.push_back({5, 5, 0.00632160669, 0});
-    cells1.push_back({5, 6, 0.00911649223, 0});
-    cells1.push_back({5, 7, 0.00518329488, 0});
+    vecmem::vector<traccc::alt_cell> cells1;
+    cells1.push_back({{5, 5, 0.00632160669, 0}, 0});
+    cells1.push_back({{5, 6, 0.00911649223, 0}, 0});
+    cells1.push_back({{5, 7, 0.00518329488, 0}, 0});
 
     EXPECT_EQ(m_c_map.size(), 2);
 


### PR DESCRIPTION
This PR almost fully eliminates the use of all the "outdated" jagged EDM in the clusterisation.
It is quite a lengthy PR as it really touches almost everything in our code, but there are still a few bits and pieces in our repository using the old edm, which is why I didn't just delete all the old headers just yet.

I'll admit that I made the physics performance "mapper" functions a bit uglier, but this whole piece of code was already a mess and the solution I implemented was the only one I could see without fully rewriting this from scratch.