### PR TITLE
Add B field as an input for track parameter estimation

### DIFF
--- a/core/include/traccc/seeding/track_params_estimation.hpp
+++ b/core/include/traccc/seeding/track_params_estimation.hpp
@@ -28,7 +28,7 @@ namespace traccc {
 class track_params_estimation
     : public algorithm<bound_track_parameters_collection_types::host(
           const spacepoint_collection_types::host&,
-          const seed_collection_types::host&)> {
+          const seed_collection_types::host&, const vector3&)> {
 
     public:
     /// Constructor for track_params_estimation
@@ -42,9 +42,9 @@ class track_params_estimation
     /// @param seeds The reconstructed track seeds of the event
     /// @return A vector of bound track parameters
     ///
-    output_type operator()(
-        const spacepoint_collection_types::host& spacepoints,
-        const seed_collection_types::host& seeds) const override;
+    output_type operator()(const spacepoint_collection_types::host& spacepoints,
+                           const seed_collection_types::host& seeds,
+                           const vector3& bfield) const override;
 
     private:
     /// The memory resource to use in the algorithm

--- a/core/include/traccc/seeding/track_params_estimation_helper.hpp
+++ b/core/include/traccc/seeding/track_params_estimation_helper.hpp
@@ -86,9 +86,10 @@ inline TRACCC_HOST_DEVICE bound_vector seed_to_bound_vector(
     // The projection of the top space point on the transverse plane of
     // the new frame
     scalar rn = local2[0] * local2[0] + local2[1] * local2[1];
-    // The (1/tanTheta) of momentum in the new frame,
+    // The (1/tanTheta) of momentum in the new frame
+    static constexpr scalar G = static_cast<scalar>(1.f / 24.f);
     scalar invTanTheta =
-        local2[2] * std::sqrt(1.f / rn) / (1.f + rho * rho * rn);
+        local2[2] * std::sqrt(1.f / rn) / (1.f + G * rho * rho * rn);
 
     // The momentum direction in the new frame (the center of the circle
     // has the coordinate (-1.*A/(2*B), 1./(2*B)))

--- a/core/src/seeding/track_params_estimation.cpp
+++ b/core/src/seeding/track_params_estimation.cpp
@@ -17,14 +17,10 @@ track_params_estimation::track_params_estimation(vecmem::memory_resource& mr)
 
 track_params_estimation::output_type track_params_estimation::operator()(
     const spacepoint_collection_types::host& spacepoints,
-    const seed_collection_types::host& seeds) const {
+    const seed_collection_types::host& seeds, const vector3& bfield) const {
 
     const unsigned int num_seeds = seeds.size();
     output_type result(num_seeds, &m_mr.get());
-
-    // convenient assumption on bfield and mass
-    // TODO: Make use of bfield extenstion in the future
-    vector3 bfield = {0, 0, 2};
 
     for (unsigned int i = 0; i < num_seeds; ++i) {
         bound_track_parameters track_params;

--- a/device/common/include/traccc/seeding/device/estimate_track_params.hpp
+++ b/device/common/include/traccc/seeding/device/estimate_track_params.hpp
@@ -25,7 +25,7 @@ TRACCC_HOST_DEVICE
 inline void estimate_track_params(
     const std::size_t globalIndex,
     const spacepoint_collection_types::const_view& spacepoints_view,
-    const seed_collection_types::const_view& seeds_view,
+    const seed_collection_types::const_view& seeds_view, const vector3& bfield,
     bound_track_parameters_collection_types::view params_view);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/impl/estimate_track_params.ipp
+++ b/device/common/include/traccc/seeding/device/impl/estimate_track_params.ipp
@@ -17,7 +17,7 @@ TRACCC_HOST_DEVICE
 inline void estimate_track_params(
     const std::size_t globalIndex,
     const spacepoint_collection_types::const_view& spacepoints_view,
-    const seed_collection_types::const_view& seeds_view,
+    const seed_collection_types::const_view& seeds_view, const vector3& bfield,
     bound_track_parameters_collection_types::view params_view) {
 
     // Check if anything needs to be done.
@@ -30,9 +30,6 @@ inline void estimate_track_params(
         spacepoints_view);
 
     bound_track_parameters_collection_types::device params_device(params_view);
-
-    // convenient assumption on bfield and mass
-    vector3 bfield = {0, 0, 2};
 
     const seed& this_seed = seeds_device.at(globalIndex);
 

--- a/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/track_params_estimation.hpp
@@ -29,7 +29,7 @@ namespace cuda {
 struct track_params_estimation
     : public algorithm<bound_track_parameters_collection_types::buffer(
           const spacepoint_collection_types::const_view&,
-          const seed_collection_types::const_view&)> {
+          const seed_collection_types::const_view&, const vector3&)> {
 
     public:
     /// Constructor for track_params_estimation
@@ -49,7 +49,8 @@ struct track_params_estimation
     ///
     output_type operator()(
         const spacepoint_collection_types::const_view& spacepoints_view,
-        const seed_collection_types::const_view& seeds_view) const override;
+        const seed_collection_types::const_view& seeds_view,
+        const vector3& bfield) const override;
 
     private:
     /// Memory resource used by the algorithm

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -23,11 +23,12 @@ namespace kernels {
 /// CUDA kernel for running @c traccc::device::estimate_track_params
 __global__ void estimate_track_params(
     spacepoint_collection_types::const_view spacepoints_view,
-    seed_collection_types::const_view seed_view,
+    seed_collection_types::const_view seed_view, const vector3 bfield,
     bound_track_parameters_collection_types::view params_view) {
 
     device::estimate_track_params(threadIdx.x + blockIdx.x * blockDim.x,
-                                  spacepoints_view, seed_view, params_view);
+                                  spacepoints_view, seed_view, bfield,
+                                  params_view);
 }
 }  // namespace kernels
 
@@ -37,7 +38,8 @@ track_params_estimation::track_params_estimation(
 
 track_params_estimation::output_type track_params_estimation::operator()(
     const spacepoint_collection_types::const_view& spacepoints_view,
-    const seed_collection_types::const_view& seeds_view) const {
+    const seed_collection_types::const_view& seeds_view,
+    const vector3& bfield) const {
 
     // Get a convenience variable for the stream that we'll be using.
     cudaStream_t stream = details::get_stream(m_stream);
@@ -66,7 +68,7 @@ track_params_estimation::output_type track_params_estimation::operator()(
 
     // run the kernel
     kernels::estimate_track_params<<<num_blocks, num_threads, 0, stream>>>(
-        spacepoints_view, seeds_view, params_buffer);
+        spacepoints_view, seeds_view, bfield, params_buffer);
     CUDA_ERROR_CHECK(cudaGetLastError());
 
     return params_buffer;

--- a/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/track_params_estimation.hpp
@@ -30,7 +30,7 @@ namespace traccc::sycl {
 struct track_params_estimation
     : public algorithm<bound_track_parameters_collection_types::buffer(
           const spacepoint_collection_types::const_view&,
-          const seed_collection_types::const_view&)> {
+          const seed_collection_types::const_view&, const vector3&)> {
 
     public:
     /// Constructor for track_params_estimation
@@ -52,7 +52,8 @@ struct track_params_estimation
     ///
     output_type operator()(
         const spacepoint_collection_types::const_view& spacepoints_view,
-        const seed_collection_types::const_view& seeds_view) const override;
+        const seed_collection_types::const_view& seeds_view,
+        const vector3& bfield) const override;
 
     private:
     // Private member variables

--- a/device/sycl/src/seeding/track_params_estimation.sycl
+++ b/device/sycl/src/seeding/track_params_estimation.sycl
@@ -30,7 +30,8 @@ track_params_estimation::track_params_estimation(
 
 track_params_estimation::output_type track_params_estimation::operator()(
     const spacepoint_collection_types::const_view& spacepoints_view,
-    const seed_collection_types::const_view& seeds_view) const {
+    const seed_collection_types::const_view& seeds_view,
+    const vector3& bfield) const {
 
     // Get the size of the seeds view
     auto seeds_size = m_copy.get_size(seeds_view);
@@ -59,11 +60,11 @@ track_params_estimation::output_type track_params_estimation::operator()(
     details::get_queue(m_queue)
         .submit([&](::sycl::handler& h) {
             h.parallel_for<kernels::estimate_track_params>(
-                trackParamsNdRange, [spacepoints_view, seeds_view,
-                                     params_view](::sycl::nd_item<1> item) {
+                trackParamsNdRange, [spacepoints_view, seeds_view, params_view,
+                                     bfield](::sycl::nd_item<1> item) {
                     device::estimate_track_params(item.get_global_linear_id(),
                                                   spacepoints_view, seeds_view,
-                                                  params_view);
+                                                  bfield, params_view);
                 });
         })
         .wait_and_throw();

--- a/examples/run/cpu/full_chain_algorithm.cpp
+++ b/examples/run/cpu/full_chain_algorithm.cpp
@@ -29,7 +29,9 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
 
     const spacepoint_formation::output_type spacepoints =
         m_spacepoint_formation(m_clusterization(cells, modules), modules);
-    return m_track_parameter_estimation(spacepoints, m_seeding(spacepoints));
+
+    return m_track_parameter_estimation(spacepoints, m_seeding(spacepoints),
+                                        {0.f, 0.f, m_finder_config.bFieldInZ});
 }
 
 }  // namespace traccc

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -109,7 +109,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
           Track params estimation
           ----------------------------*/
 
-        auto params = tp(spacepoints_per_event, seeds);
+        auto params = tp(spacepoints_per_event, seeds,
+                         {0.f, 0.f, finder_config.bFieldInZ});
 
         /*----------------------------
           Statistics

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -104,7 +104,8 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
         m_clusterization(cells_buffer, modules_buffer);
     const track_params_estimation::output_type track_params =
         m_track_parameter_estimation(spacepoints.first,
-                                     m_seeding(spacepoints.first));
+                                     m_seeding(spacepoints.first),
+                                     {0.f, 0.f, m_finder_config.bFieldInZ});
 
     // Get the final data back to the host.
     bound_track_parameters_collection_types::host result(&m_host_mr);

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -157,7 +157,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
                 traccc::performance::timer t("Track params (cuda)",
                                              elapsedTimes);
                 params_cuda_buffer =
-                    tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer);
+                    tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer,
+                            {0.f, 0.f, finder_config.bFieldInZ});
                 stream.synchronize();
             }  // stop measuring track params cuda timer
             // CPU
@@ -165,7 +166,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
             if (run_cpu) {
                 traccc::performance::timer t("Track params  (cpu)",
                                              elapsedTimes);
-                params = tp(spacepoints_per_event, seeds);
+                params = tp(spacepoints_per_event, seeds,
+                            {0.f, 0.f, finder_config.bFieldInZ});
             }  // stop measuring track params cpu timer
 
         }  // Stop measuring wall time

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -205,7 +205,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 traccc::performance::timer t("Track params (cuda)",
                                              elapsedTimes);
                 params_cuda_buffer =
-                    tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer);
+                    tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer,
+                            {0.f, 0.f, finder_config.bFieldInZ});
                 stream.synchronize();
             }  // stop measuring track params timer
 
@@ -214,7 +215,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
             if (run_cpu) {
                 traccc::performance::timer t("Track params  (cpu)",
                                              elapsedTimes);
-                params = tp(spacepoints_per_event, seeds);
+                params = tp(spacepoints_per_event, seeds,
+                            {0.f, 0.f, finder_config.bFieldInZ});
             }  // stop measuring track params cpu timer
 
         }  // Stop measuring wall time

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -123,7 +123,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
             if (run_cpu) {
                 traccc::performance::timer t("Track params  (cpu)",
                                              elapsedTimes);
-                params = tp(std::move(spacepoints_per_event), seeds);
+                params = tp(std::move(spacepoints_per_event), seeds,
+                            {0.f, 0.f, finder_config.bFieldInZ});
             }  // stop measuring track params cpu timer
 
         }  // Stop measuring wall time

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -119,7 +119,8 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
         m_clusterization(cells_buffer, modules_buffer);
     const track_params_estimation::output_type track_params =
         m_track_parameter_estimation(spacepoints.first,
-                                     m_seeding(spacepoints.first));
+                                     m_seeding(spacepoints.first),
+                                     {0.f, 0.f, m_finder_config.bFieldInZ});
 
     // Get the final data back to the host.
     bound_track_parameters_collection_types::host result(&m_host_mr);

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -157,14 +157,16 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
                 traccc::performance::timer t("Track params (sycl)",
                                              elapsedTimes);
                 params_sycl_buffer =
-                    tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer);
+                    tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer,
+                            {0.f, 0.f, finder_config.bFieldInZ});
             }  // stop measuring track params sycl timer
 
             // CPU
             if (run_cpu) {
                 traccc::performance::timer t("Track params  (cpu)",
                                              elapsedTimes);
-                params = tp(spacepoints_per_event, seeds);
+                params = tp(spacepoints_per_event, seeds,
+                            {0.f, 0.f, finder_config.bFieldInZ});
             }  // stop measuring track params cpu timer
 
         }  // Stop measuring wall time

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -231,7 +231,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 traccc::performance::timer t("Track params (sycl)",
                                              elapsedTimes);
                 params_sycl_buffer =
-                    tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer);
+                    tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer,
+                            {0.f, 0.f, finder_config.bFieldInZ});
                 q.wait_and_throw();
             }  // stop measuring track params timer
 
@@ -240,7 +241,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
             if (run_cpu) {
                 traccc::performance::timer t("Track params  (cpu)",
                                              elapsedTimes);
-                params = tp(spacepoints_per_event, seeds);
+                params = tp(spacepoints_per_event, seeds,
+                            {0.f, 0.f, finder_config.bFieldInZ});
             }  // stop measuring track params cpu timer
 
         }  // stop measuring wall time

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -14,6 +14,7 @@ traccc_add_test(cpu
     "test_kalman_fitter.cpp"
     "test_ranges.cpp"
     "test_seeding.cpp"
+    "test_track_params_estimation.cpp"
     LINK_LIBRARIES GTest::gtest_main vecmem::core 
     traccc_tests_common traccc::core traccc::io traccc::performance
     detray::core detray::utils covfie::core )

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -70,10 +70,10 @@ inline bool operator==(const Acts::BoundVector& acts_vec,
             traccc::float_epsilon * 10 &&
         std::abs(acts_vec[Acts::eBoundTheta] -
                  traccc::getter::element(traccc_vec, traccc::e_bound_theta,
-                                         0)) < traccc::float_epsilon * 10 &&
+                                         0)) < traccc::float_epsilon * 1000 &&
         std::abs(acts_vec[Acts::eBoundPhi] -
                  traccc::getter::element(traccc_vec, traccc::e_bound_phi, 0)) <
-            traccc::float_epsilon * 10) {
+            traccc::float_epsilon * 1000) {
         return true;
     }
     return false;
@@ -125,7 +125,8 @@ TEST_P(CompareWithActsSeedingTests, Run) {
       TRACCC track params estimation
       --------------------------------*/
 
-    auto tp_output = tp(spacepoints_per_event, seeds);
+    auto tp_output =
+        tp(spacepoints_per_event, seeds, {0.f, 0.f, traccc_config.bFieldInZ});
     auto& traccc_params = tp_output;
 
     /*--------------------------------
@@ -392,7 +393,10 @@ TEST_P(CompareWithActsSeedingTests, Run) {
         // Test the full track parameters estimator
         auto fullParamsOpt = estimateTrackParamsFromSeed(
             geoCtx, spacePointPtrs.begin(), spacePointPtrs.end(),
-            *bottomSurface, Acts::Vector3(0, 0, 2), 0.1);
+            *bottomSurface,
+            Acts::Vector3(
+                0, 0, acts_config.bFieldInZ / traccc::unit<traccc::scalar>::T),
+            0.1);
 
         auto acts_vec = *fullParamsOpt;
 
@@ -428,7 +432,8 @@ TEST_P(CompareWithActsSeedingTests, Run) {
     // EXPECT_EQ(acts_params.size(), traccc_params.size())
     EXPECT_NEAR(acts_params.size(), traccc_params.size(),
                 acts_params.size() * 0.001);
-    EXPECT_TRUE(params_match_ratio > 0.999);
+    EXPECT_TRUE(params_match_ratio > 0.999)
+        << "Parameter matching ratio: " << params_match_ratio << std::endl;
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpu/test_seeding.cpp
+++ b/tests/cpu/test_seeding.cpp
@@ -6,8 +6,13 @@
  */
 
 // Project include(s).
+#include "traccc/definitions/common.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
+#include "traccc/seeding/track_params_estimation.hpp"
+
+// Detray include(s).
+#include "detray/detectors/create_toy_geometry.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -15,15 +20,21 @@
 // GTest include(s).
 #include <gtest/gtest.h>
 
-#include <iostream>
-
 using namespace traccc;
 
-// Seeding with two muons
-TEST(seeding, two_low_pT_muons) {
+namespace {
 
-    // Memory resource used by the EDM.
-    vecmem::host_memory_resource host_mr;
+// Memory resource used by the EDM.
+vecmem::host_memory_resource host_mr;
+
+// Set B field
+static constexpr vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
+                           2. * unit<scalar>::T};
+
+}  // namespace
+
+// Seeding with two muons
+TEST(seeding, case1) {
 
     // Config objects
     traccc::seedfinder_config finder_config;
@@ -35,16 +46,52 @@ TEST(seeding, two_low_pT_muons) {
     finder_config.maxPtScattering = 0.5 * unit<scalar>::GeV;
     traccc::seeding_algorithm sa(finder_config, grid_config, filter_config,
                                  host_mr);
+
     spacepoint_collection_types::host spacepoints;
 
-    // Spacepoints from 16.42 GeV muon
+    // Spacepoints from 16.62 GeV muon
     spacepoints.push_back({{36.6706, 10.6472, 104.131}, {}});
     spacepoints.push_back({{94.2191, 29.6699, 113.628}, {}});
     spacepoints.push_back({{149.805, 47.9518, 122.979}, {}});
     spacepoints.push_back({{218.514, 70.3049, 134.029}, {}});
     spacepoints.push_back({{275.359, 88.668, 143.378}, {}});
 
-    // Spacepoints from 1.8 GeV muon
+    // Run seeding
+    auto seeds = sa(spacepoints);
+
+    // The number of seeds should be eqaul to one
+    ASSERT_EQ(seeds.size(), 1u);
+
+    traccc::track_params_estimation tp(host_mr);
+
+    auto bound_params = tp(spacepoints, seeds, B);
+
+    // The number of bound track parameters should be eqaul to one
+    ASSERT_EQ(bound_params.size(), 1u);
+
+    // Make sure that we have reasonable estimation on momentum
+    /* Currently disabled
+    EXPECT_NEAR(bound_params[0].p(), 16.62 * unit<scalar>::GeV,
+                0.1 * unit<scalar>::GeV);
+    */
+}
+
+TEST(seeding, case2) {
+
+    // Config objects
+    traccc::seedfinder_config finder_config;
+    traccc::spacepoint_grid_config grid_config(finder_config);
+    traccc::seedfilter_config filter_config;
+
+    // Adjust parameters
+    finder_config.deltaRMax = 100. * unit<scalar>::mm;
+    finder_config.maxPtScattering = 0.5 * unit<scalar>::GeV;
+    traccc::seeding_algorithm sa(finder_config, grid_config, filter_config,
+                                 host_mr);
+
+    spacepoint_collection_types::host spacepoints;
+
+    // Spacepoints from 1.85 GeV muon
     spacepoints.push_back({{36.301, 13.1197, 106.83}, {}});
     spacepoints.push_back({{93.9366, 33.7101, 120.978}, {}});
     spacepoints.push_back({{149.192, 52.0562, 134.678}, {}});
@@ -54,6 +101,19 @@ TEST(seeding, two_low_pT_muons) {
     // Run seeding
     auto seeds = sa(spacepoints);
 
-    // The number of seeds should be eqaul to two
-    ASSERT_EQ(seeds.size(), 2u);
+    // The number of seeds should be eqaul to one
+    ASSERT_EQ(seeds.size(), 1u);
+
+    traccc::track_params_estimation tp(host_mr);
+
+    auto bound_params = tp(spacepoints, seeds, B);
+
+    // The number of bound track parameters should be eqaul to one
+    ASSERT_EQ(bound_params.size(), 1u);
+
+    // Make sure that we have reasonable estimation on momentum
+    /* Currently disabled
+    EXPECT_NEAR(bound_params[0].p(), 1.85 * unit<scalar>::GeV,
+                0.1 * unit<scalar>::GeV);
+    */
 }

--- a/tests/cpu/test_track_params_estimation.cpp
+++ b/tests/cpu/test_track_params_estimation.cpp
@@ -1,0 +1,61 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/definitions/common.hpp"
+#include "traccc/edm/spacepoint.hpp"
+#include "traccc/seeding/seeding_algorithm.hpp"
+#include "traccc/seeding/track_params_estimation.hpp"
+
+// Detray include(s).
+#include "detray/intersection/detail/trajectories.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+using namespace traccc;
+
+TEST(track_params_estimation, helix) {
+
+    // Memory resource used by the EDM.
+    vecmem::host_memory_resource host_mr;
+
+    // Set B field
+    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
+                    2. * unit<scalar>::T};
+
+    // Track property
+    const point3 pos{0.f, 0.f, 0.f};
+    const scalar time{0.f};
+    const vector3 mom{1.f, 0.f, 1.f * unit<scalar>::GeV};
+    const scalar q{-1.f * unit<scalar>::e};
+
+    // Make a helix
+    detray::detail::helix<transform3> hlx(pos, time, mom, q, &B);
+
+    // Make three spacepoints with the helix
+    spacepoint_collection_types::host spacepoints;
+    spacepoints.push_back({hlx(50 * unit<scalar>::mm), {}});
+    spacepoints.push_back({hlx(100 * unit<scalar>::mm), {}});
+    spacepoints.push_back({hlx(150 * unit<scalar>::mm), {}});
+
+    // Make a seed from the three spacepoints
+    seed_collection_types::host seeds;
+    seeds.push_back({0u, 1u, 2u, 0.f, 0.f});
+
+    // Run track parameter estimation
+    traccc::track_params_estimation tp(host_mr);
+    auto bound_params = tp(spacepoints, seeds, B);
+
+    // Make sure that the reconstructed momentum is equal to the original
+    // momentum
+    ASSERT_EQ(bound_params.size(), 1u);
+    ASSERT_NEAR(bound_params[0].p(), getter::norm(mom), 1e-4);
+}


### PR DESCRIPTION
Update: Instead of making an alternative one, I just make the original algorithm take the b field as an input argument

---------------------------
~~Adding a track parameter estimation with detector object which holds B field. I am not replacing the original one for faster development.~~

I am trying to reconstruct the momentum of spacepoints provided by @shimasnd and @stephenswat but current algorithm giving me a wrong value when I assumed 2 T magnetic field. I think there is a bug in the current algorithm but could you guys confirm the bfield strength?