### PR TITLE
Add ability to import CMake target for covfie

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,20 @@ if( TRACCC_SETUP_ALGEBRA_PLUGINS )
    endif()
 endif()
 
+# Set up covfie.
+option( TRACCC_SETUP_COVFIE
+   "Set up the covfie target(s) explicitly" TRUE )
+option( TRACCC_USE_SYSTEM_COVFIE
+   "Pick up an existing installation of covfie from the build environment"
+   ${TRACCC_USE_SYSTEM_LIBS} )
+if( TRACCC_SETUP_COVFIE )
+   if( TRACCC_USE_SYSTEM_COVFIE )
+      find_package( covfie REQUIRED )
+   else()
+      add_subdirectory( extern/covfie )
+   endif()
+endif()
+
 # Set up dfelibs.
 option( TRACCC_SETUP_DFELIBS
    "Set up the dfelibs target(s) explicitly" TRUE )

--- a/extern/covfie/CMakeLists.txt
+++ b/extern/covfie/CMakeLists.txt
@@ -1,0 +1,38 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.14 )
+include( FetchContent )
+
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
+# Tell the user what's happening.
+message( STATUS "Fetching covfie as part of the traccc project" )
+
+# Declare where to get covfie from.
+set( TRACCC_COVFIE_SOURCE
+   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.5.0.tar.gz;URL_MD5;e6683f6eb34b6156f8ac90facc7e538e"
+   CACHE STRING "Source for covfie, when built as part of this project" )
+mark_as_advanced( TRACCC_COVFIE_SOURCE )
+FetchContent_Declare( covfie ${TRACCC_COVFIE_SOURCE} )
+
+# Options used for covfie.
+set( COVFIE_BUILD_EXAMPLES OFF CACHE BOOL "Build covfie examples")
+set( COVFIE_BUILD_TESTS OFF CACHE BOOL "Build covfie tests")
+set( COVFIE_BUILD_BENCHMARKS OFF CACHE BOOL "Build covfie benchmarks")
+
+set( COVFIE_PLATFORM_CPU ON CACHE BOOL "Enable covfie CPU platform")
+set( COVFIE_PLATFORM_CUDA ${TRACCC_BUILD_CUDA} CACHE BOOL "Enable covfie CUDA platform")
+
+set( COVFIE_REQUIRE_CXX20 OFF CACHE BOOL "Enable covfie C++20 requirement")
+set( COVFIE_QUIET ON CACHE BOOL "Quiet covfie feature warnings")
+
+# Get it into the current directory.
+FetchContent_MakeAvailable( covfie )

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -47,6 +47,8 @@ set( DETRAY_SETUP_BENCHMARK FALSE CACHE BOOL
    "Do not set up Google Benchmark as part of Detray" )
 set( DETRAY_SETUP_THRUST FALSE CACHE BOOL
    "Do not set up Thrust as part of Detray" )
+set( DETRAY_SETUP_COVFIE FALSE CACHE BOOL
+   "Do not set up covfie as part of Detray" )
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( Detray )


### PR DESCRIPTION
PR #296 introduces a dependency on some of the covfie targets, but does not actually attempt to load the library (and thus the targets). This commit adds functionality to the build system to do so.