### PR TITLE
Bug Fixes, main branch (2023.11.06.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -27,6 +27,9 @@ jobs:
           - name: CPU
             container: ghcr.io/acts-project/ubuntu2004:v30
             options:
+          - name: CPU
+            container: ghcr.io/acts-project/ubuntu2004:v30
+            options: -DTRACCC_USE_ROOT=FALSE
           - name: CUDA
             container: ghcr.io/acts-project/ubuntu2004_cuda:v30
             options: -DTRACCC_BUILD_CUDA=TRUE

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Algebra Plugins as part of the TRACCC project" )
 
 # Declare where to get Algebra Plugins from.
 set( TRACCC_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.19.0.tar.gz;URL_MD5;8357b024b1bcdb70350d8a378055cfee"   
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.19.0.tar.gz;URL_MD5;8357b024b1bcdb70350d8a378055cfee"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 
 mark_as_advanced( TRACCC_ALGEBRA_PLUGINS_SOURCE )
@@ -43,6 +43,8 @@ set( ALGEBRA_PLUGINS_SETUP_EIGEN3 FALSE CACHE BOOL
 set( ALGEBRA_PLUGINS_SETUP_VECMEM FALSE CACHE BOOL
    "Do not set up VecMem in Algebra Plugins" )
 set( ALGEBRA_PLUGINS_SETUP_GOOGLETEST FALSE CACHE BOOL
+   "Do not set up GoogleTest in Algebra Plugins" )
+set( ALGEBRA_PLUGINS_SETUP_BENCHMARK FALSE CACHE BOOL
    "Do not set up GoogleTest in Algebra Plugins" )
 
 # Get it into the current directory.

--- a/performance/src/resolution/res_plot_tool.cpp
+++ b/performance/src/resolution/res_plot_tool.cpp
@@ -103,6 +103,8 @@ void res_plot_tool::fill(res_plot_cache& cache,
 
     // Avoid unused variable warnings when building the code without ROOT.
     (void)cache;
+    (void)eta;
+    (void)pT;
 
     for (std::size_t idx = 0; idx < m_cfg.param_names.size(); idx++) {
         std::string par_name = m_cfg.param_names.at(idx);
@@ -129,6 +131,7 @@ void res_plot_tool::fill(res_plot_cache& cache,
         (void)residual;
         (void)pull;
 
+#ifdef TRACCC_HAVE_ROOT
         const auto eta_idx =
             std::min(cache.resolutions_eta[par_name]->FindBin(eta) - 1,
                      cache.resolutions_eta[par_name]->GetNbinsX() - 1);
@@ -136,7 +139,6 @@ void res_plot_tool::fill(res_plot_cache& cache,
             std::min(cache.resolutions_pT[par_name]->FindBin(pT) - 1,
                      cache.resolutions_pT[par_name]->GetNbinsX() - 1);
 
-#ifdef TRACCC_HAVE_ROOT
         cache.residuals.at(par_name)->Fill(residual);
         cache.pulls.at(par_name)->Fill(pull);
         cache.residuals_eta.at(par_name)->Fill(eta, residual);

--- a/simulation/CMakeLists.txt
+++ b/simulation/CMakeLists.txt
@@ -5,11 +5,11 @@
 # Mozilla Public License Version 2.0
 
 # Set up the "build" of the traccc::io library.
-traccc_add_library( traccc_simulation simulation 
+traccc_add_library( traccc_simulation simulation TYPE INTERFACE
   # Public headers
   "include/traccc/simulation/measurement_smearer.hpp"
   "include/traccc/simulation/simulator.hpp"
   "include/traccc/simulation/smearing_writer.hpp" )
 target_link_libraries( traccc_simulation
-  PUBLIC traccc::core traccc::io detray::core detray::utils 
-  PRIVATE dfelibs::dfelibs )
+  INTERFACE traccc::core traccc::io detray::core detray::utils
+            dfelibs::dfelibs )


### PR DESCRIPTION
This is to fix multiple, independent bugs that I ran into just by trying to build the project on my laptop.
  - Stopped `algebra-plugin` from downloading/building Google Benchmark itself. This was more of an annoyance than an actual bug.
  - Fixed the setup of the `traccc::simulation` library. This one confused the heck out of me, as to why this bug was not found before. And then I realized that I only ran into it because I turned off the build/usage of Vc. And with Vc enabled, we do get a dummy shared library for `traccc::simulation`. :dizzy_face:

```
[bash][celeborn]:build > more simulation/CMakeFiles/traccc_simulation.dir/flags.make 
# CMAKE generated file: DO NOT EDIT!
# Generated by "Unix Makefiles" Generator, CMake Version 3.26

[bash][celeborn]:build > more simulation/CMakeFiles/traccc_simulation.dir/link.txt 
/usr/bin/c++ -fPIC -O3 -g -shared -Wl,-soname,libtraccc_simulation.so.0 -o ../lib/libtraccc_simulation.so.0.6.0  -Wl,-rpath,/home/krasznaa/ATLAS/projects/traccc/build/lib:/home/krasznaa/ATLAS/projects/traccc/build/_deps/acts-build/lib: ../lib/libtraccc_io.so.0.6.0 ../lib/libtraccc_core.so.0.6.0 ../lib/libVc.a ../_deps/acts-build/lib/libActsCore.so ../lib/libvecmem_core.so.0.26.0 -Wl,-rpath-link,/home/krasznaa/ATLAS/projects/traccc/build/_deps/acts-build/lib 
[bash][celeborn]:build >
```

While if I turn off Vc, I get the much more reasonable:

```
...
-- Configuring done (6.4s)
CMake Error: CMake can not determine linker language for target: traccc_simulation
CMake Error in simulation/CMakeLists.txt:
  Exporting the target "traccc_simulation" is not allowed since its linker
  language cannot be determined
```

  - Made the code build without ROOT. This is just an oversight. When `TRACCC_USE_ROOT` was introduced, I should've added a CI test for it as well. I now did. :wink: