### PR TITLE
Fix: Sycl algorithms wait for assynchronous operations.

### DIFF
--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -400,6 +400,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     // Create result object for the CCL kernel with size overestimation
     alt_measurement_collection_types::buffer measurements_buffer(num_cells,
                                                                  m_mr.main);
+    m_copy.setup(measurements_buffer)->wait();
     alt_measurement_collection_types::view measurements_view(
         measurements_buffer);
 
@@ -464,6 +465,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
 
     spacepoint_collection_types::buffer spacepoints_buffer(
         num_measurements_host, m_mr.main);
+    m_copy.setup(spacepoints_buffer)->wait();
     spacepoint_collection_types::view spacepoints_view(spacepoints_buffer);
 
     // For the following kernel, we can now use whatever the desired number of

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -85,7 +85,7 @@ seed_finding::output_type seed_finding::operator()(
     // Set up the doublet counter buffer.
     device::doublet_counter_collection_types::buffer doublet_counter_buffer = {
         m_copy.get_size(sp_grid_prefix_sum_view), 0, m_mr.main};
-    m_copy.setup(doublet_counter_buffer);
+    m_copy.setup(doublet_counter_buffer)->wait();
 
     // Counter for the total number of doublets and triplets
     vecmem::unique_alloc_ptr<device::seeding_global_counter>
@@ -134,10 +134,10 @@ seed_finding::output_type seed_finding::operator()(
     // Set up the doublet buffers.
     device::device_doublet_collection_types::buffer doublet_buffer_mb = {
         globalCounter_host.m_nMidBot, m_mr.main};
-    m_copy.setup(doublet_buffer_mb);
+    m_copy.setup(doublet_buffer_mb)->wait();
     device::device_doublet_collection_types::buffer doublet_buffer_mt = {
         globalCounter_host.m_nMidTop, m_mr.main};
-    m_copy.setup(doublet_buffer_mt);
+    m_copy.setup(doublet_buffer_mt)->wait();
 
     // Calculate the range to run the doublet finding for.
     static constexpr unsigned int doubletFindLocalSize = 32 * 2;
@@ -164,12 +164,12 @@ seed_finding::output_type seed_finding::operator()(
     // Set up the triplet counter buffers and their views
     device::triplet_counter_spM_collection_types::buffer
         triplet_counter_spM_buffer = {doublet_counter_buffer_size, m_mr.main};
-    m_copy.setup(triplet_counter_spM_buffer);
-    m_copy.memset(triplet_counter_spM_buffer, 0);
+    m_copy.setup(triplet_counter_spM_buffer)->wait();
+    m_copy.memset(triplet_counter_spM_buffer, 0)->wait();
     device::triplet_counter_collection_types::buffer
         triplet_counter_midBot_buffer = {globalCounter_host.m_nMidBot, 0,
                                          m_mr.main};
-    m_copy.setup(triplet_counter_midBot_buffer);
+    m_copy.setup(triplet_counter_midBot_buffer)->wait();
 
     device::triplet_counter_spM_collection_types::view
         triplet_counter_spM_view = triplet_counter_spM_buffer;
@@ -230,7 +230,7 @@ seed_finding::output_type seed_finding::operator()(
     // Set up the triplet buffer and its view
     device::device_triplet_collection_types::buffer triplet_buffer = {
         globalCounter_host.m_nTriplets, m_mr.main};
-    m_copy.setup(triplet_buffer);
+    m_copy.setup(triplet_buffer)->wait();
     device::device_triplet_collection_types::view triplet_view = triplet_buffer;
 
     // Calculate the range to run the triplet finding for
@@ -299,7 +299,7 @@ seed_finding::output_type seed_finding::operator()(
     // Create seed buffer object and its view
     seed_collection_types::buffer seed_buffer(globalCounter_host.m_nTriplets, 0,
                                               m_mr.main);
-    m_copy.setup(seed_buffer);
+    m_copy.setup(seed_buffer)->wait();
     seed_collection_types::view seed_view(seed_buffer);
 
     // Calculate the range to run the seed selecting for

--- a/device/sycl/src/seeding/spacepoint_binning.sycl
+++ b/device/sycl/src/seeding/spacepoint_binning.sycl
@@ -52,8 +52,8 @@ sp_grid_buffer spacepoint_binning::operator()(
     const std::size_t grid_bins = m_axes.first.n_bins * m_axes.second.n_bins;
     vecmem::data::vector_buffer<unsigned int> grid_capacities_buff(grid_bins,
                                                                    m_mr.main);
-    m_copy.setup(grid_capacities_buff);
-    m_copy.memset(grid_capacities_buff, 0);
+    m_copy.setup(grid_capacities_buff)->wait();
+    m_copy.memset(grid_capacities_buff, 0)->wait();
     vecmem::data::vector_view<unsigned int> grid_capacities_view =
         grid_capacities_buff;
 
@@ -87,7 +87,7 @@ sp_grid_buffer spacepoint_binning::operator()(
         std::vector<std::size_t>(grid_capacities_host.begin(),
                                  grid_capacities_host.end()),
         m_mr.main, m_mr.host);
-    m_copy.setup(grid_buffer._buffer);
+    m_copy.setup(grid_buffer._buffer)->wait();
     sp_grid_view grid_view = grid_buffer;
 
     // Populate the grid.

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -38,7 +38,7 @@ track_params_estimation::output_type track_params_estimation::operator()(
     // Create device buffer for the parameters
     bound_track_parameters_collection_types::buffer params_buffer(seeds_size,
                                                                   m_mr.main);
-    m_copy.setup(params_buffer);
+    m_copy.setup(params_buffer)->wait();
 
     // Check if anything needs to be done.
     if (seeds_size == 0) {

--- a/device/sycl/src/utils/make_prefix_sum_buff.sycl
+++ b/device/sycl/src/utils/make_prefix_sum_buff.sycl
@@ -29,7 +29,7 @@ vecmem::data::vector_buffer<device::prefix_sum_element_t> make_prefix_sum_buff(
     // Create buffer and view objects for prefix sum vector
     vecmem::data::vector_buffer<device::prefix_sum_element_t> prefix_sum_buff(
         totalSize, mr.main);
-    copy.setup(prefix_sum_buff);
+    copy.setup(prefix_sum_buff)->wait();
     vecmem::data::vector_view<device::prefix_sum_element_t> prefix_sum_view =
         prefix_sum_buff;
 


### PR DESCRIPTION
As @krasznaa pointed out in #371 , my change to an assynchronous copy object was susceptible to error by missing calls to `wait()` on the various operations it does.