### PR TITLE
Update to data v3

### DIFF
--- a/data/traccc_data_get_files.sh
+++ b/data/traccc_data_get_files.sh
@@ -27,7 +27,7 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v2"}
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v3"}
 TRACCC_WEB_DIRECTORY=${TRACCC_WEB_DIRECTORY:-"https://acts.web.cern.ch/traccc/data"}
 TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}
 TRACCC_CMAKE_EXECUTABLE=${TRACCC_CMAKE_EXECUTABLE:-cmake}

--- a/data/traccc_data_package_files.sh
+++ b/data/traccc_data_package_files.sh
@@ -27,7 +27,7 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v3"}
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v4"}
 TRACCC_DATA_DIRECTORY_NAMES=("cca_test" "detray_simulation" "single_module"
    "tml_detector" "tml_full" "tml_pixel_barrel" "tml_pixels" "two_modules")
 TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}

--- a/tests/cpu/test_kalman_fitter.cpp
+++ b/tests/cpu/test_kalman_fitter.cpp
@@ -116,5 +116,11 @@ TEST_P(KalmanFittingTests, Run) {
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitValidation, KalmanFittingTests,
     ::testing::Values(std::make_tuple("1_GeV_0_phi", 100, 100),
+                      std::make_tuple("1_GeV_30_phi", 100, 100),
+                      std::make_tuple("1_GeV_60_phi", 100, 100),
                       std::make_tuple("10_GeV_0_phi", 100, 100),
-                      std::make_tuple("100_GeV_0_phi", 100, 100)));
+                      std::make_tuple("10_GeV_30_phi", 100, 100),
+                      std::make_tuple("10_GeV_60_phi", 100, 100),
+                      std::make_tuple("100_GeV_0_phi", 100, 100),
+                      std::make_tuple("100_GeV_30_phi", 100, 100),
+                      std::make_tuple("100_GeV_60_phi", 100, 100)));

--- a/tests/cuda/test_kalman_filter.cpp
+++ b/tests/cuda/test_kalman_filter.cpp
@@ -156,5 +156,11 @@ TEST_P(KalmanFittingTests, Run) {
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitValidation, KalmanFittingTests,
     ::testing::Values(std::make_tuple("1_GeV_0_phi", 100, 100),
+                      std::make_tuple("1_GeV_30_phi", 100, 100),
+                      std::make_tuple("1_GeV_60_phi", 100, 100),
                       std::make_tuple("10_GeV_0_phi", 100, 100),
-                      std::make_tuple("100_GeV_0_phi", 100, 100)));
+                      std::make_tuple("10_GeV_30_phi", 100, 100),
+                      std::make_tuple("10_GeV_60_phi", 100, 100),
+                      std::make_tuple("100_GeV_0_phi", 100, 100),
+                      std::make_tuple("100_GeV_30_phi", 100, 100),
+                      std::make_tuple("100_GeV_60_phi", 100, 100)));

--- a/tests/sycl/test_kalman_filter.sycl
+++ b/tests/sycl/test_kalman_filter.sycl
@@ -177,5 +177,11 @@ TEST_P(KalmanFittingTests, Run) {
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitValidation, KalmanFittingTests,
     ::testing::Values(std::make_tuple("1_GeV_0_phi", 100, 100),
+                      std::make_tuple("1_GeV_30_phi", 100, 100),
+                      std::make_tuple("1_GeV_60_phi", 100, 100),
                       std::make_tuple("10_GeV_0_phi", 100, 100),
-                      std::make_tuple("100_GeV_0_phi", 100, 100)));
+                      std::make_tuple("10_GeV_30_phi", 100, 100),
+                      std::make_tuple("10_GeV_60_phi", 100, 100),
+                      std::make_tuple("100_GeV_0_phi", 100, 100),
+                      std::make_tuple("100_GeV_30_phi", 100, 100),
+                      std::make_tuple("100_GeV_60_phi", 100, 100)));


### PR DESCRIPTION
- Replace the old simulation data for KF validation after bug fixes in detray simulation
- Added more cases for KF validation

Following command was used for data generation
```
# Kalman filter validation
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --gen-mom-gev=1:1 --gen-phi-degree=0:0 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/1_GeV_0_phi/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --gen-mom-gev=1:1 --gen-phi-degree=30:30 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/1_GeV_30_phi/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --gen-mom-gev=1:1 --gen-phi-degree=60:60 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/1_GeV_60_phi/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --gen-mom-gev=10:10 --gen-phi-degree=0:0 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/10_GeV_0_phi/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --gen-mom-gev=10:10 --gen-phi-degree=30:30 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/10_GeV_30_phi/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --gen-mom-gev=10:10 --gen-phi-degree=60:60 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/10_GeV_60_phi/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --gen-mom-gev=100:100 --gen-phi-degree=0:0 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/100_GeV_0_phi/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --gen-mom-gev=100:100 --gen-phi-degree=30:30 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/100_GeV_30_phi/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:0:0 --gen-eta=0:0 --gen-mom-gev=100:100 --gen-phi-degree=60:60 --events=100 --gen-nparticles=100 --output_directory=detray_simulation/telescope/kf_validation/100_GeV_60_phi/

# Sparse Tracks
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:200:200 --gen-eta=0:0 --events=10000 --gen-nparticles=1 --output_directory=detray_simulation/telescope/sparse_tracks/single_tracks/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:200:200 --gen-eta=0:0 --events=10000 --gen-nparticles=2 --output_directory=detray_simulation/telescope/sparse_tracks/double_tracks/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:200:200 --gen-eta=0:0 --events=10000 --gen-nparticles=3 --output_directory=detray_simulation/telescope/sparse_tracks/triple_tracks/
./bin/traccc_simulate_telescope --gen-vertex-xyz-std-mm=0:200:200 --gen-eta=0:0 --events=10000 --gen-nparticles=10 --output_directory=detray_simulation/telescope/sparse_tracks/decade_tracks/
```