### PR TITLE
Measurement comparison operator only with detray barcode

### DIFF
--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -48,24 +48,14 @@ struct measurement {
 TRACCC_HOST_DEVICE
 inline bool operator<(const measurement& lhs, const measurement& rhs) {
 
-    if (lhs.module_link != rhs.module_link) {
-        return lhs.module_link < rhs.module_link;
-    } else if (std::abs(lhs.local[0] - rhs.local[0]) > float_epsilon) {
-        return (lhs.local[0] < rhs.local[0]);
-    } else {
-        return (lhs.local[1] < rhs.local[1]);
-    }
+    return lhs.surface_link < rhs.surface_link;
 }
 
 /// Equality operator for measurements
 TRACCC_HOST_DEVICE
 inline bool operator==(const measurement& lhs, const measurement& rhs) {
 
-    return ((lhs.module_link == rhs.module_link) &&
-            (std::abs(lhs.local[0] - rhs.local[0]) < float_epsilon) &&
-            (std::abs(lhs.local[1] - rhs.local[1]) < float_epsilon) &&
-            (std::abs(lhs.variance[0] - rhs.variance[0]) < float_epsilon) &&
-            (std::abs(lhs.variance[1] - rhs.variance[1]) < float_epsilon));
+    return lhs.surface_link == rhs.surface_link;
 }
 
 /// Declare all measurement collection types


### PR DESCRIPTION
Let me see if this passes the CI.
I would need this for converting clusterization output (`measurement_collection`) to track finding input (`measurement_container`)