### PR TITLE
Optional Material, main branch (2023.08.15.)

### DIFF
--- a/examples/options/src/options/seeding_input_options.cpp
+++ b/examples/options/src/options/seeding_input_options.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,8 +13,7 @@ traccc::seeding_input_config::seeding_input_config(
 
     desc.add_options()("detector_file", po::value<std::string>()->required(),
                        "specify detector file");
-    desc.add_options()("material_file", po::value<std::string>()->required(),
-                       "specify material file");
+    desc.add_options()("material_file", "specify material file");
     desc.add_options()("run_detray_geometry",
                        po::value<bool>()->default_value(false),
                        "generate performance result");
@@ -22,6 +21,8 @@ traccc::seeding_input_config::seeding_input_config(
 
 void traccc::seeding_input_config::read(const po::variables_map& vm) {
     detector_file = vm["detector_file"].as<std::string>();
-    material_file = vm["material_file"].as<std::string>();
+    if (vm.count("material_file")) {
+        material_file = vm["material_file"].as<std::string>();
+    }
     run_detray_geometry = vm["run_detray_geometry"].as<bool>();
 }


### PR DESCRIPTION
Made it optional to specify a material file for seeding. Since as we discussed with @beomki-yeo and @niermann999 on Mattermost, the current seeding code (on the TML geometry) works fine without such a file.

Pinging @StewMH as well. :wink: