### PR TITLE
(Device) Clusterization Fix, main branch (2023.09.30.)

### DIFF
--- a/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
+++ b/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
@@ -102,6 +102,7 @@ TRACCC_HOST void fill_measurement(
     if (totalWeight > 0.) {
         measurement m;
         m.module_link = module_link;
+        m.surface_link = detray::geometry::barcode{module.module};
         // normalize the cell position
         m.local = mean;
         // normalize the variance

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -107,6 +107,9 @@ inline void aggregate_cluster(
     out.local = mean;
     out.variance = var;
     out.module_link = module_link;
+    out.surface_link = detray::geometry::barcode{this_module.module};
+    // The following will need to be filled properly "soon".
+    out.meas_dim = 2u;
 }
 
 }  // namespace traccc::device


### PR DESCRIPTION
Properly initialize the `traccc::measurement` `meas_dim` and `surface_link` members. Because in device code those values do not get initialized to their default values. (No constructor executed when allocating a device buffer.)

At the same time fixed the way that `surface_link` would be set, in the host code as well.

With this fix the comparisons between the host and device code are back to the expected values. :relieved:

```
[bash][Legolas]:build > ./bin/traccc_seq_example_cuda --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_full/ttbar_mu20/ --events=2 --run_cpu=1
Running ./bin/traccc_seq_example_cuda  tml_full/ttbar_mu20/ 2
===>>> Event 0 <<<===
Number of spacepoints: 15919 (host), 15919 (device)
  Matching rate(s):
    - 97.9898% at 0.01% uncertainty
    - 99.3278% at 0.1% uncertainty
    - 99.3278% at 1% uncertainty
    - 99.3278% at 5% uncertainty
Number of seeds: 2340 (host), 2340 (device)
  Matching rate(s):
    - 87.8205% at 0.01% uncertainty
    - 99.1026% at 0.1% uncertainty
    - 99.8291% at 1% uncertainty
    - 99.8718% at 5% uncertainty
Number of track parameters: 2340 (host), 2340 (device)
  Matching rate(s):
    - 98.4615% at 0.01% uncertainty
    - 99.9145% at 0.1% uncertainty
    - 99.9145% at 1% uncertainty
    - 99.9145% at 5% uncertainty
===>>> Event 1 <<<===
Number of spacepoints: 11943 (host), 11943 (device)
  Matching rate(s):
    - 97.9821% at 0.01% uncertainty
    - 99.2883% at 0.1% uncertainty
    - 99.2883% at 1% uncertainty
    - 99.2883% at 5% uncertainty
Number of seeds: 1584 (host), 1584 (device)
  Matching rate(s):
    - 84.4066% at 0.01% uncertainty
    - 98.8005% at 0.1% uncertainty
    - 99.6843% at 1% uncertainty
    - 99.8737% at 5% uncertainty
Number of track parameters: 1584 (host), 1584 (device)
  Matching rate(s):
    - 98.2323% at 0.01% uncertainty
    - 99.8106% at 0.1% uncertainty
    - 99.8737% at 1% uncertainty
    - 99.8737% at 5% uncertainty
==> Statistics ... 
- read    95678 cells from 12529 modules
- created (cpu)  27862 measurements     
- created (cpu)  27862 spacepoints     
- created (cuda) 27862 spacepoints     
- created  (cpu) 3924 seeds
- created (cuda) 3924 seeds
==>Elapsed times...
           File reading  (cpu)  183 ms
         Clusterization (cuda)  1 ms
         Clusterization  (cpu)  3 ms
   Spacepoint formation  (cpu)  0 ms
                Seeding (cuda)  1 ms
                Seeding  (cpu)  16 ms
           Track params (cuda)  0 ms
           Track params  (cpu)  0 ms
                     Wall time  206 ms
[bash][Legolas]:build > ./bin/traccc_seq_example_sycl --detector_file=tml_detector/trackml-detector.csv --digitization_config_file=tml_detector/default-geometric-config-generic.json --input_directory=tml_full/ttbar_mu20/ --events=2 --run_cpu=1
Running ./bin/traccc_seq_example_sycl  tml_full/ttbar_mu20/ 2
Running Seeding on device: NVIDIA GeForce RTX 3080
===>>> Event 0 <<<===
Number of spacepoints: 15919 (host), 15919 (device)
  Matching rate(s):
    - 98.0024% at 0.01% uncertainty
    - 99.3278% at 0.1% uncertainty
    - 99.3278% at 1% uncertainty
    - 99.3278% at 5% uncertainty
Number of seeds: 2340 (host), 2340 (device)
  Matching rate(s):
    - 87.6496% at 0.01% uncertainty
    - 99.1026% at 0.1% uncertainty
    - 99.8291% at 1% uncertainty
    - 99.8718% at 5% uncertainty
Number of track parameters: 2340 (host), 2340 (device)
  Matching rate(s):
    - 98.1197% at 0.01% uncertainty
    - 99.9145% at 0.1% uncertainty
    - 99.9145% at 1% uncertainty
    - 99.9145% at 5% uncertainty
===>>> Event 1 <<<===
Number of spacepoints: 11943 (host), 11943 (device)
  Matching rate(s):
    - 97.9821% at 0.01% uncertainty
    - 99.2883% at 0.1% uncertainty
    - 99.2883% at 1% uncertainty
    - 99.2883% at 5% uncertainty
Number of seeds: 1584 (host), 1584 (device)
  Matching rate(s):
    - 83.9015% at 0.01% uncertainty
    - 98.8636% at 0.1% uncertainty
    - 99.8106% at 1% uncertainty
    - 99.8737% at 5% uncertainty
Number of track parameters: 1584 (host), 1584 (device)
  Matching rate(s):
    - 97.8535% at 0.01% uncertainty
    - 99.8106% at 0.1% uncertainty
    - 99.8737% at 1% uncertainty
    - 99.8737% at 5% uncertainty
==> Statistics ... 
- read    95678 cells from 12529 modules
- created (cpu)  27862 measurements
- created (cpu)  27862 spacepoints
- created (sycl) 27862 spacepoints     
- created  (cpu) 3924 seeds
- created (sycl) 3924 seeds
==>Elapsed times...
           File reading  (cpu)  184 ms
         Clusterization (sycl)  1 ms
         Clusterization  (cpu)  3 ms
   Spacepoint formation  (cpu)  0 ms
                Seeding (sycl)  2 ms
                Seeding  (cpu)  16 ms
           Track params (sycl)  0 ms
           Track params  (cpu)  0 ms
                     Wall time  209 ms
[bash][Legolas]:build >
```