### PR TITLE
Ensure synchronisation with async copies

### DIFF
--- a/device/common/src/make_prefix_sum_buffer.cpp
+++ b/device/common/src/make_prefix_sum_buffer.cpp
@@ -34,7 +34,7 @@ prefix_sum_buffer_t make_prefix_sum_buffer(
         vecmem::data::vector_buffer<prefix_sum_size_t> sizes_sum_buff(
             sizes_sum.size(), mr.main);
         copy.setup(sizes_sum_buff);
-        (copy)(vecmem::get_data(sizes_sum), sizes_sum_buff);
+        (copy)(vecmem::get_data(sizes_sum), sizes_sum_buff)->wait();
         vecmem::data::vector_view<prefix_sum_size_t> sizes_sum_view(
             sizes_sum_buff);
 

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -26,7 +26,6 @@
 #include <vecmem/memory/cuda/device_memory_resource.hpp>
 #include <vecmem/memory/host_memory_resource.hpp>
 #include <vecmem/utils/cuda/async_copy.hpp>
-#include <vecmem/utils/cuda/copy.hpp>
 
 // ACTS include(s).
 #include <Acts/Definitions/Units.hpp>
@@ -60,11 +59,10 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
 
     traccc::cuda::stream stream;
 
-    vecmem::cuda::copy copy;
-    vecmem::cuda::async_copy async_copy{stream.cudaStream()};
+    vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    traccc::cuda::seeding_algorithm sa_cuda{mr, async_copy, stream};
-    traccc::cuda::track_params_estimation tp_cuda{mr, async_copy, stream};
+    traccc::cuda::seeding_algorithm sa_cuda{mr, copy, stream};
+    traccc::cuda::track_params_estimation tp_cuda{mr, copy, stream};
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
@@ -169,8 +167,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         // Copy the seeds to the host for comparisons
         traccc::seed_collection_types::host seeds_cuda;
         traccc::bound_track_parameters_collection_types::host params_cuda;
-        copy(seeds_cuda_buffer, seeds_cuda);
-        copy(params_cuda_buffer, params_cuda);
+        copy(seeds_cuda_buffer, seeds_cuda)->wait();
+        copy(params_cuda_buffer, params_cuda)->wait();
 
         if (run_cpu) {
             // Show which event we are currently presenting the results for.

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -168,8 +168,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         // Copy the seeds to the host for comparison.
         traccc::seed_collection_types::host seeds_sycl;
         traccc::bound_track_parameters_collection_types::host params_sycl;
-        copy(seeds_sycl_buffer, seeds_sycl);
-        copy(params_sycl_buffer, params_sycl);
+        copy(seeds_sycl_buffer, seeds_sycl)->wait();
+        copy(params_sycl_buffer, params_sycl)->wait();
 
         if (run_cpu && i_cfg.check_performance) {
             // Show which event we are currently presenting the results for.

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -242,9 +242,9 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
         traccc::seed_collection_types::host seeds_sycl;
         traccc::bound_track_parameters_collection_types::host params_sycl;
         if (run_cpu || i_cfg.check_performance) {
-            copy(spacepoints_sycl_buffer, spacepoints_per_event_sycl);
-            copy(seeds_sycl_buffer, seeds_sycl);
-            copy(params_sycl_buffer, params_sycl);
+            copy(spacepoints_sycl_buffer, spacepoints_per_event_sycl)->wait();
+            copy(seeds_sycl_buffer, seeds_sycl)->wait();
+            copy(params_sycl_buffer, params_sycl)->wait();
         }
 
         if (run_cpu) {


### PR DESCRIPTION
Fixing a small issue which apparently has not manifested itself so far, but could be a source of trouble. When the examples were changed to use asynchronous copies some synchronisation points were missed. I'm not sure whether in the CUDA case that was already not implicitly done. 