### PR TITLE
KF unit test with in-situ simulation

### DIFF
--- a/core/include/traccc/utils/unit_vectors.hpp
+++ b/core/include/traccc/utils/unit_vectors.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -33,6 +33,14 @@ TRACCC_HOST_DEVICE inline scalar eta(const vector3& v) {
 
 TRACCC_HOST_DEVICE inline scalar theta(const vector3& v) {
     return std::atan2(std::sqrt(v[0] * v[0] + v[1] * v[1]), v[2]);
+}
+
+template <typename range_t>
+TRACCC_HOST_DEVICE inline range_t eta_to_theta_range(const range_t& eta_range) {
+    // @NOTE: eta_range[0] is converted to theta_range[1] and eta_range[1]
+    // to theta_range[0] because theta(minEta) > theta(maxEta)
+    return {2 * std::atan(std::exp(-eta_range[1])),
+            2 * std::atan(std::exp(-eta_range[0]))};
 }
 
 }  // namespace traccc

--- a/device/cuda/src/fitting/fitting_algorithm.cu
+++ b/device/cuda/src/fitting/fitting_algorithm.cu
@@ -97,7 +97,7 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
 // Explicit template instantiation
 using device_detector_type =
     detray::detector<detray::detector_registry::template telescope_detector<
-                         detray::unbounded<detray::rectangle2D<>>>,
+                         detray::rectangle2D<>>,
                      covfie::field_view, detray::device_container_types>;
 using rk_stepper_type = detray::rk_stepper<
     covfie::field<device_detector_type::bfield_backend_type>::view_t,

--- a/device/sycl/src/fitting/fitting_algorithm.sycl
+++ b/device/sycl/src/fitting/fitting_algorithm.sycl
@@ -98,7 +98,7 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
 // Explicit template instantiation
 using device_detector_type =
     detray::detector<detray::detector_registry::template telescope_detector<
-                         detray::unbounded<detray::rectangle2D<>>>,
+                         detray::rectangle2D<>>,
                      covfie::field_view, detray::device_container_types>;
 using rk_stepper_type = detray::rk_stepper<
     covfie::field<device_detector_type::bfield_backend_type>::view_t,

--- a/examples/options/include/traccc/options/particle_gen_options.hpp
+++ b/examples/options/include/traccc/options/particle_gen_options.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/options/options.hpp"
+#include "traccc/utils/unit_vectors.hpp"
 
 // Detray include(s).
 #include "detray/definitions/units.hpp"
@@ -67,11 +68,7 @@ struct particle_gen_options {
         const auto phi_range_degree =
             vm["gen-phi-degree"].as<Reals<scalar_t, 2>>();
         const auto eta_range = vm["gen-eta"].as<Reals<scalar_t, 2>>();
-        // @TODO: remove the conversion here...
-        // @NOTE: I put eta_range[0] into theta_range[1] and eta_range[1] into
-        // theta_range[0] on purpose because theta(minEta) > theta(maxEta)
-        theta_range = {2 * std::atan(std::exp(-eta_range[1])),
-                       2 * std::atan(std::exp(-eta_range[0]))};
+        theta_range = eta_to_theta_range(eta_range);
         phi_range = {phi_range_degree[0] * detray::unit<scalar_t>::degree,
                      phi_range_degree[1] * detray::unit<scalar_t>::degree};
     }

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.30.0.tar.gz;URL_MD5;b70821a32f96e429e6407cca0f8d9aad"
+   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.31.0.tar.gz;URL_MD5;477273df340f668197cf6fea9d9a9246"
    CACHE STRING "Source for Detray, when built as part of this project" )
 
 mark_as_advanced( TRACCC_DETRAY_SOURCE )

--- a/tests/common/tests/kalman_fitting_test.hpp
+++ b/tests/common/tests/kalman_fitting_test.hpp
@@ -12,12 +12,12 @@
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 
 // detray include(s).
