### PR TITLE
Sort track parameters before CKF

### DIFF
--- a/core/include/traccc/edm/track_parameters.hpp
+++ b/core/include/traccc/edm/track_parameters.hpp
@@ -29,4 +29,13 @@ using bound_covariance = bound_track_parameters::covariance_type;
 using bound_track_parameters_collection_types =
     collection_types<bound_track_parameters>;
 
+/// Comparator based on theta
+struct bound_track_parameters_sort_comp {
+    TRACCC_HOST_DEVICE
+    bool operator()(const bound_track_parameters& lhs,
+                    const bound_track_parameters& rhs) {
+        return lhs.theta() < rhs.theta();
+    }
+};
+
 }  // namespace traccc

--- a/io/src/csv/read_measurements.cpp
+++ b/io/src/csv/read_measurements.cpp
@@ -19,7 +19,7 @@
 namespace traccc::io::csv {
 
 void read_measurements(measurement_reader_output& out,
-                       std::string_view filename, bool do_sort) {
+                       std::string_view filename, const bool do_sort) {
 
     // Construct the measurement reader object.
     auto reader = make_measurement_reader(filename);

--- a/io/src/csv/read_measurements.cpp
+++ b/io/src/csv/read_measurements.cpp
@@ -19,7 +19,7 @@
 namespace traccc::io::csv {
 
 void read_measurements(measurement_reader_output& out,
-                       std::string_view filename) {
+                       std::string_view filename, bool do_sort) {
 
     // Construct the measurement reader object.
     auto reader = make_measurement_reader(filename);
@@ -82,8 +82,10 @@ void read_measurements(measurement_reader_output& out,
         result_measurements.push_back(meas);
     }
 
-    std::sort(result_measurements.begin(), result_measurements.end(),
-              measurement_sort_comp());
+    if (do_sort) {
+        std::sort(result_measurements.begin(), result_measurements.end(),
+                  measurement_sort_comp());
+    }
 }
 
 measurement_container_types::host read_measurements_container(

--- a/io/src/csv/read_measurements.hpp
+++ b/io/src/csv/read_measurements.hpp
@@ -22,6 +22,6 @@ namespace traccc::io::csv {
 /// @param filename The file to read the measurement data from
 ///
 void read_measurements(measurement_reader_output& out,
-                       std::string_view filename);
+                       std::string_view filename, bool do_sort = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_measurements.hpp
+++ b/io/src/csv/read_measurements.hpp
@@ -22,6 +22,6 @@ namespace traccc::io::csv {
 /// @param filename The file to read the measurement data from
 ///
 void read_measurements(measurement_reader_output& out,
-                       std::string_view filename, bool do_sort = true);
+                       std::string_view filename, const bool do_sort = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_spacepoints.cpp
+++ b/io/src/csv/read_spacepoints.cpp
@@ -27,7 +27,7 @@ void read_spacepoints(spacepoint_reader_output& out, std::string_view filename,
                       const geometry& geom) {
     // Read measurements
     measurement_reader_output meas_reader_out;
-    read_measurements(meas_reader_out, meas_filename);
+    read_measurements(meas_reader_out, meas_filename, false);
 
     // Measurement hit id reader
     auto mhid_reader =


### PR DESCRIPTION
Performance increaseis not very great right now. I will come back to this once we have fast navigation 

```
./bin/traccc_seeding_example_cuda --input_directory=detray_simulation/toy_detector/n_particles_2000/ --check_performance=true --detector_file=detray_json/toy_detector_geometry.json --material_file=detray_json/toy_detector_homogeneous_material.json --event=10 --track_candidates_range=3:10 --constraint-step-size-mm=10000 --run_cpu=1 --skip=0

AFTER
==> Statistics ... 
- read    106829 spacepoints from 26487 modules
- created  (cpu)  114031 seeds
- created (cuda)  114026 seeds
- created  (cpu) 117470 found tracks
- created (cuda) 117481 found tracks
- created  (cpu) 117470 fitted tracks
- created (cuda) 117481 fitted tracks
==>Elapsed times...
            Hit reading  (cpu)  2711 ms
                Seeding (cuda)  17 ms
                Seeding  (cpu)  606 ms
           Track params (cuda)  16 ms
           Track params  (cpu)  24 ms
 Track finding with CKF (cuda)  492 ms
  Track finding with CKF (cpu)  7828 ms
  Track fitting with KF (cuda)  261 ms
   Track fitting with KF (cpu)  3496 ms
                     Wall time  15474 ms


BEFORE
==> Statistics ... 
- read    106829 spacepoints from 26487 modules
- created  (cpu)  114031 seeds
- created (cuda)  114027 seeds
- created  (cpu) 117470 found tracks
- created (cuda) 117481 found tracks
- created  (cpu) 117470 fitted tracks
- created (cuda) 117481 fitted tracks
==>Elapsed times...
            Hit reading  (cpu)  2742 ms
                Seeding (cuda)  18 ms
                Seeding  (cpu)  601 ms
           Track params (cuda)  3 ms
           Track params  (cpu)  23 ms
 Track finding with CKF (cuda)  511 ms
  Track finding with CKF (cpu)  7982 ms
  Track fitting with KF (cuda)  272 ms
   Track fitting with KF (cpu)  3560 ms
                     Wall time  15737 ms
```