### PR TITLE
Avoid racing condition in CI test geometry I/O

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,8 +18,7 @@ build_cuda:
         -DCMAKE_BUILD_TYPE=Release
         -DTRACCC_BUILD_TESTING=ON
         -DTRACCC_BUILD_CUDA=ON
-      - cmake --build build
-
+      - cmake --build build --parallel 2
 
 test_cuda:
   stage: test

--- a/tests/common/tests/kalman_fitting_telescope_test.hpp
+++ b/tests/common/tests/kalman_fitting_telescope_test.hpp
@@ -62,7 +62,8 @@ class KalmanFittingTelescopeTests : public KalmanFittingTests {
     }
 
     protected:
-    static void SetUpTestCase() {
+    virtual void SetUp() override {
+
         vecmem::host_memory_resource host_mr;
 
         detray::tel_det_config<> tel_cfg{rectangle};
@@ -77,7 +78,8 @@ class KalmanFittingTelescopeTests : public KalmanFittingTests {
         // Write detector file
         auto writer_cfg = detray::io::detector_writer_config{}
                               .format(detray::io::format::json)
-                              .replace_files(true);
+                              .replace_files(true)
+                              .path(std::get<0>(GetParam()));
         detray::io::write_detector(det, name_map, writer_cfg);
     }
 };

--- a/tests/common/tests/kalman_fitting_wire_chamber_test.hpp
+++ b/tests/common/tests/kalman_fitting_wire_chamber_test.hpp
@@ -63,7 +63,7 @@ class KalmanFittingWireChamberTests : public KalmanFittingTests {
     }
 
     protected:
-    static void SetUpTestCase() {
+    virtual void SetUp() override {
         vecmem::host_memory_resource host_mr;
 
         detray::wire_chamber_config wire_chamber_cfg;
@@ -76,7 +76,8 @@ class KalmanFittingWireChamberTests : public KalmanFittingTests {
         // Write detector file
         auto writer_cfg = detray::io::detector_writer_config{}
                               .format(detray::io::format::json)
-                              .replace_files(true);
+                              .replace_files(true)
+                              .path(std::get<0>(GetParam()));
         detray::io::write_detector(det, name_map, writer_cfg);
     }
 };

--- a/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
@@ -78,10 +78,11 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     detray::io::write_detector(det, name_map, writer_cfg);
 
     // Read back detector file
+    const std::string path = name + "/";
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file("telescope_detector_geometry.json")
-        .add_file("telescope_detector_homogeneous_material.json")
-        .add_file("telescope_detector_surface_grids.json");
+    reader_cfg.add_file(path + "telescope_detector_geometry.json")
+        .add_file(path + "telescope_detector_homogeneous_material.json")
+        .add_file(path + "telescope_detector_surface_grids.json");
 
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
@@ -115,7 +116,6 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     typename writer_type::config smearer_writer_cfg{meas_smearer};
 
     // Run simulator
-    const std::string path = name + "/";
     const std::string full_path = io::data_directory() + path;
     std::filesystem::create_directories(full_path);
     auto sim = traccc::simulator<host_detector_type, b_field_t, generator_type,

--- a/tests/cpu/test_kalman_fitter_telescope.cpp
+++ b/tests/cpu/test_kalman_fitter_telescope.cpp
@@ -61,10 +61,11 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     vecmem::host_memory_resource host_mr;
 
     // Read back detector file
+    const std::string path = name + "/";
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file("telescope_detector_geometry.json")
-        .add_file("telescope_detector_homogeneous_material.json")
-        .add_file("telescope_detector_surface_grids.json");
+    reader_cfg.add_file(path + "telescope_detector_geometry.json")
+        .add_file(path + "telescope_detector_homogeneous_material.json")
+        .add_file(path + "telescope_detector_surface_grids.json");
 
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
@@ -97,7 +98,6 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     typename writer_type::config smearer_writer_cfg{meas_smearer};
 
     // Run simulator
-    const std::string path = name + "/";
     const std::string full_path = io::data_directory() + path;
     std::filesystem::create_directories(full_path);
     auto sim = traccc::simulator<host_detector_type, b_field_t, generator_type,

--- a/tests/cpu/test_kalman_fitter_wire_chamber.cpp
+++ b/tests/cpu/test_kalman_fitter_wire_chamber.cpp
@@ -59,9 +59,10 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
     vecmem::host_memory_resource host_mr;
 
     // Read back detector file
+    const std::string path = name + "/";
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file("wire_chamber_geometry.json")
-        .add_file("wire_chamber_homogeneous_material.json")
+    reader_cfg.add_file(path + "wire_chamber_geometry.json")
+        .add_file(path + "wire_chamber_homogeneous_material.json")
         //.add_file("wire_chamber_surface_grids.json")
         .do_check(true);
 
@@ -96,7 +97,6 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
     typename writer_type::config smearer_writer_cfg{meas_smearer};
 
     // Run simulator
-    const std::string path = name + "/";
     const std::string full_path = io::data_directory() + path;
     std::filesystem::create_directories(full_path);
     auto sim = traccc::simulator<host_detector_type, b_field_t, generator_type,

--- a/tests/cuda/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cuda/test_ckf_sparse_tracks_telescope.cpp
@@ -88,10 +88,11 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     detray::io::write_detector(det, name_map, writer_cfg);
 
     // Read back detector file
+    const std::string path = name + "/";
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file("telescope_detector_geometry.json")
-        .add_file("telescope_detector_homogeneous_material.json")
-        .add_file("telescope_detector_surface_grids.json");
+    reader_cfg.add_file(path + "telescope_detector_geometry.json")
+        .add_file(path + "telescope_detector_homogeneous_material.json")
+        .add_file(path + "telescope_detector_surface_grids.json");
 
     auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
@@ -127,7 +128,6 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     typename writer_type::config smearer_writer_cfg{meas_smearer};
 
     // Run simulator
-    const std::string path = name + "/";
     const std::string full_path = io::data_directory() + path;
     std::filesystem::create_directories(full_path);
     auto sim = traccc::simulator<host_detector_type, b_field_t, generator_type,
@@ -287,7 +287,7 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
 INSTANTIATE_TEST_SUITE_P(
     CkfSparseTrackTelescopeValidation0, CkfSparseTrackTelescopeTests,
     ::testing::Values(std::make_tuple(
-        "single_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cuda_single_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 200.f, 200.f},
         std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 1, 5000)));
@@ -295,7 +295,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     CkfSparseTrackTelescopeValidation1, CkfSparseTrackTelescopeTests,
     ::testing::Values(std::make_tuple(
-        "double_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cuda_double_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 200.f, 200.f},
         std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 2, 2500)));
@@ -303,7 +303,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     CkfSparseTrackTelescopeValidation2, CkfSparseTrackTelescopeTests,
     ::testing::Values(std::make_tuple(
-        "quadra_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cuda_quadra_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 200.f, 200.f},
         std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 4, 1250)));
