### PR TITLE
Add a test for cuda and cpu ckf comparison

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,10 +12,10 @@ add_library( traccc_tests_common STATIC
     "common/tests/atlas_cuts.hpp"
     "common/tests/cca_test.hpp"
     "common/tests/ckf_telescope_test.hpp"
-    "common/tests/ckf_wire_chamber_test.hpp"
     "common/tests/data_test.hpp"
     "common/tests/kalman_fitting_test.hpp"
     "common/tests/kalman_fitting_telescope_test.hpp"
+    "common/tests/kalman_fitting_toy_detector_test.hpp"
     "common/tests/kalman_fitting_wire_chamber_test.hpp"
     "common/tests/kalman_fitting_test.cpp"
     "common/tests/space_point.hpp" )

--- a/tests/common/tests/ckf_toy_detector_test.hpp
+++ b/tests/common/tests/ckf_toy_detector_test.hpp
@@ -8,11 +8,11 @@
 #pragma once
 
 // Project include(s).
-#include "kalman_fitting_telescope_test.hpp"
+#include "kalman_fitting_toy_detector_test.hpp"
 
 namespace traccc {
 
-/// Combinatorial Kalman Finding Test with Sparse tracks
-class CkfSparseTrackWireChamberTests : public KalmanFittingWireChamberTests {};
+/// Combinatorial Kalman Finding Test to Comapre CPU results
+class CkfToyDetectorTests : public KalmanFittingToyDetectorTests {};
 
 }  // namespace traccc

