### PR TITLE
Remove duplicate detector file option

### DIFF
--- a/examples/options/src/options/full_tracking_input_options.cpp
+++ b/examples/options/src/options/full_tracking_input_options.cpp
@@ -10,15 +10,11 @@
 
 traccc::full_tracking_input_config::full_tracking_input_config(
     po::options_description& desc) {
-
-    desc.add_options()("detector_file", po::value<std::string>()->required(),
-                       "specify detector file");
     desc.add_options()("digitization_config_file",
                        po::value<std::string>()->required(),
                        "specify the digitization configuration file");
 }
 
 void traccc::full_tracking_input_config::read(const po::variables_map& vm) {
-    detector_file = vm["detector_file"].as<std::string>();
     digitization_config_file = vm["digitization_config_file"].as<std::string>();
 }


### PR DESCRIPTION
This commit removes the duplicately defined detector file option from the full tracking options, so that the examples no longer fail to run.