### PR TITLE
Fix the track candidate range in finding config option

### DIFF
--- a/examples/options/src/options/finding_input_options.cpp
+++ b/examples/options/src/options/finding_input_options.cpp
@@ -14,7 +14,7 @@ traccc::finding_input_config::finding_input_config(
     desc.add_options()("track_candidates_range",
                        po::value<Reals<unsigned int, 2>>()
                            ->value_name("MIN:MAX")
-                           ->default_value({6, 30}),
+                           ->default_value({3, 30}),
                        "Range of track candidates number");
 }
 


### PR DESCRIPTION
I forgot to fix this one in #481