### PR TITLE
Clang & CUDA Fix, main branch (2023.10.30.)

### DIFF
--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -43,12 +43,12 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/cca/component_connection.cu"
   # Clusterization
   "include/traccc/cuda/clusterization/experimental/clusterization_algorithm.hpp"
-  "src/clusterization/experimental/clusterization_algorithm.cu"
+  "src/clusterization/experimental/clusterization_algorithm_exp.cu"
   "include/traccc/cuda/clusterization/clusterization_algorithm.hpp"
   "src/clusterization/clusterization_algorithm.cu"
   # Finding
   "include/traccc/cuda/finding/finding_algorithm.hpp"
-  "src/finding/finding_algorithm.cu"  
+  "src/finding/finding_algorithm.cu"
   # Fitting
   "include/traccc/cuda/fitting/fitting_algorithm.hpp"
   "src/fitting/fitting_algorithm.cu")

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -23,16 +23,18 @@
 // System include(s).
 #include <algorithm>
 
-namespace traccc::cuda {
-
 namespace {
+
 /// These indices in clusterization will only range from 0 to
 /// max_cells_per_partition, so we only need a short.
 using index_t = unsigned short;
 
 static constexpr int TARGET_CELLS_PER_THREAD = 8;
 static constexpr int MAX_CELLS_PER_THREAD = 12;
+
 }  // namespace
+
+namespace traccc::cuda {
 
 namespace kernels {
 

--- a/device/cuda/src/clusterization/experimental/clusterization_algorithm_exp.cu
+++ b/device/cuda/src/clusterization/experimental/clusterization_algorithm_exp.cu
@@ -23,16 +23,18 @@
 #include <thrust/execution_policy.h>
 #include <thrust/sort.h>
 
-namespace traccc::cuda::experimental {
-
 namespace {
+
 /// These indices in clusterization will only range from 0 to
 /// max_cells_per_partition, so we only need a short.
 using index_t = unsigned short;
 
 static constexpr int TARGET_CELLS_PER_THREAD = 8;
 static constexpr int MAX_CELLS_PER_THREAD = 12;
+
 }  // namespace
+
+namespace traccc::cuda::experimental {
 
 namespace kernels {
 

--- a/tests/cuda/test_clusterization.cpp
+++ b/tests/cuda/test_clusterization.cpp
@@ -48,8 +48,8 @@ TEST(clusterization, cuda) {
     modules.push_back({});
 
     // Run Clusterization
-    cuda::experimental::clusterization_algorithm ca_cuda(mr, copy, stream,
-                                                         1024);
+    traccc::cuda::experimental::clusterization_algorithm ca_cuda(mr, copy,
+                                                                 stream, 1024);
 
     auto measurements_buffer =
         ca_cuda(vecmem::get_data(cells), vecmem::get_data(modules));

--- a/tests/cuda/test_spacepoint_formation.cpp
+++ b/tests/cuda/test_spacepoint_formation.cpp
@@ -72,8 +72,8 @@ TEST(spacepoint_formation, cuda) {
     measurements.push_back({{10.f, 15.f}, {0.f, 0.f}, surfaces[8u].barcode()});
 
     // Run spacepoint formation
-    cuda::experimental::spacepoint_formation<device_detector_type> sp_formation(
-        mr, copy, stream);
+    traccc::cuda::experimental::spacepoint_formation<device_detector_type>
+        sp_formation(mr, copy, stream);
     auto spacepoints_buffer =
         sp_formation(detray::get_data(det), vecmem::get_data(measurements));
 


### PR DESCRIPTION
The `cuda` namespace is not pointing clearly at `traccc::cuda` in the presence of `using namespace traccc`. At least Clang doesn't seem to think so. :thinking:

```
[ 95%] Building CXX object tests/cuda/CMakeFiles/traccc_test_cuda.dir/test_clusterization.cpp.o
/home/krasznaa/ATLAS/projects/traccc/traccc/tests/cuda/test_clusterization.cpp:51:5: error: reference to 'cuda' is ambiguous
    cuda::experimental::clusterization_algorithm ca_cuda(mr, copy, stream,
    ^
/software/cuda/12.0.1/x86_64/include/cuda/std/detail/libcxx/include/type_traits:4861:1: note: candidate found by name lookup is 'cuda'
_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION
^
/software/cuda/12.0.1/x86_64/include/cuda/std/detail/__config:192:61: note: expanded from macro '_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION'
#define _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION namespace cuda { namespace std {
                                                            ^
/home/krasznaa/ATLAS/projects/traccc/traccc/device/cuda/include/traccc/cuda/clusterization/experimental/clusterization_algorithm.hpp:22:19: note: candidate found by name lookup is 'traccc::cuda'
namespace traccc::cuda::experimental {
                  ^
/home/krasznaa/ATLAS/projects/traccc/traccc/tests/cuda/test_clusterization.cpp:55:9: error: use of undeclared identifier 'ca_cuda'
        ca_cuda(vecmem::get_data(cells), vecmem::get_data(modules));
        ^
2 errors generated.
```

At the same time I also renamed one of the `clusterization_algorithm.cu` source files, since it seems that `nvcc` cannot deal with two source files having the same name. (The preprocessor seems to overwrite temporary files with each other in some weird way.) Which seems to be the reason for the intermittent CI failures since #449.

As discussed [on Mattermost](https://mattermost.web.cern.ch/acts/channels/traccc), the "file name clash" happens because of:

https://github.com/acts-project/traccc/blob/main/cmake/traccc-compiler-options-cuda.cmake#L32

So it's a bug in our build setup, and not an inherent bug in CUDA or CMake as it turns out.