### PR TITLE
Remove unused geometry writing part

### DIFF
--- a/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
@@ -63,21 +63,6 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     // Memory resources used by the application.
     vecmem::host_memory_resource host_mr;
 
-    detray::tel_det_config<> tel_cfg{rectangle};
-    tel_cfg.positions(plane_positions);
-    tel_cfg.module_material(mat);
-    tel_cfg.mat_thickness(thickness);
-    tel_cfg.pilot_track(traj);
-
-    // Create telescope detector
-    auto [det, name_map] = create_telescope_detector(host_mr, tel_cfg);
-
-    // Write detector file
-    auto writer_cfg = detray::io::detector_writer_config{}
-                          .format(detray::io::format::json)
-                          .replace_files(true);
-    detray::io::write_detector(det, name_map, writer_cfg);
-
     // Read back detector file
     const std::string path = name + "/";
     detray::io::detector_reader_config reader_cfg{};
@@ -214,9 +199,6 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
         static_cast<scalar>(n_success) / (n_truth_tracks * n_events);
 
     ASSERT_FLOAT_EQ(success_rate, 1.00f);
-
-    // Remove the data
-    std::filesystem::remove_all(full_path);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpu/test_kalman_fitter_telescope.cpp
+++ b/tests/cpu/test_kalman_fitter_telescope.cpp
@@ -171,9 +171,6 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
         static_cast<scalar>(n_success) / (n_truth_tracks * n_events);
 
     ASSERT_FLOAT_EQ(success_rate, 1.00f);
-
-    // Remove the data
-    std::filesystem::remove_all(full_path);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpu/test_kalman_fitter_wire_chamber.cpp
+++ b/tests/cpu/test_kalman_fitter_wire_chamber.cpp
@@ -179,9 +179,6 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
 
     ASSERT_GE(success_rate, 0.99f);
     ASSERT_LE(success_rate, 1.00f);
-
-    // Remove the data
-    std::filesystem::remove_all(full_path);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cuda/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cuda/test_ckf_sparse_tracks_telescope.cpp
@@ -73,21 +73,6 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     traccc::memory_resource mr{device_mr, &host_mr};
     vecmem::cuda::managed_memory_resource mng_mr;
 
-    detray::tel_det_config<> tel_cfg{rectangle};
-    tel_cfg.positions(plane_positions);
-    tel_cfg.module_material(mat);
-    tel_cfg.mat_thickness(thickness);
-    tel_cfg.pilot_track(traj);
-
-    // Create telescope detector
-    auto [det, name_map] = create_telescope_detector(host_mr, tel_cfg);
-
-    // Write detector file
-    auto writer_cfg = detray::io::detector_writer_config{}
-                          .format(detray::io::format::json)
-                          .replace_files(true);
-    detray::io::write_detector(det, name_map, writer_cfg);
-
     // Read back detector file
     const std::string path = name + "/";
     detray::io::detector_reader_config reader_cfg{};
@@ -280,9 +265,6 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
         static_cast<scalar>(n_success) / (n_truth_tracks * n_events);
 
     ASSERT_FLOAT_EQ(success_rate, 1.00f);
-
-    // Remove the data
-    std::filesystem::remove_all(full_path);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cuda/test_kalman_fitter_telescope.cpp
+++ b/tests/cuda/test_kalman_fitter_telescope.cpp
@@ -216,9 +216,6 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
         static_cast<scalar>(n_success) / (n_truth_tracks * n_events);
 
     ASSERT_FLOAT_EQ(success_rate, 1.00f);
-
-    // Remove the data
-    std::filesystem::remove_all(full_path);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/sycl/test_kalman_fitter_telescope.sycl
+++ b/tests/sycl/test_kalman_fitter_telescope.sycl
@@ -223,9 +223,6 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     static const std::vector<std::string> pull_names{
         "pull_d0", "pull_z0", "pull_phi", "pull_theta", "pull_qop"};
     pull_value_tests(fit_writer_cfg.file_path, pull_names);
-
-    // Remove the data
-    std::filesystem::remove_all(full_path);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Two changes:
(1) Ckf tests were writing geometry json again (`SetUp()` writes geometry json file first)
(2) Remove `remove_all` to keep simulated file