### PR TITLE
Add `return` to Kalman actor abort

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -83,6 +83,7 @@ struct kalman_actor : detray::actor {
         // If the iterator reaches the end, terminate the propagation
         if (actor_state.is_complete()) {
             propagation._heartbeat &= navigation.abort();
+            return;
         }
 
         // triggered only for sensitive surfaces
@@ -93,6 +94,7 @@ struct kalman_actor : detray::actor {
             // Abort if the propagator fails to find the next measurement
             if (navigation.current_object() != trk_state.surface_link()) {
                 propagation._heartbeat &= navigation.abort();
+                return;
             }
 
             // This track state is not a hole


### PR DESCRIPTION
Without `return`, `get_surface()` can be called when the track is not on a surface