### PR TITLE
Remove multiple cache in performance writer

### DIFF
--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -54,9 +54,6 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
         traccc::seeding_performance_writer::config{});
-    if (i_cfg.check_performance) {
-        sd_performance_writer.add_cache("CPU");
-    }
 
     // Loop over events
     for (unsigned int event = common_opts.skip;
@@ -91,7 +88,7 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
             traccc::event_map evt_map(event, i_cfg.detector_file,
                                       common_opts.input_directory,
                                       common_opts.input_directory, host_mr);
-            sd_performance_writer.write("CPU", vecmem::get_data(seeds),
+            sd_performance_writer.write(vecmem::get_data(seeds),
                                         vecmem::get_data(spacepoints_per_event),
                                         evt_map);
         }

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -68,10 +68,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     traccc::seeding_performance_writer sd_performance_writer(
         traccc::seeding_performance_writer::config{});
 
-    if (i_cfg.check_performance) {
-        sd_performance_writer.add_cache("CPU");
-    }
-
     // Loop over events
     for (unsigned int event = common_opts.skip;
          event < common_opts.events + common_opts.skip; ++event) {
@@ -132,7 +128,7 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 common_opts.input_directory, common_opts.input_directory,
                 common_opts.input_directory, host_mr);
 
-            sd_performance_writer.write("CPU", vecmem::get_data(seeds),
+            sd_performance_writer.write(vecmem::get_data(seeds),
                                         vecmem::get_data(spacepoints_per_event),
                                         evt_map);
         }

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -84,8 +84,6 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
         std::make_unique<traccc::stepped_percentage>(0.6f));
 
     if (i_cfg.check_performance) {
-        sd_performance_writer.add_cache("CPU");
-        sd_performance_writer.add_cache("CUDA");
         nsd_performance_writer.initialize();
     }
 
@@ -231,13 +229,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
                 reader_output.spacepoints.begin(), evt_map);
 
             sd_performance_writer.write(
-                "CUDA", vecmem::get_data(seeds_cuda),
+                vecmem::get_data(seeds_cuda),
                 vecmem::get_data(reader_output.spacepoints), evt_map);
-            if (run_cpu) {
-                sd_performance_writer.write(
-                    "CPU", vecmem::get_data(seeds),
-                    vecmem::get_data(reader_output.spacepoints), evt_map);
-            }
         }
     }
 

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -88,10 +88,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
         traccc::seeding_performance_writer::config{});
-    if (i_cfg.check_performance) {
-        sd_performance_writer.add_cache("CPU");
-        sd_performance_writer.add_cache("CUDA");
-    }
 
     traccc::performance::timing_info elapsedTimes;
 
@@ -274,14 +270,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 common_opts.input_directory, common_opts.input_directory,
                 common_opts.input_directory, host_mr);
             sd_performance_writer.write(
-                "CUDA", vecmem::get_data(seeds_cuda),
+                vecmem::get_data(seeds_cuda),
                 vecmem::get_data(spacepoints_per_event_cuda), evt_map);
-
-            if (run_cpu) {
-                sd_performance_writer.write(
-                    "CPU", vecmem::get_data(seeds),
-                    vecmem::get_data(spacepoints_per_event), evt_map);
-            }
         }
     }
 

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -87,10 +87,6 @@ int seq_run(const traccc::finding_input_config& i_cfg,
     traccc::finding_performance_writer find_performance_writer(
         traccc::finding_performance_writer::config{});
 
-    if (i_cfg.check_performance) {
-        find_performance_writer.add_cache("CPU");
-    }
-
     traccc::fitting_performance_writer::config writer_cfg;
     writer_cfg.file_path = "performance_track_fitting.root";
     traccc::fitting_performance_writer fit_performance_writer(writer_cfg);
@@ -295,8 +291,8 @@ int seq_run(const traccc::finding_input_config& i_cfg,
         }
 
         if (i_cfg.check_performance) {
-            find_performance_writer.write(
-                "CPU", traccc::get_data(track_candidates), evt_map2);
+            find_performance_writer.write(traccc::get_data(track_candidates),
+                                          evt_map2);
 
             for (unsigned int i = 0; i < track_states_cuda.size(); i++) {
                 const auto& trk_states_per_track =

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -64,10 +64,6 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
         traccc::seeding_performance_writer::config{});
-    if (i_cfg.check_performance) {
-        sd_performance_writer.add_cache("CPU");
-        sd_performance_writer.add_cache("KOKKOS");
-    }
 
     traccc::performance::timing_info elapsedTimes;
 

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -82,10 +82,6 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
         traccc::seeding_performance_writer::config{});
-    if (i_cfg.check_performance) {
-        sd_performance_writer.add_cache("CPU");
-        sd_performance_writer.add_cache("SYCL");
-    }
 
     traccc::performance::timing_info elapsedTimes;
 
@@ -218,13 +214,8 @@ int seq_run(const traccc::seeding_input_config& i_cfg,
                                       common_opts.input_directory,
                                       common_opts.input_directory, host_mr);
             sd_performance_writer.write(
-                "SYCL", vecmem::get_data(seeds_sycl),
+                vecmem::get_data(seeds_sycl),
                 vecmem::get_data(reader_output.spacepoints), evt_map);
-            if (run_cpu) {
-                sd_performance_writer.write(
-                    "CPU", vecmem::get_data(seeds),
-                    vecmem::get_data(reader_output.spacepoints), evt_map);
-            }
         }
     }
 

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -115,10 +115,6 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
         traccc::seeding_performance_writer::config{});
-    if (i_cfg.check_performance) {
-        sd_performance_writer.add_cache("CPU");
-        sd_performance_writer.add_cache("SYCL");
-    }
 
     traccc::performance::timing_info elapsedTimes;
 
@@ -300,14 +296,8 @@ int seq_run(const traccc::full_tracking_input_config& i_cfg,
                 common_opts.input_directory, common_opts.input_directory,
                 common_opts.input_directory, host_mr);
             sd_performance_writer.write(
-                "SYCL", vecmem::get_data(seeds_sycl),
+                vecmem::get_data(seeds_sycl),
                 vecmem::get_data(spacepoints_per_event_sycl), evt_map);
-
-            if (run_cpu) {
-                sd_performance_writer.write(
-                    "CPU", vecmem::get_data(seeds),
-                    vecmem::get_data(spacepoints_per_event), evt_map);
-            }
         }
     }
 

--- a/performance/include/traccc/efficiency/finding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/finding_performance_writer.hpp
@@ -59,10 +59,7 @@ class finding_performance_writer {
     /// Destructor
     ~finding_performance_writer();
 
-    void add_cache(std::string_view name);
-
-    void write(std::string_view name,
-               const track_candidate_container_types::const_view&
+    void write(const track_candidate_container_types::const_view&
                    track_candidates_view,
                const event_map2& evt_map);
 

--- a/performance/include/traccc/efficiency/seeding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/seeding_performance_writer.hpp
@@ -60,10 +60,7 @@ class seeding_performance_writer {
     /// Destructor
     ~seeding_performance_writer();
 
-    void add_cache(std::string_view name);
-
-    void write(std::string_view name,
-               const seed_collection_types::const_view& seeds_view,
+    void write(const seed_collection_types::const_view& seeds_view,
                const spacepoint_collection_types::const_view& spacepoints_view,
                const event_map& evt_map);
 

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -35,12 +35,11 @@ struct seeding_performance_writer_data {
 
     /// Plot tool for efficiency
     eff_plot_tool m_eff_plot_tool;
-    std::map<std::string, eff_plot_tool::eff_plot_cache> m_eff_plot_caches;
+    eff_plot_tool::eff_plot_cache m_eff_plot_cache;
 
     /// Plot tool for duplication rate
     duplication_plot_tool m_duplication_plot_tool;
-    std::map<std::string, duplication_plot_tool::duplication_plot_cache>
-        m_duplication_plot_caches;
+    duplication_plot_tool::duplication_plot_cache m_duplication_plot_cache;
 
     measurement_particle_map m_measurement_particle_map;
     particle_map m_particle_map;
@@ -51,19 +50,17 @@ struct seeding_performance_writer_data {
 
 seeding_performance_writer::seeding_performance_writer(const config& cfg)
     : m_cfg(cfg),
-      m_data(std::make_unique<details::seeding_performance_writer_data>(cfg)) {}
+      m_data(std::make_unique<details::seeding_performance_writer_data>(cfg)) {
+
+    m_data->m_eff_plot_tool.book("seeding", m_data->m_eff_plot_cache);
+    m_data->m_duplication_plot_tool.book("seeding",
+                                         m_data->m_duplication_plot_cache);
+}
 
 seeding_performance_writer::~seeding_performance_writer() {}
 
-void seeding_performance_writer::add_cache(std::string_view name) {
-
-    m_data->m_eff_plot_tool.book(name, m_data->m_eff_plot_caches[name.data()]);
-    m_data->m_duplication_plot_tool.book(
-        name, m_data->m_duplication_plot_caches[name.data()]);
-}
-
 void seeding_performance_writer::write(
-    std::string_view name, const seed_collection_types::const_view& seeds_view,
+    const seed_collection_types::const_view& seeds_view,
     const spacepoint_collection_types::const_view& spacepoints_view,
     const event_map& evt_map) {
 
@@ -99,11 +96,10 @@ void seeding_performance_writer::write(
             n_matched_seeds_for_particle = it->second;
         }
 
-        m_data->m_eff_plot_tool.fill(m_data->m_eff_plot_caches[name.data()],
-                                     ptc, is_matched);
-        m_data->m_duplication_plot_tool.fill(
-            m_data->m_duplication_plot_caches[name.data()], ptc,
-            n_matched_seeds_for_particle - 1);
+        m_data->m_eff_plot_tool.fill(m_data->m_eff_plot_cache, ptc, is_matched);
+        m_data->m_duplication_plot_tool.fill(m_data->m_duplication_plot_cache,
+                                             ptc,
+                                             n_matched_seeds_for_particle - 1);
     }
 }
 
@@ -124,13 +120,8 @@ void seeding_performance_writer::finalize() {
               << std::endl;
 #endif  // TRACCC_HAVE_ROOT
 
-    for (auto const& [name, cache] : m_data->m_eff_plot_caches) {
-        m_data->m_eff_plot_tool.write(cache);
-    }
-
-    for (auto const& [name, cache] : m_data->m_duplication_plot_caches) {
-        m_data->m_duplication_plot_tool.write(cache);
-    }
+    m_data->m_eff_plot_tool.write(m_data->m_eff_plot_cache);
+    m_data->m_duplication_plot_tool.write(m_data->m_duplication_plot_cache);
 }
 
 }  // namespace traccc


### PR DESCRIPTION
Seeding and finding performance writer that I added used to allow multiple caches for CPU and GPU performance; This PR removes that because I think it is a bit over-engineering.

Depends on #411 