### PR TITLE
(Xcode) Warning Fix, main branch, 2023.09.30.

### DIFF
--- a/performance/src/resolution/stat_plot_tool.cpp
+++ b/performance/src/resolution/stat_plot_tool.cpp
@@ -40,6 +40,7 @@ void stat_plot_tool::fill(stat_plot_cache& cache,
 
     // Avoid unused variable warnings when building the code without ROOT.
     (void)cache;
+    (void)fit_info;
 
 #ifdef TRACCC_HAVE_ROOT
     const auto& ndf = fit_info.ndf;


### PR DESCRIPTION
Avoid an unused variable warning without [ROOT](https://root.cern/), with [Xcode 15](https://developer.apple.com/xcode/). (Though it may probably show up with other compilers as well...)