### PR TITLE
Add oneDPL for SYCL

### DIFF
--- a/.github/ci_setup.sh
+++ b/.github/ci_setup.sh
@@ -13,6 +13,14 @@
 # The platform name.
 PLATFORM_NAME=$1
 
+# Set up the correct environment for the SYCL tests.
+if [ "${PLATFORM_NAME}" = "SYCL" ]; then
+   if [ -f "/opt/intel/oneapi/setvars.sh" ]; then
+      source /opt/intel/oneapi/setvars.sh
+   fi
+   export SYCL_DEVICE_FILTER=host
+fi
+
 # Make sure that GNU Make and CTest would use all available cores.
 export MAKEFLAGS="-j`nproc`"
 export CTEST_PARALLEL_LEVEL=`nproc`

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -41,16 +41,6 @@ jobs:
           - Debug
         include:
           - platform:
-              name: "SYCL"
-              container: "ghcr.io/acts-project/ubuntu2004_cuda_oneapi:v37"
-              options: -DTRACCC_BUILD_SYCL=TRUE -DTRACCC_BUILD_CUDA=FALSE -DVECMEM_BUILD_CUDA_LIBRARY=FALSE
-            build: Release
-          - platform:
-              name: "SYCL"
-              container: "ghcr.io/acts-project/ubuntu2004_rocm_oneapi:v37"
-              options: -DTRACCC_BUILD_SYCL=TRUE -DVECMEM_BUILD_HIP_LIBRARY=FALSE
-            build: Release
-          - platform:
               name: "CUDA"
               container: ghcr.io/acts-project/ubuntu2004_cuda:v30
               options: -DTRACCC_BUILD_CUDA=TRUE -DTRACCC_ENABLE_NVTX_PROFILING=TRUE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,3 +37,41 @@ test_cuda:
     - nvidia-smi
     - ctest --output-on-failure -E "^SeedingValidation/CompareWithActsSeedingTests.*"
 
+
+build_sycl:
+  tags: [docker]
+  stage: build
+  image: "ghcr.io/acts-project/ubuntu2004_oneapi:v30"
+  artifacts:
+    paths:
+      - build
+  script:
+      - git clone $CLONE_URL src
+      - git -C src checkout $HEAD_SHA
+      - source src/.github/ci_setup.sh SYCL
+      - >
+        cmake -S src -B build 
+        -DCMAKE_BUILD_TYPE=Release
+        -DTRACCC_BUILD_CUDA=OFF
+        -DTRACCC_BUILD_SYCL=ON
+        -DBUILD_TESTING=ON 
+        -DTRACCC_BUILD_TESTING=ON
+      - cmake --build build
+
+
+test_sycl:
+  stage: test
+  tags: [docker-gpu-nvidia]
+  image: "ghcr.io/acts-project/ubuntu2004_oneapi:v30"
+  needs:
+    - build_sycl
+  script:
+    - git clone $CLONE_URL src
+    - cd src
+    - git checkout $HEAD_SHA
+    - source .github/ci_setup.sh SYCL
+    - data/traccc_data_get_files.sh
+    - cd ..
+    - cd build
+    - nvidia-smi
+    - ctest --output-on-failure -E "^SeedingValidation/CompareWithActsSeedingTests.*"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,4 +74,4 @@ test_sycl:
     - cd ..
     - cd build
     - nvidia-smi
-    - ctest --output-on-failure -E "^SeedingValidation/CompareWithActsSeedingTests.*"
+    - ctest --output-on-failure -E "(^SeedingValidation/CompareWithActsSeedingTests.*)|(^dpl.*)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,22 @@ if( TRACCC_SETUP_TBB )
    endif()
 endif()
 
+# Set up DPL if SYCL is built.
+if( TRACCC_BUILD_SYCL )
+   option( TRACCC_SETUP_DPL
+      "Set up the DPL target(s) explicitly" TRUE )
+   option( TRACCC_USE_SYSTEM_DPL
+      "Pick up an existing installation of DPL from the build environment"
+      ${TRACCC_USE_SYSTEM_LIBS} )
+   if( TRACCC_SETUP_DPL )
+      if( TRACCC_USE_SYSTEM_DPL )
+         find_package( DPL REQUIRED )
+      else()
+      add_subdirectory( extern/dpl )
+      endif()
+   endif()
+endif()
+
 # Set up Kokkos.
 option( TRACCC_SETUP_KOKKOS
    "Set up the Kokkos library" ${TRACCC_BUILD_KOKKOS} )

--- a/extern/dpl/CMakeLists.txt
+++ b/extern/dpl/CMakeLists.txt
@@ -1,0 +1,37 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.14 )
+include( FetchContent )
+
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
+# Tell the user what's happening.
+message( STATUS "Building oneDPL as part of the TRACCC project" )
+
+# Declare where to get DPL from.
+set( TRACCC_DPL_SOURCE
+   "URL;https://github.com/oneapi-src/oneDPL/archive/refs/tags/oneDPL-2022.2.0-rc1.tar.gz;URL_MD5;e63a3903873636b464db6ee7a9364055"
+   CACHE STRING "Source for DPL, when built as part of this project" )
+mark_as_advanced( TRACCC_DPL_SOURCE )
+FetchContent_Declare( DPL ${TRACCC_DPL_SOURCE} )
+
+# Set the default oneDPL threading backend.
+set( ONEDPL_BACKEND "dpcpp" CACHE STRING "oneDPL threading backend" )
+
+# Get it into the current directory.
+FetchContent_MakeAvailable( DPL )
+
+# Treat the oneDPL headers as "system headers", to avoid getting warnings from
+# them.
+get_target_property( _incDirs oneDPL INTERFACE_INCLUDE_DIRECTORIES )
+target_include_directories( oneDPL
+   SYSTEM INTERFACE ${_incDirs} )
+unset( _incDirs )

--- a/extern/dpl/README.md
+++ b/extern/dpl/README.md
@@ -1,0 +1,4 @@
+# Build Recipe for oneDPL
+
+This directory holds a build recipe for building
+[DPL](https://github.com/oneapi-src/oneDPL) for this project.

--- a/extern/tbb/CMakeLists.txt
+++ b/extern/tbb/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -27,5 +27,23 @@ FetchContent_Declare( TBB ${TRACCC_TBB_SOURCE} )
 set( TBB_TEST FALSE CACHE BOOL "Turn off the TBB tests" )
 set( TBB_STRICT FALSE CACHE BOOL "Do not throw errors on compiler warnings" )
 
-# Get it into the current directory.
+# Get it into the current directory. Setting TBB_DIR locally to an empty string
+# is necessary so that incremental rebuilds would not get confused about the
+# TBB_DIR cache variable set a little further down in this file. (The TBB CMake
+# configuration is plenty weird...)
+set( TBB_DIR "" )
 FetchContent_MakeAvailable( TBB )
+
+# Make CMake pick up a no-op TBBConfig.cmake file in any possible
+# find_package(TBB) call. (Mostly needed in case other externals also need
+# TBB.)
+include( CMakePackageConfigHelpers )
+configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/TBBConfig.cmake.in"
+   "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/TBBConfig.cmake"
+   @ONLY )
+write_basic_package_version_file(
+   "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/TBBConfig-version.cmake"
+   VERSION "2021.7.0"
+   COMPATIBILITY "AnyNewerVersion" )
+set( TBB_DIR "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}" CACHE PATH
+   "TBBConfig.cmake location" )

--- a/extern/tbb/TBBConfig.cmake.in
+++ b/extern/tbb/TBBConfig.cmake.in
@@ -1,0 +1,8 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Dummy file for making find_package(TBB) calls a no-op when the TRACCC
+# project is building TBB itself.

