### PR TITLE
Add default destructors to virtual classes

### DIFF
--- a/performance/include/traccc/efficiency/track_filter.hpp
+++ b/performance/include/traccc/efficiency/track_filter.hpp
@@ -34,6 +34,11 @@ struct track_filter {
      * @return false if the particle does not pass the cut.
      */
     virtual bool operator()(const particle &p) const = 0;
+
+    /**
+     * @brief Default destructor
+     */
+    virtual ~track_filter() = default;
 };
 
 /**

--- a/performance/include/traccc/efficiency/track_matcher.hpp
+++ b/performance/include/traccc/efficiency/track_matcher.hpp
@@ -38,6 +38,10 @@ struct track_matcher {
      */
     virtual std::optional<uint64_t> operator()(
         const std::vector<std::vector<uint64_t>>& v) const = 0;
+    /**
+     * @brief Default destructor
+     */
+    virtual ~track_matcher() = default;
 };
 
 /**


### PR DESCRIPTION
#369 introduced a compiler warning for newer versions of gcc our CI didn't pickup which this PR fixes (sample warning follows).

```
/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/unique_ptr.h:95:2: warning: delete called on 'traccc::track_filter' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
        delete __ptr;
```