@@ -311,7 +311,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     CkfSparseTrackTelescopeValidation3, CkfSparseTrackTelescopeTests,
     ::testing::Values(std::make_tuple(
-        "decade_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cuda_decade_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 200.f, 200.f},
         std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 10, 500)));

--- a/tests/cuda/test_kalman_fitter_telescope.cpp
+++ b/tests/cuda/test_kalman_fitter_telescope.cpp
@@ -74,10 +74,11 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // Read back detector file
+    const std::string path = name + "/";
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file("telescope_detector_geometry.json")
-        .add_file("telescope_detector_homogeneous_material.json")
-        .add_file("telescope_detector_surface_grids.json");
+    reader_cfg.add_file(path + "telescope_detector_geometry.json")
+        .add_file(path + "telescope_detector_homogeneous_material.json")
+        .add_file(path + "telescope_detector_surface_grids.json");
 
     auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
@@ -114,7 +115,6 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     typename writer_type::config smearer_writer_cfg{meas_smearer};
 
     // Run simulator
-    const std::string path = name + "/";
     const std::string full_path = io::data_directory() + path;
     std::filesystem::create_directories(full_path);
     auto sim = traccc::simulator<host_detector_type, b_field_t, generator_type,
@@ -223,7 +223,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation0, KalmanFittingTelescopeTests,
     ::testing::Values(std::make_tuple(
-        "1_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cuda_1_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
         std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f}, 100,
         100)));
@@ -231,7 +231,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation1, KalmanFittingTelescopeTests,
     ::testing::Values(std::make_tuple(
-        "10_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cuda_10_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{10.f, 10.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));
@@ -239,7 +239,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation2, KalmanFittingTelescopeTests,
     ::testing::Values(std::make_tuple(
-        "100_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "cuda_100_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{100.f, 100.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));

--- a/tests/sycl/test_kalman_fitter_telescope.sycl
+++ b/tests/sycl/test_kalman_fitter_telescope.sycl
@@ -95,10 +95,11 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     vecmem::sycl::shared_memory_resource shared_mr;
 
     // Read back detector file
+    const std::string path = name + "/";
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file("telescope_detector_geometry.json")
-        .add_file("telescope_detector_homogeneous_material.json")
-        .add_file("telescope_detector_surface_grids.json");
+    reader_cfg.add_file(path + "telescope_detector_geometry.json")
+        .add_file(path + "telescope_detector_homogeneous_material.json")
+        .add_file(path + "telescope_detector_surface_grids.json");
 
     auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(shared_mr, reader_cfg);
@@ -134,7 +135,6 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     typename writer_type::config smearer_writer_cfg{meas_smearer};
 
     // Run simulator
-    const std::string path = name + "/";
     const std::string full_path = io::data_directory() + path;
     std::filesystem::create_directories(full_path);
     auto sim = traccc::simulator<host_detector_type, b_field_t, generator_type,
@@ -230,7 +230,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation0, KalmanFittingTelescopeTests,
     ::testing::Values(std::make_tuple(
-        "1_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "sycl_1_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
         std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f}, 100,
         100)));
@@ -238,7 +238,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation1, KalmanFittingTelescopeTests,
     ::testing::Values(std::make_tuple(
-        "10_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "sycl_10_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{10.f, 10.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));
@@ -246,7 +246,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation2, KalmanFittingTelescopeTests,
     ::testing::Values(std::make_tuple(
-        "100_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        "sycl_100_GeV_0_phi", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{100.f, 100.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, 100, 100)));


### PR DESCRIPTION
This PR makes each test suite read and write geometry files in a dedicated directory to avoid the racing condition in CI tests