### PR TITLE
Add quality reporting for seeds of arbitrary length

### DIFF
--- a/core/include/traccc/edm/nseed.hpp
+++ b/core/include/traccc/edm/nseed.hpp
@@ -1,0 +1,62 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <traccc/edm/container.hpp>
+#include <traccc/edm/seed.hpp>
+#include <traccc/edm/spacepoint.hpp>
+
+namespace traccc {
+/**
+ * @brief Seed of arbitrary size.
+ *
+ * This type represents a set of at least three and at most N spacepoints which
+ * are presumed to belong to a single track.
+ *
+ * @tparam N The maximum capacity of the seed.
+ */
+template <std::size_t N>
+struct nseed {
+    /*
+     * Enforce the minimum seed size of three.
+     */
+    static_assert(N >= 3, "Seeds must contain at least three spacepoints.");
+
+    /*
+     * Should be the same as the three-seed type.
+     */
+    using link_type = spacepoint_collection_types::host::size_type;
+
+    /**
+     * @brief Construct a new n-seed object from a 3-seed object.
+     *
+     * @param s A 3-seed.
+     */
+    nseed(const seed& s)
+        : _size(3), _sps({s.spB_link, s.spM_link, s.spT_link}) {}
+
+    /**
+     * @brief Get the size of the seed.
+     */
+    std::size_t size() const { return _size; }
+
+    /**
+     * @brief Get the first space point identifier in the seed.
+     */
+    const link_type* cbegin() const { return &_sps[0]; }
+
+    /**
+     * @brief Get the one-after-last space point identifier in the seed.
+     */
+    const link_type* cend() const { return &_sps[_size]; }
+
+    private:
+    std::size_t _size;
+    std::array<link_type, N> _sps;
+};
+}  // namespace traccc

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -12,6 +12,10 @@ traccc_add_library( traccc_performance performance TYPE SHARED
    "include/traccc/efficiency/seeding_performance_writer.hpp"
    "src/efficiency/seeding_performance_writer.cpp"
    "src/efficiency/track_classification.hpp"
+   "include/traccc/efficiency/nseed_performance_writer.hpp"
+   "src/efficiency/nseed_performance_writer.cpp"
+   "src/efficiency/track_filter.cpp"
+   "src/efficiency/track_matcher.cpp"
    # Resolution calculation code.
    "include/traccc/resolution/fitting_performance_writer.hpp"
    "include/traccc/resolution/res_plot_tool_config.hpp"

--- a/performance/include/traccc/efficiency/nseed_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/nseed_performance_writer.hpp
@@ -1,0 +1,123 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <Acts/Definitions/Units.hpp>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <set>
+#include <traccc/edm/alt_measurement.hpp>
+#include <traccc/edm/nseed.hpp>
+#include <traccc/edm/spacepoint.hpp>
+#include <traccc/efficiency/track_filter.hpp>
+#include <traccc/efficiency/track_matcher.hpp>
+#include <traccc/io/event_map.hpp>
+#include <traccc/utils/unit_vectors.hpp>
+
+using namespace Acts::UnitLiterals;
+
+namespace traccc {
+class nseed_performance_writer {
+    public:
+    struct statistics {
+        std::size_t true_seeds = 0, false_seeds = 0;
+        std::size_t matched_tracks = 0, unmatched_tracks = 0;
+    };
+
+    nseed_performance_writer(const std::string& p,
+                             std::unique_ptr<track_filter>&& f,
+                             std::unique_ptr<track_matcher>&& m);
+
+    void initialize();
+    void finalize();
+
+    template <typename SeedIt, typename SpIt>
+    void register_event(std::size_t ev, const SeedIt sb, const SeedIt se,
+                        const SpIt pb, const event_map& em) {
+        std::size_t seed_id = 0;
+
+        std::multiset<std::size_t> matched_tracks;
+
+        for (SeedIt s = sb; s != se; ++s) {
+            std::vector<std::vector<uint64_t>> particle_ids;
+
+            std::transform(
+                s->cbegin(), s->cend(), std::back_inserter(particle_ids),
+                [pb,
+                 &em](const spacepoint_collection_types::host::size_type& l) {
+                    traccc::alt_measurement meas = (pb + l)->meas;
+
+                    const auto& ptcs = em.meas_ptc_map.find(meas)->second;
+
+                    std::vector<uint64_t> ptc_ids;
+
+                    for (auto const& [ptc, _] : ptcs) {
+                        ptc_ids.push_back(ptc.particle_id);
+                    }
+
+                    return ptc_ids;
+                });
+
+            std::optional<uint64_t> pid = _matcher->operator()(particle_ids);
+
+            if (pid) {
+                _stats.true_seeds++;
+
+                matched_tracks.insert(*pid);
+            } else {
+                _stats.false_seeds++;
+            }
+
+            write_seed_row(ev, seed_id++, s->size(), pid);
+        }
+
+        for (const auto& [_, ptc] : em.ptc_map) {
+            bool pass = _filter->operator()(ptc);
+
+            if (pass) {
+                if (matched_tracks.count(ptc.particle_id) > 0) {
+                    _stats.matched_tracks++;
+                } else {
+                    _stats.unmatched_tracks++;
+                }
+            }
+
+            const scalar eta = traccc::eta(ptc.mom);
+            const scalar phi = traccc::phi(ptc.mom);
+            const scalar pT = getter::perp(ptc.mom);
+
+            write_track_row(ev, ptc.particle_id, pass, ptc.charge, eta, phi,
+                            pT);
+        }
+    }
+
+    std::string generate_report_str() const;
+
+    private:
+    static constexpr std::string_view sep = ",";
+
+    void write_seed_header();
+    void write_seed_row(std::size_t, std::size_t, std::size_t,
+                        std::optional<std::size_t>);
+
+    void write_track_header();
+    void write_track_row(std::size_t, std::size_t, bool, int, scalar, scalar,
+                         scalar);
+
+    std::string _prefix;
+
+    std::unique_ptr<track_filter> _filter;
+    std::unique_ptr<track_matcher> _matcher;
+
+    std::ofstream output_seed_file, output_track_file;
+
+    statistics _stats;
+};
+}  // namespace traccc

--- a/performance/include/traccc/efficiency/track_filter.hpp
+++ b/performance/include/traccc/efficiency/track_filter.hpp
@@ -1,0 +1,62 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <string>
+#include <traccc/definitions/primitives.hpp>
+#include <traccc/edm/particle.hpp>
+
+namespace traccc {
+/**
+ * @brief Abstract track filtering descriptor.
+ *
+ * This abstract class represents a methodology for selecting particles that
+ * are relevant to the current track reconstruction. Allows irrelevant tracks
+ * to be omitted from efficiency calculations.
+ */
+struct track_filter {
+    /**
+     * @brief Return a human-readable name for this filtering method.
+     */
+    virtual std::string get_name() const = 0;
+
+    /**
+     * @brief Determine whether a given particle is relevant to tracking.
+     *
+     * @param p The particle in question.
+     *
+     * @return true if the particle passes the cut.
+     * @return false if the particle does not pass the cut.
+     */
+    virtual bool operator()(const particle &p) const = 0;
+};
+
+/**
+ * @brief Simple η and pT cut for charged particles.
+ *
+ * Describes a cut requiring the absolute value of η to be smaller than a given
+ * value, and for the pT value to be greater than a given threshold. Also
+ * requires the particle to be charged.
+ */
+struct simple_charged_eta_pt_cut : track_filter {
+    /**
+     * @brief Construct a new cut object.
+     *
+     * @param eta The maximum value for |η|
+     * @param pT The minimum value for pT
+     */
+    simple_charged_eta_pt_cut(scalar eta, scalar pT);
+
+    virtual std::string get_name() const override final;
+
+    virtual bool operator()(const particle &) const override final;
+
+    private:
+    scalar m_eta, m_pT;
+};
+}  // namespace traccc

--- a/performance/include/traccc/efficiency/track_matcher.hpp
+++ b/performance/include/traccc/efficiency/track_matcher.hpp
@@ -1,0 +1,82 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <traccc/definitions/primitives.hpp>
+#include <traccc/edm/particle.hpp>
+#include <vector>
+
+namespace traccc {
+/**
+ * @brief Abstract track matching descriptor.
+ *
+ * This abstract class represents a methodology for matching seeds to
+ * particles.
+ */
+struct track_matcher {
+    /**
+     * @brief Return a human-readable name for this matching method.
+     */
+    virtual std::string get_name() const = 0;
+
+    /**
+     * @brief Determine the most likely particle, if any, for a given seed.
+     *
+     * @param v A vector of sets of particle identifiers, such that the outer
+     * vector represents the list of spacepoints in a seed, and the inner sets
+     * represent the particles that match that spacepoint (usually only one).
+     *
+     * @return The matched particle identifier, or nothing if no particle
+     * matches.
+     */
+    virtual std::optional<uint64_t> operator()(
+        const std::vector<std::vector<uint64_t>>& v) const = 0;
+};
+
+/**
+ * @brief Matcher based on minimum majority size.
+ *
+ * This matcher matches a seed to the track with the greatest number of
+ * matching spacepoints, with a minimum percentage-defined size of the
+ * majority.
+ */
+struct stepped_percentage : track_matcher {
+    /**
+     * @brief Construct a new particle matcher.
+     *
+     * @param r The minimum ratio in [0, 1] of spacepoints that must belong to
+     * the same particle.
+     */
+    stepped_percentage(scalar r);
+
+    virtual std::string get_name() const override final;
+
+    virtual std::optional<uint64_t> operator()(
+        const std::vector<std::vector<uint64_t>>&) const override final;
+
+    private:
+    scalar m_min_ratio;
+};
+
+/**
+ * @brief Matcher requiring exact particle matching.
+ *
+ * This matcher matches a seed to a track iff all spacepoints in the seed map
+ * onto the same particle.
+ */
+struct exact : track_matcher {
+    exact();
+
+    virtual std::string get_name() const override final;
+
+    virtual std::optional<uint64_t> operator()(
+        const std::vector<std::vector<uint64_t>>&) const override final;
+};
+}  // namespace traccc

--- a/performance/src/efficiency/nseed_performance_writer.cpp
+++ b/performance/src/efficiency/nseed_performance_writer.cpp
@@ -1,0 +1,147 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <memory>
+#include <optional>
+#include <traccc/efficiency/nseed_performance_writer.hpp>
+#include <traccc/efficiency/track_filter.hpp>
+#include <traccc/efficiency/track_matcher.hpp>
+
+namespace traccc {
+nseed_performance_writer::nseed_performance_writer(
+    const std::string& prefix, std::unique_ptr<track_filter>&& filter,
+    std::unique_ptr<track_matcher>&& matcher)
+    : _prefix(prefix),
+      _filter(std::forward<std::unique_ptr<track_filter>>(filter)),
+      _matcher(std::forward<std::unique_ptr<track_matcher>>(matcher)) {}
+
+void nseed_performance_writer::initialize() {
+    output_seed_file.open(_prefix + "seeds.csv");
+    output_track_file.open(_prefix + "tracks.csv");
+
+    /*
+     * This is a while away from proper file handling in C++, but it'll do.
+     */
+    assert(output_seed_file.good());
+    assert(output_track_file.good());
+
+    write_seed_header();
+    write_track_header();
+}
+
+void nseed_performance_writer::finalize() {
+    if (output_seed_file.is_open()) {
+        output_seed_file.close();
+    }
+
+    if (output_track_file.is_open()) {
+        output_track_file.close();
+    }
+}
+
+void nseed_performance_writer::write_seed_header() {
+    if (output_seed_file.good()) {
+        output_seed_file << "event_id" << sep << "seed_id" << sep << "length"
+                         << sep << "particle_id" << std::endl;
+    }
+}
+
+void nseed_performance_writer::write_seed_row(
+    std::size_t event_id, std::size_t seed_id, std::size_t length,
+    std::optional<std::size_t> particle_id) {
+    if (output_seed_file.good()) {
+        output_seed_file << event_id << sep << seed_id << sep << length << sep
+                         << (particle_id ? std::to_string(*particle_id) : "-1")
+                         << std::endl;
+    }
+}
+
+void nseed_performance_writer::write_track_header() {
+    if (output_track_file.good()) {
+        output_track_file << "event_id" << sep << "particle_id" << sep
+                          << "pass_cuts" << sep << "q" << sep << "eta" << sep
+                          << "phi" << sep << "pt" << std::endl;
+    }
+}
+
+void nseed_performance_writer::write_track_row(std::size_t event_id,
+                                               std::size_t particle_id,
+                                               bool pass_cuts, int q,
+                                               scalar eta, scalar phi,
+                                               scalar pt) {
+    if (output_track_file.good()) {
+        output_track_file << event_id << sep << particle_id << sep
+                          << (pass_cuts ? "true" : "false") << sep << q << sep
+                          << eta << sep << phi << sep << pt << std::endl;
+    }
+}
+
+std::string nseed_performance_writer::generate_report_str() const {
+    /*
+     * Construct a stonking great string. Constructing a string of fixed format
+     * like this isn't optimal, but hey it's an R&D project.
+     */
+    char buffer[512];
+    std::string result;
+
+    /*
+     * Print a cute little header.
+     */
+    snprintf(buffer, 512, "==> Seed finding efficiency ...\n");
+    result.append(buffer);
+
+    /*
+     * Print descriptors of the filter and matcher.
+     */
+    snprintf(buffer, 512, "- %-20s : %s\n", "Particle filter",
+             _filter->get_name().c_str());
+    result.append(buffer);
+    snprintf(buffer, 512, "- %-20s : %s\n", "Particle matcher",
+             _matcher->get_name().c_str());
+    result.append(buffer);
+
+    /*
+     * Print some discrete statistics...
+     */
+    snprintf(buffer, 512, "- %-20s : %7ld\n", "Total seeds",
+             (_stats.true_seeds + _stats.false_seeds));
+    result.append(buffer);
+    snprintf(buffer, 512, "- %-20s : %7ld\n", "True seeds", _stats.true_seeds);
+    result.append(buffer);
+    snprintf(buffer, 512, "- %-20s : %7ld\n", "False seeds",
+             _stats.false_seeds);
+    result.append(buffer);
+    snprintf(buffer, 512, "- %-20s : %7ld\n", "Total tracks",
+             (_stats.unmatched_tracks + _stats.matched_tracks));
+    result.append(buffer);
+    snprintf(buffer, 512, "- %-20s : %7ld\n", "Matched tracks",
+             _stats.matched_tracks);
+    result.append(buffer);
+    snprintf(buffer, 512, "- %-20s : %7ld\n", "Unmatched tracks",
+             _stats.unmatched_tracks);
+    result.append(buffer);
+
+    /*
+     * ...and some compound statistics.
+     */
+    snprintf(buffer, 512, "- %-20s : %6.2f%%\n", "Precision",
+             (100. * static_cast<double>(_stats.true_seeds) /
+              static_cast<double>(_stats.true_seeds + _stats.false_seeds)));
+    result.append(buffer);
+    snprintf(buffer, 512, "- %-20s : %6.2f%%\n", "Fake rate",
+             (100. * static_cast<double>(_stats.false_seeds) /
+              static_cast<double>(_stats.true_seeds + _stats.false_seeds)));
+    result.append(buffer);
+    snprintf(
+        buffer, 512, "- %-20s : %6.2f%%\n", "Recall/Efficiency",
+        (100. * static_cast<double>(_stats.matched_tracks) /
+         static_cast<double>(_stats.unmatched_tracks + _stats.matched_tracks)));
+    result.append(buffer);
+
+    return result;
+}
+}  // namespace traccc

--- a/performance/src/efficiency/track_filter.cpp
+++ b/performance/src/efficiency/track_filter.cpp
@@ -1,0 +1,31 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <string>
+#include <traccc/definitions/primitives.hpp>
+#include <traccc/edm/particle.hpp>
+#include <traccc/efficiency/track_filter.hpp>
+#include <traccc/utils/unit_vectors.hpp>
+
+namespace traccc {
+simple_charged_eta_pt_cut::simple_charged_eta_pt_cut(scalar eta, scalar pt)
+    : m_eta(eta), m_pT(pt) {}
+
+std::string simple_charged_eta_pt_cut::get_name() const {
+    char buffer[512];
+    snprintf(buffer, 512, "Charged with |η| ≤ %.2f and pT ≥ %.3f GeV", m_eta,
+             m_pT);
+    return std::string(buffer);
+}
+
+bool simple_charged_eta_pt_cut::operator()(const particle& p) const {
+    const scalar eta = traccc::eta(p.mom);
+    const scalar pT = getter::perp(p.mom);
+
+    return p.charge != 0 && std::abs(eta) <= m_eta && pT >= m_pT;
+}
+}  // namespace traccc

--- a/performance/src/efficiency/track_matcher.cpp
+++ b/performance/src/efficiency/track_matcher.cpp
@@ -1,0 +1,91 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <optional>
+#include <set>
+#include <string>
+#include <traccc/definitions/primitives.hpp>
+#include <traccc/edm/particle.hpp>
+#include <traccc/efficiency/track_matcher.hpp>
+#include <vector>
+
+namespace traccc {
+stepped_percentage::stepped_percentage(scalar ratio) : m_min_ratio(ratio) {}
+
+std::string stepped_percentage::get_name() const {
+    char buffer[512];
+    snprintf(buffer, 512, "Stepped with ≥ %.1f%% similarity",
+             100.f * m_min_ratio);
+    return std::string(buffer);
+}
+
+std::optional<uint64_t> stepped_percentage::operator()(
+    const std::vector<std::vector<uint64_t>>& p) const {
+    std::multiset<uint64_t> cnt;
+
+    /*
+     * Record all the particle identifiers in a multiset in order to count
+     * them.
+     */
+    for (const std::vector<uint64_t>& i : p) {
+        for (uint64_t j : i) {
+            cnt.insert(j);
+        }
+    }
+
+    /*
+     * From the maximum size, decrease the matching count required until we
+     * find a match or we dip below the threshold.
+     */
+    for (std::size_t n = p.size();
+         n <= p.size() &&
+         (static_cast<float>(n) / static_cast<float>(p.size())) > m_min_ratio;
+         --n) {
+        for (uint64_t i : cnt) {
+            if (cnt.count(i) == n) {
+                return {i};
+            }
+        }
+    }
+
+    return {};
+}
+
+exact::exact() {}
+
+std::string exact::get_name() const {
+    char buffer[512];
+    snprintf(buffer, 512, "Exact");
+    return std::string(buffer);
+}
+
+std::optional<uint64_t> exact::operator()(
+    const std::vector<std::vector<uint64_t>>& p) const {
+    std::multiset<uint64_t> cnt;
+
+    /*
+     * Record all the particle identifiers in a multiset in order to count
+     * them.
+     */
+    for (const std::vector<uint64_t>& i : p) {
+        for (uint64_t j : i) {
+            cnt.insert(j);
+        }
+    }
+
+    /*
+     * Find a particle which matches every single spacepoint.
+     */
+    for (uint64_t i : cnt) {
+        if (cnt.count(i) == p.size()) {
+            return {i};
+        }
+    }
+
+    return {};
+}
+}  // namespace traccc


### PR DESCRIPTION
As far as I understand, the seed efficiency tools we have now don't really work with seeds that are not of size 3, and it also appears that they are not currently working for the CUDA code. This PR introduces code that functions similarly, but allows matching and filtering to be configured. It also outputs its data to files that can be analyzed further.

Example output:

```
$ ./build/bin/traccc_seeding_example_cuda --detector_file tml_detector/trackml-detector.csv --events 10 --input_directory tml_full/ttbar_mu300/ --check_performance=1
Running ./build/bin/traccc_seeding_example_cuda tml_detector/trackml-detector.csv tml_full/ttbar_mu300/ 10
==> Seed finding efficiency ...
- Particle filter      : Charged with |η| ≤ 2.70 and pT ≥ 1.000 GeV
- Particle matcher     : Stepped with ≥ 60.0% similarity
- Total seeds          :  294740
- True seeds           :  208530
- False seeds          :   86210
- Total tracks         :   13076
- Matched tracks       :   11632
- Unmatched tracks     :    1444
- Precision            :  70.75%
- Fake rate            :  29.25%
- Recall/Efficiency    :  88.96%
```