--- a/tests/cpu/test_kalman_fitter.cpp
+++ b/tests/cpu/test_kalman_fitter.cpp
@@ -155,25 +155,25 @@ TEST_P(KalmanFittingTests, Run) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation0, KalmanFittingTests,
+    CpuKalmanFitValidation0, KalmanFittingTests,
     ::testing::Values(std::make_tuple(
-        "1_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cpu_1_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
         std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f}, 100,
         100)));
 
 INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation1, KalmanFittingTests,
+    CpuKalmanFitValidation1, KalmanFittingTests,
     ::testing::Values(std::make_tuple(
-        "10_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cpu_10_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{10.f, 10.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));
 
 INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation2, KalmanFittingTests,
+    CpuKalmanFitValidation2, KalmanFittingTests,
     ::testing::Values(std::make_tuple(
-        "100_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cpu_100_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{100.f, 100.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));

--- a/tests/cuda/test_kalman_filter.cpp
+++ b/tests/cuda/test_kalman_filter.cpp
@@ -195,25 +195,25 @@ TEST_P(KalmanFittingTests, Run) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation0, KalmanFittingTests,
+    CudaKalmanFitValidation0, KalmanFittingTests,
     ::testing::Values(std::make_tuple(
-        "1_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cuda_1_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
         std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f}, 100,
         100)));
 
 INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation1, KalmanFittingTests,
+    CudaKalmanFitValidation1, KalmanFittingTests,
     ::testing::Values(std::make_tuple(
-        "10_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cuda_10_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{10.f, 10.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));
 
 INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation2, KalmanFittingTests,
+    CudaKalmanFitValidation2, KalmanFittingTests,
     ::testing::Values(std::make_tuple(
-        "100_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cuda_100_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{100.f, 100.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -12,6 +12,7 @@ traccc_add_test(
     sycl
 
     # Define the sources for the test.
+    test_dpl.sycl
     test_kalman_filter.sycl
 
     LINK_LIBRARIES
@@ -25,4 +26,5 @@ traccc_add_test(
     traccc::performance
     traccc::io
     traccc_tests_common
+    oneDPL
 )

--- a/tests/sycl/test_dpl.sycl
+++ b/tests/sycl/test_dpl.sycl
@@ -1,0 +1,124 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// DPL include(s).
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_buffer.hpp>
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/memory/sycl/device_memory_resource.hpp>
+#include <vecmem/utils/sycl/copy.hpp>
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+namespace {
+
+// Simple asynchronous handler function
+auto handle_async_error = [](::sycl::exception_list elist) {
+    for (auto& e : elist) {
+        try {
+            std::rethrow_exception(e);
+        } catch (::sycl::exception& e) {
+            std::cout << "ASYNC EXCEPTION!!\n";
+            std::cout << e.what() << "\n";
+        }
+    }
+};
+
+}  // namespace
+
+TEST(dpl, sort) {
+
+    ::sycl::queue q(handle_async_error);
+    vecmem::sycl::copy copy{&q};
+    vecmem::host_memory_resource host_resource;
+    vecmem::sycl::device_memory_resource device_resource{&q};
+
+    vecmem::vector<unsigned int> host_vector{{3, 2, 1, 8, 4}, &host_resource};
+
+    auto host_buffer = vecmem::get_data(host_vector);
+    auto device_buffer = copy.to(vecmem::get_data(host_vector), device_resource,
+                                 vecmem::copy::type::host_to_device);
+
+    vecmem::device_vector<unsigned int> device_vector(device_buffer);
+
+    oneapi::dpl::sort(oneapi::dpl::execution::dpcpp_default,
+                      device_vector.begin(), device_vector.end());
+
+    copy(device_buffer, host_buffer, vecmem::copy::type::device_to_host);
+
+    ASSERT_EQ(host_vector[0], 1);
+    ASSERT_EQ(host_vector[1], 2);
+    ASSERT_EQ(host_vector[2], 3);
+    ASSERT_EQ(host_vector[3], 4);
+    ASSERT_EQ(host_vector[4], 8);
+}
+
+TEST(dpl, scan) {
+
+    ::sycl::queue q(handle_async_error);
+    vecmem::sycl::copy copy{&q};
+    vecmem::host_memory_resource host_resource;
+    vecmem::sycl::device_memory_resource device_resource{&q};
+
+    vecmem::vector<unsigned int> host_vector{{3, 2, 1, 8, 4}, &host_resource};
+
+    auto host_buffer = vecmem::get_data(host_vector);
+    auto device_buffer = copy.to(vecmem::get_data(host_vector), device_resource,
+                                 vecmem::copy::type::host_to_device);
+
+    vecmem::device_vector<unsigned int> device_vector(device_buffer);
+
+    oneapi::dpl::inclusive_scan(oneapi::dpl::execution::dpcpp_default,
+                                device_vector.begin(), device_vector.end(),
+                                device_vector.begin());
+
+    copy(device_buffer, host_buffer, vecmem::copy::type::device_to_host);
+
+    ASSERT_EQ(host_vector[0], 3);
+    ASSERT_EQ(host_vector[1], 5);
+    ASSERT_EQ(host_vector[2], 6);
+    ASSERT_EQ(host_vector[3], 14);
+    ASSERT_EQ(host_vector[4], 18);
+}
+
+TEST(dpl, fill) {
+
+    ::sycl::queue q(handle_async_error);
+    vecmem::sycl::copy copy{&q};
+    vecmem::host_memory_resource host_resource;
+    vecmem::sycl::device_memory_resource device_resource{&q};
+
+    vecmem::vector<unsigned int> host_vector{{1, 1, 1, 1, 1, 1, 1},
+                                             &host_resource};
+
+    auto host_buffer = vecmem::get_data(host_vector);
+    auto device_buffer = copy.to(vecmem::get_data(host_vector), device_resource,
+                                 vecmem::copy::type::host_to_device);
+
+    vecmem::device_vector<unsigned int> device_vector(device_buffer);
+
+    oneapi::dpl::fill(oneapi::dpl::execution::dpcpp_default,
+                      device_vector.begin(), device_vector.end(), 112);
+
+    copy(device_buffer, host_buffer, vecmem::copy::type::device_to_host);
+
+    ASSERT_EQ(host_vector[0], 112);
+    ASSERT_EQ(host_vector[1], 112);
+    ASSERT_EQ(host_vector[2], 112);
+    ASSERT_EQ(host_vector[3], 112);
+    ASSERT_EQ(host_vector[4], 112);
+    ASSERT_EQ(host_vector[5], 112);
+    ASSERT_EQ(host_vector[6], 112);
+}

--- a/tests/sycl/test_kalman_filter.sycl
+++ b/tests/sycl/test_kalman_filter.sycl
@@ -216,25 +216,25 @@ TEST_P(KalmanFittingTests, Run) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation0, KalmanFittingTests,
+    SyclKalmanFitValidation0, KalmanFittingTests,
     ::testing::Values(std::make_tuple(
-        "1_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "sycl_1_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
         std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f}, 100,
         100)));
 
 INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation1, KalmanFittingTests,
+    SyclKalmanFitValidation1, KalmanFittingTests,
     ::testing::Values(std::make_tuple(
-        "10_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "sycl_10_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{10.f, 10.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));
 
 INSTANTIATE_TEST_SUITE_P(
-    KalmanFitValidation2, KalmanFittingTests,
+    SyclKalmanFitValidation2, KalmanFittingTests,
     ::testing::Values(std::make_tuple(
-        "100_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "sycl_100_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{100.f, 100.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));


### PR DESCRIPTION
Now depends on #461

--------------------------------
As thrust functions doesn't seem to work with SYCL... (#437)

oneDPL is compiled only when SYCL is built
BTW, there is a tons of warnings from my compiler. Maybe my compiler is too old or I am using a wrong version of DPL.