--- a/tests/common/tests/kalman_fitting_toy_detector_test.hpp
+++ b/tests/common/tests/kalman_fitting_toy_detector_test.hpp
@@ -1,0 +1,64 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "kalman_fitting_test.hpp"
+
+// Detray include(s).
+#include "detray/detectors/bfield.hpp"
+#include "detray/detectors/create_toy_geometry.hpp"
+#include "detray/io/common/detector_reader.hpp"
+#include "detray/io/common/detector_writer.hpp"
+
+namespace traccc {
+
+/// Kalman Finding Test for toy geometry
+class KalmanFittingToyDetectorTests : public KalmanFittingTests {
+
+    public:
+    /// Number of barrel layers
+    static constexpr inline unsigned int n_barrels{4u};
+
+    /// Number of endcap layers
+    static constexpr inline unsigned int n_endcaps{7u};
+
+    /// B field value and its type
+    static constexpr vector3 B{0, 0, 2 * detray::unit<scalar>::T};
+
+    /// Measurement smearing parameters
+    static constexpr std::array<scalar, 2u> smearing{
+        50.f * detray::unit<scalar>::um, 50.f * detray::unit<scalar>::um};
+
+    /// Standard deviations for seed track parameters
+    static constexpr std::array<scalar, e_bound_size> stddevs = {
+        0.01 * detray::unit<scalar>::mm,
+        0.01 * detray::unit<scalar>::mm,
+        0.001,
+        0.001,
+        0.01 / detray::unit<scalar>::GeV,
+        0.01 * detray::unit<scalar>::ns};
+
+    protected:
+    virtual void SetUp() override {
+        vecmem::host_memory_resource host_mr;
+
+        // Create the toy geometry
+        auto [det, name_map] =
+            detray::create_toy_geometry(host_mr, {n_barrels, n_endcaps});
+
+        // Write detector file
+        auto writer_cfg = detray::io::detector_writer_config{}
+                              .format(detray::io::format::json)
+                              .replace_files(true)
+                              .path(std::get<0>(GetParam()));
+        detray::io::write_detector(det, name_map, writer_cfg);
+    }
+};
+
+}  // namespace traccc

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -29,7 +29,7 @@ traccc_add_test(
     # Define the sources for the test.
     test_basic.cu
     test_cca.cpp
-    test_ckf_sparse_tracks_telescope.cpp
+    test_ckf_toy_detector.cpp
     test_copy.cu
     test_kalman_fitter_telescope.cpp
     test_clusterization.cpp

--- a/tests/cuda/test_ckf_toy_detector.cpp
+++ b/tests/cuda/test_ckf_toy_detector.cpp
@@ -7,23 +7,21 @@
 
 // Project include(s).
 #include "traccc/cuda/finding/finding_algorithm.hpp"
-#include "traccc/cuda/fitting/fitting_algorithm.hpp"
 #include "traccc/device/container_d2h_copy_alg.hpp"
 #include "traccc/device/container_h2d_copy_alg.hpp"
-#include "traccc/edm/track_candidate.hpp"
+#include "traccc/finding/finding_algorithm.hpp"
+#include "traccc/io/event_map2.hpp"
 #include "traccc/io/read_measurements.hpp"
 #include "traccc/io/utils.hpp"
-#include "traccc/resolution/fitting_performance_writer.hpp"
+#include "traccc/performance/container_comparator.hpp"
 #include "traccc/simulation/simulator.hpp"
-#include "traccc/utils/memory_resource.hpp"
 #include "traccc/utils/ranges.hpp"
-#include "traccc/utils/seed_generator.hpp"
 
 // Test include(s).
-#include "tests/ckf_telescope_test.hpp"
+#include "tests/ckf_toy_detector_test.hpp"
+#include "traccc/utils/seed_generator.hpp"
 
 // detray include(s).
-#include "detray/detectors/create_telescope_detector.hpp"
 #include "detray/io/common/detector_reader.hpp"
 #include "detray/io/common/detector_writer.hpp"
 #include "detray/propagator/propagator.hpp"
@@ -43,8 +41,8 @@
 #include <string>
 
 using namespace traccc;
-// This defines the local frame test suite
-TEST_P(CkfSparseTrackTelescopeTests, Run) {
+
+TEST_P(CkfToyDetectorTests, Run) {
 
     // Get the parameters
     const std::string name = std::get<0>(GetParam());
@@ -58,13 +56,8 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     const unsigned int n_truth_tracks = std::get<7>(GetParam());
     const unsigned int n_events = std::get<8>(GetParam());
 
-    // Performance writer
-    traccc::fitting_performance_writer::config fit_writer_cfg;
-    fit_writer_cfg.file_path = "performance_track_fitting_" + name + ".root";
-    traccc::fitting_performance_writer fit_performance_writer(fit_writer_cfg);
-
     /*****************************
-     * Build a telescope geometry
+     * Build a toy detector
      *****************************/
 
     // Memory resources used by the application.
@@ -76,8 +69,9 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     // Read back detector file
     const std::string path = name + "/";
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file(path + "telescope_detector_geometry.json")
-        .add_file(path + "telescope_detector_homogeneous_material.json");
+    reader_cfg.add_file(path + "toy_detector_geometry.json")
+        .add_file(path + "toy_detector_homogeneous_material.json")
+        .add_file(path + "toy_detector_surface_grids.json");
 
     auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
@@ -108,6 +102,7 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     // Smearing value for measurements
     traccc::measurement_smearer<transform3> meas_smearer(smearing[0],
                                                          smearing[1]);
+
     using writer_type =
         traccc::smearing_writer<traccc::measurement_smearer<transform3>>;
 
@@ -150,14 +145,12 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
         rk_stepper_type, device_navigator_type>::config_type cfg;
 
     // Finding algorithm object
+    traccc::finding_algorithm<rk_stepper_type, host_navigator_type>
+        host_finding(cfg);
+
+    // Finding algorithm object
     traccc::cuda::finding_algorithm<rk_stepper_type, device_navigator_type>
         device_finding(cfg, mr, copy, stream);
-
-    // Fitting algorithm object
-    typename traccc::cuda::fitting_algorithm<device_fitter_type>::config_type
-        fit_cfg;
-    traccc::cuda::fitting_algorithm<device_fitter_type> device_fitting(
-        fit_cfg, mr, copy, stream);
 
     // Iterate over events
     for (std::size_t i_evt = 0; i_evt < n_events; i_evt++) {
@@ -166,12 +159,12 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
         traccc::event_map2 evt_map(i_evt, path, path, path);
 
         traccc::track_candidate_container_types::host truth_track_candidates =
-            evt_map.generate_truth_candidates(sg, mng_mr);
+            evt_map.generate_truth_candidates(sg, host_mr);
 
         ASSERT_EQ(truth_track_candidates.size(), n_truth_tracks);
 
         // Prepare truth seeds
-        traccc::bound_track_parameters_collection_types::host seeds(mr.host);
+        traccc::bound_track_parameters_collection_types::host seeds(&host_mr);
         for (unsigned int i_trk = 0; i_trk < n_truth_tracks; i_trk++) {
             seeds.push_back(truth_track_candidates.at(i_trk).header);
         }
@@ -208,7 +201,11 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
                 seeds.size(),
             mr.main, mr.host);
 
-        // Run finding
+        // Run host finding
+        auto track_candidates =
+            host_finding(host_det, field, measurements_per_event, seeds);
+
+        // Run device finding
         track_candidates_cuda_buffer =
             device_finding(det_view, field, navigation_buffer,
                            measurements_buffer, seeds_buffer);
@@ -216,83 +213,44 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
         traccc::track_candidate_container_types::host track_candidates_cuda =
             track_candidate_d2h(track_candidates_cuda_buffer);
 
-        ASSERT_EQ(track_candidates_cuda.size(), n_truth_tracks);
+        // Simple check
+        ASSERT_EQ(track_candidates.size(), track_candidates.size());
+        ASSERT_GE(track_candidates.size(), n_truth_tracks);
 
-        // Instantiate cuda containers/collections
-        traccc::track_state_container_types::buffer track_states_cuda_buffer{
-            {{}, *(mr.host)}, {{}, *(mr.host), mr.host}};
+        // Make sure that the outputs from cpu and cuda CKF are equivalent
+        unsigned int n_matches = 0u;
+        for (unsigned int i = 0u; i < track_candidates.size(); i++) {
+            auto iso =
+                traccc::details::is_same_object(track_candidates.at(i).items);
 
-        // Run fitting
-        track_states_cuda_buffer = device_fitting(
-            det_view, field, navigation_buffer, track_candidates_cuda_buffer);
-
-        traccc::track_state_container_types::host track_states_cuda =
-            track_state_d2h(track_states_cuda_buffer);
-
-        ASSERT_EQ(track_states_cuda.size(), n_truth_tracks);
-
-        for (unsigned int i_trk = 0; i_trk < n_truth_tracks; i_trk++) {
-
-            const auto& track_states_per_track = track_states_cuda[i_trk].items;
-            const auto& fit_res = track_states_cuda[i_trk].header;
-
-            consistency_tests(track_states_per_track);
-
-            ndf_tests(fit_res, track_states_per_track);
-
-            fit_performance_writer.write(track_states_per_track, fit_res,
-                                         host_det, evt_map);
+            for (unsigned int j = 0u; j < track_candidates_cuda.size(); j++) {
+                if (iso(track_candidates_cuda.at(j).items)) {
+                    n_matches++;
+                    break;
+                }
+            }
         }
+
+        float matching_rate = float(n_matches) / track_candidates.size();
+
+        EXPECT_FLOAT_EQ(matching_rate, 1.f);
     }
-
-    fit_performance_writer.finalize();
-
-    /********************
-     * Pull value test
-     ********************/
-
-    static const std::vector<std::string> pull_names{
-        "pull_d0", "pull_z0", "pull_phi", "pull_theta", "pull_qop"};
-    pull_value_tests(fit_writer_cfg.file_path, pull_names);
-
-    /********************
-     * Success rate test
-     ********************/
-
-    scalar success_rate =
-        static_cast<scalar>(n_success) / (n_truth_tracks * n_events);
-
-    ASSERT_FLOAT_EQ(success_rate, 1.00f);
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    CkfSparseTrackTelescopeValidation0, CkfSparseTrackTelescopeTests,
+    CkfToyDetectorValidation0, CkfToyDetectorTests,
     ::testing::Values(std::make_tuple(
-        "cuda_telescope_single_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 200.f, 200.f},
-        std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
-        std::array<scalar, 2u>{0.f, 0.f}, -1.f, 1, 5000)));
+        "toy_n_particles_1", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        std::array<scalar, 2u>{1.f, 100.f}, std::array<scalar, 2u>{-3.f, 3.f},
+        std::array<scalar, 2u>{0.f, 2.0f * detray::constant<scalar>::pi}, -1.f,
+        1, 1)));
 
 INSTANTIATE_TEST_SUITE_P(
-    CkfSparseTrackTelescopeValidation1, CkfSparseTrackTelescopeTests,
+    CkfToyDetectorValidation1, CkfToyDetectorTests,
     ::testing::Values(std::make_tuple(
-        "cuda_telescope_double_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 200.f, 200.f},
-        std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
-        std::array<scalar, 2u>{0.f, 0.f}, -1.f, 2, 2500)));
-
-INSTANTIATE_TEST_SUITE_P(
-    CkfSparseTrackTelescopeValidation2, CkfSparseTrackTelescopeTests,
-    ::testing::Values(std::make_tuple(
-        "cuda_telescope_quadra_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 200.f, 200.f},
-        std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
-        std::array<scalar, 2u>{0.f, 0.f}, -1.f, 4, 1250)));
-
-INSTANTIATE_TEST_SUITE_P(
-    CkfSparseTrackTelescopeValidation3, CkfSparseTrackTelescopeTests,
-    ::testing::Values(std::make_tuple(
-        "cuda_telescope_decade_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 200.f, 200.f},
-        std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
-        std::array<scalar, 2u>{0.f, 0.f}, -1.f, 10, 500)));
+        "toy_n_particles_10000", std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        std::array<scalar, 2u>{1.f, 100.f}, std::array<scalar, 2u>{-3.f, 3.f},
+        std::array<scalar, 2u>{0.f, 2.0f * detray::constant<scalar>::pi}, -1.f,
+        10000, 1)));


### PR DESCRIPTION
This PR adds a test for cuda and cpu ckf comparison. 
I think that the comparison test w.r.t cpu outputs is enough for GPU.

Therefore, the original cuda test for sparse tracks is removed.  