-#include <detray/core/detector.hpp>
-#include <detray/detectors/detector_metadata.hpp>
-#include <detray/propagator/navigator.hpp>
-#include <detray/propagator/rk_stepper.hpp>
-
-#include "detray/masks/unbounded.hpp"
+#include "detray/core/detector.hpp"
+#include "detray/detectors/detector_metadata.hpp"
+#include "detray/masks/masks.hpp"
+#include "detray/propagator/navigator.hpp"
+#include "detray/propagator/rk_stepper.hpp"
+#include "detray/simulation/event_generator/track_generators.hpp"
 
 // GTest include(s).
 #include <gtest/gtest.h>
@@ -31,20 +31,27 @@ namespace traccc {
 
 /// Kalman Fitting Test with Telescope Geometry
 ///
-/// Parameter for data directory
+/// Test parameters:
+/// (1) name
+/// (2) momentum range
+/// (3) eta range
+/// (4) phi range
+/// (5) number of tracks per event
+/// (6) number of events
 class KalmanFittingTests
-    : public ::testing::TestWithParam<
-          std::tuple<std::string, unsigned int, unsigned int>> {
+    : public ::testing::TestWithParam<std::tuple<
+          std::string, std::array<scalar, 2u>, std::array<scalar, 2u>,
+          std::array<scalar, 2u>, unsigned int, unsigned int>> {
 
     public:
     /// Type declarations
     using host_detector_type =
         detray::detector<detray::detector_registry::template telescope_detector<
-                             detray::unbounded<detray::rectangle2D<>>>,
+                             detray::rectangle2D<>>,
                          covfie::field, detray::host_container_types>;
     using device_detector_type =
         detray::detector<detray::detector_registry::template telescope_detector<
-                             detray::unbounded<detray::rectangle2D<>>>,
+                             detray::rectangle2D<>>,
                          covfie::field_view, detray::device_container_types>;
 
     using b_field_t = typename host_detector_type::bfield_type;
@@ -57,17 +64,37 @@ class KalmanFittingTests
     using device_fitter_type =
         kalman_fitter<rk_stepper_type, device_navigator_type>;
 
+    // Use deterministic random number generator for testing
+    using uniform_gen_t =
+        detray::random_numbers<scalar, std::uniform_real_distribution<scalar>,
+                               std::seed_seq>;
+
+    // Origin of particles
+    static const inline point3 origin{0.f, 0.f, 0.f};
+    static const inline point3 origin_stddev{0.f, 0.f, 0.f};
+
     /// Plane alignment direction (aligned to x-axis)
     static const inline detray::detail::ray<transform3> traj{
         {0, 0, 0}, 0, {1, 0, 0}, -1};
+
     /// Position of planes (in mm unit)
     static const inline std::vector<scalar> plane_positions = {
         20., 40., 60., 80., 100., 120., 140, 160, 180.};
+
     /// B field value and its type
     static constexpr vector3 B{2 * detray::unit<scalar>::T, 0, 0};
+
     /// Plane material and thickness
     static const inline detray::silicon_tml<scalar> mat = {};
     static constexpr scalar thickness = 0.5 * detray::unit<scalar>::mm;
+
+    // Rectangle mask for the telescope geometry
+    static constexpr detray::mask<detray::rectangle2D<>> rectangle{0u, 100000.f,
+                                                                   100000.f};
+
+    /// Measurement smearing parameters
+    static constexpr std::array<scalar, 2u> smearing{
+        50 * detray::unit<scalar>::um, 50 * detray::unit<scalar>::um};
 
     /// Standard deviations for seed track parameters
     static constexpr std::array<scalar, e_bound_size> stddevs = {

--- a/tests/cpu/test_kalman_fitter.cpp
+++ b/tests/cpu/test_kalman_fitter.cpp
@@ -9,7 +9,9 @@
 #include "tests/seed_generator.hpp"
 #include "traccc/edm/track_state.hpp"
 #include "traccc/fitting/fitting_algorithm.hpp"
+#include "traccc/io/utils.hpp"
 #include "traccc/resolution/fitting_performance_writer.hpp"
+#include "traccc/utils/unit_vectors.hpp"
 
 // Test include(s).
 #include "tests/kalman_fitting_test.hpp"
@@ -17,6 +19,7 @@
 // detray include(s).
 #include "detray/detectors/create_telescope_detector.hpp"
 #include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/simulation/simulator.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -25,43 +28,60 @@
 #include <gtest/gtest.h>
 
 // System include(s).
-#include <climits>
+#include <filesystem>
+#include <string>
 
 using namespace traccc;
 
-// This defines the local frame test suite
 TEST_P(KalmanFittingTests, Run) {
 
-    const std::string dir = std::get<0>(GetParam());
-    const unsigned int n_truth_tracks = std::get<1>(GetParam());
-    const unsigned int n_events = std::get<2>(GetParam());
-
-    // Input path
-    const std::string full_path =
-        "detray_simulation/telescope/kf_validation/" + dir + "/";
+    // Get the parameters
+    const std::string name = std::get<0>(GetParam());
+    const std::array<scalar, 2u> mom_range = std::get<1>(GetParam());
+    const std::array<scalar, 2u> eta_range = std::get<2>(GetParam());
+    const std::array<scalar, 2u> theta_range = eta_to_theta_range(eta_range);
+    const std::array<scalar, 2u> phi_range = std::get<3>(GetParam());
+    const unsigned int n_truth_tracks = std::get<4>(GetParam());
+    const unsigned int n_events = std::get<5>(GetParam());
 
     // Performance writer
     traccc::fitting_performance_writer::config writer_cfg;
-    writer_cfg.file_path = "performance_track_fitting_" + dir + ".root";
-
+    writer_cfg.file_path = "performance_track_fitting_" + name + ".root";
     traccc::fitting_performance_writer fit_performance_writer(writer_cfg);
 
     /*****************************
      * Build a telescope geometry
      *****************************/
 
-    // Memory resource
+    // Memory resources used by the application.
     vecmem::host_memory_resource host_mr;
-
-    // Use rectangle surfaces
-    detray::mask<detray::unbounded<detray::rectangle2D<>>> rectangle{
-        0u, 10000.f * detray::unit<scalar>::mm,
-        10000.f * detray::unit<scalar>::mm};
 
     const host_detector_type det = create_telescope_detector(
         host_mr,
         b_field_t(b_field_t::backend_t::configuration_t{B[0], B[1], B[2]}),
         rectangle, plane_positions, mat, thickness, traj);
+
+    /***************************
+     * Generate simulation data
+     ***************************/
+
+    auto generator =
+        detray::random_track_generator<traccc::free_track_parameters,
+                                       uniform_gen_t>(n_truth_tracks, origin,
+                                                      origin_stddev, mom_range,
+                                                      theta_range, phi_range);
+
+    // Smearing value for measurements
+    detray::measurement_smearer<transform3> meas_smearer(smearing[0],
+                                                         smearing[1]);
+
+    // Run simulator
+    const std::string path = name + "/";
+    const std::string full_path = io::data_directory() + path;
+    std::filesystem::create_directories(full_path);
+    auto sim = detray::simulator(n_events, det, std::move(generator),
+                                 meas_smearer, full_path);
+    sim.run();
 
     /***************
      * Run fitting
@@ -76,7 +96,7 @@ TEST_P(KalmanFittingTests, Run) {
     // Iterate over events
     for (std::size_t i_evt = 0; i_evt < n_events; i_evt++) {
         // Event map
-        traccc::event_map2 evt_map(i_evt, full_path, full_path, full_path);
+        traccc::event_map2 evt_map(i_evt, path, path, path);
 
         // Truth Track Candidates
         traccc::track_candidate_container_types::host track_candidates =
@@ -111,24 +131,26 @@ TEST_P(KalmanFittingTests, Run) {
     static const std::vector<std::string> pull_names{
         "pull_d0", "pull_z0", "pull_phi", "pull_theta", "pull_qop"};
     pull_value_tests(writer_cfg.file_path, pull_names);
+
+    // Remove the data
+    std::filesystem::remove_all(full_path);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation, KalmanFittingTests,
-    ::testing::Values(std::make_tuple("1_GeV_0_phi", 100, 100),
-                      std::make_tuple("10_GeV_0_phi", 100, 100),
-                      std::make_tuple("100_GeV_0_phi", 100, 100)));
+INSTANTIATE_TEST_SUITE_P(KalmanFitValidation0, KalmanFittingTests,
+                         ::testing::Values(std::make_tuple(
+                             "1_GeV_0_phi", std::array<scalar, 2u>{1.f, 1.f},
+                             std::array<scalar, 2u>{0.f, 0.f},
+                             std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));
 
-/*
-INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation, KalmanFittingTests,
-    ::testing::Values(std::make_tuple("1_GeV_0_phi", 100, 100),
-                      std::make_tuple("1_GeV_30_phi", 100, 100),
-                      std::make_tuple("1_GeV_60_phi", 100, 100),
-                      std::make_tuple("10_GeV_0_phi", 100, 100),
-                      std::make_tuple("10_GeV_30_phi", 100, 100),
-                      std::make_tuple("10_GeV_60_phi", 100, 100),
-                      std::make_tuple("100_GeV_0_phi", 100, 100),
-                      std::make_tuple("100_GeV_30_phi", 100, 100),
-                      std::make_tuple("100_GeV_60_phi", 100, 100)));
-*/
+INSTANTIATE_TEST_SUITE_P(KalmanFitValidation1, KalmanFittingTests,
+                         ::testing::Values(std::make_tuple(
+                             "10_GeV_0_phi", std::array<scalar, 2u>{10.f, 10.f},
+                             std::array<scalar, 2u>{0.f, 0.f},
+                             std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));
+
+INSTANTIATE_TEST_SUITE_P(KalmanFitValidation2, KalmanFittingTests,
+                         ::testing::Values(std::make_tuple(
+                             "100_GeV_0_phi",
+                             std::array<scalar, 2u>{100.f, 100.f},
+                             std::array<scalar, 2u>{0.f, 0.f},
+                             std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));

--- a/tests/cuda/test_kalman_filter.cpp
+++ b/tests/cuda/test_kalman_filter.cpp
@@ -12,6 +12,7 @@
 #include "traccc/device/container_h2d_copy_alg.hpp"
 #include "traccc/edm/track_state.hpp"
 #include "traccc/fitting/fitting_algorithm.hpp"
+#include "traccc/io/utils.hpp"
 #include "traccc/performance/details/is_same_object.hpp"
 #include "traccc/resolution/fitting_performance_writer.hpp"
 #include "traccc/utils/memory_resource.hpp"
@@ -35,26 +36,26 @@
 #include <gtest/gtest.h>
 
 // System include(s).
-#include <climits>
-#include <iostream>
+#include <filesystem>
+#include <string>
 
 using namespace traccc;
 
 // This defines the local frame test suite
 TEST_P(KalmanFittingTests, Run) {
 
-    const std::string dir = std::get<0>(GetParam());
-    const unsigned int n_truth_tracks = std::get<1>(GetParam());
-    const unsigned int n_events = std::get<2>(GetParam());
-
-    // Input path
-    const std::string full_path =
-        "detray_simulation/telescope/kf_validation/" + dir + "/";
+    // Get the parameters
+    const std::string name = std::get<0>(GetParam());
+    const std::array<scalar, 2u> mom_range = std::get<1>(GetParam());
+    const std::array<scalar, 2u> eta_range = std::get<2>(GetParam());
+    const std::array<scalar, 2u> theta_range = eta_to_theta_range(eta_range);
+    const std::array<scalar, 2u> phi_range = std::get<3>(GetParam());
+    const unsigned int n_truth_tracks = std::get<4>(GetParam());
+    const unsigned int n_events = std::get<5>(GetParam());
 
     // Performance writer
     traccc::fitting_performance_writer::config writer_cfg;
-    writer_cfg.file_path = "performance_track_fitting_" + dir + ".root";
-
+    writer_cfg.file_path = "performance_track_fitting_" + name + ".root";
     traccc::fitting_performance_writer fit_performance_writer(writer_cfg);
 
     /*****************************
@@ -67,15 +68,32 @@ TEST_P(KalmanFittingTests, Run) {
     traccc::memory_resource mr{device_mr, &host_mr};
     vecmem::cuda::managed_memory_resource mng_mr;
 
-    // Use rectangle surfaces
-    detray::mask<detray::unbounded<detray::rectangle2D<>>> rectangle{
-        0u, 10000.f * detray::unit<scalar>::mm,
-        10000.f * detray::unit<scalar>::mm};
-
     host_detector_type host_det = create_telescope_detector(
         mng_mr,
         b_field_t(b_field_t::backend_t::configuration_t{B[0], B[1], B[2]}),
         rectangle, plane_positions, mat, thickness, traj);
+
+    /***************************
+     * Generate simulation data
+     ***************************/
+
+    auto generator =
+        detray::random_track_generator<traccc::free_track_parameters,
+                                       uniform_gen_t>(n_truth_tracks, origin,
+                                                      origin_stddev, mom_range,
+                                                      theta_range, phi_range);
+
+    // Smearing value for measurements
+    detray::measurement_smearer<transform3> meas_smearer(smearing[0],
+                                                         smearing[1]);
+
+    // Run simulator
+    const std::string path = name + "/";
+    const std::string full_path = io::data_directory() + path;
+    std::filesystem::create_directories(full_path);
+    auto sim = detray::simulator(n_events, host_det, std::move(generator),
+                                 meas_smearer, full_path);
+    sim.run();
 
     /***************
      * Run fitting
@@ -99,7 +117,7 @@ TEST_P(KalmanFittingTests, Run) {
     // Iterate over events
     for (std::size_t i_evt = 0; i_evt < n_events; i_evt++) {
         // Event map
-        traccc::event_map2 evt_map(i_evt, full_path, full_path, full_path);
+        traccc::event_map2 evt_map(i_evt, path, path, path);
 
         // Truth Track Candidates
         traccc::track_candidate_container_types::host track_candidates =
@@ -151,24 +169,26 @@ TEST_P(KalmanFittingTests, Run) {
     static const std::vector<std::string> pull_names{
         "pull_d0", "pull_z0", "pull_phi", "pull_theta", "pull_qop"};
     pull_value_tests(writer_cfg.file_path, pull_names);
+
+    // Remove the data
+    std::filesystem::remove_all(full_path);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation, KalmanFittingTests,
-    ::testing::Values(std::make_tuple("1_GeV_0_phi", 100, 100),
-                      std::make_tuple("10_GeV_0_phi", 100, 100),
-                      std::make_tuple("100_GeV_0_phi", 100, 100)));
+INSTANTIATE_TEST_SUITE_P(KalmanFitValidation0, KalmanFittingTests,
+                         ::testing::Values(std::make_tuple(
+                             "1_GeV_0_phi", std::array<scalar, 2u>{1.f, 1.f},
+                             std::array<scalar, 2u>{0.f, 0.f},
+                             std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));
 
-/*
-INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation, KalmanFittingTests,
-    ::testing::Values(std::make_tuple("1_GeV_0_phi", 100, 100),
-                      std::make_tuple("1_GeV_30_phi", 100, 100),
-                      std::make_tuple("1_GeV_60_phi", 100, 100),
-                      std::make_tuple("10_GeV_0_phi", 100, 100),
-                      std::make_tuple("10_GeV_30_phi", 100, 100),
-                      std::make_tuple("10_GeV_60_phi", 100, 100),
-                      std::make_tuple("100_GeV_0_phi", 100, 100),
-                      std::make_tuple("100_GeV_30_phi", 100, 100),
-                      std::make_tuple("100_GeV_60_phi", 100, 100)));
-*/
+INSTANTIATE_TEST_SUITE_P(KalmanFitValidation1, KalmanFittingTests,
+                         ::testing::Values(std::make_tuple(
+                             "10_GeV_0_phi", std::array<scalar, 2u>{10.f, 10.f},
+                             std::array<scalar, 2u>{0.f, 0.f},
+                             std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));
+
+INSTANTIATE_TEST_SUITE_P(KalmanFitValidation2, KalmanFittingTests,
+                         ::testing::Values(std::make_tuple(
+                             "100_GeV_0_phi",
+                             std::array<scalar, 2u>{100.f, 100.f},
+                             std::array<scalar, 2u>{0.f, 0.f},
+                             std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));

--- a/tests/sycl/test_kalman_filter.sycl
+++ b/tests/sycl/test_kalman_filter.sycl
@@ -14,6 +14,7 @@
 #include "traccc/device/container_h2d_copy_alg.hpp"
 #include "traccc/edm/track_state.hpp"
 #include "traccc/fitting/fitting_algorithm.hpp"
+#include "traccc/io/utils.hpp"
 #include "traccc/performance/details/is_same_object.hpp"
 #include "traccc/resolution/fitting_performance_writer.hpp"
 #include "traccc/sycl/fitting/fitting_algorithm.hpp"
@@ -38,9 +39,9 @@
 #include <gtest/gtest.h>
 
 // System include(s).
-#include <climits>
 #include <exception>
-#include <iostream>
+#include <filesystem>
+#include <string>
 
 using namespace traccc;
 
@@ -59,18 +60,18 @@ auto handle_async_error = [](::sycl::exception_list elist) {
 // This defines the local frame test suite
 TEST_P(KalmanFittingTests, Run) {
 
-    const std::string dir = std::get<0>(GetParam());
-    const unsigned int n_truth_tracks = std::get<1>(GetParam());
-    const unsigned int n_events = std::get<2>(GetParam());
-
-    // Input path
-    const std::string full_path =
-        "detray_simulation/telescope/kf_validation/" + dir + "/";
+    // Get the parameters
+    const std::string name = std::get<0>(GetParam());
+    const std::array<scalar, 2u> mom_range = std::get<1>(GetParam());
+    const std::array<scalar, 2u> eta_range = std::get<2>(GetParam());
+    const std::array<scalar, 2u> theta_range = eta_to_theta_range(eta_range);
+    const std::array<scalar, 2u> phi_range = std::get<3>(GetParam());
+    const unsigned int n_truth_tracks = std::get<4>(GetParam());
+    const unsigned int n_events = std::get<5>(GetParam());
 
     // Performance writer
     traccc::fitting_performance_writer::config writer_cfg;
-    writer_cfg.file_path = "performance_track_fitting_" + dir + ".root";
-
+    writer_cfg.file_path = "performance_track_fitting_" + name + ".root";
     traccc::fitting_performance_writer fit_performance_writer(writer_cfg);
 
     /*****************************
@@ -88,15 +89,32 @@ TEST_P(KalmanFittingTests, Run) {
     traccc::memory_resource mr{device_mr, &host_mr};
     vecmem::sycl::shared_memory_resource shared_mr;
 
-    // Use rectangle surfaces
-    detray::mask<detray::unbounded<detray::rectangle2D<>>> rectangle{
-        0u, 10000.f * detray::unit<scalar>::mm,
-        10000.f * detray::unit<scalar>::mm};
-
     host_detector_type host_det = create_telescope_detector(
         shared_mr,
         b_field_t(b_field_t::backend_t::configuration_t{B[0], B[1], B[2]}),
         rectangle, plane_positions, mat, thickness, traj);
+
+    /***************************
+     * Generate simulation data
+     ***************************/
+
+    auto generator =
+        detray::random_track_generator<traccc::free_track_parameters,
+                                       uniform_gen_t>(n_truth_tracks, origin,
+                                                      origin_stddev, mom_range,
+                                                      theta_range, phi_range);
+
+    // Smearing value for measurements
+    detray::measurement_smearer<transform3> meas_smearer(smearing[0],
+                                                         smearing[1]);
+
+    // Run simulator
+    const std::string path = name + "/";
+    const std::string full_path = io::data_directory() + path;
+    std::filesystem::create_directories(full_path);
+    auto sim = detray::simulator(n_events, host_det, std::move(generator),
+                                 meas_smearer, full_path);
+    sim.run();
 
     /***************
      * Run fitting
@@ -120,7 +138,7 @@ TEST_P(KalmanFittingTests, Run) {
     // Iterate over events
     for (std::size_t i_evt = 0; i_evt < n_events; i_evt++) {
         // Event map
-        traccc::event_map2 evt_map(i_evt, full_path, full_path, full_path);
+        traccc::event_map2 evt_map(i_evt, path, path, path);
 
         // Truth Track Candidates
         traccc::track_candidate_container_types::host track_candidates =
@@ -172,24 +190,26 @@ TEST_P(KalmanFittingTests, Run) {
     static const std::vector<std::string> pull_names{
         "pull_d0", "pull_z0", "pull_phi", "pull_theta", "pull_qop"};
     pull_value_tests(writer_cfg.file_path, pull_names);
+
+    // Remove the data
+    std::filesystem::remove_all(full_path);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation, KalmanFittingTests,
-    ::testing::Values(std::make_tuple("1_GeV_0_phi", 100, 100),
-                      std::make_tuple("10_GeV_0_phi", 100, 100),
-                      std::make_tuple("100_GeV_0_phi", 100, 100)));
+INSTANTIATE_TEST_SUITE_P(KalmanFitValidation0, KalmanFittingTests,
+                         ::testing::Values(std::make_tuple(
+                             "1_GeV_0_phi", std::array<scalar, 2u>{1.f, 1.f},
+                             std::array<scalar, 2u>{0.f, 0.f},
+                             std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));
 
-/*
-INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation, KalmanFittingTests,
-    ::testing::Values(std::make_tuple("1_GeV_0_phi", 100, 100),
-                      std::make_tuple("1_GeV_30_phi", 100, 100),
-                      std::make_tuple("1_GeV_60_phi", 100, 100),
-                      std::make_tuple("10_GeV_0_phi", 100, 100),
-                      std::make_tuple("10_GeV_30_phi", 100, 100),
-                      std::make_tuple("10_GeV_60_phi", 100, 100),
-                      std::make_tuple("100_GeV_0_phi", 100, 100),
-                      std::make_tuple("100_GeV_30_phi", 100, 100),
-                      std::make_tuple("100_GeV_60_phi", 100, 100)));
-*/
+INSTANTIATE_TEST_SUITE_P(KalmanFitValidation1, KalmanFittingTests,
+                         ::testing::Values(std::make_tuple(
+                             "10_GeV_0_phi", std::array<scalar, 2u>{10.f, 10.f},
+                             std::array<scalar, 2u>{0.f, 0.f},
+                             std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));
+
+INSTANTIATE_TEST_SUITE_P(KalmanFitValidation2, KalmanFittingTests,
+                         ::testing::Values(std::make_tuple(
+                             "100_GeV_0_phi",
+                             std::array<scalar, 2u>{100.f, 100.f},
+                             std::array<scalar, 2u>{0.f, 0.f},
+                             std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));


### PR DESCRIPTION
This PR makes the KF unit test run the simulation before reconstruction instead of utilizing pre-generated simulation data.
The motivation is obvious - it has been very painful to update the traccc-data whenever there is a change in the detray simulation.