### PR TITLE
SYCL and Build Updates, main branch (2023.03.23.)

### DIFF
--- a/.github/ci_setup.sh
+++ b/.github/ci_setup.sh
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 #
@@ -12,18 +12,6 @@
 
 # The platform name.
 PLATFORM_NAME=$1
-
-# Set up the correct environment for the SYCL tests.
-if [ "${PLATFORM_NAME}" = "SYCL" ]; then
-   source /opt/intel/oneapi/setvars.sh
-   export CXX=`which clang++`
-   export SYCLCXX=`which dpcpp`
-   export SYCL_DEVICE_FILTER=host
-   # This is a hack to make Acts's "--coverage" flag work correctly with
-   # oneAPI 2021.2.0. It may be removed once we update to a version of oneAPI
-   # in the CI that does not have this issue.
-   export LDFLAGS="-L${CMPLR_ROOT}/linux/compiler/lib/intel64_lin -lirc"
-fi
 
 # Make sure that GNU Make and CTest would use all available cores.
 export MAKEFLAGS="-j`nproc`"

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -26,17 +26,30 @@ jobs:
         platform:
           - name: CPU
             container: ghcr.io/acts-project/ubuntu2004:v30
+            options:
           - name: CUDA
             container: ghcr.io/acts-project/ubuntu2004_cuda:v30
-          - name: SYCL
-            container: ghcr.io/acts-project/ubuntu2004_oneapi:v30
+            options: -DTRACCC_BUILD_CUDA=TRUE
           - name: KOKKOS
             container: ghcr.io/acts-project/ubuntu2004:v30
+            options: -DTRACCC_BUILD_KOKKOS=TRUE
           - name: ALPAKA
             container: ghcr.io/acts-project/ubuntu2204:v33
+            options: -DTRACCC_BUILD_ALPAKA=TRUE
         build:
           - Release
           - Debug
+        include:
+          - platform:
+              name: "SYCL"
+              container: "ghcr.io/acts-project/ubuntu2004_cuda_oneapi:v37"
+              options: -DTRACCC_BUILD_SYCL=TRUE -DTRACCC_BUILD_CUDA=FALSE -DVECMEM_BUILD_CUDA_LIBRARY=FALSE
+            build: Release
+          - platform:
+              name: "SYCL"
+              container: "ghcr.io/acts-project/ubuntu2004_rocm_oneapi:v37"
+              options: -DTRACCC_BUILD_SYCL=TRUE -DVECMEM_BUILD_HIP_LIBRARY=FALSE
+            build: Release
     # Use BASH as the shell from the images.
     defaults:
       run:
@@ -53,13 +66,13 @@ jobs:
       - name: Configure
         run: |
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
-          cmake -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DTRACCC_BUILD_${{ matrix.platform.name }}=TRUE -DTRACCC_FAIL_ON_WARNINGS=TRUE -S ${GITHUB_WORKSPACE} -B build
+          cmake -DCMAKE_BUILD_TYPE=${{ matrix.build }} ${{ matrix.platform.options }} -DTRACCC_FAIL_ON_WARNINGS=TRUE -S ${GITHUB_WORKSPACE} -B build
       - name: Build
         run: |
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
           cmake --build build
       - name: Test
-        if: "matrix.platform.name != 'CUDA'"
+        if: "matrix.platform.name == 'CPU'"
         run: |
           cd build
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -145,20 +145,15 @@ void fast_sv_1(index_t* f, index_t* gf,
 
 class ccl_kernel {
     public:
-    ccl_kernel(
-        const alt_cell_collection_types::const_view cells,
-        const cell_module_collection_types::const_view modules,
-        const index_t max_cells_per_partition,
-        const index_t target_cells_per_partition,
-        alt_measurement_collection_types::view measurements,
-        unsigned int* num_measurements,
-        vecmem::data::vector_view<unsigned int> cell_links,
-        ::sycl::accessor<unsigned int, 1, ::sycl::access::mode::read_write,
-                         ::sycl::access::target::local>
-            shared_uint,
-        ::sycl::accessor<index_t, 1, ::sycl::access::mode::read_write,
-                         ::sycl::access::target::local>
-            shared_idx)
+    ccl_kernel(const alt_cell_collection_types::const_view cells,
+               const cell_module_collection_types::const_view modules,
+               const index_t max_cells_per_partition,
+               const index_t target_cells_per_partition,
+               alt_measurement_collection_types::view measurements,
+               unsigned int* num_measurements,
+               vecmem::data::vector_view<unsigned int> cell_links,
+               ::sycl::local_accessor<unsigned int> shared_uint,
+               ::sycl::local_accessor<index_t> shared_idx)
         : cells_view(cells),
           modules_view(modules),
           m_max_cells_per_partition(max_cells_per_partition),
@@ -302,10 +297,10 @@ class ccl_kernel {
         for (index_t tst = 0, cid; (cid = tst * blockDim + tid) < size; ++tst) {
 
             if (f[cid] == cid) {
-                ::sycl::ext::oneapi::atomic_ref<
-                    unsigned int, ::sycl::memory_order::relaxed,
-                    ::sycl::memory_scope::work_group,
-                    ::sycl::access::address_space::local_space>(outi)
+                ::sycl::atomic_ref<unsigned int, ::sycl::memory_order::relaxed,
+                                   ::sycl::memory_scope::work_group,
+                                   ::sycl::access::address_space::local_space>(
+                    outi)
                     .fetch_add(1);
             }
         }
@@ -321,12 +316,12 @@ class ccl_kernel {
          * amount of threads per block, this has no sever implications.
          */
         if (tid == 0) {
-            outi = ::sycl::ext::oneapi::atomic_ref<
-                       unsigned int, ::sycl::memory_order::relaxed,
-                       ::sycl::memory_scope::device,
-                       ::sycl::access::address_space::global_space>(
-                       measurement_count)
-                       .fetch_add(outi);
+            outi =
+                ::sycl::atomic_ref<unsigned int, ::sycl::memory_order::relaxed,
+                                   ::sycl::memory_scope::device,
+                                   ::sycl::access::address_space::global_space>(
+                    measurement_count)
+                    .fetch_add(outi);
         }
 
         item.barrier();
@@ -354,7 +349,7 @@ class ccl_kernel {
                  * output array which we can write to.
                  */
                 const unsigned int id =
-                    ::sycl::ext::oneapi::atomic_ref<
+                    ::sycl::atomic_ref<
                         unsigned int, ::sycl::memory_order::relaxed,
                         ::sycl::memory_scope::work_group,
                         ::sycl::access::address_space::local_space>(outi)
@@ -376,12 +371,8 @@ class ccl_kernel {
     alt_measurement_collection_types::view measurements_view;
     unsigned int* m_measurement_count;
     vecmem::data::vector_view<unsigned int> cell_links_view;
-    ::sycl::accessor<unsigned int, 1, ::sycl::access::mode::read_write,
-                     ::sycl::access::target::local>
-        m_shared_uint;
-    ::sycl::accessor<index_t, 1, ::sycl::access::mode::read_write,
-                     ::sycl::access::target::local>
-        m_shared_idx;
+    ::sycl::local_accessor<unsigned int> m_shared_uint;
+    ::sycl::local_accessor<index_t> m_shared_idx;
 };
 
 }  // namespace kernels
@@ -458,12 +449,9 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
         .submit([&ndrange, &cells, &modules, max_cells_per_partition,
                  &target_cells_per_partition, &measurements_view, &cell_links,
                  &num_measurements_device](::sycl::handler& h) {
-            ::sycl::accessor<unsigned int, 1, ::sycl::access::mode::read_write,
-                             ::sycl::access::target::local>
-                shared_uint(3, h);
-            ::sycl::accessor<index_t, 1, ::sycl::access::mode::read_write,
-                             ::sycl::access::target::local>
-                shared_idx(2 * max_cells_per_partition, h);
+            ::sycl::local_accessor<unsigned int> shared_uint(3, h);
+            ::sycl::local_accessor<index_t> shared_idx(
+                2 * max_cells_per_partition, h);
 
             h.parallel_for<kernels::ccl_kernel>(
                 ndrange, kernels::ccl_kernel(

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -286,11 +286,9 @@ seed_finding::output_type seed_finding::operator()(
         details::get_queue(m_queue).submit([&](::sycl::handler& h) {
             // Array for temporary storage of triplet weights for comparing
             // within kernel
-            ::sycl::accessor<scalar, 1, ::sycl::access::mode::read_write,
-                             ::sycl::access::target::local>
-                local_mem(m_seedfilter_config.compatSeedLimit *
-                              weightUpdatingLocalSize,
-                          h);
+            ::sycl::local_accessor<scalar> local_mem(
+                m_seedfilter_config.compatSeedLimit * weightUpdatingLocalSize,
+                h);
 
             h.parallel_for<kernels::update_triplet_weights>(
                 weightUpdatingRange,
@@ -334,11 +332,10 @@ seed_finding::output_type seed_finding::operator()(
         .submit([&](::sycl::handler& h) {
             // Array for temporary storage of triplets for comparing within
             // kernel
-            ::sycl::accessor<triplet, 1, ::sycl::access::mode::read_write,
-                             ::sycl::access::target::local>
-                local_mem(m_seedfilter_config.max_triplets_per_spM *
-                              seedSelectingLocalSize,
-                          h);
+            ::sycl::local_accessor<triplet> local_mem(
+                m_seedfilter_config.max_triplets_per_spM *
+                    seedSelectingLocalSize,
+                h);
 
             h.parallel_for<kernels::select_seeds>(
                 seedSelectingRange,

--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# CMake 3.12+ is needed for OBJECT libraries.
+cmake_minimum_required( VERSION 3.12 )
+
 # Project include(s).
 include( traccc-compiler-options-sycl )
 
@@ -28,7 +31,7 @@ traccc_add_executable( seq_example_sycl "seq_example_sycl.sycl"
 #
 # Set up the "throughput applications".
 #
-add_library( traccc_examples_sycl STATIC
+add_library( traccc_examples_sycl OBJECT
    "full_chain_algorithm.hpp"
    "full_chain_algorithm.sycl" )
 target_link_libraries( traccc_examples_sycl

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -85,7 +85,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     uint64_t n_seeds_sycl = 0;
 
     // Creating SYCL queue object
-    ::sycl::queue q(::sycl::gpu_selector{}, handle_async_error);
+    ::sycl::queue q(handle_async_error);
     std::cout << "Running Seeding on device: "
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -35,6 +35,7 @@ traccc_add_test(
     test_sync.cu
 
     LINK_LIBRARIES
+    CUDA::cudart
     GTest::gtest
     vecmem::cuda
     detray::core


### PR DESCRIPTION
This is an attempt to make the builds not print a gazillion warnings with modern oneAPI and CUDA compilers.

First off, I switched the CI to using [ghcr.io/acts-project/ubuntu2004_cuda_oneapi:v37](https://github.com/acts-project/machines/pkgs/container/ubuntu2004_cuda_oneapi) and  [ghcr.io/acts-project/ubuntu2004_rocm_oneapi:v37](https://github.com/acts-project/machines/pkgs/container/ubuntu2004_rocm_oneapi). For now I removed the use of [ubuntu2004_oneapi](https://github.com/acts-project/machines/pkgs/container/ubuntu2004_oneapi), because:
  - The very latest version, oneAPI 2023.0.0, has a bug that prevents it building our full project (https://github.com/intel/llvm/issues/8588);
  - The current version used in the image (oneAPI 2022.0.2) is not compatible with the changes in this PR;
  - I did not want to update to oneAPI 2022.2.0. I'm not even entirely sure if it would support `sycl::local_accessor`, but I mainly just wanted to wait for oneAPI 2023.1 instead... (May re-visit this idea later on...)

I retired all the deprecated types from the SYCL code, to avoid warnings about them.

I modified `traccc_examples_sycl` to be an `OBJECT` instead of a `STATIC` library. As this avoids the following type of warning during linking:

```
[ 96%] Linking SYCL executable ../../../bin/traccc_throughput_st_sycl
error: overriding the module target triple with nvptx64-nvidia-cuda [-Werror,-Woverride-module]
```

(Something to be followed up with the Intel developers.)

Finally, I was getting a bunch of warnings from CUDA headers, while building [tests/cuda/test_thrust.cu](https://github.com/acts-project/traccc/blob/main/tests/cuda/test_thrust.cu). Which I believe is one of the problems that @guilhermeAlmeida1 was running into, and what triggered #354 and #360. The problem here was that the CUDA headers were picked up "implicitly" by `nvcc`. By making it explicit that the test should use `CUDA::cudart`, the build treats the CUDA headers as "system headers".

All in all, the code builds without warnings in this setup once again... :partying_face: