### PR TITLE
Athena Fix, main branch (2023.11.15.)

### DIFF
--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 find_package( CUDAToolkit )
 if( CUDAToolkit_FOUND )
    target_link_libraries( traccc_performance
-      PRIVATE CUDA::cudart )
+      PRIVATE CUDA::cudart ${CMAKE_DL_LIBS} )
    target_compile_definitions( traccc_performance
       PRIVATE TRACCC_HAVE_NVTX )
 endif()


### PR DESCRIPTION
Link `traccc::performance` explicitly against `${CMAKE_DL_LIBS}`. This is necessary on some platforms to be able to use the NVTX code properly. Most notably, I bumped into this while building the project on top of `Athena-main-x86_64-centos7-gcc11-opt`. 😉 