### PR TITLE
CMake Export Fix, main branch (2023.03.24.)

### DIFF
--- a/cmake/traccc-config.cmake.in
+++ b/cmake/traccc-config.cmake.in
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,6 +13,13 @@ set( TRACCC_BUILD_SYCL     @TRACCC_BUILD_SYCL@ )
 set( TRACCC_BUILD_FUTHARK  @TRACCC_BUILD_FUTHARK@ )
 set( TRACCC_BUILD_KOKKOS   @TRACCC_BUILD_KOKKOS@ )
 set( TRACCC_BUILD_EXAMPLES @TRACCC_BUILD_EXAMPLES@ )
+set( TRACCC_USE_ROOT       @TRACCC_USE_ROOT@ )
+
+# Set up some simple variables for using the package.
+set( traccc_VERSION "@PROJECT_VERSION@" )
+set_and_check( traccc_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@" )
+set_and_check( traccc_LIBRARY_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@" )
+set_and_check( traccc_CMAKE_DIR   "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@" )
 
 # Make the "traccc modules" visible to CMake.
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}" )
@@ -34,18 +41,14 @@ find_dependency( algebra-plugins )
 find_dependency( detray )
 if( TRACCC_BUILD_EXAMPLES )
    find_dependency( Boost COMPONENTS program_options )
-   find_dependency( ROOT COMPONENTS Core RIO Tree Hist )
+   if( TRACCC_USE_ROOT )
+      find_dependency( ROOT COMPONENTS Core RIO Tree Hist )
+   endif()
 endif()
 
 # Set up the traccc::Thrust target.
 set( TRACCC_THRUST_OPTIONS @TRACCC_THRUST_OPTIONS@ )
 thrust_create_target( traccc::Thrust ${TRACCC_THRUST_OPTIONS} )
-
-# Set up some simple variables for using the package.
-set( traccc_VERSION "@PROJECT_VERSION@" )
-set_and_check( traccc_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@" )
-set_and_check( traccc_LIBRARY_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@" )
-set_and_check( traccc_CMAKE_DIR   "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@" )
 
 # Include the file listing all the imported targets and options.
 include( "${traccc_CMAKE_DIR}/traccc-config-targets.cmake" )


### PR DESCRIPTION
This is a sibling of https://github.com/acts-project/algebra-plugins/pull/96 and https://github.com/acts-project/detray/pull/419. It fixes the issue described in https://github.com/acts-project/algebra-plugins/issues/36, and helps with #364.

For an explanation of why the `set_and_check(...)` statements needed to move, see https://github.com/acts-project/algebra-plugins/pull/96.

The one extra in this PR is that I now taught the exported configuration about `TRACCC_USE_ROOT`. Which I forgot to do in #328. :frowning: