### PR TITLE
Sort measurements in CCA

### DIFF
--- a/core/include/traccc/finding/finding_algorithm.ipp
+++ b/core/include/traccc/finding/finding_algorithm.ipp
@@ -29,30 +29,21 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
      * Measurement Operations
      *****************************************************************/
 
-    // Copy the measurements
-    measurement_collection_types::host sorted_measurements = measurements;
-
-    // Sort the measurements w.r.t geometry barcode
-    std::sort(sorted_measurements.begin(), sorted_measurements.end(),
-              measurement_sort_comp());
-
     // Get copy of barcode uniques
     std::vector<measurement> uniques;
-    uniques.resize(sorted_measurements.size());
+    uniques.resize(measurements.size());
 
-    auto end =
-        std::unique_copy(sorted_measurements.begin(), sorted_measurements.end(),
-                         uniques.begin(), measurement_equal_comp());
+    auto end = std::unique_copy(measurements.begin(), measurements.end(),
+                                uniques.begin(), measurement_equal_comp());
     unsigned int n_modules = end - uniques.begin();
 
     // Get upper bounds of unique elements
     std::vector<unsigned int> upper_bounds;
     upper_bounds.reserve(n_modules);
     for (unsigned int i = 0; i < n_modules; i++) {
-        auto up = std::upper_bound(sorted_measurements.begin(),
-                                   sorted_measurements.end(), uniques[i],
-                                   measurement_sort_comp());
-        upper_bounds.push_back(std::distance(sorted_measurements.begin(), up));
+        auto up = std::upper_bound(measurements.begin(), measurements.end(),
+                                   uniques[i], measurement_sort_comp());
+        upper_bounds.push_back(std::distance(measurements.begin(), up));
     }
 
     // Get the number of measurements of each module
@@ -178,7 +169,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
                 bound_track_parameters bound_param(in_param.surface_link(),
                                                    in_param.vector(),
                                                    in_param.covariance());
-                const auto& meas = sorted_measurements[item_id];
+                const auto& meas = measurements[item_id];
 
                 track_state<transform3_type> trk_state(meas);
 
@@ -281,7 +272,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 
             auto& cand = *it;
 
-            cand = sorted_measurements.at(L.meas_idx);
+            cand = measurements.at(L.meas_idx);
 
             // Break the loop if the iterator is at the first candidate and
             // fill the seed

--- a/device/cuda/src/clusterization/experimental/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/experimental/clusterization_algorithm.cu
@@ -19,6 +19,10 @@
 // Vecmem include(s).
 #include <vecmem/utils/copy.hpp>
 
+// Thrust include(s).
+#include <thrust/execution_policy.h>
+#include <thrust/sort.h>
+
 namespace traccc::cuda::experimental {
 
 namespace {
@@ -140,6 +144,10 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
         cudaMemcpyDeviceToDevice, stream));
 
     m_stream.synchronize();
+
+    // Sort the measurements w.r.t geometry barcode
+    thrust::sort(thrust::cuda::par.on(stream), new_measurements_device.begin(),
+                 new_measurements_device.end(), measurement_sort_comp());
 
     return new_measurements_buffer;
 }

--- a/device/sycl/src/clusterization/experimental/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/experimental/clusterization_algorithm.sycl
@@ -159,6 +159,12 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
                 sizeof(measurement) * (*num_measurements_host))
         .wait_and_throw();
 
+    // @NOTE Uncomment once the onedpl is available
+    // oneapi::dpl::experimental::sort_async(
+    //    oneapi::dpl::execution::dpcpp_default,
+    //    new_measurements_device.begin(), new_measurements_device.end(),
+    //    measurement_sort_comp());
+
     return new_measurements_buffer;
 }
 

--- a/io/src/csv/read_measurements.cpp
+++ b/io/src/csv/read_measurements.cpp
@@ -81,6 +81,9 @@ void read_measurements(measurement_reader_output& out,
 
         result_measurements.push_back(meas);
     }
+
+    std::sort(result_measurements.begin(), result_measurements.end(),
+              measurement_sort_comp());
 }
 
 measurement_container_types::host read_measurements_container(


### PR DESCRIPTION
I think it is pointless to do measurement-sort in CKF. At least we can reduce a copy operation by moving the sort to CCA.
Of course, note that the best approach would be modifying CCA to yield the sorted measurements directly.

+ Also note that the measurement output of CPU clusterization is always sorted, and it makes sense to unify the output property (sorted-ness) of CPU and GPU clusterization
