### PR TITLE
Change CCL kernel to common code

### DIFF
--- a/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
+++ b/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
@@ -1,0 +1,71 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/alt_measurement.hpp"
+#include "traccc/edm/cell.hpp"
+#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/spacepoint.hpp"
+
+// Vecmem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
+#include <vecmem/memory/memory_resource.hpp>
+
+// System include(s).
+#include <cstddef>
+
+namespace traccc::device {
+
+namespace {
+/// These indices in clusterization will only range from 0 to
+/// max_cells_per_partition, so we only need a short
+using index_t = unsigned short;
+
+static constexpr int TARGET_CELLS_PER_THREAD = 8;
+static constexpr int MAX_CELLS_PER_THREAD = 12;
+}  // namespace
+
+/// Function which reads raw detector cells and turns them into measurements.
+///
+/// @param[in] threadId current thread index
+/// @param[in] blckDim  current thread block size
+/// @param[in] blckId   current thread block index
+/// @param[in] cells_view    collection of cells
+/// @param[in] modules_view  collection of modules to which the cells are linked
+/// @param[in] max_cells_per_partition maximum number of cells per thread block
+/// @param[in] target_cells_per_partition average number of cells per thread
+/// block
+/// @param partition_start    partition start point for this thread block
+/// @param partition_end      partition end point for this thread block
+/// @param outi               number of measurements for this partition
+/// @param f  array of "parent" indices for all cells in this partition
+/// @param gf array of "grandparent" indices for all cells in this partition
+/// @param barrier  A generic object for block-wide synchronisation
+/// @param[out] measurements_view collection of measurements
+/// @param[out] measurement_count number of measurements
+/// @param[out] cell_links    collection of links to measurements each cell is
+/// put into
+template <typename barrier_t>
+TRACCC_DEVICE inline void ccl_kernel(
+    const index_t threadId, const index_t blckDim, const unsigned int blockId,
+    const cell_collection_types::const_view cells_view,
+    const cell_module_collection_types::const_view modules_view,
+    const index_t max_cells_per_partition,
+    const index_t target_cells_per_partition, unsigned int& partition_start,
+    unsigned int& partition_end, unsigned int& outi, index_t* f, index_t* gf,
+    barrier_t& barrier,
+    alt_measurement_collection_types::view measurements_view,
+    unsigned int& measurement_count,
+    vecmem::data::vector_view<unsigned int> cell_links);
+
+}  // namespace traccc::device
+
+// Include the implementation.
+#include "traccc/clusterization/device/impl/ccl_kernel.ipp"

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -8,8 +8,6 @@
 #pragma once
 
 // Project include(s)
-#include <vecmem/memory/device_atomic_ref.hpp>
-
 #include "traccc/clusterization/detail/measurement_creation_helper.hpp"
 
 namespace traccc::device {

--- a/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
@@ -1,0 +1,318 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/clusterization/device/aggregate_cluster.hpp"
+#include "traccc/clusterization/device/reduce_problem_cell.hpp"
+
+namespace traccc::device {
+
+/// Implementation of a FastSV algorithm with the following steps:
+///   1) mix of stochastic and aggressive hooking
+///   2) shortcutting
+///
+/// The implementation corresponds to an adapted versiion of Algorithm 3 of
+/// the following paper:
+/// https://www.sciencedirect.com/science/article/pii/S0743731520302689
+///
+///                     This array only gets updated at the end of the iteration
+///                     to prevent race conditions.
+/// @param[in] adjc     The number of adjacent cells
+/// @param[in] adjv     Vector of adjacent cells
+/// @param[in] tid      The thread index
+/// @param[in] blckDim  The block size
+/// @param[inout] f     array holding the parent cell ID for the current
+/// iteration.
+/// @param[inout] gf    array holding grandparent cell ID from the previous
+/// iteration.
+/// @param[in] barrier  A generic object for block-wide synchronisation
+///
+template <typename barrier_t>
+TRACCC_DEVICE void fast_sv_1(index_t* f, index_t* gf,
+                             unsigned char adjc[MAX_CELLS_PER_THREAD],
+                             index_t adjv[MAX_CELLS_PER_THREAD][8],
+                             const index_t tid, const index_t blckDim,
+                             barrier_t& barrier) {
+    /*
+     * The algorithm finishes if an iteration leaves the arrays unchanged.
+     * This varible will be set if a change is made, and dictates if another
+     * loop is necessary.
+     */
+    bool gf_changed;
+
+    do {
+        /*
+         * Reset the end-parameter to false, so we can set it to true if we
+         * make a change to the gf array.
+         */
+        gf_changed = false;
+
+        /*
+         * The algorithm executes in a loop of three distinct parallel
+         * stages. In this first one, a mix of stochastic and aggressive
+         * hooking, we examine adjacent cells and copy their grand parents
+         * cluster ID if it is lower than ours, essentially merging the two
+         * together.
+         */
+        for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
+            const index_t cid = tst * blckDim + tid;
+
+            __builtin_assume(adjc[tst] <= 8);
+            for (unsigned char k = 0; k < adjc[tst]; ++k) {
+                index_t q = gf[adjv[tst][k]];
+
+                if (gf[cid] > q) {
+                    f[f[cid]] = q;
+                    f[cid] = q;
+                }
+            }
+        }
+
+        /*
+         * Each stage in this algorithm must be preceded by a
+         * synchronization barrier!
+         */
+        barrier.blockBarrier();
+
+#pragma unroll
+        for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
+            const index_t cid = tst * blckDim + tid;
+            /*
+             * The second stage is shortcutting, which is an optimisation that
+             * allows us to look at any shortcuts in the cluster IDs that we
+             * can merge without adjacency information.
+             */
+            if (f[cid] > gf[cid]) {
+                f[cid] = gf[cid];
+            }
+        }
+
+        /*
+         * Synchronize before the final stage.
+         */
+        barrier.blockBarrier();
+
+#pragma unroll
+        for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
+            const index_t cid = tst * blckDim + tid;
+            /*
+             * Update the array for the next generation, keeping track of any
+             * changes we make.
+             */
+            if (gf[cid] != f[f[cid]]) {
+                gf[cid] = f[f[cid]];
+                gf_changed = true;
+            }
+        }
+
+        /*
+         * To determine whether we need another iteration, we use block
+         * voting mechanics. Each thread checks if it has made any changes
+         * to the arrays, and votes. If any thread votes true, all threads
+         * will return a true value and go to the next iteration. Only if
+         * all threads return false will the loop exit.
+         */
+    } while (barrier.blockOr(gf_changed));
+}
+
+template <typename barrier_t>
+TRACCC_DEVICE inline void ccl_kernel(
+    const index_t threadId, const index_t blckDim, const unsigned int blockId,
+    const cell_collection_types::const_view cells_view,
+    const cell_module_collection_types::const_view modules_view,
+    const index_t max_cells_per_partition,
+    const index_t target_cells_per_partition, unsigned int& partition_start,
+    unsigned int& partition_end, unsigned int& outi, index_t* f, index_t* gf,
+    barrier_t& barrier,
+    alt_measurement_collection_types::view measurements_view,
+    unsigned int& measurement_count,
+    vecmem::data::vector_view<unsigned int> cell_links) {
+
+    // Get device copy of input parameters
+    const cell_collection_types::const_device cells_device(cells_view);
+    const cell_module_collection_types::const_device modules_device(
+        modules_view);
+    alt_measurement_collection_types::device measurements_device(
+        measurements_view);
+
+    const unsigned int num_cells = cells_device.size();
+
+    /*
+     * First, we determine the exact range of cells that is to be examined
+     * by this block of threads. We start from an initial range determined
+     * by the block index multiplied by the target number of cells per
+     * block. We then shift both the start and the end of the block forward
+     * (to a later point in the array); start and end may be moved different
+     * amounts.
+     */
+    if (threadId == 0) {
+        unsigned int start = blockId * target_cells_per_partition;
+        assert(start < num_cells);
+        unsigned int end =
+            std::min(num_cells, start + target_cells_per_partition);
+        outi = 0;
+
+        /*
+         * Next, shift the starting point to a position further in the
+         * array; the purpose of this is to ensure that we are not operating
+         * on any cells that have been claimed by the previous block (if
+         * any).
+         */
+        while (start != 0 &&
+               cells_device[start - 1].module_link ==
+                   cells_device[start].module_link &&
+               cells_device[start].channel1 <=
+                   cells_device[start - 1].channel1 + 1) {
+            ++start;
+        }
+
+        /*
+         * Then, claim as many cells as we need past the naive end of the
+         * current block to ensure that we do not end our partition on a
+         * cell that is not a possible boundary!
+         */
+        while (end < num_cells &&
+               cells_device[end - 1].module_link ==
+                   cells_device[end].module_link &&
+               cells_device[end].channel1 <=
+                   cells_device[end - 1].channel1 + 1) {
+            ++end;
+        }
+        partition_start = start;
+        partition_end = end;
+    }
+
+    barrier.blockBarrier();
+
+    // Vector of indices of the adjacent cells
+    index_t adjv[MAX_CELLS_PER_THREAD][8];
+    /*
+     * The number of adjacent cells for each cell must start at zero, to
+     * avoid uninitialized memory. adjv does not need to be zeroed, as
+     * we will only access those values if adjc indicates that the value
+     * is set.
+     */
+    // Number of adjacent cells
+    unsigned char adjc[MAX_CELLS_PER_THREAD];
+
+    // It seems that sycl runs into undefined behaviour when calling
+    // group synchronisation functions when some threads have already run
+    // into a return. As such, we cannot use returns in this kernel.
+
+    // Get partition for this thread group
+    const index_t size = partition_end - partition_start;
+    assert(size <= max_cells_per_partition);
+
+#pragma unroll
+    for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
+        adjc[tst] = 0;
+    }
+
+    for (index_t tst = 0, cid; (cid = tst * blckDim + threadId) < size; ++tst) {
+        /*
+         * Look for adjacent cells to the current one.
+         */
+        device::reduce_problem_cell(cells_device, cid, partition_start,
+                                    partition_end, adjc[tst], adjv[tst]);
+    }
+
+#pragma unroll
+    for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
+        const index_t cid = tst * blckDim + threadId;
+        /*
+         * At the start, the values of f and gf should be equal to the
+         * ID of the cell.
+         */
+        f[cid] = cid;
+        gf[cid] = cid;
+    }
+
+    /*
+     * Now that the data has initialized, we synchronize again before we
+     * move onto the actual processing part.
+     */
+    barrier.blockBarrier();
+
+    /*
+     * Run FastSV algorithm, which will update the father index to that of
+     * the cell belonging to the same cluster with the lowest index.
+     */
+    fast_sv_1(&f[0], &gf[0], adjc, adjv, threadId, blckDim, barrier);
+
+    barrier.blockBarrier();
+
+    /*
+     * Count the number of clusters by checking how many cells have
+     * themself assigned as a parent.
+     */
+    for (index_t tst = 0, cid; (cid = tst * blckDim + threadId) < size; ++tst) {
+
+        if (f[cid] == cid) {
+            // Increment the summary values in the header object.
+            vecmem::device_atomic_ref<unsigned int,
+                                      vecmem::device_address_space::local>
+                atom(outi);
+            atom.fetch_add(1);
+        }
+    }
+
+    barrier.blockBarrier();
+
+    /*
+     * Add the number of clusters of each thread block to the total
+     * number of clusters. At the same time, a cluster id is retrieved
+     * for the next data processing step.
+     * Note that this might be not the same cluster as has been treated
+     * previously. However, since each thread block spawns a the maximum
+     * amount of threads per block, this has no sever implications.
+     */
+    if (threadId == 0) {
+        vecmem::device_atomic_ref<unsigned int,
+                                  vecmem::device_address_space::global>
+            atom(measurement_count);
+        outi = atom.fetch_add(outi);
+    }
+
+    barrier.blockBarrier();
+
+    /*
+     * Get the position to fill the measurements found in this thread group.
+     */
+    const unsigned int groupPos = outi;
+
+    barrier.blockBarrier();
+
+    if (threadId == 0) {
+        outi = 0;
+    }
+
+    barrier.blockBarrier();
+
+    const vecmem::data::vector_view<unsigned short> f_view(
+        max_cells_per_partition, &f[0]);
+
+    for (index_t tst = 0, cid; (cid = tst * blckDim + threadId) < size; ++tst) {
+        if (f[cid] == cid) {
+            /*
+             * If we are a cluster owner, atomically claim a position in the
+             * output array which we can write to.
+             */
+            vecmem::device_atomic_ref<unsigned int,
+                                      vecmem::device_address_space::local>
+                atom(outi);
+            const unsigned int id = atom.fetch_add(1);
+
+            device::aggregate_cluster(cells_device, modules_device, f_view,
+                                      partition_start, partition_end, cid,
+                                      measurements_device[groupPos + id],
+                                      cell_links, groupPos + id);
+        }
+    }
+}
+
+}  // namespace traccc::device

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -19,6 +19,7 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   # Utility definitions.
   "include/traccc/cuda/utils/definitions.hpp"
   "include/traccc/cuda/utils/make_prefix_sum_buff.hpp"
+  "include/traccc/cuda/utils/barrier.hpp"
   "src/utils/make_prefix_sum_buff.cu"
   "include/traccc/cuda/utils/stream.hpp"
   "src/utils/stream.cpp"

--- a/device/cuda/include/traccc/cuda/utils/barrier.hpp
+++ b/device/cuda/include/traccc/cuda/utils/barrier.hpp
@@ -1,0 +1,23 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+
+namespace traccc::cuda {
+
+struct barrier {
+    TRACCC_DEVICE
+    void blockBarrier() { __syncthreads(); }
+
+    TRACCC_DEVICE
+    bool blockOr(bool predicate) { return __syncthreads_or(predicate); }
+};
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -8,10 +8,12 @@
 // CUDA Library include(s).
 #include "../utils/utils.hpp"
 #include "traccc/cuda/clusterization/clusterization_algorithm.hpp"
+#include "traccc/cuda/utils/barrier.hpp"
 #include "traccc/cuda/utils/definitions.hpp"
 
 // Project include(s)
 #include "traccc/clusterization/device/aggregate_cluster.hpp"
+#include "traccc/clusterization/device/ccl_kernel.hpp"
 #include "traccc/clusterization/device/form_spacepoints.hpp"
 #include "traccc/clusterization/device/reduce_problem_cell.hpp"
 
@@ -34,302 +36,27 @@ static constexpr int MAX_CELLS_PER_THREAD = 12;
 
 namespace kernels {
 
-/// Implementation of a FastSV algorithm with the following steps:
-///   1) mix of stochastic and aggressive hooking
-///   2) shortcutting
-///
-/// The implementation corresponds to an adapted versiion of Algorithm 3 of
-/// the following paper:
-/// https://www.sciencedirect.com/science/article/pii/S0743731520302689
-///
-/// @param[inout] f     array holding the parent cell ID for the current
-/// iteration.
-/// @param[inout] gf    array holding grandparent cell ID from the previous
-/// iteration.
-///                     This array only gets updated at the end of the iteration
-///                     to prevent race conditions.
-/// @param[in] adjc     The number of adjacent cells
-/// @param[in] adjv     Vector of adjacent cells
-/// @param[in] tid      The thread index
-///
-__device__ void fast_sv_1(index_t* f, index_t* gf,
-                          unsigned char adjc[MAX_CELLS_PER_THREAD],
-                          index_t adjv[MAX_CELLS_PER_THREAD][8], index_t tid,
-                          const index_t blckDim) {
-    /*
-     * The algorithm finishes if an iteration leaves the arrays unchanged.
-     * This varible will be set if a change is made, and dictates if another
-     * loop is necessary.
-     */
-    bool gf_changed;
-
-    do {
-        /*
-         * Reset the end-parameter to false, so we can set it to true if we
-         * make a change to the gf array.
-         */
-        gf_changed = false;
-
-        /*
-         * The algorithm executes in a loop of three distinct parallel
-         * stages. In this first one, a mix of stochastic and aggressive
-         * hooking, we examine adjacent cells and copy their grand parents
-         * cluster ID if it is lower than ours, essentially merging the two
-         * together.
-         */
-        for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
-            const index_t cid = tst * blckDim + tid;
-
-            __builtin_assume(adjc[tst] <= 8);
-            for (unsigned char k = 0; k < adjc[tst]; ++k) {
-                index_t q = gf[adjv[tst][k]];
-
-                if (gf[cid] > q) {
-                    f[f[cid]] = q;
-                    f[cid] = q;
-                }
-            }
-        }
-
-        /*
-         * Each stage in this algorithm must be preceded by a
-         * synchronization barrier!
-         */
-        __syncthreads();
-
-#pragma unroll
-        for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
-            const index_t cid = tst * blckDim + tid;
-            /*
-             * The second stage is shortcutting, which is an optimisation that
-             * allows us to look at any shortcuts in the cluster IDs that we
-             * can merge without adjacency information.
-             */
-            if (f[cid] > gf[cid]) {
-                f[cid] = gf[cid];
-            }
-        }
-
-        /*
-         * Synchronize before the final stage.
-         */
-        __syncthreads();
-
-#pragma unroll
-        for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
-            const index_t cid = tst * blckDim + tid;
-            /*
-             * Update the array for the next generation, keeping track of any
-             * changes we make.
-             */
-            if (gf[cid] != f[f[cid]]) {
-                gf[cid] = f[f[cid]];
-                gf_changed = true;
-            }
-        }
-
-        /*
-         * To determine whether we need another iteration, we use block
-         * voting mechanics. Each thread checks if it has made any changes
-         * to the arrays, and votes. If any thread votes true, all threads
-         * will return a true value and go to the next iteration. Only if
-         * all threads return false will the loop exit.
-         */
-    } while (__syncthreads_or(gf_changed));
-}
-
+/// CUDA kernel for running @c traccc::device::ccl_kernel
 __global__ void ccl_kernel(
     const cell_collection_types::const_view cells_view,
     const cell_module_collection_types::const_view modules_view,
-    const unsigned short max_cells_per_partition,
-    const unsigned short target_cells_per_partition,
+    const index_t max_cells_per_partition,
+    const index_t target_cells_per_partition,
     alt_measurement_collection_types::view measurements_view,
     unsigned int& measurement_count,
     vecmem::data::vector_view<unsigned int> cell_links) {
-
-    const index_t tid = threadIdx.x;
-    const index_t blckDim = blockDim.x;
-
-    const cell_collection_types::const_device cells_device(cells_view);
-    const unsigned int num_cells = cells_device.size();
-    __shared__ unsigned int start, end;
-    /*
-     * This variable will be used to write to the output later.
-     */
+    __shared__ unsigned int partition_start, partition_end;
     __shared__ unsigned int outi;
-
-    /*
-     * First, we determine the exact range of cells that is to be examined by
-     * this block of threads. We start from an initial range determined by the
-     * block index multiplied by the target number of cells per block. We then
-     * shift both the start and the end of the block forward (to a later point
-     * in the array); start and end may be moved different amounts.
-     */
-    if (tid == 0) {
-        /*
-         * Initialize shared variables.
-         */
-        start = blockIdx.x * target_cells_per_partition;
-        assert(start < num_cells);
-        end = std::min(num_cells, start + target_cells_per_partition);
-        outi = 0;
-
-        /*
-         * Next, shift the starting point to a position further in the array;
-         * the purpose of this is to ensure that we are not operating on any
-         * cells that have been claimed by the previous block (if any).
-         */
-        while (start != 0 &&
-               cells_device[start - 1].module_link ==
-                   cells_device[start].module_link &&
-               cells_device[start].channel1 <=
-                   cells_device[start - 1].channel1 + 1) {
-            ++start;
-        }
-
-        /*
-         * Then, claim as many cells as we need past the naive end of the
-         * current block to ensure that we do not end our partition on a cell
-         * that is not a possible boundary!
-         */
-        while (end < num_cells &&
-               cells_device[end - 1].module_link ==
-                   cells_device[end].module_link &&
-               cells_device[end].channel1 <=
-                   cells_device[end - 1].channel1 + 1) {
-            ++end;
-        }
-    }
-    __syncthreads();
-
-    const index_t size = end - start;
-    assert(size <= max_cells_per_partition);
-
-    // Check if any work needs to be done
-    if (tid >= size) {
-        return;
-    }
-
-    const cell_module_collection_types::const_device modules_device(
-        modules_view);
-
-    alt_measurement_collection_types::device measurements_device(
-        measurements_view);
-
-    // Vector of indices of the adjacent cells
-    index_t adjv[MAX_CELLS_PER_THREAD][8];
-    /*
-     * The number of adjacent cells for each cell must start at zero, to
-     * avoid uninitialized memory. adjv does not need to be zeroed, as
-     * we will only access those values if adjc indicates that the value
-     * is set.
-     */
-    // Number of adjacent cells
-    unsigned char adjc[MAX_CELLS_PER_THREAD];
-
-#pragma unroll
-    for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
-        adjc[tst] = 0;
-    }
-
-    for (index_t tst = 0, cid; (cid = tst * blckDim + tid) < size; ++tst) {
-        /*
-         * Look for adjacent cells to the current one.
-         */
-        device::reduce_problem_cell(cells_device, cid, start, end, adjc[tst],
-                                    adjv[tst]);
-    }
-
-    /*
-     * These arrays are the meat of the pudding of this algorithm, and we
-     * will constantly be writing and reading from them which is why we
-     * declare them to be in the fast shared memory. Note that this places a
-     * limit on the maximum contiguous activations per module, as the amount of
-     * shared memory is limited. These could always be moved to global memory,
-     * but the algorithm would be decidedly slower in that case.
-     */
     extern __shared__ index_t shared_v[];
     index_t* f = &shared_v[0];
     index_t* f_next = &shared_v[max_cells_per_partition];
