### PR TITLE
Fix: Do not sort measurments in spacepoint reading

### DIFF
--- a/io/src/csv/read_measurements.cpp
+++ b/io/src/csv/read_measurements.cpp
@@ -19,7 +19,7 @@
 namespace traccc::io::csv {
 
 void read_measurements(measurement_reader_output& out,
-                       std::string_view filename) {
+                       std::string_view filename, const bool do_sort) {
 
     // Construct the measurement reader object.
     auto reader = make_measurement_reader(filename);
@@ -82,8 +82,10 @@ void read_measurements(measurement_reader_output& out,
         result_measurements.push_back(meas);
     }
 
-    std::sort(result_measurements.begin(), result_measurements.end(),
-              measurement_sort_comp());
+    if (do_sort) {
+        std::sort(result_measurements.begin(), result_measurements.end(),
+                  measurement_sort_comp());
+    }
 }
 
 measurement_container_types::host read_measurements_container(

--- a/io/src/csv/read_measurements.hpp
+++ b/io/src/csv/read_measurements.hpp
@@ -20,6 +20,7 @@ namespace traccc::io::csv {
 ///
 /// @param out A measurement & a cell_module (host) collections
 /// @param filename The file to read the measurement data from
+/// @param do_sort Whether to sort the measurements or not
 ///
 void read_measurements(measurement_reader_output& out,
                        std::string_view filename, const bool do_sort = true);

--- a/io/src/csv/read_measurements.hpp
+++ b/io/src/csv/read_measurements.hpp
@@ -22,6 +22,6 @@ namespace traccc::io::csv {
 /// @param filename The file to read the measurement data from
 ///
 void read_measurements(measurement_reader_output& out,
-                       std::string_view filename);
+                       std::string_view filename, const bool do_sort = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_spacepoints.cpp
+++ b/io/src/csv/read_spacepoints.cpp
@@ -27,7 +27,7 @@ void read_spacepoints(spacepoint_reader_output& out, std::string_view filename,
                       const geometry& geom) {
     // Read measurements
     measurement_reader_output meas_reader_out;
-    read_measurements(meas_reader_out, meas_filename);
+    read_measurements(meas_reader_out, meas_filename, false);
 
     // Measurement hit id reader
     auto mhid_reader =


### PR DESCRIPTION
Fixing a bug introduced by #467. Seeding example is not woking now

measurement-to-hit id is broken when measurements is shuffled by sorting.
