### PR TITLE
Record fitting statistics (Ndf, Chi2) in KF and Add its plot tool

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -51,6 +51,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
   "include/traccc/fitting/kalman_filter/kalman_actor.hpp"
   "include/traccc/fitting/kalman_filter/kalman_fitter.hpp"
+  "include/traccc/fitting/kalman_filter/statistics_updater.hpp"
   "include/traccc/fitting/fitting_algorithm.hpp"
   # Seed finding algorithmic code.
   "include/traccc/seeding/detail/lin_circle.hpp"

--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -24,20 +24,14 @@ template <typename algebra_t>
 struct fitter_info {
     using scalar_type = typename algebra_t::scalar_type;
 
-    /// Seed track parameter
-    detray::bound_track_parameters<algebra_t> seed_params;
-
     /// Fitted track parameter
     detray::bound_track_parameters<algebra_t> fit_params;
 
     /// Number of degree of freedoms of fitted track
-    scalar_type ndf;
+    scalar_type ndf{0};
 
     /// Chi square of fitted track
-    scalar_type chi2;
-
-    /// P-value of fitted track
-    scalar_type p_val;
+    scalar_type chi2{0};
 };
 
 /// Fitting result per measurement
@@ -147,6 +141,9 @@ struct track_state {
     inline const bound_track_parameters_type& smoothed() const {
         return m_smoothed;
     }
+
+    public:
+    bool is_hole{true};
 
     private:
     detray::geometry::barcode m_surface_link;

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/track_parameters.hpp"
+#include "traccc/edm/track_state.hpp"
 
 // detray include(s).
 #include "detray/propagator/navigator.hpp"
@@ -22,12 +23,12 @@ template <typename algebra_t>
 struct gain_matrix_smoother {
 
     // Type declarations
-    using output_type = bool;
     using matrix_operator = typename algebra_t::matrix_actor;
     using size_type = typename matrix_operator::size_ty;
     template <size_type ROWS, size_type COLS>
     using matrix_type =
         typename matrix_operator::template matrix_type<ROWS, COLS>;
+    using scalar_type = typename algebra_t::scalar_type;
 
     /// Gain matrix smoother operation
     ///
@@ -42,7 +43,7 @@ struct gain_matrix_smoother {
     ///
     /// @return true if the update succeeds
     template <typename mask_group_t, typename index_t>
-    TRACCC_HOST_DEVICE inline output_type operator()(
+    TRACCC_HOST_DEVICE inline void operator()(
         const mask_group_t& mask_group, const index_t& index,
         track_state<algebra_t>& cur_state,
         const track_state<algebra_t>& next_state) {
@@ -64,7 +65,7 @@ struct gain_matrix_smoother {
         const matrix_type<6, 6>& cur_filtered_cov = cur_filtered.covariance();
 
         // Regularization matrix for numerical stability
-        static constexpr scalar epsilon = 1e-13;
+        static constexpr scalar_type epsilon = 1e-13f;
         const matrix_type<6, 6> regularization =
             matrix_operator().template identity<e_bound_size, e_bound_size>() *
             epsilon;
@@ -90,18 +91,19 @@ struct gain_matrix_smoother {
         const typename mask_group_t::value_type::projection_matrix_type H =
             mask_group[index].projection_matrix(cur_filtered);
 
+        constexpr const unsigned int D =
+            mask_group_t::value_type::shape::meas_dim;
+
         // Calculate smoothed chi square
-        const matrix_type<2, 1>& meas_local = cur_state.measurement_local();
-        const matrix_type<2, 2>& V = cur_state.measurement_covariance();
-        const matrix_type<2, 1> residual = meas_local - H * smt_vec;
-        const matrix_type<2, 2> R =
+        const matrix_type<D, 1>& meas_local = cur_state.measurement_local();
+        const matrix_type<D, D>& V = cur_state.measurement_covariance();
+        const matrix_type<D, 1> residual = meas_local - H * smt_vec;
+        const matrix_type<D, D> R =
             V - H * smt_cov * matrix_operator().transpose(H);
         const matrix_type<1, 1> chi2 = matrix_operator().transpose(residual) *
                                        matrix_operator().inverse(R) * residual;
 
         cur_state.smoothed_chi2() = matrix_operator().element(chi2, 0, 0);
-
-        return true;
     }
 };
 

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -37,7 +37,7 @@ struct gain_matrix_updater {
     ///
     /// @return true if the update succeeds
     template <typename mask_group_t, typename index_t>
-    TRACCC_HOST_DEVICE inline bool operator()(
+    TRACCC_HOST_DEVICE inline void operator()(
         const mask_group_t& mask_group, const index_t& index,
         track_state<algebra_t>& trk_state,
         bound_track_parameters& bound_params) const {
@@ -46,15 +46,19 @@ struct gain_matrix_updater {
         // @Note: Make constexpr work
         const matrix_type<6, 6> I66 =
             matrix_operator().template identity<e_bound_size, e_bound_size>();
-        const matrix_type<2, 2> I22 =
-            matrix_operator().template identity<2, 2>();
+
+        constexpr const unsigned int D =
+            mask_group_t::value_type::shape::meas_dim;
+
+        const matrix_type<D, D> I_m =
+            matrix_operator().template identity<D, D>();
 
         // projection matrix
         const typename mask_group_t::value_type::projection_matrix_type H =
             mask_group[index].projection_matrix(bound_params);
 
         // Measurement data on surface
-        const matrix_type<2, 1>& meas_local = trk_state.measurement_local();
+        const matrix_type<D, 1>& meas_local = trk_state.measurement_local();
 
         // Predicted vector of bound track parameters
         const matrix_type<6, 1>& predicted_vec = bound_params.vector();
@@ -67,13 +71,13 @@ struct gain_matrix_updater {
         trk_state.predicted().set_covariance(predicted_cov);
 
         // Spatial resolution (Measurement covariance)
-        const matrix_type<2, 2> V = trk_state.measurement_covariance();
+        const matrix_type<D, D> V = trk_state.measurement_covariance();
 
-        const matrix_type<2, 2> M =
+        const matrix_type<D, D> M =
             H * predicted_cov * matrix_operator().transpose(H) + V;
 
         // Kalman gain matrix
-        const matrix_type<6, 2> K = predicted_cov *
+        const matrix_type<6, D> K = predicted_cov *
                                     matrix_operator().transpose(H) *
                                     matrix_operator().inverse(M);
 
@@ -83,10 +87,10 @@ struct gain_matrix_updater {
         const matrix_type<6, 6> filtered_cov = (I66 - K * H) * predicted_cov;
 
         // Residual between measurement and (projected) filtered vector
-        const matrix_type<2, 1> residual = meas_local - H * filtered_vec;
+        const matrix_type<D, 1> residual = meas_local - H * filtered_vec;
 
         // Calculate the chi square
-        const matrix_type<2, 2> R = (I22 - H * K) * V;
+        const matrix_type<D, D> R = (I_m - H * K) * V;
         const matrix_type<1, 1> chi2 = matrix_operator().transpose(residual) *
                                        matrix_operator().inverse(R) * residual;
 
@@ -98,8 +102,6 @@ struct gain_matrix_updater {
         trk_state.filtered().set_vector(filtered_vec);
         trk_state.filtered().set_covariance(filtered_cov);
         trk_state.filtered_chi2() = matrix_operator().element(chi2, 0, 0);
-
-        return true;
     }
 };
 

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -10,7 +10,6 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/track_state.hpp"
-#include "traccc/fitting/kalman_filter/gain_matrix_smoother.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
 
 // detray include(s).
@@ -95,6 +94,9 @@ struct kalman_actor : detray::actor {
             if (navigation.current_object() != trk_state.surface_link()) {
                 propagation._heartbeat &= navigation.abort();
             }
+
+            // This track state is not a hole
+            trk_state.is_hole = false;
 
             // Set full jacobian
             trk_state.jacobian() = stepping._full_jacobian;

--- a/core/include/traccc/fitting/kalman_filter/statistics_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/statistics_updater.hpp
@@ -1,0 +1,50 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/track_state.hpp"
+
+namespace traccc {
+
+/// Type unrolling functor to update the fitting quality
+template <typename algebra_t>
+struct statistics_updater {
+
+    using scalar_type = typename algebra_t::scalar_type;
+
+    /// Update track fitting qualities (NDoF and Chi2)
+    ///
+    /// @param mask_group mask group that contains the mask of the current
+    /// surface
+    /// @param index mask index of the current surface
+    /// @param fit_info fitting information such as NDoF or Chi2
+    /// @param trk_state track state of the current surface
+    template <typename mask_group_t, typename index_t>
+    TRACCC_HOST_DEVICE inline void operator()(
+        const mask_group_t& /*mask_group*/, const index_t& /*index*/,
+        fitter_info<algebra_t>& fit_info,
+        const track_state<algebra_t>& trk_state) {
+
+        if (!trk_state.is_hole) {
+
+            // Measurement dimension
+            constexpr const unsigned int D =
+                mask_group_t::value_type::shape::meas_dim;
+
+            // NDoF = NDoF + number of coordinates per measurement
+            fit_info.ndf += static_cast<scalar_type>(D);
+
+            // total_chi2 = total_chi2 + chi2
+            fit_info.chi2 += trk_state.smoothed_chi2();
+        }
+    }
+};
+
+}  // namespace traccc

--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -49,7 +49,11 @@ TRACCC_HOST_DEVICE inline void fit(
 
     typename fitter_t::state fitter_state(track_states_per_track);
 
+    // Run fitting
     fitter.fit(seed_param, fitter_state, nav_candidates.at(globalIndex));
+
+    // Get the final fitting information
+    track_states[globalIndex].header = fitter_state.m_fit_info;
 }
 
 }  // namespace traccc::device

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -19,9 +19,12 @@ traccc_add_library( traccc_performance performance TYPE SHARED
    # Resolution calculation code.
    "include/traccc/resolution/fitting_performance_writer.hpp"
    "include/traccc/resolution/res_plot_tool_config.hpp"
+   "include/traccc/resolution/stat_plot_tool_config.hpp"
    "src/resolution/fitting_performance_writer.cpp"
    "src/resolution/res_plot_tool.hpp"
    "src/resolution/res_plot_tool.cpp"
+   "src/resolution/stat_plot_tool.hpp"
+   "src/resolution/stat_plot_tool.cpp"
    # Utils
    "include/traccc/utils/ranges.hpp"
    "include/traccc/utils/helpers.hpp"

--- a/performance/include/traccc/resolution/fitting_performance_writer.hpp
+++ b/performance/include/traccc/resolution/fitting_performance_writer.hpp
@@ -9,6 +9,7 @@
 
 // Library include(s).
 #include "traccc/resolution/res_plot_tool_config.hpp"
+#include "traccc/resolution/stat_plot_tool_config.hpp"
 
 // Project include(s).
 #include "traccc/edm/track_parameters.hpp"
@@ -37,7 +38,8 @@ class fitting_performance_writer {
         /// Output file mode
         std::string file_mode = "RECREATE";
         /// Plot tool configurations.
-        res_plot_tool_config config;
+        res_plot_tool_config res_config;
+        stat_plot_tool_config stat_config;
     };
 
     /// Constructor with writer config
@@ -53,7 +55,8 @@ class fitting_performance_writer {
     /// @param evt_map event map to find the truth values
     template <typename detector_t>
     void write(const track_state_collection_types::host& track_states_per_track,
-               const detector_t& det, event_map2& evt_map) {
+               const fitter_info<transform3>& fit_info, const detector_t& det,
+               event_map2& evt_map) {
 
         auto& m_p_map = evt_map.meas_ptc_map;
 
@@ -91,7 +94,8 @@ class fitting_performance_writer {
             ptc.charge / getter::norm(global_mom);
 
         // For the moment, only fill with the first measurements
-        write_impl(truth_param, trk_state.smoothed());
+        write_res(truth_param, trk_state.smoothed());
+        write_stat(fit_info);
     }
 
     /// Writing caches into the file
@@ -99,8 +103,11 @@ class fitting_performance_writer {
 
     private:
     /// Non-templated part of the @c write(...) function
-    void write_impl(const bound_track_parameters& truth_param,
-                    const bound_track_parameters& fit_param);
+    void write_res(const bound_track_parameters& truth_param,
+                   const bound_track_parameters& fit_param);
+
+    /// Non-templated part of the @c write(...) function
+    void write_stat(const fitter_info<transform3>& fit_info);
 
     /// Configuration for the tool
     config m_cfg;

--- a/performance/include/traccc/resolution/stat_plot_tool_config.hpp
+++ b/performance/include/traccc/resolution/stat_plot_tool_config.hpp
@@ -23,6 +23,7 @@ struct stat_plot_tool_config {
     std::map<std::string, plot_helpers::binning> var_binning = {
         {"ndf", plot_helpers::binning("ndf", 10, 0., 0.)},
         {"chi2", plot_helpers::binning("chi2", 100, 0., 50.)},
+        {"reduced_chi2", plot_helpers::binning("chi2/ndf", 100, 0., 10.)},
         {"pval", plot_helpers::binning("pval", 100, 0., 1.)}};
 };
 

--- a/performance/include/traccc/resolution/stat_plot_tool_config.hpp
+++ b/performance/include/traccc/resolution/stat_plot_tool_config.hpp
@@ -1,0 +1,29 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "traccc/utils/helpers.hpp"
+
+// System include(s).
+#include <map>
+#include <vector>
+
+namespace traccc {
+
+/// @brief Configuration structure for @c traccc::stat_plot_tool
+struct stat_plot_tool_config {
+
+    /// Binning setups
+    std::map<std::string, plot_helpers::binning> var_binning = {
+        {"ndf", plot_helpers::binning("ndf", 10, 0., 0.)},
+        {"chi2", plot_helpers::binning("chi2", 100, 0., 50.)},
+        {"pval", plot_helpers::binning("pval", 100, 0., 1.)}};
+};
+
+}  // namespace traccc

--- a/performance/src/resolution/fitting_performance_writer.cpp
+++ b/performance/src/resolution/fitting_performance_writer.cpp
@@ -9,6 +9,7 @@
 #include "traccc/resolution/fitting_performance_writer.hpp"
 
 #include "res_plot_tool.hpp"
+#include "stat_plot_tool.hpp"
 
 // ROOT include(s).
 #ifdef TRACCC_HAVE_ROOT
@@ -28,11 +29,14 @@ struct fitting_performance_writer_data {
     /// Constructor
     fitting_performance_writer_data(
         const fitting_performance_writer::config& cfg)
-        : m_res_plot_tool(cfg.config) {}
+        : m_res_plot_tool(cfg.res_config), m_stat_plot_tool(cfg.stat_config) {}
 
     /// Plot tool for resolution
     res_plot_tool m_res_plot_tool;
     res_plot_tool::res_plot_cache m_res_plot_cache;
+    /// Plot tool for statistics
+    stat_plot_tool m_stat_plot_tool;
+    stat_plot_tool::stat_plot_cache m_stat_plot_cache;
 };
 
 }  // namespace details
@@ -42,6 +46,7 @@ fitting_performance_writer::fitting_performance_writer(const config& cfg)
       m_data(std::make_unique<details::fitting_performance_writer_data>(cfg)) {
 
     m_data->m_res_plot_tool.book(m_data->m_res_plot_cache);
+    m_data->m_stat_plot_tool.book(m_data->m_stat_plot_cache);
 }
 
 fitting_performance_writer::~fitting_performance_writer() {}
@@ -64,14 +69,21 @@ void fitting_performance_writer::finalize() {
 #endif  // TRACCC_HAVE_ROOT
 
     m_data->m_res_plot_tool.write(m_data->m_res_plot_cache);
+    m_data->m_stat_plot_tool.write(m_data->m_stat_plot_cache);
 }
 
-void fitting_performance_writer::write_impl(
+void fitting_performance_writer::write_res(
     const bound_track_parameters& truth_param,
     const bound_track_parameters& fit_param) {
 
     m_data->m_res_plot_tool.fill(m_data->m_res_plot_cache, truth_param,
                                  fit_param);
+}
+
+void fitting_performance_writer::write_stat(
+    const fitter_info<transform3>& fit_info) {
+
+    m_data->m_stat_plot_tool.fill(m_data->m_stat_plot_cache, fit_info);
 }
 
 }  // namespace traccc

--- a/performance/src/resolution/stat_plot_tool.cpp
+++ b/performance/src/resolution/stat_plot_tool.cpp
@@ -25,9 +25,12 @@ void stat_plot_tool::book(stat_plot_cache& cache) const {
 #ifdef TRACCC_HAVE_ROOT
     plot_helpers::binning b_ndf = m_cfg.var_binning.at("ndf");
     plot_helpers::binning b_chi2 = m_cfg.var_binning.at("chi2");
+    plot_helpers::binning b_reduced_chi2 = m_cfg.var_binning.at("reduced_chi2");
     plot_helpers::binning b_pval = m_cfg.var_binning.at("pval");
     cache.ndf_hist = plot_helpers::book_histo("ndf", "NDF", b_ndf);
     cache.chi2_hist = plot_helpers::book_histo("chi2", "Chi2", b_chi2);
+    cache.reduced_chi2_hist =
+        plot_helpers::book_histo("reduced_chi2", "Chi2/NDF", b_reduced_chi2);
     cache.pval_hist = plot_helpers::book_histo("pval", "p value", b_pval);
 #endif  // TRACCC_HAVE_ROOT
 }
@@ -43,6 +46,7 @@ void stat_plot_tool::fill(stat_plot_cache& cache,
     const auto& chi2 = fit_info.chi2;
     cache.ndf_hist->Fill(ndf);
     cache.chi2_hist->Fill(chi2);
+    cache.reduced_chi2_hist->Fill(chi2 / ndf);
     cache.pval_hist->Fill(ROOT::Math::chisquared_cdf_c(chi2, ndf));
 #endif  // TRACCC_HAVE_ROOT
 }
@@ -55,6 +59,7 @@ void stat_plot_tool::write(const stat_plot_cache& cache) const {
 #ifdef TRACCC_HAVE_ROOT
     cache.ndf_hist->Write();
     cache.chi2_hist->Write();
+    cache.reduced_chi2_hist->Write();
     cache.pval_hist->Write();
 #endif  // TRACCC_HAVE_ROOT
 }

--- a/performance/src/resolution/stat_plot_tool.cpp
+++ b/performance/src/resolution/stat_plot_tool.cpp
@@ -1,0 +1,62 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "stat_plot_tool.hpp"
+
+// ROOT include(s).
+#ifdef TRACCC_HAVE_ROOT
+#include <Math/ProbFuncMathCore.h>
+#endif  // TRACCC_HAVE_ROOT
+
+namespace traccc {
+
+stat_plot_tool::stat_plot_tool(const stat_plot_tool_config& cfg) : m_cfg(cfg) {}
+
+void stat_plot_tool::book(stat_plot_cache& cache) const {
+
+    // Avoid unused variable warnings when building the code without ROOT.
+    (void)cache;
+
+#ifdef TRACCC_HAVE_ROOT
+    plot_helpers::binning b_ndf = m_cfg.var_binning.at("ndf");
+    plot_helpers::binning b_chi2 = m_cfg.var_binning.at("chi2");
+    plot_helpers::binning b_pval = m_cfg.var_binning.at("pval");
+    cache.ndf_hist = plot_helpers::book_histo("ndf", "NDF", b_ndf);
+    cache.chi2_hist = plot_helpers::book_histo("chi2", "Chi2", b_chi2);
+    cache.pval_hist = plot_helpers::book_histo("pval", "p value", b_pval);
+#endif  // TRACCC_HAVE_ROOT
+}
+
+void stat_plot_tool::fill(stat_plot_cache& cache,
+                          const fitter_info<transform3>& fit_info) const {
+
+    // Avoid unused variable warnings when building the code without ROOT.
+    (void)cache;
+
+#ifdef TRACCC_HAVE_ROOT
+    const auto& ndf = fit_info.ndf;
+    const auto& chi2 = fit_info.chi2;
+    cache.ndf_hist->Fill(ndf);
+    cache.chi2_hist->Fill(chi2);
+    cache.pval_hist->Fill(ROOT::Math::chisquared_cdf_c(chi2, ndf));
+#endif  // TRACCC_HAVE_ROOT
+}
+
+void stat_plot_tool::write(const stat_plot_cache& cache) const {
+
+    // Avoid unused variable warnings when building the code without ROOT.
+    (void)cache;
+
+#ifdef TRACCC_HAVE_ROOT
+    cache.ndf_hist->Write();
+    cache.chi2_hist->Write();
+    cache.pval_hist->Write();
+#endif  // TRACCC_HAVE_ROOT
+}
+
+}  // namespace traccc

--- a/performance/src/resolution/stat_plot_tool.hpp
+++ b/performance/src/resolution/stat_plot_tool.hpp
@@ -1,0 +1,60 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Library include(s).
+#include "../utils/helpers.hpp"
+#include "traccc/resolution/stat_plot_tool_config.hpp"
+
+// Project include(s).
+#include "traccc/edm/track_state.hpp"
+
+namespace traccc {
+
+class stat_plot_tool {
+
+    public:
+    /// @brief Nested Cache struct
+    struct stat_plot_cache {
+#ifdef TRACCC_HAVE_ROOT
+        // Histogram for the number of DoFs
+        std::unique_ptr<TH1> ndf_hist;
+        // Histogram for the chi sqaure
+        std::unique_ptr<TH1> chi2_hist;
+        // Histogram for the pvalue
+        std::unique_ptr<TH1> pval_hist;
+#endif  // TRACCC_HAVE_ROOT
+    };
+
+    /// Constructor
+    ///
+    /// @param cfg Configuration struct
+    stat_plot_tool(const stat_plot_tool_config& cfg);
+
+    /// @brief book the statistics plots
+    ///
+    /// @param cache the cache for statistics plots
+    void book(stat_plot_cache& cache) const;
+
+    /// @brief fill the cache
+    ///
+    /// @param cache the cache for statistics plots
+    /// @param fit_info fitting information that contains statistics
+    void fill(stat_plot_cache& cache,
+              const fitter_info<transform3>& fit_info) const;
+
+    /// @brief write the statistics plots into ROOT
+    ///
+    /// @param cache the cache for statistics plots
+    void write(const stat_plot_cache& cache) const;
+
+    private:
+    stat_plot_tool_config m_cfg;  ///< The Config class
+};
+
+}  // namespace traccc

--- a/performance/src/resolution/stat_plot_tool.hpp
+++ b/performance/src/resolution/stat_plot_tool.hpp
@@ -26,6 +26,8 @@ class stat_plot_tool {
         std::unique_ptr<TH1> ndf_hist;
         // Histogram for the chi sqaure
         std::unique_ptr<TH1> chi2_hist;
+        // Histogram for the chi2/ndf
+        std::unique_ptr<TH1> reduced_chi2_hist;
         // Histogram for the pvalue
         std::unique_ptr<TH1> pval_hist;
 #endif  // TRACCC_HAVE_ROOT

--- a/tests/cpu/test_kalman_fitter.cpp
+++ b/tests/cpu/test_kalman_fitter.cpp
@@ -117,8 +117,11 @@ TEST_P(KalmanFittingTests, Run) {
 
             const auto& track_states_per_track = track_states[i_trk].items;
             ASSERT_EQ(track_states_per_track.size(), plane_positions.size());
+            const auto& fit_info = track_states[i_trk].header;
+            ASSERT_FLOAT_EQ(fit_info.ndf, 2 * plane_positions.size() - 5.f);
 
-            fit_performance_writer.write(track_states_per_track, det, evt_map);
+            fit_performance_writer.write(track_states_per_track, fit_info, det,
+                                         evt_map);
         }
     }
 

--- a/tests/cuda/test_kalman_filter.cpp
+++ b/tests/cuda/test_kalman_filter.cpp
@@ -156,8 +156,10 @@ TEST_P(KalmanFittingTests, Run) {
 
         for (std::size_t i_trk = 0; i_trk < n_tracks; i_trk++) {
             auto& device_states = track_states_cuda[i_trk].items;
-
-            fit_performance_writer.write(device_states, host_det, evt_map);
+            const auto& fit_info = track_states_cuda[i_trk].header;
+            ASSERT_FLOAT_EQ(fit_info.ndf, 2 * plane_positions.size() - 5.f);
+            fit_performance_writer.write(device_states, fit_info, host_det,
+                                         evt_map);
         }
     }
 

--- a/tests/sycl/test_kalman_filter.sycl
+++ b/tests/sycl/test_kalman_filter.sycl
@@ -177,8 +177,10 @@ TEST_P(KalmanFittingTests, Run) {
 
         for (std::size_t i_trk = 0; i_trk < n_tracks; i_trk++) {
             auto& device_states = track_states_sycl[i_trk].items;
-
-            fit_performance_writer.write(device_states, host_det, evt_map);
+            const auto& fit_info = track_states_sycl[i_trk].header;
+            ASSERT_FLOAT_EQ(fit_info.ndf, 2 * plane_positions.size() - 5.f);
+            fit_performance_writer.write(device_states, fit_info, host_det,
+                                         evt_map);
         }
     }
 


### PR DESCRIPTION
This PR records the Ndf and Chi2 of fitted track into the header of `track_state_container`

Ndf is the summation of the measurement dimension subtracted by 5 and (global) Chi2 is the summation of (local) chi2 of each measurement. The KF unit test is also enhanced by checking the (Ndf == 2 * number of planes - 5)


Here is how the plots look like...

<img src="https://github.com/acts-project/traccc/assets/63090140/bc1ab921-a76f-4598-b8df-fa217ae92ab6"  width="300" >

<img src="https://github.com/acts-project/traccc/assets/63090140/9300f08b-c874-47c8-a0ad-3005bace6b75"  width="300">

<img src="https://github.com/acts-project/traccc/assets/63090140/9209cdb5-6d81-427e-8460-b3947898a5cc"  width="300" >


There is an issue that the pvalue distribution is not uniform but I think I know how to fix it. I will handle the issue in the next PRs