+    traccc::cuda::barrier barry_r;
 
-#pragma unroll
-    for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
-        const index_t cid = tst * blckDim + tid;
-        /*
-         * At the start, the values of f and f_next should be equal to the
-         * ID of the cell.
-         */
-        f[cid] = cid;
-        f_next[cid] = cid;
-    }
-
-    /*
-     * Now that the data has initialized, we synchronize again before we
-     * move onto the actual processing part.
-     */
-    __syncthreads();
-
-    /*
-     * Run FastSV algorithm, which will update the father index to that of the
-     * cell belonging to the same cluster with the lowest index.
-     */
-    fast_sv_1(f, f_next, adjc, adjv, tid, blckDim);
-
-    __syncthreads();
-
-    /*
-     * Count the number of clusters by checking how many cells have
-     * themself assigned as a parent.
-     */
-    for (index_t tst = 0, cid; (cid = tst * blckDim + tid) < size; ++tst) {
-        if (f[cid] == cid) {
-            atomicAdd(&outi, 1);
-        }
-    }
-
-    __syncthreads();
-
-    /*
-     * Add the number of clusters of each thread block to the total
-     * number of clusters. At the same time, a cluster id is retrieved
-     * for the next data processing step.
-     * Note that this might be not the same cluster as has been treated
-     * previously. However, since each thread block spawns a the maximum
-     * amount of threads per block, this has no sever implications.
-     */
-    if (tid == 0) {
-        outi = atomicAdd(&measurement_count, outi);
-    }
-
-    __syncthreads();
-
-    /*
-     * Get the position to fill the measurements found in this thread group.
-     */
-    const unsigned int groupPos = outi;
-
-    __syncthreads();
-
-    if (tid == 0) {
-        outi = 0;
-    }
-
-    __syncthreads();
-
-    vecmem::data::vector_view<index_t> f_view(max_cells_per_partition, f);
-
-    for (index_t tst = 0, cid; (cid = tst * blckDim + tid) < size; ++tst) {
-        if (f[cid] == cid) {
-            /*
-             * If we are a cluster owner, atomically claim a position in the
-             * output array which we can write to.
-             */
-            const unsigned int id = atomicAdd(&outi, 1);
-            device::aggregate_cluster(
-                cells_device, modules_device, f_view, start, end, cid,
-                measurements_device[groupPos + id], cell_links, groupPos + id);
-        }
-    }
+    device::ccl_kernel(threadIdx.x, blockDim.x, blockIdx.x, cells_view,
+                       modules_view, max_cells_per_partition,
+                       target_cells_per_partition, partition_start,
+                       partition_end, outi, f, f_next, barry_r,
+                       measurements_view, measurement_count, cell_links);
 }
 
 __global__ void form_spacepoints(
@@ -367,6 +94,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     // Create result object for the CCL kernel with size overestimation
     alt_measurement_collection_types::buffer measurements_buffer(num_cells,
                                                                  m_mr.main);
+    m_copy.setup(measurements_buffer);
 
     // Counter for number of measurements
     vecmem::unique_alloc_ptr<unsigned int> num_measurements_device =
@@ -387,6 +115,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
 
     // Create buffer for linking cells to their spacepoints.
     vecmem::data::vector_buffer<unsigned int> cell_links(num_cells, m_mr.main);
+    m_copy.setup(cell_links);
 
     // Launch ccl kernel. Each thread will handle a single cell.
     kernels::
@@ -408,6 +137,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
 
     spacepoint_collection_types::buffer spacepoints_buffer(
         *num_measurements_host, m_mr.main);
+    m_copy.setup(spacepoints_buffer);
 
     // For the following kernel, we can now use whatever the desired number of
     // threads per block.

--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -23,6 +23,7 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
   "include/traccc/sycl/utils/queue_wrapper.hpp"
   "include/traccc/sycl/utils/calculate1DimNdRange.hpp"
   "include/traccc/sycl/utils/make_prefix_sum_buff.hpp"
+  "include/traccc/sycl/utils/barrier.hpp"
   # implementation files
   "src/clusterization/clusterization_algorithm.sycl"
   "src/fitting/fitting_algorithm.sycl"

--- a/device/sycl/include/traccc/sycl/utils/barrier.hpp
+++ b/device/sycl/include/traccc/sycl/utils/barrier.hpp
@@ -1,0 +1,31 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+
+namespace traccc::sycl {
+
+struct barrier {
+    barrier(::sycl::nd_item<1> item) : m_item(item){};
+
+    TRACCC_DEVICE
+    void blockBarrier() { m_item.barrier(); }
+
+    TRACCC_DEVICE
+    bool blockOr(bool predicate) {
+        m_item.barrier();
+        return ::sycl::any_of_group(m_item.get_group(), predicate);
+    }
+
+    private:
+    ::sycl::nd_item<1> m_item;
+};
+
+}  // namespace traccc::sycl

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -8,10 +8,12 @@
 // Local include(s).
 #include "../utils/get_queue.hpp"
 #include "traccc/sycl/clusterization/clusterization_algorithm.hpp"
+#include "traccc/sycl/utils/barrier.hpp"
 #include "traccc/sycl/utils/calculate1DimNdRange.hpp"
 
 // Project include(s)
 #include "traccc/clusterization/device/aggregate_cluster.hpp"
+#include "traccc/clusterization/device/ccl_kernel.hpp"
 #include "traccc/clusterization/device/form_spacepoints.hpp"
 #include "traccc/clusterization/device/reduce_problem_cell.hpp"
 
@@ -35,345 +37,11 @@ static constexpr int MAX_CELLS_PER_THREAD = 12;
 
 namespace kernels {
 
+/// Class identifying the kernel running @c traccc::device::ccl_kernel
+class ccl_kernel;
+
 /// Class identifying the kernel running @c traccc::device::form_spacepoints
 class form_spacepoints;
-
-/// Implementation of a FastSV algorithm with the following steps:
-///   1) mix of stochastic and aggressive hooking
-///   2) shortcutting
-///
-/// The implementation corresponds to an adapted versiion of Algorithm 3 of
-/// the following paper:
-/// https://www.sciencedirect.com/science/article/pii/S0743731520302689
-///
-/// @param[inout] f     array holding the parent cell ID for the current
-/// iteration.
-/// @param[inout] gf    array holding grandparent cell ID from the previous
-/// iteration.
-///                     This array only gets updated at the end of the iteration
-///                     to prevent race conditions.
-/// @param[in] adjc     The number of adjacent cells
-/// @param[in] adjv     Vector of adjacent cells
-/// @param[in] tid      The thread index
-///
-void fast_sv_1(index_t* f, index_t* gf,
-               unsigned char adjc[MAX_CELLS_PER_THREAD],
-               index_t adjv[MAX_CELLS_PER_THREAD][8], const index_t tid,
-               const index_t blockDim, ::sycl::nd_item<1> item) {
-    /*
-     * The algorithm finishes if an iteration leaves the arrays unchanged.
-     * This varible will be set if a change is made, and dictates if another
-     * loop is necessary.
-     */
-    bool gf_changed;
-
-    do {
-        /*
-         * Reset the end-parameter to false, so we can set it to true if we
-         * make a change to the gf array.
-         */
-        gf_changed = false;
-
-        /*
-         * The algorithm executes in a loop of three distinct parallel
-         * stages. In this first one, a mix of stochastic and aggressive
-         * hooking, we examine adjacent cells and copy their grand parents
-         * cluster ID if it is lower than ours, essentially merging the two
-         * together.
-         */
-        for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
-            const index_t cid = tst * blockDim + tid;
-
-            __builtin_assume(adjc[tst] <= 8);
-            for (unsigned char k = 0; k < adjc[tst]; ++k) {
-                index_t q = gf[adjv[tst][k]];
-
-                if (gf[cid] > q) {
-                    f[f[cid]] = q;
-                    f[cid] = q;
-                }
-            }
-        }
-
-        /*
-         * Each stage in this algorithm must be preceded by a
-         * synchronization barrier!
-         */
-        item.barrier();
-
-#pragma unroll
-        for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
-            const index_t cid = tst * blockDim + tid;
-            /*
-             * The second stage is shortcutting, which is an optimisation that
-             * allows us to look at any shortcuts in the cluster IDs that we
-             * can merge without adjacency information.
-             */
-            if (f[cid] > gf[cid]) {
-                f[cid] = gf[cid];
-            }
-        }
-
-        /*
-         * Synchronize before the final stage.
-         */
-        item.barrier();
-
-#pragma unroll
-        for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
-            const index_t cid = tst * blockDim + tid;
-            /*
-             * Update the array for the next generation, keeping track of any
-             * changes we make.
-             */
-            if (gf[cid] != f[f[cid]]) {
-                gf[cid] = f[f[cid]];
-                gf_changed = true;
-            }
-        }
-
-        /*
-         * To determine whether we need another iteration, we use block
-         * voting mechanics. Each thread checks if it has made any changes
-         * to the arrays, and votes. If any thread votes true, all threads
-         * will return a true value and go to the next iteration. Only if
-         * all threads return false will the loop exit.
-         */
-    } while (item.barrier(),
-             ::sycl::any_of_group(item.get_group(), gf_changed));
-}
-
-class ccl_kernel {
-    public:
-    ccl_kernel(const cell_collection_types::const_view cells,
-               const cell_module_collection_types::const_view modules,
-               const index_t max_cells_per_partition,
-               const index_t target_cells_per_partition,
-               alt_measurement_collection_types::view measurements,
-               unsigned int* num_measurements,
-               vecmem::data::vector_view<unsigned int> cell_links,
-               ::sycl::local_accessor<unsigned int> shared_uint,
-               ::sycl::local_accessor<index_t> shared_idx)
-        : cells_view(cells),
-          modules_view(modules),
-          m_max_cells_per_partition(max_cells_per_partition),
-          m_target_cells_per_partition(target_cells_per_partition),
-          measurements_view(measurements),
-          m_measurement_count(num_measurements),
-          cell_links_view(cell_links),
-          m_shared_uint(shared_uint),
-          m_shared_idx(shared_idx) {}
-
-    void operator()(::sycl::nd_item<1> item) const {
-
-        const index_t tid = item.get_local_linear_id();
-        const index_t blockDim = item.get_local_range(0);
-
-        const cell_collection_types::const_device cells_device(cells_view);
-        const unsigned int num_cells = cells_device.size();
-
-        unsigned int& start = m_shared_uint[0];
-        unsigned int& end = m_shared_uint[1];
-        /*
-         * This variable will be used to write to the output later.
-         */
-        unsigned int& outi = m_shared_uint[2];
-
-        index_t* f = &m_shared_idx[0];
-        index_t* f_next = &m_shared_idx[m_max_cells_per_partition];
-        /*
-         * First, we determine the exact range of cells that is to be examined
-         * by this block of threads. We start from an initial range determined
-         * by the block index multiplied by the target number of cells per
-         * block. We then shift both the start and the end of the block forward
-         * (to a later point in the array); start and end may be moved different
-         * amounts.
-         */
-        if (tid == 0) {
-            start = item.get_group_linear_id() * m_target_cells_per_partition;
-            assert(start < num_cells);
-            end = std::min(num_cells, start + m_target_cells_per_partition);
-            outi = 0;
-
-            /*
-             * Next, shift the starting point to a position further in the
-             * array; the purpose of this is to ensure that we are not operating
-             * on any cells that have been claimed by the previous block (if
-             * any).
-             */
-            while (start != 0 &&
-                   cells_device[start - 1].module_link ==
-                       cells_device[start].module_link &&
-                   cells_device[start].channel1 <=
-                       cells_device[start - 1].channel1 + 1) {
-                ++start;
-            }
-
-            /*
-             * Then, claim as many cells as we need past the naive end of the
-             * current block to ensure that we do not end our partition on a
-             * cell that is not a possible boundary!
-             */
-            while (end < num_cells &&
-                   cells_device[end - 1].module_link ==
-                       cells_device[end].module_link &&
-                   cells_device[end].channel1 <=
-                       cells_device[end - 1].channel1 + 1) {
-                ++end;
-            }
-        }
-
-        item.barrier();
-
-        // Get partition for this thread group
-        const index_t size = end - start;
-        assert(size <= m_max_cells_per_partition);
-
-        const cell_module_collection_types::const_device modules_device(
-            modules_view);
-
-        alt_measurement_collection_types::device measurements_device(
-            measurements_view);
-
-        unsigned int& measurement_count = m_measurement_count[0];
-
-        // Vector of indices of the adjacent cells
-        index_t adjv[MAX_CELLS_PER_THREAD][8];
-        /*
-         * The number of adjacent cells for each cell must start at zero, to
-         * avoid uninitialized memory. adjv does not need to be zeroed, as
-         * we will only access those values if adjc indicates that the value
-         * is set.
-         */
-        // Number of adjacent cells
-        unsigned char adjc[MAX_CELLS_PER_THREAD];
-
-        // It seems that sycl runs into undefined behaviour when calling
-        // group synchronisation functions when some threads have already run
-        // into a return. As such, we cannot use returns in this kernel.
-
-#pragma unroll
-        for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
-            adjc[tst] = 0;
-        }
-
-        for (index_t tst = 0, cid; (cid = tst * blockDim + tid) < size; ++tst) {
-            /*
-             * Look for adjacent cells to the current one.
-             */
-            device::reduce_problem_cell(cells_device, cid, start, end,
-                                        adjc[tst], adjv[tst]);
-        }
-
-#pragma unroll
-        for (index_t tst = 0; tst < MAX_CELLS_PER_THREAD; ++tst) {
-            const index_t cid = tst * blockDim + tid;
-            /*
-             * At the start, the values of f and f_next should be equal to the
-             * ID of the cell.
-             */
-            f[cid] = cid;
-            f_next[cid] = cid;
-        }
-
-        /*
-         * Now that the data has initialized, we synchronize again before we
-         * move onto the actual processing part.
-         */
-        item.barrier();
-
-        /*
-         * Run FastSV algorithm, which will update the father index to that of
-         * the cell belonging to the same cluster with the lowest index.
-         */
-        fast_sv_1(&f[0], &f_next[0], adjc, adjv, tid, blockDim, item);
-
-        item.barrier();
-
-        /*
-         * Count the number of clusters by checking how many cells have
-         * themself assigned as a parent.
-         */
-        for (index_t tst = 0, cid; (cid = tst * blockDim + tid) < size; ++tst) {
-
-            if (f[cid] == cid) {
-                ::sycl::atomic_ref<unsigned int, ::sycl::memory_order::relaxed,
-                                   ::sycl::memory_scope::work_group,
-                                   ::sycl::access::address_space::local_space>(
-                    outi)
-                    .fetch_add(1);
-            }
-        }
-
-        item.barrier();
-
-        /*
-         * Add the number of clusters of each thread block to the total
-         * number of clusters. At the same time, a cluster id is retrieved
-         * for the next data processing step.
-         * Note that this might be not the same cluster as has been treated
-         * previously. However, since each thread block spawns a the maximum
-         * amount of threads per block, this has no sever implications.
-         */
-        if (tid == 0) {
-            outi =
-                ::sycl::atomic_ref<unsigned int, ::sycl::memory_order::relaxed,
-                                   ::sycl::memory_scope::device,
-                                   ::sycl::access::address_space::global_space>(
-                    measurement_count)
-                    .fetch_add(outi);
-        }
-
-        item.barrier();
-
-        /*
-         * Get the position to fill the measurements found in this thread group.
-         */
-        const unsigned int groupPos = outi;
-
-        item.barrier();
-
-        if (tid == 0) {
-            outi = 0;
-        }
-
-        item.barrier();
-
-        const vecmem::data::vector_view<unsigned short> f_view(
-            m_max_cells_per_partition, &f[0]);
-
-        for (index_t tst = 0, cid; (cid = tst * blockDim + tid) < size; ++tst) {
-            if (f[cid] == cid) {
-                /*
-                 * If we are a cluster owner, atomically claim a position in the
-                 * output array which we can write to.
-                 */
-                const unsigned int id =
-                    ::sycl::atomic_ref<
-                        unsigned int, ::sycl::memory_order::relaxed,
-                        ::sycl::memory_scope::work_group,
-                        ::sycl::access::address_space::local_space>(outi)
-                        .fetch_add(1);
-
-                device::aggregate_cluster(cells_device, modules_device, f_view,
-                                          start, end, cid,
-                                          measurements_device[groupPos + id],
-                                          cell_links_view, groupPos + id);
-            }
-        }
-    }
-
-    private:
-    const cell_collection_types::const_view cells_view;
-    const cell_module_collection_types::const_view modules_view;
-    const unsigned short m_max_cells_per_partition;
-    const unsigned short m_target_cells_per_partition;
-    alt_measurement_collection_types::view measurements_view;
-    unsigned int* m_measurement_count;
-    vecmem::data::vector_view<unsigned int> cell_links_view;
-    ::sycl::local_accessor<unsigned int> m_shared_uint;
-    ::sycl::local_accessor<index_t> m_shared_idx;
-};
 
 }  // namespace kernels
 
@@ -424,7 +92,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     const unsigned int target_cells_per_partition =
         m_target_cells_per_partition;
 
-    ::sycl::nd_range ndrange(
+    ::sycl::nd_range cclKernelRange(
         ::sycl::range<1>(num_partitions * threads_per_partition),
         ::sycl::range<1>(threads_per_partition));
 
@@ -437,22 +105,34 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
 
     // Create buffer for linking cells to their spacepoints.
     vecmem::data::vector_buffer<unsigned int> cell_links(num_cells, m_mr.main);
+    m_copy.setup(cell_links)->wait();
+    vecmem::data::vector_view<unsigned int> cell_links_view(cell_links);
 
+    auto aux_num_measurements_device = num_measurements_device.get();
     // Run ccl kernel
     details::get_queue(m_queue)
-        .submit([&ndrange, &cells, &modules, max_cells_per_partition,
-                 &target_cells_per_partition, &measurements_view, &cell_links,
-                 &num_measurements_device](::sycl::handler& h) {
+        .submit([&](::sycl::handler& h) {
             ::sycl::local_accessor<unsigned int> shared_uint(3, h);
             ::sycl::local_accessor<index_t> shared_idx(
                 2 * max_cells_per_partition, h);
 
             h.parallel_for<kernels::ccl_kernel>(
-                ndrange, kernels::ccl_kernel(
-                             cells, modules, max_cells_per_partition,
-                             target_cells_per_partition, measurements_view,
-                             num_measurements_device.get(), cell_links,
-                             shared_uint, shared_idx));
+                cclKernelRange, [=](::sycl::nd_item<1> item) {
+                    index_t* f = &shared_idx[0];
+                    index_t* f_next = &shared_idx[max_cells_per_partition];
+                    unsigned int& partition_start = shared_uint[0];
+                    unsigned int& partition_end = shared_uint[1];
+                    unsigned int& outi = shared_uint[2];
+                    traccc::sycl::barrier barry_r(item);
+
+                    device::ccl_kernel(
+                        item.get_local_linear_id(), item.get_local_range(0),
+                        item.get_group_linear_id(), cells, modules,
+                        max_cells_per_partition, target_cells_per_partition,
+                        partition_start, partition_end, outi, f, f_next,
+                        barry_r, measurements_view,
+                        *aux_num_measurements_device, cell_links_view);
+                });
         })
         .wait_and_throw();
 

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.24.0.tar.gz;URL_MD5;f6936ea57921d7e5110606c7a9e9a371"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.25.0.tar.gz;URL_MD5;7fc14592c693c9853d27ca21ec528555"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Depends on https://github.com/acts-project/vecmem/pull/228

When I first implemented the "new" clustering code I made into fully separate CUDA/SYCL implementations due to some difficulties with harmonising them. This PR brings them back to sharing most of the code.

It also introduces 2 new types, `traccc::sycl::barrier` & `traccc::cuda::barrier`. These allow for easily calling block synchronisation functions within common code using templating.
