### PR TITLE
Reduce the memory usage of array wrapper tests

### DIFF
--- a/tests/cuda/test_array_wrapper.cu
+++ b/tests/cuda/test_array_wrapper.cu
@@ -63,7 +63,7 @@ __global__ void fillWrapperKernel(
 TEST(CUDAArrayWrapper, SoALayout) {
     vecmem::cuda::device_memory_resource mr;
 
-    uint32_t n = 1024u * 1024u * 1024u;
+    uint32_t n = 1024u * 1024u;
 
     traccc::array_wrapper<traccc::soa, vector>::owner o(mr, n);
 
@@ -96,7 +96,7 @@ TEST(CUDAArrayWrapper, SoALayout) {
 TEST(CUDAArrayWrapper, AoSLayout) {
     vecmem::cuda::device_memory_resource mr;
 
-    uint32_t n = 1024u * 1024u * 1024u;
+    uint32_t n = 1024u * 1024u;
 
     traccc::array_wrapper<traccc::aos, vector>::owner o(mr, n);
 


### PR DESCRIPTION
The array wrapper tests use a rather large amount of memory in order to establish the performance relevance of the changes, but this also breaks the CI tests in #237. This commit reduces the allocation size for several gigabytes to several megabytes, which the CI machine should be able to satisfy in virtually all situations.