### PR TITLE
is_same_object Warning Fix, main branch (2023.09.08.)

### DIFF
--- a/performance/include/traccc/performance/impl/is_same_track_candidates.ipp
+++ b/performance/include/traccc/performance/impl/is_same_track_candidates.ipp
@@ -20,7 +20,7 @@ class is_same_object<track_candidate_collection_types::host> {
     public:
     /// Constructor with a reference object, and an allowed uncertainty
     is_same_object(const track_candidate_collection_types::host& ref,
-                   scalar unc = float_epsilon);
+                   scalar = float_epsilon);
 
     /// Specialised implementation for @c traccc::bound_track_parameters
     bool operator()(const track_candidate_collection_types::host& obj) const;
@@ -28,8 +28,6 @@ class is_same_object<track_candidate_collection_types::host> {
     private:
     /// The reference object
     std::reference_wrapper<const track_candidate_collection_types::host> m_ref;
-    /// The uncertainty
-    scalar m_unc;
 
 };  // class is_same_object<track_candidate_collection_types::host>
 

--- a/performance/src/performance/details/is_same_object.cpp
+++ b/performance/src/performance/details/is_same_object.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -107,8 +107,8 @@ bool is_same_object<bound_track_parameters>::operator()(
 /// @{
 
 is_same_object<track_candidate_collection_types::host>::is_same_object(
-    const track_candidate_collection_types::host& ref, scalar unc)
-    : m_ref(ref), m_unc(unc) {}
+    const track_candidate_collection_types::host& ref, scalar)
+    : m_ref(ref) {}
 
 bool is_same_object<track_candidate_collection_types::host>::operator()(
     const track_candidate_collection_types::host& obj) const {


### PR DESCRIPTION
To ease myself back into working with our R&D code, this is a simple fix for the following warning. :wink:

```
In file included from /mnt/hdd1/krasznaa/projects/traccc/traccc/performance/src/performance/details/is_same_object.cpp:9:
In file included from /mnt/hdd1/krasznaa/projects/traccc/traccc/performance/include/traccc/performance/details/is_same_object.hpp:51:
/mnt/hdd1/krasznaa/projects/traccc/traccc/performance/include/traccc/performance/impl/is_same_track_candidates.ipp:32:12: warning: private field 'm_unc' is not used [-Wunused-private-field]
    scalar m_unc;
           ^
```

It is only Clang that complains about this. And our CI has been producing this warning since a while. :thinking:

https://github.com/acts-project/traccc/actions/runs/6101027882/job/16556520988

I'll open a separate PR for making sure that the CI would fail on warnings in the SYCL builds, as it should...