### PR TITLE
Compiler Option Fixes, main branch (2023.09.08.)

### DIFF
--- a/cmake/traccc-compiler-options-cpp.cmake
+++ b/cmake/traccc-compiler-options-cpp.cmake
@@ -14,7 +14,8 @@ endif()
 
 # Turn on a number of warnings for the "known compilers".
 if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
-    ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" ) )
+    ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" ) OR
+    ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM" ) )
 
    # Basic flags for all build modes.
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wall" )

--- a/cmake/traccc-compiler-options-sycl.cmake
+++ b/cmake/traccc-compiler-options-sycl.cmake
@@ -7,6 +7,12 @@
 # Include the helper function(s).
 include( traccc-functions )
 
+# Only tweak the flags for the Intel compiler.
+if( NOT ( ( "${CMAKE_SYCL_COMPILER_ID}" STREQUAL "IntelLLVM" ) OR
+          ( "${CMAKE_SYCL_COMPILER_ID}" MATCHES "Clang" ) ) )
+   return()
+endif()
+
 # Basic flags for all build modes.
 foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
    traccc_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wall" )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Project include(s).
+include( traccc-compiler-options-cpp )
+
 # Set up the "build" of the traccc::core library.
 traccc_add_library( traccc_core core TYPE SHARED
   # Common definitions.
@@ -84,7 +87,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/seeding/spacepoint_binning.hpp"
   "src/seeding/spacepoint_binning.cpp" )
 target_link_libraries( traccc_core
-  PUBLIC Eigen3::Eigen vecmem::core detray::core traccc::Thrust 
+  PUBLIC Eigen3::Eigen vecmem::core detray::core traccc::Thrust
          traccc::algebra )
 
 # Prevent Eigen from getting confused when building code for a

--- a/core/src/seeding/track_params_estimation.cpp
+++ b/core/src/seeding/track_params_estimation.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -31,9 +31,9 @@ track_params_estimation::output_type track_params_estimation::operator()(
             seed_to_bound_vector(spacepoints, seeds[i], bfield, PION_MASS_MEV));
 
         // Set Covariance
-        for (std::size_t i = 0; i < e_bound_size; i++) {
-            getter::element(track_params.covariance(), i, i) =
-                stddev[i] * stddev[i];
+        for (std::size_t j = 0; j < e_bound_size; ++j) {
+            getter::element(track_params.covariance(), j, j) =
+                stddev[j] * stddev[j];
         }
 
         // Get geometry ID for bottom spacepoint

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,8 +1,11 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
+
+# Project include(s).
+include( traccc-compiler-options-cpp )
 
 add_subdirectory(options)
 add_subdirectory(run)

--- a/extern/kokkos/CMakeLists.txt
+++ b/extern/kokkos/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -29,3 +29,10 @@ set( Kokkos_ENABLE_SERIAL TRUE CACHE BOOL
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( Kokkos )
+
+# Treat the Kokkos headers as "system headers", to avoid getting warnings from
+# them.
+get_target_property( _incDirs kokkoscore INTERFACE_INCLUDE_DIRECTORIES )
+target_include_directories( kokkoscore
+   SYSTEM PUBLIC ${_incDirs} )
+unset( _incDirs )

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -1,8 +1,11 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
+
+# Project include(s).
+include( traccc-compiler-options-cpp )
 
 # Look for OpenMP.
 find_package( OpenMP COMPONENTS CXX )

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Project include(s).
+include( traccc-compiler-options-cpp )
+
 # Set up the build of the traccc::performance library.
 traccc_add_library( traccc_performance performance TYPE SHARED
    # Efficiency calculation code.

--- a/performance/src/efficiency/nseed_performance_writer.cpp
+++ b/performance/src/efficiency/nseed_performance_writer.cpp
@@ -51,11 +51,11 @@ void nseed_performance_writer::write_seed_header() {
 }
 
 void nseed_performance_writer::write_seed_row(
-    std::size_t event_id, std::size_t seed_id, std::size_t length,
-    std::optional<std::size_t> particle_id) {
+    std::size_t evt_id, std::size_t seed_id, std::size_t length,
+    std::optional<std::size_t> part_id) {
     if (output_seed_file.good()) {
-        output_seed_file << event_id << sep << seed_id << sep << length << sep
-                         << (particle_id ? std::to_string(*particle_id) : "-1")
+        output_seed_file << evt_id << sep << seed_id << sep << length << sep
+                         << (part_id ? std::to_string(*part_id) : "-1")
                          << std::endl;
     }
 }
@@ -68,13 +68,13 @@ void nseed_performance_writer::write_track_header() {
     }
 }
 
-void nseed_performance_writer::write_track_row(std::size_t event_id,
-                                               std::size_t particle_id,
+void nseed_performance_writer::write_track_row(std::size_t evt_id,
+                                               std::size_t part_id,
                                                bool pass_cuts, int q,
                                                scalar eta, scalar phi,
                                                scalar pt) {
     if (output_track_file.good()) {
-        output_track_file << event_id << sep << particle_id << sep
+        output_track_file << evt_id << sep << part_id << sep
                           << (pass_cuts ? "true" : "false") << sep << q << sep
                           << eta << sep << phi << sep << pt << std::endl;
     }

--- a/performance/src/performance/timer.cpp
+++ b/performance/src/performance/timer.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,8 +39,8 @@ timer::~timer() {
     const std::chrono::nanoseconds totalTime = end - m_start;
     const auto pos =
         std::find_if(m_timing_info.data.begin(), m_timing_info.data.end(),
-                     [&m_name = m_name](const timing_info_pair& element) {
-                         return element.first == m_name;
+                     [&name = m_name](const timing_info_pair& element) {
+                         return element.first == name;
                      });
 
     if (pos == m_timing_info.data.end()) {

--- a/performance/src/performance/timing_info.cpp
+++ b/performance/src/performance/timing_info.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,9 +19,10 @@ namespace traccc::performance {
 std::chrono::nanoseconds timing_info::get_time(
     std::string_view timer_name) const {
 
-    auto it = std::find_if(
-        data.begin(), data.end(),
-        [&timer_name](timing_info_pair it) { return it.first == timer_name; });
+    auto it = std::find_if(data.begin(), data.end(),
+                           [&timer_name](timing_info_pair itr) {
+                               return itr.first == timer_name;
+                           });
     if (it == data.end()) {
         throw std::invalid_argument("Unknown component name received");
     }


### PR DESCRIPTION
As I mentioned in #454, I found that our builds are not quite as "rigorous" as I thought they would be. "Extended warning flags" were not used until now in many places unfortunately.

After fixing the CMake code to apply all the warning flags correctly, I also had to fix a few of the warnings that showed up as a result. In all cases about variables shadowing each other. (Kokkos had some other warnings as well, but those I silenced by making our build consider the Kokkos headers as "system headers", as it should.)