### PR TITLE
Data Files V4, main branch (2023.10.18.)

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -3,13 +3,14 @@
 #
 # Mozilla Public License Version 2.0
 #
-cca_test/
-detray_simulation/
-single_module/
-tml_detector/
-tml_full/
-tml_pixel_barrel/
-tml_pixels/
-two_modules/
+cca_test
+detray_simulation
+geometries
+single_module
+tml_detector
+tml_full
+tml_pixel_barrel
+tml_pixels
+two_modules
 *.tar.gz
 *.md5

--- a/data/traccc_data_get_files.sh
+++ b/data/traccc_data_get_files.sh
@@ -27,7 +27,7 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v3"}
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v4"}
 TRACCC_WEB_DIRECTORY=${TRACCC_WEB_DIRECTORY:-"https://acts.web.cern.ch/traccc/data"}
 TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}
 TRACCC_CMAKE_EXECUTABLE=${TRACCC_CMAKE_EXECUTABLE:-cmake}

--- a/data/traccc_data_package_files.sh
+++ b/data/traccc_data_package_files.sh
@@ -27,8 +27,8 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v4"}
-TRACCC_DATA_DIRECTORY_NAMES=("cca_test" "detray_simulation" "single_module"
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v5"}
+TRACCC_DATA_DIRECTORY_NAMES=("cca_test" "detray_simulation" "geometries" "single_module"
    "tml_detector" "tml_full" "tml_pixel_barrel" "tml_pixels" "two_modules")
 TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}
 TRACCC_CMAKE_EXECUTABLE=${TRACCC_CMAKE_EXECUTABLE:-cmake}


### PR DESCRIPTION
On @niermann999's request I created V4 of the data files with the addition of detector description files for the toy detector.

Joana, the new files are under `${TRACCC_TEST_DATA_DIR}/geometries/toy_detector/`. I thought that at one point we'll probably want to clean up the test files a little, giving the directory a bit more "organized layout". But for now I didn't move anything else.

@fiedlerp, since I ended up touching `data/.gitignore` in this PR anyway, I incorporated your changes from #468. We should discuss in that PR how you should probably re-fork the repository afterwards, to get rid of your (now probably unmerged) changes from the `main` branch of your fork. :thinking: