### PR TITLE
Fix: use correct memory resources for host vectors

### DIFF
--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -129,7 +129,8 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
 
     // Copy number of measurements to host
     vecmem::unique_alloc_ptr<unsigned int> num_measurements_host =
-        vecmem::make_unique_alloc<unsigned int>(*(m_mr.host));
+        vecmem::make_unique_alloc<unsigned int>(
+            (m_mr.host != nullptr) ? *(m_mr.host) : m_mr.main);
     CUDA_ERROR_CHECK(cudaMemcpyAsync(
         num_measurements_host.get(), num_measurements_device.get(),
         sizeof(unsigned int), cudaMemcpyDeviceToHost, stream));

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -137,32 +137,34 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
         .wait_and_throw();
 
     // Copy number of measurements to host
-    unsigned int num_measurements_host;
+    vecmem::unique_alloc_ptr<unsigned int> num_measurements_host =
+        vecmem::make_unique_alloc<unsigned int>(
+            (m_mr.host != nullptr) ? *(m_mr.host) : m_mr.main);
     details::get_queue(m_queue)
-        .memcpy(&num_measurements_host, num_measurements_device.get(),
+        .memcpy(num_measurements_host.get(), num_measurements_device.get(),
                 sizeof(unsigned int))
         .wait_and_throw();
 
     spacepoint_collection_types::buffer spacepoints_buffer(
-        num_measurements_host, m_mr.main);
+        *num_measurements_host, m_mr.main);
     m_copy.setup(spacepoints_buffer)->wait();
     spacepoint_collection_types::view spacepoints_view(spacepoints_buffer);
 
     // For the following kernel, we can now use whatever the desired number of
     // threads per block.
     auto spacepointsRange = traccc::sycl::calculate1DimNdRange(
-        num_measurements_host, m_max_work_group_size);
+        *num_measurements_host, m_max_work_group_size);
 
     // Run form spacepoints kernel, turning 2D measurements into 3D spacepoints
     details::get_queue(m_queue)
         .submit([&](::sycl::handler& h) {
             h.parallel_for<kernels::form_spacepoints>(
                 spacepointsRange,
-                [measurements_view, modules, num_measurements_host,
+                [measurements_view, modules, aux_num_measurements_device,
                  spacepoints_view](::sycl::nd_item<1> item) {
                     device::form_spacepoints(
                         item.get_global_linear_id(), measurements_view, modules,
-                        num_measurements_host, spacepoints_view);
+                        *aux_num_measurements_device, spacepoints_view);
                 });
         })
         .wait_and_throw();

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -126,18 +126,21 @@ seed_finding::output_type seed_finding::operator()(
         .wait_and_throw();
 
     // Get the summary values.
-    device::seeding_global_counter globalCounter_host;
+    vecmem::unique_alloc_ptr<device::seeding_global_counter>
+        globalCounter_host =
+            vecmem::make_unique_alloc<device::seeding_global_counter>(
+                (m_mr.host != nullptr) ? *(m_mr.host) : m_mr.main);
     details::get_queue(m_queue)
-        .memcpy(&globalCounter_host, globalCounter_device.get(),
+        .memcpy(globalCounter_host.get(), globalCounter_device.get(),
                 sizeof(device::seeding_global_counter))
         .wait_and_throw();
 
     // Set up the doublet buffers.
     device::device_doublet_collection_types::buffer doublet_buffer_mb = {
-        globalCounter_host.m_nMidBot, m_mr.main};
+        globalCounter_host->m_nMidBot, m_mr.main};
     m_copy.setup(doublet_buffer_mb)->wait();
     device::device_doublet_collection_types::buffer doublet_buffer_mt = {
-        globalCounter_host.m_nMidTop, m_mr.main};
+        globalCounter_host->m_nMidTop, m_mr.main};
     m_copy.setup(doublet_buffer_mt)->wait();
 
     // Calculate the range to run the doublet finding for.
