### PR TITLE
Profiler

### DIFF
--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -46,7 +46,7 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/fitting/fitting_algorithm.cu")
   
 target_compile_options( traccc_cuda
-  PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr -Xcompiler -finstrument-functions -fPIC -lnvToolsExt -lineinfo> )
+  PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr -Xcompiler -finstrument-functions -fPIC -lnvToolsExt> )
 target_link_libraries( traccc_cuda
   PUBLIC traccc::core detray::core detray::utils vecmem::core covfie::core
   PRIVATE CUDA::cudart traccc::device_common vecmem::cuda )

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -46,7 +46,7 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/fitting/fitting_algorithm.cu")
   
 target_compile_options( traccc_cuda
-  PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr> )
+  PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr -Xcompiler -finstrument-functions -fPIC -lnvToolsExt -lineinfo> )
 target_link_libraries( traccc_cuda
   PUBLIC traccc::core detray::core detray::utils vecmem::core covfie::core
   PRIVATE CUDA::cudart traccc::device_common vecmem::cuda )

--- a/examples/run/cuda/CMakeLists.txt
+++ b/examples/run/cuda/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries( traccc_examples_cuda
    PUBLIC CUDA::cudart vecmem::core vecmem::cuda traccc::core
           traccc::device_common traccc::cuda )
 
-traccc_add_executable( throughput_st_cuda "throughput_st.cpp"
+traccc_add_executable( throughput_st_cuda "throughput_st.cpp" "inst_nvtx.cpp"
    LINK_LIBRARIES vecmem::core vecmem::cuda traccc::io traccc::performance
                   traccc::core traccc::device_common traccc::cuda
                   traccc::options traccc_examples_cuda )

--- a/examples/run/cuda/inst_nvtx.cpp
+++ b/examples/run/cuda/inst_nvtx.cpp
@@ -1,0 +1,87 @@
+/* Copyright (c) 2014, NVIDIA CORPORATION. All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <dlfcn.h>
+#include <cxxabi.h>
+#include "nvtx3/nvToolsExt.h"
+
+const char* const default_name = "Unknown";
+
+const uint32_t colors[] = { 0xff00ff00, 0xff0000ff, 0xffffff00, 0xffff00ff, 0xff00ffff, 0xffff0000, 0xffffffff };
+const int num_colors = sizeof(colors)/sizeof(uint32_t);
+static int color_id = 0;
+
+extern "C" void __cyg_profile_func_enter(void *this_fn, void *call_site) __attribute__((no_instrument_function));
+extern "C" void __cyg_profile_func_exit(void *this_fn, void *call_site) __attribute__((no_instrument_function));
+
+void rangePush(const char* const name ) __attribute__((no_instrument_function));
+void rangePop() __attribute__((no_instrument_function));
+
+extern "C" void __cyg_profile_func_enter(void *this_fn, void *call_site)
+{
+	Dl_info this_fn_info;
+	if ( dladdr( this_fn, &this_fn_info ) )
+	{
+		int status = 0;
+		rangePush(abi::__cxa_demangle(this_fn_info.dli_sname,0, 0, &status));
+	}
+	else
+	{
+		rangePush(default_name);
+	}
+} /* __cyg_profile_func_enter */
+
+extern "C" void __cyg_profile_func_exit(void *this_fn, void *call_site)
+{
+	rangePop();
+} /* __cyg_profile_func_enter */
+
+void rangePush(const char* const name )
+{
+	nvtxEventAttributes_t eventAttrib = {0};
+	eventAttrib.version = NVTX_VERSION;
+	eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+	eventAttrib.colorType = NVTX_COLOR_ARGB;
+	eventAttrib.color = colors[color_id];
+	color_id = (color_id+1)%num_colors;
+	eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+	if ( name != 0 )
+	{
+		eventAttrib.message.ascii = name;
+	}
+	else
+	{
+		eventAttrib.message.ascii = default_name;
+	}
+	nvtxRangePushEx(&eventAttrib);
+}
+
+void rangePop()
+{
+	nvtxRangePop();
+}


### PR DESCRIPTION
Sorry for the delay, there was a bug that I was busy trying to find for the longest time. So I added some functionality to get fine grained profiling that can hopefully be useful for finding bottle necks. The command I use to run the profiler is:
`nsys profile --trace="cuda,nvtx" --cudabacktrace=all --cuda-um-cpu-page-faults=true --cuda-um-gpu-page-faults=true --stats=true build/bin/traccc_throughput_st_cuda --detector_file=tml_detector/trackml-detector.csv --input_directory=tml_full/single_muon/ --digitization_config_file=tml_detector/detector-geometric-config-generic.json --processed_events=1`

I also attached the output of the command.
[profile_cmndline_output.txt](https://github.com/acts-project/traccc/files/11060670/profile_cmndline_output.txt)
