### PR TITLE
Remove synchronization from cuda chain

### DIFF
--- a/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
@@ -22,12 +22,13 @@
 
 namespace traccc::cuda {
 
-/// Algorithm performing hit clusterization in a naive way
+/// Algorithm performing hit clusterization
 ///
-/// This algorithm implements a very trivial parallelization for the hit
-/// clusterization. Simply handling every detector module in its own thread.
-/// Which is a fairly simple way of translating the single-threaded CPU
-/// algorithm, but also a pretty bad algorithm for a GPU.
+/// This algorithm implements hit clusterization in a massively-parallel
+/// approach. Each thread handles a pre-determined number of detector cells.
+///
+/// This algorithm returns a buffer which is not necessarily filled yet. A
+/// synchronisation statement is required before destroying this buffer.
 ///
 class clusterization_algorithm
     : public algorithm<std::pair<spacepoint_collection_types::buffer,

--- a/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_finding.hpp
@@ -25,6 +25,10 @@
 namespace traccc::cuda {
 
 /// Seed finding for cuda
+///
+/// This algorithm returns a buffer which is not necessarily filled yet. A
+/// synchronisation statement is required before destroying this buffer.
+///
 class seed_finding : public algorithm<seed_collection_types::buffer(
                          const spacepoint_collection_types::const_view&,
                          const sp_grid_const_view&)> {

--- a/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seeding_algorithm.hpp
@@ -26,6 +26,10 @@
 namespace traccc::cuda {
 
 /// Main algorithm for performing the track seeding on an NVIDIA GPU
+///
+/// This algorithm returns a buffer which is not necessarily filled yet. A
+/// synchronisation statement is required before destroying this buffer.
+///
 class seeding_algorithm : public algorithm<seed_collection_types::buffer(
                               const spacepoint_collection_types::const_view&)> {
 

--- a/device/cuda/include/traccc/cuda/seeding/spacepoint_binning.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/spacepoint_binning.hpp
@@ -25,6 +25,10 @@
 namespace traccc::cuda {
 
 /// Spacepoing binning executed on a CUDA device
+///
+/// This algorithm returns a buffer which is not necessarily filled yet. A
+/// synchronisation statement is required before destroying this buffer.
+///
 class spacepoint_binning
     : public algorithm<sp_grid_buffer(
           const spacepoint_collection_types::const_view&)> {

--- a/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
@@ -22,6 +22,10 @@ namespace traccc {
 namespace cuda {
 
 /// track parameter estimation for cuda
+///
+/// This algorithm returns a buffer which is not necessarily filled yet. A
+/// synchronisation statement is required before destroying this buffer.
+///
 struct track_params_estimation
     : public algorithm<bound_track_parameters_collection_types::buffer(
           const spacepoint_collection_types::const_view&,

--- a/device/cuda/include/traccc/cuda/utils/make_prefix_sum_buff.hpp
+++ b/device/cuda/include/traccc/cuda/utils/make_prefix_sum_buff.hpp
@@ -23,6 +23,9 @@ namespace traccc::cuda {
 /// vector's elements in device Example: Jagged vector with sizes = {3,2,1,...}
 /// Returns: {[0,0], [0,1], [0,2], [1,0], [1,1], [2,0], ...}
 ///
+/// This algorithm returns a buffer which is not necessarily filled yet. A
+/// synchronisation statement is required before or destroying this buffer.
+///
 /// @param[in] sizes       The sizes of the jagged vector
 /// @param copy A "copy object" capable of dealing with the view
 /// @param mr   The memory resource to create the buffer with
@@ -35,6 +38,9 @@ vecmem::data::vector_buffer<device::prefix_sum_element_t> make_prefix_sum_buff(
 /// Function that returns vector of prefix_sum_element_t for accessing a jagged
 /// vector's elements in device Example: Jagged vector with sizes = {3,2,1,...}
 /// Returns: {[0,0], [0,1], [0,2], [1,0], [1,1], [2,0], ...}
+///
+/// This algorithm returns a buffer which is not necessarily filled yet. A
+/// synchronisation statement is required before or destroying this buffer.
 ///
 /// @param[in] sizes       The sizes of the jagged vector
 /// @param copy A "copy object" capable of dealing with the view

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -152,7 +152,6 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
         spacepoints_buffer);
 
     CUDA_ERROR_CHECK(cudaGetLastError());
-    m_stream.synchronize();
 
     return {std::move(spacepoints_buffer), std::move(cell_links)};
 }

--- a/device/cuda/src/seeding/spacepoint_binning.cu
+++ b/device/cuda/src/seeding/spacepoint_binning.cu
@@ -102,7 +102,6 @@ sp_grid_buffer spacepoint_binning::operator()(
     kernels::populate_grid<<<num_blocks, num_threads, 0, stream>>>(
         m_config, spacepoints_view, grid_view);
     CUDA_ERROR_CHECK(cudaGetLastError());
-    m_stream.synchronize();
 
     // Return the freshly filled buffer.
     return grid_buffer;

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -67,10 +67,7 @@ track_params_estimation::output_type track_params_estimation::operator()(
     // run the kernel
     kernels::estimate_track_params<<<num_blocks, num_threads, 0, stream>>>(
         spacepoints_view, seeds_view, params_buffer);
-
-    // cuda error check
     CUDA_ERROR_CHECK(cudaGetLastError());
-    m_stream.synchronize();
 
     return params_buffer;
 }

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -128,6 +128,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
                 traccc::performance::timer t("Seeding (cuda)", elapsedTimes);
                 // Reconstruct the spacepoints into seeds.
                 seeds_cuda_buffer = sa_cuda(spacepoints_cuda_buffer);
+                stream.synchronize();
             }  // stop measuring seeding cuda timer
 
             // CPU
@@ -148,6 +149,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
                                              elapsedTimes);
                 params_cuda_buffer =
                     tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer);
+                stream.synchronize();
             }  // stop measuring track params cuda timer
             // CPU
 

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -178,6 +178,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
             {
                 traccc::performance::timer t("Seeding (cuda)", elapsedTimes);
                 seeds_cuda_buffer = sa_cuda(spacepoints_cuda_buffer);
+                stream.synchronize();
             }  // stop measuring seeding cuda timer
 
             // CPU
@@ -198,6 +199,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                                              elapsedTimes);
                 params_cuda_buffer =
                     tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer);
+                stream.synchronize();
             }  // stop measuring track params timer
 
             // CPU

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -168,6 +168,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 // Reconstruct it into spacepoints on the device.
                 spacepoints_sycl_buffer =
                     ca_sycl(cells_buffer, modules_buffer).first;
+                q.wait_and_throw();
             }  // stop measuring clusterization sycl timer
 
             if (run_cpu) {
@@ -203,6 +204,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
             {
                 traccc::performance::timer t("Seeding (sycl)", elapsedTimes);
                 seeds_sycl_buffer = sa_sycl(spacepoints_sycl_buffer);
+                q.wait_and_throw();
             }  // stop measuring seeding sycl timer
 
             // CPU
@@ -222,6 +224,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                                              elapsedTimes);
                 params_sycl_buffer =
                     tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer);
+                q.wait_and_throw();
             }  // stop measuring track params timer
 
             // CPU


### PR DESCRIPTION
Removes a bunch of synchronization points in the CUDA code which are not necessary.

Note: In SYCL all of these waits are still there, given that the queue object is out-of-order.