@@ -168,7 +171,7 @@ seed_finding::output_type seed_finding::operator()(
     m_copy.setup(triplet_counter_spM_buffer)->wait();
     m_copy.memset(triplet_counter_spM_buffer, 0)->wait();
     device::triplet_counter_collection_types::buffer
-        triplet_counter_midBot_buffer = {globalCounter_host.m_nMidBot,
+        triplet_counter_midBot_buffer = {globalCounter_host->m_nMidBot,
                                          m_mr.main,
                                          vecmem::data::buffer_type::resizable};
     m_copy.setup(triplet_counter_midBot_buffer)->wait();
@@ -181,7 +184,7 @@ seed_finding::output_type seed_finding::operator()(
     // Calculate the range to run the triplet counting for.
     static constexpr unsigned int tripletCountLocalSize = 32 * 2;
     auto tripletCountRange = traccc::sycl::calculate1DimNdRange(
-        globalCounter_host.m_nMidBot, tripletCountLocalSize);
+        globalCounter_host->m_nMidBot, tripletCountLocalSize);
 
     // Wait here for the find_doublets kernel to finish
     find_doublets_kernel.wait_and_throw();
@@ -225,13 +228,13 @@ seed_finding::output_type seed_finding::operator()(
         .wait_and_throw();
 
     details::get_queue(m_queue)
-        .memcpy(&globalCounter_host, globalCounter_device.get(),
+        .memcpy(globalCounter_host.get(), globalCounter_device.get(),
                 sizeof(device::seeding_global_counter))
         .wait_and_throw();
 
     // Set up the triplet buffer and its view
     device::device_triplet_collection_types::buffer triplet_buffer = {
-        globalCounter_host.m_nTriplets, m_mr.main};
+        globalCounter_host->m_nTriplets, m_mr.main};
     m_copy.setup(triplet_buffer)->wait();
     device::device_triplet_collection_types::view triplet_view = triplet_buffer;
 
@@ -261,7 +264,7 @@ seed_finding::output_type seed_finding::operator()(
     // Calculate the range to run the weight updating for
     static constexpr unsigned int weightUpdatingLocalSize = 32 * 2;
     auto weightUpdatingRange = traccc::sycl::calculate1DimNdRange(
-        globalCounter_host.m_nTriplets, weightUpdatingLocalSize);
+        globalCounter_host->m_nTriplets, weightUpdatingLocalSize);
 
     // Wait here for the find_triplets kernel to finish
     find_triplets_kernel.wait_and_throw();
@@ -300,7 +303,7 @@ seed_finding::output_type seed_finding::operator()(
 
     // Create seed buffer object and its view
     seed_collection_types::buffer seed_buffer(
-        globalCounter_host.m_nTriplets, m_mr.main,
+        globalCounter_host->m_nTriplets, m_mr.main,
         vecmem::data::buffer_type::resizable);
     m_copy.setup(seed_buffer)->wait();
     seed_collection_types::view seed_view(seed_buffer);

--- a/examples/io/create_binaries.cpp
+++ b/examples/io/create_binaries.cpp
@@ -38,9 +38,10 @@ int create_binaries(const std::string& detector_file,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Read the cells from the relevant event file
-        auto cells_csv = traccc::io::read_cells(
-            event, common_opts.input_directory, common_opts.input_data_format,
-            &surface_transforms, &digi_cfg, &host_mr);
+        traccc::io::cell_reader_output cells_csv(&host_mr);
+        traccc::io::read_cells(cells_csv, event, common_opts.input_directory,
+                               common_opts.input_data_format,
+                               &surface_transforms, &digi_cfg);
 
         // Write binary file
         traccc::io::write(event, common_opts.input_directory,
@@ -49,9 +50,10 @@ int create_binaries(const std::string& detector_file,
                           vecmem::get_data(cells_csv.modules));
 
         // Read the hits from the relevant event file
-        auto spacepoints_csv = traccc::io::read_spacepoints(
-            event, common_opts.input_directory, surface_transforms,
-            common_opts.input_data_format, &host_mr);
+        traccc::io::spacepoint_reader_output spacepoints_csv(&host_mr);
+        traccc::io::read_spacepoints(
+            spacepoints_csv, event, common_opts.input_directory,
+            surface_transforms, common_opts.input_data_format);
 
         // Write binary file
         traccc::io::write(event, common_opts.input_directory,
@@ -60,9 +62,10 @@ int create_binaries(const std::string& detector_file,
                           vecmem::get_data(spacepoints_csv.modules));
 
         // Read the measurements from the relevant event file
-        auto measurements_csv = traccc::io::read_measurements(
-            event, common_opts.input_directory, common_opts.input_data_format,
-            &host_mr);
+        traccc::io::measurement_reader_output measurements_csv(&host_mr);
+        traccc::io::read_measurements(measurements_csv, event,
+                                      common_opts.input_directory,
+                                      common_opts.input_data_format);
 
         // Write binary file
         traccc::io::write(event, common_opts.input_directory,

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -80,17 +80,19 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
     HOST_MR uncached_host_mr;
 
     // Read in all input events into memory.
-    demonstrator_input input;
+    demonstrator_input input(&uncached_host_mr);
+
     {
         performance::timer t{"File reading", times};
-        for (unsigned int event = 0; event < throughput_cfg.loaded_events;
-             ++event) {
-            input = io::read(
-                throughput_cfg.loaded_events, throughput_cfg.input_directory,
-                throughput_cfg.detector_file,
-                throughput_cfg.digitization_config_file,
-                throughput_cfg.input_data_format, &uncached_host_mr);
+        // Create empty inputs using the correct memory resource
+        for (std::size_t i = 0; i < throughput_cfg.loaded_events; ++i) {
+            input.push_back(demonstrator_input::value_type(&uncached_host_mr));
         }
+        // Read event data into input vector
+        io::read(input, throughput_cfg.loaded_events,
+                 throughput_cfg.input_directory, throughput_cfg.detector_file,
+                 throughput_cfg.digitization_config_file,
+                 throughput_cfg.input_data_format);
     }
 
     // Set up cached memory resources on top of the host memory resource

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -69,17 +69,19 @@ int throughput_st(std::string_view description, int argc, char* argv[],
             : static_cast<vecmem::memory_resource&>(uncached_host_mr);
 
     // Read in all input events into memory.
-    demonstrator_input input;
+    demonstrator_input input(&uncached_host_mr);
+
     {
         performance::timer t{"File reading", times};
-        for (unsigned int event = 0; event < throughput_cfg.loaded_events;
-             ++event) {
-            input = io::read(
-                throughput_cfg.loaded_events, throughput_cfg.input_directory,
-                throughput_cfg.detector_file,
-                throughput_cfg.digitization_config_file,
-                throughput_cfg.input_data_format, &uncached_host_mr);
+        // Create empty inputs using the correct memory resource
+        for (std::size_t i = 0; i < throughput_cfg.loaded_events; ++i) {
+            input.push_back(demonstrator_input::value_type(&uncached_host_mr));
         }
+        // Read event data into input vector
+        io::read(input, throughput_cfg.loaded_events,
+                 throughput_cfg.input_directory, throughput_cfg.detector_file,
+                 throughput_cfg.digitization_config_file,
+                 throughput_cfg.input_data_format);
     }
 
     // Set up the full-chain algorithm.

--- a/examples/run/cpu/ccl_example.cpp
+++ b/examples/run/cpu/ccl_example.cpp
@@ -105,8 +105,9 @@ int main(int argc, char* argv[]) {
 
     auto time_read_start = std::chrono::high_resolution_clock::now();
 
-    traccc::cell_collection_types::host data =
-        traccc::io::read_cells(event_file).cells;
+    traccc::io::cell_reader_output readOut(&mem);
+    traccc::io::read_cells(readOut, event_file);
+    traccc::cell_collection_types::host data = readOut.cells;
 
     auto time_read_end = std::chrono::high_resolution_clock::now();
 

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -57,9 +57,10 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Read the hits from the relevant event file
-        auto readOut = traccc::io::read_spacepoints(
-            event, common_opts.input_directory, surface_transforms,
-            common_opts.input_data_format, &host_mr);
+        traccc::io::spacepoint_reader_output readOut(&host_mr);
+        traccc::io::read_spacepoints(
+            readOut, event, common_opts.input_directory, surface_transforms,
+            common_opts.input_data_format);
         traccc::spacepoint_collection_types::host& spacepoints_per_event =
             readOut.spacepoints;
 

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -70,10 +70,12 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     for (unsigned int event = common_opts.skip;
          event < common_opts.events + common_opts.skip; ++event) {
 
+        traccc::io::cell_reader_output readOut(&host_mr);
+
         // Read the cells from the relevant event file
-        auto readOut = traccc::io::read_cells(
-            event, common_opts.input_directory, common_opts.input_data_format,
-            &surface_transforms, &digi_cfg, &host_mr);
+        traccc::io::read_cells(readOut, event, common_opts.input_directory,
+                               common_opts.input_data_format,
+                               &surface_transforms, &digi_cfg);
         traccc::cell_collection_types::host& cells_per_event = readOut.cells;
         traccc::cell_module_collection_types::host& modules_per_event =
             readOut.modules;

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -96,7 +96,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
                                      m_seeding(spacepoints.first));
 
     // Get the final data back to the host.
-    bound_track_parameters_collection_types::host result;
+    bound_track_parameters_collection_types::host result(&m_host_mr);
     m_copy(track_params, result);
     m_stream.synchronize();
 

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -93,7 +93,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Instantiate host containers/collections
-        traccc::io::cell_reader_output read_out_per_event;
+        traccc::io::cell_reader_output read_out_per_event(mr.host);
         traccc::clusterization_algorithm::output_type measurements_per_event;
         traccc::spacepoint_formation::output_type spacepoints_per_event;
         traccc::seeding_algorithm::output_type seeds;
@@ -113,10 +113,10 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 traccc::performance::timer t("File reading  (cpu)",
                                              elapsedTimes);
                 // Read the cells from the relevant event file into host memory.
-                read_out_per_event = traccc::io::read_cells(
-                    event, common_opts.input_directory,
-                    common_opts.input_data_format, &surface_transforms,
-                    &digi_cfg, &cuda_host_mr);
+                traccc::io::read_cells(read_out_per_event, event,
+                                       common_opts.input_directory,
+                                       common_opts.input_data_format,
+                                       &surface_transforms, &digi_cfg);
             }  // stop measuring file reading timer
 
             const traccc::cell_collection_types::host& cells_per_event =

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -103,7 +103,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     for (unsigned int event = common_opts.skip;
          event < common_opts.events + common_opts.skip; ++event) {
 
-        traccc::io::spacepoint_reader_output reader_output;
+        traccc::io::spacepoint_reader_output reader_output(&host_mr);
         traccc::seeding_algorithm::output_type seeds;
         traccc::track_params_estimation::output_type params;
 
@@ -117,9 +117,9 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
                 traccc::performance::timer t("Hit reading  (cpu)",
                                              elapsedTimes);
                 // Read the hits from the relevant event file
-                reader_output = traccc::io::read_spacepoints(
-                    event, common_opts.input_directory, surface_transforms,
-                    common_opts.input_data_format, &host_mr);
+                traccc::io::read_spacepoints(
+                    reader_output, event, common_opts.input_directory,
+                    surface_transforms, common_opts.input_data_format);
             }  // stop measuring hit reading timer
 
             traccc::spacepoint_collection_types::host& spacepoints_per_event =

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -63,9 +63,10 @@ int par_run(const std::string &detector_file,
     for (unsigned int event = 0; event < events; ++event) {
 
         // Read the cells from the relevant event file
-        auto readOut =
-            traccc::io::read_cells(event, cells_dir, traccc::data_format::csv,
-                                   &surface_transforms, &digi_cfg, &resource);
+        traccc::io::cell_reader_output readOut(&resource);
+        traccc::io::read_cells(readOut, event, cells_dir,
+                               traccc::data_format::csv, &surface_transforms,
+                               &digi_cfg);
         traccc::cell_collection_types::host &cells_per_event = readOut.cells;
         traccc::cell_module_collection_types::host &modules_per_event =
             readOut.modules;

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -110,7 +110,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
                                      m_seeding(spacepoints.first));
 
     // Get the final data back to the host.
-    bound_track_parameters_collection_types::host result;
+    bound_track_parameters_collection_types::host result(&m_host_mr);
     (m_copy)(track_params, result);
     m_data->m_queue.wait_and_throw();
 

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -31,6 +31,7 @@
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
 #include <vecmem/memory/sycl/device_memory_resource.hpp>
+#include <vecmem/memory/sycl/host_memory_resource.hpp>
 #include <vecmem/utils/sycl/async_copy.hpp>
 
 // System include(s).
@@ -59,8 +60,9 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
 
     // Memory resources used by the application.
     vecmem::host_memory_resource host_mr;
+    vecmem::sycl::host_memory_resource sycl_host_mr{&q};
     vecmem::sycl::device_memory_resource device_mr{&q};
-    traccc::memory_resource mr{device_mr, &host_mr};
+    traccc::memory_resource mr{device_mr, &sycl_host_mr};
 
     traccc::seeding_algorithm sa(host_mr);
     traccc::track_params_estimation tp(host_mr);
@@ -85,7 +87,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Instantiate host containers/collections
-        traccc::io::spacepoint_reader_output reader_output;
+        traccc::io::spacepoint_reader_output reader_output(mr.host);
         traccc::seeding_algorithm::output_type seeds;
         traccc::track_params_estimation::output_type params;
 
@@ -105,9 +107,9 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
                 traccc::performance::timer t("Hit reading  (cpu)",
                                              elapsedTimes);
                 // Read the hits from the relevant event file
-                reader_output = traccc::io::read_spacepoints(
-                    event, common_opts.input_directory, surface_transforms,
-                    common_opts.input_data_format, &host_mr);
+                traccc::io::read_spacepoints(
+                    reader_output, event, common_opts.input_directory,
+                    surface_transforms, common_opts.input_data_format);
 
             }  // stop measuring hit reading timer
 

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -89,8 +89,9 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
 
     // Memory resources used by the application.
     vecmem::host_memory_resource host_mr;
+    vecmem::sycl::host_memory_resource sycl_host_mr{&q};
     vecmem::sycl::device_memory_resource device_mr{&q};
-    traccc::memory_resource mr{device_mr, &host_mr};
+    traccc::memory_resource mr{device_mr, &sycl_host_mr};
 
     traccc::clusterization_algorithm ca(host_mr);
     traccc::spacepoint_formation sf(host_mr);
@@ -119,7 +120,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
          event < common_opts.events + common_opts.skip; ++event) {
 
         // Instantiate host containers/collections
-        traccc::io::cell_reader_output read_out_per_event;
+        traccc::io::cell_reader_output read_out_per_event(mr.host);
         traccc::clusterization_algorithm::output_type measurements_per_event;
         traccc::spacepoint_formation::output_type spacepoints_per_event;
         traccc::seeding_algorithm::output_type seeds;
@@ -139,10 +140,10 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 traccc::performance::timer t("File reading  (cpu)",
                                              elapsedTimes);
                 // Read the cells from the relevant event file into host memory.
-                read_out_per_event = traccc::io::read_cells(
-                    event, common_opts.input_directory,
-                    common_opts.input_data_format, &surface_transforms,
-                    &digi_cfg, &host_mr);
+                traccc::io::read_cells(read_out_per_event, event,
+                                       common_opts.input_directory,
+                                       common_opts.input_data_format,
+                                       &surface_transforms, &digi_cfg);
             }  // stop measuring file reading timer
 
             const traccc::cell_collection_types::host& cells_per_event =

--- a/examples/run/sycl/throughput_mt.cpp
+++ b/examples/run/sycl/throughput_mt.cpp
@@ -17,7 +17,8 @@ int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
     static const bool use_host_caching = true;
-    return traccc::throughput_mt<traccc::sycl::full_chain_algorithm>(
+    return traccc::throughput_mt<traccc::sycl::full_chain_algorithm,
+                                 vecmem::sycl::host_memory_resource>(
         "Multi-threaded SYCL GPU throughput tests", argc, argv,
         use_host_caching);
 }

--- a/io/include/traccc/io/read.hpp
+++ b/io/include/traccc/io/read.hpp
@@ -11,9 +11,6 @@
 #include "traccc/io/data_format.hpp"
 #include "traccc/io/demonstrator_edm.hpp"
 
-// VecMem include(s).
-#include <vecmem/memory/memory_resource.hpp>
-
 // System include(s).
 #include <string_view>
 
@@ -24,18 +21,16 @@ namespace traccc::io {
 /// This function can read data about multiple events into memory at the
 /// same time. Even using (OpenMP) parallelism for the reading if possible.
 ///
+/// @param out An object with the requested events worth of input
 /// @param events The number of events to read input data for
 /// @param directory The directory to read the cell data from
 /// @param detector_file The file describing the detector geometry
 /// @param digi_config_file The file describing the detector digitization
 /// @param format The format of the event file(s)
-/// @param mr The memory resource to allocate the container(s) with
-/// @return An object with the requested events worth of input
 ///
-demonstrator_input read(std::size_t events, std::string_view directory,
-                        std::string_view detector_file,
-                        std::string_view digi_config_file,
-                        data_format format = data_format::csv,
-                        vecmem::memory_resource *mr = nullptr);
+void read(demonstrator_input& out, std::size_t events,
+          std::string_view directory, std::string_view detector_file,
+          std::string_view digi_config_file,
+          data_format format = data_format::csv);
 
 }  // namespace traccc::io

--- a/io/include/traccc/io/read_cells.hpp
+++ b/io/include/traccc/io/read_cells.hpp
@@ -16,9 +16,6 @@
 #include "traccc/geometry/digitization_config.hpp"
 #include "traccc/geometry/geometry.hpp"
 
-// VecMem include(s).
-#include <vecmem/memory/memory_resource.hpp>
-
 // System include(s).
 #include <cstddef>
 #include <string_view>
@@ -30,35 +27,32 @@ namespace traccc::io {
 /// The file to read is selected according the naming conventions used in
 /// our data.
 ///
+/// @param out A cell & a cell_module (host) collections
 /// @param event The event ID to read in the cells for
 /// @param directory The directory holding the cell data files
 /// @param format The format of the cell data files (to read)
 /// @param geom The description of the detector geometry
 /// @param dconfig The detector's digitization configuration
-/// @param mr The memory resource to create the host collection with
-/// @return A cell (host) collection & a cell_module collection
 ///
-cell_reader_output read_cells(std::size_t event, std::string_view directory,
-                              data_format format = data_format::csv,
-                              const geometry *geom = nullptr,
-                              const digitization_config *dconfig = nullptr,
-                              vecmem::memory_resource *mr = nullptr);
+void read_cells(cell_reader_output &out, std::size_t event,
+                std::string_view directory,
+                data_format format = data_format::csv,
+                const geometry *geom = nullptr,
+                const digitization_config *dconfig = nullptr);
 
 /// Read cell data into memory
 ///
 /// The file name is selected explicitly by the user.
 ///
+/// @param out A cell & a cell_module (host) collections
 /// @param filename The file to read the cell data from
 /// @param format The format of the cell data files (to read)
 /// @param geom The description of the detector geometry
 /// @param dconfig The detector's digitization configuration
-/// @param mr The memory resource to create the host collection with
-/// @return A cell (host) collection & a cell_module collection
 ///
-cell_reader_output read_cells(std::string_view filename,
-                              data_format format = data_format::csv,
-                              const geometry *geom = nullptr,
-                              const digitization_config *dconfig = nullptr,
-                              vecmem::memory_resource *mr = nullptr);
+void read_cells(cell_reader_output &out, std::string_view filename,
+                data_format format = data_format::csv,
+                const geometry *geom = nullptr,
+                const digitization_config *dconfig = nullptr);
 
 }  // namespace traccc::io

--- a/io/include/traccc/io/read_measurements.hpp
+++ b/io/include/traccc/io/read_measurements.hpp
@@ -14,9 +14,6 @@
 #include "traccc/edm/measurement.hpp"
 #include "traccc/io/reader_edm.hpp"
 
-// VecMem include(s).
-#include <vecmem/memory/memory_resource.hpp>
-
 // System include(s).
 #include <cstddef>
 #include <string_view>
@@ -28,28 +25,25 @@ namespace traccc::io {
 /// The file to read is selected according the naming conventions used in
 /// our data.
 ///
+/// @param out A measurement & a cell_module (host) collections
 /// @param event The event ID to read in the cells for
 /// @param directory The directory holding the cell data files
 /// @param format The format of the cell data files (to read)
-/// @param mr The memory resource to create the host container with
-/// @return A cell (host) container
 ///
-measurement_reader_output read_measurements(
-    std::size_t event, std::string_view directory,
-    data_format format = data_format::csv,
-    vecmem::memory_resource *mr = nullptr);
+void read_measurements(measurement_reader_output& out, std::size_t event,
+                       std::string_view directory,
+                       data_format format = data_format::csv);
 
 /// Read measurement data into memory
 ///
 /// The file name is selected explicitly by the user.
 ///
+/// @param out A measurement & a cell_module (host) collections
 /// @param filename The file to read the cell data from
 /// @param format The format of the cell data files (to read)
-/// @param mr The memory resource to create the host container with
-/// @return A cell (host) container
 ///
-measurement_reader_output read_measurements(
-    std::string_view filename, data_format format = data_format::csv,
-    vecmem::memory_resource *mr = nullptr);
+void read_measurements(measurement_reader_output& out,
+                       std::string_view filename,
+                       data_format format = data_format::csv);
 
 }  // namespace traccc::io

--- a/io/include/traccc/io/read_spacepoints.hpp
+++ b/io/include/traccc/io/read_spacepoints.hpp
@@ -15,45 +15,38 @@
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/geometry/geometry.hpp"
 
-// VecMem include(s).
-#include <vecmem/memory/memory_resource.hpp>
-
 // System include(s).
 #include <cstddef>
 #include <string_view>
 
 namespace traccc::io {
 
-/// Read cell data into memory
+/// Read spacepoint data into memory
 ///
 /// The file to read is selected according the naming conventions used in
 /// our data.
 ///
+/// @param out A spacepoint & a cell_module (host) collections
 /// @param event The event ID to read in the cells for
 /// @param directory The directory holding the cell data files
 /// @param geom The description of the detector geometry
 /// @param format The format of the cell data files (to read)
-/// @param mr The memory resource to create the host collection with
-/// @return A cell (host) collection
 ///
-spacepoint_reader_output read_spacepoints(
-    std::size_t event, std::string_view directory, const geometry &geom,
-    data_format format = data_format::csv,
-    vecmem::memory_resource *mr = nullptr);
+void read_spacepoints(spacepoint_reader_output& out, std::size_t event,
+                      std::string_view directory, const geometry& geom,
+                      data_format format = data_format::csv);
 
-/// Read cell data into memory
+/// Read spacepoint data into memory
 ///
 /// The file name is selected explicitly by the user.
 ///
+/// @param out A spacepoint & a cell_module (host) collections
 /// @param filename The file to read the cell data from
 /// @param geom The description of the detector geometry
 /// @param format The format of the cell data files (to read)
-/// @param mr The memory resource to create the host collection with
-/// @return A cell (host) collection
 ///
-spacepoint_reader_output read_spacepoints(
-    std::string_view filename, const geometry &geom,
-    data_format format = data_format::csv,
-    vecmem::memory_resource *mr = nullptr);
+void read_spacepoints(spacepoint_reader_output& out, std::string_view filename,
+                      const geometry& geom,
+                      data_format format = data_format::csv);
 
 }  // namespace traccc::io

--- a/io/include/traccc/io/reader_edm.hpp
+++ b/io/include/traccc/io/reader_edm.hpp
@@ -19,6 +19,9 @@ namespace traccc::io {
 struct cell_reader_output {
     cell_collection_types::host cells;
     cell_module_collection_types::host modules;
+
+    cell_reader_output() {}
+    cell_reader_output(vecmem::memory_resource* mr) : cells(mr), modules(mr) {}
 };
 
 /// Type definition for the reading of measurements into a vector of
@@ -27,6 +30,10 @@ struct cell_reader_output {
 struct measurement_reader_output {
     alt_measurement_collection_types::host measurements;
     cell_module_collection_types::host modules;
+
+    measurement_reader_output() {}
+    measurement_reader_output(vecmem::memory_resource* mr)
+        : measurements(mr), modules(mr) {}
 };
 
 /// Type definition for the reading of spacepoints into a vector of spacepoitns
@@ -35,6 +42,10 @@ struct measurement_reader_output {
 struct spacepoint_reader_output {
     spacepoint_collection_types::host spacepoints;
     cell_module_collection_types::host modules;
+
+    spacepoint_reader_output() {}
+    spacepoint_reader_output(vecmem::memory_resource* mr)
+        : spacepoints(mr), modules(mr) {}
 };
 
 }  // namespace traccc::io

--- a/io/src/csv/read_cells.hpp
+++ b/io/src/csv/read_cells.hpp
@@ -13,9 +13,6 @@
 #include "traccc/geometry/geometry.hpp"
 #include "traccc/io/reader_edm.hpp"
 
-// VecMem include(s).
-#include <vecmem/memory/memory_resource.hpp>
-
 // System include(s).
 #include <string_view>
 
@@ -23,15 +20,13 @@ namespace traccc::io::csv {
 
 /// Read cell information from a specific CSV file
 ///
+/// @param out A cell (host) collection & a cell_module collection
 /// @param filename The file to read the cell data from
 /// @param geom The description of the detector geometry
 /// @param dconfig The detector's digitization configuration
-/// @param mr The memory resource to create the host collection with
-/// @return A cell (host) collection & a cell_module collection
 ///
-cell_reader_output read_cells(std::string_view filename,
-                              const geometry* geom = nullptr,
-                              const digitization_config* dconfig = nullptr,
-                              vecmem::memory_resource* mr = nullptr);
+void read_cells(cell_reader_output& out, std::string_view filename,
+                const geometry* geom = nullptr,
+                const digitization_config* dconfig = nullptr);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_measurements.cpp
+++ b/io/src/csv/read_measurements.cpp
@@ -15,20 +15,16 @@
 
 namespace traccc::io::csv {
 
-measurement_reader_output read_measurements(std::string_view filename,
-                                            vecmem::memory_resource* mr) {
+void read_measurements(measurement_reader_output& out,
+                       std::string_view filename) {
 
     // Construct the measurement reader object.
     auto reader = make_measurement_reader(filename);
 
     // Create the result collection.
-    alt_measurement_collection_types::host result_measurements;
-    cell_module_collection_types::host result_modules;
-
-    if (mr != nullptr) {
-        result_measurements = alt_measurement_collection_types::host{mr};
-        result_modules = cell_module_collection_types::host{mr};
-    }
+    alt_measurement_collection_types::host& result_measurements =
+        out.measurements;
+    cell_module_collection_types::host& result_modules = out.modules;
 
     std::map<geometry_id, unsigned int> m;
 
@@ -56,9 +52,6 @@ measurement_reader_output read_measurements(std::string_view filename,
 
         result_measurements.push_back(meas);
     }
-
-    // Return the container.
-    return {std::move(result_measurements), std::move(result_modules)};
 }
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_measurements.hpp
+++ b/io/src/csv/read_measurements.hpp
@@ -11,9 +11,6 @@
 #include "traccc/edm/alt_measurement.hpp"
 #include "traccc/io/reader_edm.hpp"
 
-// VecMem include(s).
-#include <vecmem/memory/memory_resource.hpp>
-
 // System include(s).
 #include <string_view>
 
@@ -21,11 +18,10 @@ namespace traccc::io::csv {
 
 /// Read measurement information from a specific CSV file
 ///
+/// @param out A measurement & a cell_module (host) collections
 /// @param filename The file to read the measurement data from
-/// @param mr The memory resource to create the host container with
-/// @return A measurement (host) container
 ///
-measurement_reader_output read_measurements(
-    std::string_view filename, vecmem::memory_resource* mr = nullptr);
+void read_measurements(measurement_reader_output& out,
+                       std::string_view filename);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_spacepoints.cpp
+++ b/io/src/csv/read_spacepoints.cpp
@@ -16,21 +16,15 @@
 
 namespace traccc::io::csv {
 
-spacepoint_reader_output read_spacepoints(std::string_view filename,
-                                          const geometry& geom,
-                                          vecmem::memory_resource* mr) {
+void read_spacepoints(spacepoint_reader_output& out, std::string_view filename,
+                      const geometry& geom) {
 
     // Construct the spacepoint reader object.
     auto reader = make_hit_reader(filename);
 
     // Create the result collection.
-    spacepoint_collection_types::host result_spacepoints;
-    cell_module_collection_types::host result_modules;
-
-    if (mr != nullptr) {
-        result_spacepoints = spacepoint_collection_types::host{mr};
-        result_modules = cell_module_collection_types::host{mr};
-    }
+    spacepoint_collection_types::host& result_spacepoints = out.spacepoints;
+    cell_module_collection_types::host& result_modules = out.modules;
 
     std::map<geometry_id, unsigned int> m;
 
@@ -67,9 +61,6 @@ spacepoint_reader_output read_spacepoints(std::string_view filename,
 
         result_spacepoints.push_back(sp);
     }
-
-    // Return the container.
-    return {std::move(result_spacepoints), std::move(result_modules)};
 }
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_spacepoints.hpp
+++ b/io/src/csv/read_spacepoints.hpp
@@ -12,9 +12,6 @@
 #include "traccc/geometry/geometry.hpp"
 #include "traccc/io/reader_edm.hpp"
 
-// VecMem include(s).
-#include <vecmem/memory/memory_resource.hpp>
-
 // System include(s).
 #include <string_view>
 
@@ -22,13 +19,11 @@ namespace traccc::io::csv {
 
 /// Read spacepoint information from a specific CSV file
 ///
+/// @param out A spacepoint & a cell_module (host) collections
 /// @param filename The file to read the spacepoint data from
 /// @param geom The description of the detector geometry
-/// @param mr The memory resource to create the host collection with
-/// @return A spacepoint (host) collection
 ///
-spacepoint_reader_output read_spacepoints(
-    std::string_view filename, const geometry& geom,
-    vecmem::memory_resource* mr = nullptr);
+void read_spacepoints(spacepoint_reader_output& out, std::string_view filename,
+                      const geometry& geom);
 
 }  // namespace traccc::io::csv

--- a/io/src/mapper.cpp
+++ b/io/src/mapper.cpp
@@ -205,8 +205,9 @@ generate_measurement_cell_map(std::size_t event,
     auto digi_cfg = io::read_digitization_config(digi_config_file);
 
     // Read the cells from the relevant event file
-    auto readOut = io::read_cells(event, cells_dir, traccc::data_format::csv,
-                                  &surface_transforms, &digi_cfg, &resource);
+    traccc::io::cell_reader_output readOut(&resource);
+    io::read_cells(readOut, event, cells_dir, traccc::data_format::csv,
+                   &surface_transforms, &digi_cfg);
     cell_collection_types::host& cells_per_event = readOut.cells;
     cell_module_collection_types::host& modules_per_event = readOut.modules;
 
@@ -268,8 +269,9 @@ measurement_particle_map generate_measurement_particle_map(
     auto surface_transforms = io::read_geometry(detector_file);
 
     // Read the spacepoints from the relevant event file
-    auto readOut = io::read_spacepoints(event, hits_dir, surface_transforms,
-                                        traccc::data_format::csv, &resource);
+    traccc::io::spacepoint_reader_output readOut(&resource);
+    io::read_spacepoints(readOut, event, hits_dir, surface_transforms,
+                         traccc::data_format::csv);
     spacepoint_collection_types::host& spacepoints_per_event =
         readOut.spacepoints;
     cell_module_collection_types::host& modules = readOut.modules;

--- a/io/src/read.cpp
+++ b/io/src/read.cpp
@@ -19,28 +19,22 @@
 
 namespace traccc::io {
 
-demonstrator_input read(std::size_t events, std::string_view directory,
-                        std::string_view detector_file,
-                        std::string_view digi_config_file, data_format format,
-                        vecmem::memory_resource *mr) {
+void read(demonstrator_input& out, std::size_t events,
+          std::string_view directory, std::string_view detector_file,
+          std::string_view digi_config_file, data_format format) {
 
     // Read in the detector configuration.
     const geometry geom = io::read_geometry(detector_file);
     const digitization_config digi_cfg =
         io::read_digitization_config(digi_config_file);
 
-    // Construct the result object.
-    demonstrator_input result{events, mr};
+    assert(out.size() >= events);
 
     // Read in the cell data for all events. In parallel if possible.
 #pragma omp parallel for
     for (std::size_t event = 0; event < events; ++event) {
-        result[event] =
-            io::read_cells(event, directory, format, &geom, &digi_cfg, mr);
+        io::read_cells(out[event], event, directory, format, &geom, &digi_cfg);
     }
-
-    // Return the container.
-    return result;
 }
 
 }  // namespace traccc::io

--- a/io/src/read_binary.hpp
+++ b/io/src/read_binary.hpp
@@ -24,6 +24,7 @@ namespace traccc::io::details {
 /// @param filename The full input filename
 /// @param mr Is the memory resource to create the result container with
 ///
+/// TODO: Change container reading to not own its result object
 template <typename container_t>
 container_t read_binary_container(std::string_view filename,
                                   vecmem::memory_resource* mr = nullptr) {
@@ -72,8 +73,7 @@ container_t read_binary_container(std::string_view filename,
 /// @param mr Is the memory resource to create the result collection with
 ///
 template <typename collection_t>
-collection_t read_binary_collection(std::string_view filename,
-                                    vecmem::memory_resource* mr = nullptr) {
+void read_binary_collection(collection_t& result, std::string_view filename) {
 
     // Make sure that the chosen types work.
     static_assert(std::is_standard_layout_v<typename collection_t::value_type>,
@@ -86,15 +86,12 @@ collection_t read_binary_collection(std::string_view filename,
     std::size_t size;
     in_file.read(reinterpret_cast<char*>(&size), sizeof(std::size_t));
 
-    // Create the result collection, and set it to the correct size.
-    collection_t result(size, mr);
+    // Set result to the correct size.
+    result.resize(size);
 
     // Read the items into memory.
     in_file.read(reinterpret_cast<char*>(result.data()),
                  size * sizeof(typename collection_t::value_type));
-
-    // Return the newly created container.
-    return result;
 }
 
 }  // namespace traccc::io::details

--- a/io/src/read_cells.cpp
+++ b/io/src/read_cells.cpp
@@ -14,42 +14,39 @@
 
 namespace traccc::io {
 
-cell_reader_output read_cells(std::size_t event, std::string_view directory,
-                              data_format format, const geometry* geom,
-                              const digitization_config* dconfig,
-                              vecmem::memory_resource* mr) {
+void read_cells(cell_reader_output& out, std::size_t event,
+                std::string_view directory, data_format format,
+                const geometry* geom, const digitization_config* dconfig) {
 
     switch (format) {
-        case data_format::csv:
-            return read_cells(data_directory() + directory.data() +
-                                  get_event_filename(event, "-cells.csv"),
-                              format, geom, dconfig, mr);
+        case data_format::csv: {
+            read_cells(out,
+                       data_directory() + directory.data() +
+                           get_event_filename(event, "-cells.csv"),
+                       format, geom, dconfig);
+            break;
+        }
         case data_format::binary: {
-            auto cells =
-                details::read_binary_collection<cell_collection_types::host>(
-                    data_directory() + directory.data() +
-                        get_event_filename(event, "-cells.dat"),
-                    mr);
-            auto modules = details::read_binary_collection<
-                cell_module_collection_types::host>(
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-modules.dat"),
-                mr);
-            return {std::move(cells), std::move(modules)};
+            details::read_binary_collection<cell_collection_types::host>(
+                out.cells, data_directory() + directory.data() +
+                               get_event_filename(event, "-cells.dat"));
+            details::read_binary_collection<cell_module_collection_types::host>(
+                out.modules, data_directory() + directory.data() +
+                                 get_event_filename(event, "-modules.dat"));
+            break;
         }
         default:
             throw std::invalid_argument("Unsupported data format");
     }
 }
 
-cell_reader_output read_cells(std::string_view filename, data_format format,
-                              const geometry* geom,
-                              const digitization_config* dconfig,
-                              vecmem::memory_resource* mr) {
+void read_cells(cell_reader_output& out, std::string_view filename,
+                data_format format, const geometry* geom,
+                const digitization_config* dconfig) {
 
     switch (format) {
         case data_format::csv:
-            return csv::read_cells(filename, geom, dconfig, mr);
+            return csv::read_cells(out, filename, geom, dconfig);
 
         default:
             throw std::invalid_argument("Unsupported data format");

--- a/io/src/read_measurements.cpp
+++ b/io/src/read_measurements.cpp
@@ -14,42 +14,41 @@
 
 namespace traccc::io {
 
-measurement_reader_output read_measurements(std::size_t event,
-                                            std::string_view directory,
-                                            data_format format,
-                                            vecmem::memory_resource* mr) {
+void read_measurements(measurement_reader_output& out, std::size_t event,
+                       std::string_view directory, data_format format) {
 
     switch (format) {
-        case data_format::csv:
-            return read_measurements(
+        case data_format::csv: {
+            read_measurements(
+                out,
                 data_directory() + directory.data() +
                     get_event_filename(event, "-measurements.csv"),
-                format, mr);
+                format);
+            break;
+        }
         case data_format::binary: {
-            auto measurements = details::read_binary_collection<
+
+            details::read_binary_collection<
                 alt_measurement_collection_types::host>(
+                out.measurements,
                 data_directory() + directory.data() +
-                    get_event_filename(event, "-measurements.dat"),
-                mr);
-            auto modules = details::read_binary_collection<
-                cell_module_collection_types::host>(
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-modules.dat"),
-                mr);
-            return {std::move(measurements), std::move(modules)};
+                    get_event_filename(event, "-measurements.dat"));
+            details::read_binary_collection<cell_module_collection_types::host>(
+                out.modules, data_directory() + directory.data() +
+                                 get_event_filename(event, "-modules.dat"));
+            break;
         }
         default:
             throw std::invalid_argument("Unsupported data format");
     }
 }
 
-measurement_reader_output read_measurements(std::string_view filename,
-                                            data_format format,
-                                            vecmem::memory_resource* mr) {
+void read_measurements(measurement_reader_output& out,
+                       std::string_view filename, data_format format) {
 
     switch (format) {
         case data_format::csv:
-            return csv::read_measurements(filename, mr);
+            return csv::read_measurements(out, filename);
         default:
             throw std::invalid_argument("Unsupported data format");
     }

--- a/io/src/read_spacepoints.cpp
+++ b/io/src/read_spacepoints.cpp
@@ -14,43 +14,38 @@
 
 namespace traccc::io {
 
-spacepoint_reader_output read_spacepoints(std::size_t event,
-                                          std::string_view directory,
-                                          const geometry& geom,
-                                          data_format format,
-                                          vecmem::memory_resource* mr) {
+void read_spacepoints(spacepoint_reader_output& out, std::size_t event,
+                      std::string_view directory, const geometry& geom,
+                      data_format format) {
 
     switch (format) {
-        case data_format::csv:
-            return read_spacepoints(data_directory() + directory.data() +
-                                        get_event_filename(event, "-hits.csv"),
-                                    geom, format, mr);
+        case data_format::csv: {
+            read_spacepoints(out,
+                             data_directory() + directory.data() +
+                                 get_event_filename(event, "-hits.csv"),
+                             geom, format);
+            break;
+        }
         case data_format::binary: {
-            auto hits = details::read_binary_collection<
-                spacepoint_collection_types::host>(
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-hits.dat"),
-                mr);
-            auto modules = details::read_binary_collection<
-                cell_module_collection_types::host>(
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-modules.dat"),
-                mr);
-            return {std::move(hits), std::move(modules)};
+            details::read_binary_collection<spacepoint_collection_types::host>(
+                out.spacepoints, data_directory() + directory.data() +
+                                     get_event_filename(event, "-hits.dat"));
+            details::read_binary_collection<cell_module_collection_types::host>(
+                out.modules, data_directory() + directory.data() +
+                                 get_event_filename(event, "-modules.dat"));
+            break;
         }
         default:
             throw std::invalid_argument("Unsupported data format");
     }
 }
 
-spacepoint_reader_output read_spacepoints(std::string_view filename,
-                                          const geometry& geom,
-                                          data_format format,
-                                          vecmem::memory_resource* mr) {
+void read_spacepoints(spacepoint_reader_output& out, std::string_view filename,
+                      const geometry& geom, data_format format) {
 
     switch (format) {
         case data_format::csv:
-            return csv::read_spacepoints(filename, geom, mr);
+            return csv::read_spacepoints(out, filename, geom);
         default:
             throw std::invalid_argument("Unsupported data format");
     }

--- a/tests/common/tests/cca_test.hpp
+++ b/tests/common/tests/cca_test.hpp
@@ -92,7 +92,8 @@ class ConnectedComponentAnalysisTests
         std::string file_truth =
             get_datafile("cca_test/" + file_prefix + "_truth.csv");
 
-        auto data = traccc::io::read_cells(file_hits);
+        traccc::io::cell_reader_output data;
+        traccc::io::read_cells(data, file_hits);
         traccc::cell_collection_types::host &cells = data.cells;
         traccc::cell_module_collection_types::host &modules = data.modules;
 

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -129,9 +129,9 @@ TEST_P(CompareWithActsSeedingTests, Run) {
     auto surface_transforms = traccc::io::read_geometry(detector_file);
 
     // Read the hits from the relevant event file
-    auto reader_output =
-        traccc::io::read_spacepoints(event, hits_dir, surface_transforms,
-                                     traccc::data_format::csv, &host_mr);
+    traccc::io::spacepoint_reader_output reader_output(&host_mr);
+    traccc::io::read_spacepoints(reader_output, event, hits_dir,
+                                 surface_transforms, traccc::data_format::csv);
 
     traccc::spacepoint_collection_types::host& spacepoints_per_event =
         reader_output.spacepoints;

--- a/tests/cpu/test_clusterization_resolution.cpp
+++ b/tests/cpu/test_clusterization_resolution.cpp
@@ -45,9 +45,9 @@ TEST_P(SurfaceBinningTests, Run) {
     traccc::spacepoint_formation sf(host_mr);
 
     // Read the cells from the relevant event file
-    auto readOut =
-        traccc::io::read_cells(event, data_dir, traccc::data_format::csv,
-                               &surface_transforms, &digi_cfg, &host_mr);
+    traccc::io::cell_reader_output readOut(&host_mr);
+    traccc::io::read_cells(readOut, event, data_dir, traccc::data_format::csv,
+                           &surface_transforms, &digi_cfg);
 
     const traccc::cell_collection_types::host& cells_truth = readOut.cells;
     const traccc::cell_module_collection_types::host& modules = readOut.modules;
@@ -57,9 +57,9 @@ TEST_P(SurfaceBinningTests, Run) {
     auto spacepoints_recon = sf(measurements_recon, modules);
 
     // Read the hits from the relevant event file
-    auto sp_readOut =
-        traccc::io::read_spacepoints(event, data_dir, surface_transforms,
-                                     traccc::data_format::csv, &host_mr);
+    traccc::io::spacepoint_reader_output sp_readOut(&host_mr);
+    traccc::io::read_spacepoints(sp_readOut, event, data_dir,
+                                 surface_transforms, traccc::data_format::csv);
 
     const traccc::spacepoint_collection_types::host& spacepoints_truth =
         sp_readOut.spacepoints;

--- a/tests/io/test_binary.cpp
+++ b/tests/io/test_binary.cpp
@@ -43,9 +43,10 @@ TEST(io_binary, cell) {
         "tml_detector/default-geometric-config-generic.json");
 
     // Read csv file
-    auto reader_csv =
-        traccc::io::read_cells(event, cells_directory, traccc::data_format::csv,
-                               &surface_transforms, &digi_cfg, &host_mr);
+    traccc::io::cell_reader_output reader_csv(&host_mr);
+    traccc::io::read_cells(reader_csv, event, cells_directory,
+                           traccc::data_format::csv, &surface_transforms,
+                           &digi_cfg);
     const traccc::cell_collection_types::host& cells_csv = reader_csv.cells;
     const traccc::cell_module_collection_types::host& modules_csv =
         reader_csv.modules;
@@ -56,9 +57,10 @@ TEST(io_binary, cell) {
                       vecmem::get_data(modules_csv));
 
     // Read binary file
-    auto reader_binary = traccc::io::read_cells(
-        event, cells_directory, traccc::data_format::binary,
-        &surface_transforms, &digi_cfg, &host_mr);
+    traccc::io::cell_reader_output reader_binary(&host_mr);
+    traccc::io::read_cells(reader_binary, event, cells_directory,
+                           traccc::data_format::binary, &surface_transforms,
+                           &digi_cfg);
     const traccc::cell_collection_types::host& cells_binary =
         reader_binary.cells;
     const traccc::cell_module_collection_types::host& modules_binary =
@@ -111,9 +113,9 @@ TEST(io_binary, spacepoint) {
         traccc::io::read_geometry("tml_detector/trackml-detector.csv");
 
     // Read csv file
-    auto reader_csv =
-        traccc::io::read_spacepoints(event, hits_directory, surface_transforms,
-                                     traccc::data_format::csv, &host_mr);
+    traccc::io::spacepoint_reader_output reader_csv(&host_mr);
+    traccc::io::read_spacepoints(reader_csv, event, hits_directory,
+                                 surface_transforms, traccc::data_format::csv);
     const traccc::spacepoint_collection_types::host& spacepoints_csv =
         reader_csv.spacepoints;
     const traccc::cell_module_collection_types::host& modules_csv =
@@ -125,9 +127,10 @@ TEST(io_binary, spacepoint) {
                       vecmem::get_data(modules_csv));
 
     // Read binary file
-    auto reader_binary =
-        traccc::io::read_spacepoints(event, hits_directory, surface_transforms,
-                                     traccc::data_format::binary, &host_mr);
+    traccc::io::spacepoint_reader_output reader_binary(&host_mr);
+    traccc::io::read_spacepoints(reader_binary, event, hits_directory,
+                                 surface_transforms,
+                                 traccc::data_format::binary);
     const traccc::spacepoint_collection_types::host& spacepoints_binary =
         reader_binary.spacepoints;
     const traccc::cell_module_collection_types::host& modules_binary =
@@ -174,8 +177,9 @@ TEST(io_binary, measurement) {
     vecmem::host_memory_resource host_mr;
 
     // Read csv file
-    auto reader_csv = traccc::io::read_measurements(
-        event, measurements_directory, traccc::data_format::csv, &host_mr);
+    traccc::io::measurement_reader_output reader_csv(&host_mr);
+    traccc::io::read_measurements(reader_csv, event, measurements_directory,
+                                  traccc::data_format::csv);
     const traccc::alt_measurement_collection_types::host& measurements_csv =
         reader_csv.measurements;
     const traccc::cell_module_collection_types::host& modules_csv =
@@ -187,8 +191,9 @@ TEST(io_binary, measurement) {
         vecmem::get_data(measurements_csv), vecmem::get_data(modules_csv));
 
     // Read binary file
-    auto reader_binary = traccc::io::read_measurements(
-        event, measurements_directory, traccc::data_format::binary, &host_mr);
+    traccc::io::measurement_reader_output reader_binary(&host_mr);
+    traccc::io::read_measurements(reader_binary, event, measurements_directory,
+                                  traccc::data_format::binary);
     const traccc::alt_measurement_collection_types::host& measurements_binary =
         reader_binary.measurements;
     const traccc::cell_module_collection_types::host& modules_binary =

--- a/tests/io/test_csv.cpp
+++ b/tests/io/test_csv.cpp
@@ -28,8 +28,10 @@ class io : public traccc::tests::data_test {};
 // This defines the local frame test suite
 TEST_F(io, csv_read_single_module) {
 
-    auto single_module_cells = traccc::io::read_cells(
-        get_datafile("single_module/cells.csv"), traccc::data_format::csv);
+    traccc::io::cell_reader_output single_module_cells;
+    traccc::io::read_cells(single_module_cells,
+                           get_datafile("single_module/cells.csv"),
+                           traccc::data_format::csv);
     auto& cells = single_module_cells.cells;
     auto& modules = single_module_cells.modules;
     ASSERT_EQ(cells.size(), 6u);
@@ -46,8 +48,10 @@ TEST_F(io, csv_read_single_module) {
 // This defines the local frame test suite
 TEST_F(io, csv_read_two_modules) {
 
-    auto two_module_cells = traccc::io::read_cells(
-        get_datafile("two_modules/cells.csv"), traccc::data_format::csv);
+    traccc::io::cell_reader_output two_module_cells;
+    traccc::io::read_cells(two_module_cells,
+                           get_datafile("two_modules/cells.csv"),
+                           traccc::data_format::csv);
     auto& cells = two_module_cells.cells;
     auto& modules = two_module_cells.modules;
     ASSERT_EQ(modules.size(), 2u);
@@ -86,13 +90,12 @@ TEST_F(io, csv_read_tml_transforms) {
 // This reads in the tml pixel barrel first event
 TEST_F(io, csv_read_tml_pixelbarrel) {
 
-    auto tml_barrel_modules =
-        traccc::io::read_cells(
-            get_datafile("tml_pixel_barrel/event000000000-cells.csv"),
-            traccc::data_format::csv)
-            .modules;
+    traccc::io::cell_reader_output readOut;
+    traccc::io::read_cells(
+        readOut, get_datafile("tml_pixel_barrel/event000000000-cells.csv"),
+        traccc::data_format::csv);
 
-    ASSERT_EQ(tml_barrel_modules.size(), 2382u);
+    ASSERT_EQ(readOut.modules.size(), 2382u);
 }
 
 // This checks if hit and measurement container from the first single muon event
@@ -104,13 +107,16 @@ TEST_F(io, csv_read_tml_single_muon) {
         traccc::io::read_geometry("tml_detector/trackml-detector.csv");
 
     // Read the hits from the relevant event file
-    auto spacepoints_per_event = traccc::io::read_spacepoints(
-        0, "tml_full/single_muon/", surface_transforms,
-        traccc::data_format::csv, &resource);
+    traccc::io::spacepoint_reader_output spacepoints_per_event(&resource);
+    traccc::io::read_spacepoints(spacepoints_per_event, 0,
+                                 "tml_full/single_muon/", surface_transforms,
+                                 traccc::data_format::csv);
 
     // Read the measurements from the relevant event file
-    auto measurements_per_event = traccc::io::read_measurements(
-        0, "tml_full/single_muon/", traccc::data_format::csv, &resource);
+    traccc::io::measurement_reader_output measurements_per_event(&resource);
+    traccc::io::read_measurements(measurements_per_event, 0,
+                                  "tml_full/single_muon/",
+                                  traccc::data_format::csv);
 
     // Read the particles from the relevant event file
     traccc::particle_collection_types::host particles_per_event =


### PR DESCRIPTION
Throughout our code frequently use assignment operations to define host vectors, which easily leads to creating these objects on default memory.
This PR addresses this issue. The largest of these changes is in the IO interface, where the result objects are now passed by reference to the file reading functions, e.g.
```c++
cells_collection cells = io::read_cells(filename, mem_resource)
```
Now becomes:
```c++
cells_collection cells(mem_resource)
io::read_cells(cells, filename)
```
