### PR TITLE
Cell Reading with Detray Geometry, main branch (2023.12.19.)

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -7,6 +7,7 @@ cca_test
 detray_simulation
 geometries
 single_module
+odd
 tml_detector
 tml_full
 tml_pixel_barrel

--- a/data/traccc_data_get_files.sh
+++ b/data/traccc_data_get_files.sh
@@ -27,7 +27,7 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v4"}
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v5"}
 TRACCC_WEB_DIRECTORY=${TRACCC_WEB_DIRECTORY:-"https://acts.web.cern.ch/traccc/data"}
 TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}
 TRACCC_CMAKE_EXECUTABLE=${TRACCC_CMAKE_EXECUTABLE:-cmake}

--- a/data/traccc_data_package_files.sh
+++ b/data/traccc_data_package_files.sh
@@ -27,9 +27,10 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v5"}
-TRACCC_DATA_DIRECTORY_NAMES=("cca_test" "detray_simulation" "geometries" "single_module"
-   "tml_detector" "tml_full" "tml_pixel_barrel" "tml_pixels" "two_modules")
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v6"}
+TRACCC_DATA_DIRECTORY_NAMES=("cca_test" "detray_simulation" "geometries" "odd"
+   "single_module" "tml_detector" "tml_full" "tml_pixel_barrel" "tml_pixels"
+   "two_modules")
 TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}
 TRACCC_CMAKE_EXECUTABLE=${TRACCC_CMAKE_EXECUTABLE:-cmake}
 

--- a/examples/io/create_binaries.cpp
+++ b/examples/io/create_binaries.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -25,7 +25,7 @@ int create_binaries(const std::string& detector_file,
                     const traccc::common_options& common_opts) {
 
     // Read the surface transforms
-    auto surface_transforms = traccc::io::read_geometry(detector_file);
+    auto [surface_transforms, _] = traccc::io::read_geometry(detector_file);
 
     // Read the digitization configuration file
     auto digi_cfg = traccc::io::read_digitization_config(digi_config_file);

--- a/examples/options/include/traccc/options/detector_input_options.hpp
+++ b/examples/options/include/traccc/options/detector_input_options.hpp
@@ -25,6 +25,8 @@ struct detector_input_options {
     std::string material_file;
     /// The file containing the surface grid description
     std::string grid_file;
+    /// Use detray::detector for the geometry handling
+    bool use_detray_detector = false;
 
     /// Constructor on top of a common @c program_options object
     ///

--- a/examples/options/src/options/detector_input_options.cpp
+++ b/examples/options/src/options/detector_input_options.cpp
@@ -28,6 +28,9 @@ traccc::detector_input_options::detector_input_options(
     desc.add_options()("grid-file",
                        po::value(&grid_file)->default_value(grid_file),
                        "specify surface grid file");
+    desc.add_options()("use-detray-detector",
+                       po::bool_switch(&use_detray_detector),
+                       "Use detray::detector for the geometry handling");
 }
 
 void traccc::detector_input_options::read(const po::variables_map&) {}
@@ -35,9 +38,11 @@ void traccc::detector_input_options::read(const po::variables_map&) {}
 std::ostream& operator<<(std::ostream& out, const detector_input_options& opt) {
 
     out << ">>> Detector options <<<\n"
-        << "  Detector file : " << opt.detector_file << "\n"
-        << "  Material file : " << opt.material_file << "\n"
-        << "  Grid file     : " << opt.grid_file;
+        << "  Detector file        : " << opt.detector_file << "\n"
+        << "  Material file        : " << opt.material_file << "\n"
+        << "  Grid file            : " << opt.grid_file << "\n"
+        << "  Use detray::detector : "
+        << (opt.use_detray_detector ? "yes" : "no") << "\n";
     return out;
 }
 

--- a/examples/run/cpu/CMakeLists.txt
+++ b/examples/run/cpu/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,7 +10,7 @@ traccc_add_executable( seeding_example "seeding_example.cpp"
 
 traccc_add_executable( seq_example "seq_example.cpp"
    LINK_LIBRARIES vecmem::core traccc::core traccc::io
-   traccc::performance traccc::options detray::utils detray::io)
+   traccc::performance traccc::options)
 
 traccc_add_executable( truth_finding_example "truth_finding_example.cpp"
    LINK_LIBRARIES vecmem::core detray::utils traccc::core traccc::io

--- a/examples/run/cpu/CMakeLists.txt
+++ b/examples/run/cpu/CMakeLists.txt
@@ -1,23 +1,23 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 traccc_add_executable( seeding_example "seeding_example.cpp"
-   LINK_LIBRARIES vecmem::core traccc::core traccc::io 
+   LINK_LIBRARIES vecmem::core traccc::core traccc::io
    traccc::performance traccc::options detray::utils detray::io)
 
 traccc_add_executable( seq_example "seq_example.cpp"
-   LINK_LIBRARIES vecmem::core traccc::core traccc::io 
-   traccc::performance traccc::options)
+   LINK_LIBRARIES vecmem::core traccc::core traccc::io
+   traccc::performance traccc::options detray::utils detray::io)
 
 traccc_add_executable( truth_finding_example "truth_finding_example.cpp"
-   LINK_LIBRARIES vecmem::core detray::utils traccc::core traccc::io 
+   LINK_LIBRARIES vecmem::core detray::utils traccc::core traccc::io
    traccc::performance traccc::options)
 
 traccc_add_executable( truth_fitting_example "truth_fitting_example.cpp"
-   LINK_LIBRARIES vecmem::core detray::io detray::utils traccc::core 
+   LINK_LIBRARIES vecmem::core detray::io detray::utils traccc::core
    traccc::io traccc::performance traccc::options)
 
 traccc_add_executable( ccl_example "ccl_example.cpp"

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -26,10 +26,6 @@
 #include "traccc/options/full_tracking_input_options.hpp"
 #include "traccc/options/handle_argument_errors.hpp"
 
-// Detray include(s).
-#include "detray/core/detector.hpp"
-#include "detray/io/frontend/detector_reader.hpp"
-
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
 
@@ -46,42 +42,11 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts) {
 
-    // Memory resource used by the application.
-    vecmem::host_memory_resource host_mr;
-
-    // Construct a traccc::geometry object.
-    traccc::geometry surface_transforms;
-    using barcode_map_type = std::map<std::uint64_t, detray::geometry::barcode>;
-    std::unique_ptr<barcode_map_type> barcode_map;
-    if (det_opts.use_detray_detector) {
-
-        // Construct a detector object.
-        detray::io::detector_reader_config reader_cfg{};
-        reader_cfg.add_file(traccc::io::data_directory() +
-                            det_opts.detector_file);
-        if (!det_opts.material_file.empty()) {
-            reader_cfg.add_file(traccc::io::data_directory() +
-                                det_opts.material_file);
-        }
-        if (!det_opts.grid_file.empty()) {
-            reader_cfg.add_file(traccc::io::data_directory() +
-                                det_opts.grid_file);
-        }
-        auto [detector, _] =
-            detray::io::read_detector<detray::detector<> >(host_mr, reader_cfg);
-
-        // Construct an "old style geometry" from the detector object.
-        surface_transforms = traccc::io::alt_read_geometry(detector);
-
-        // Construct a map from Acts surface identifiers to Detray barcodes.
-        barcode_map = std::make_unique<barcode_map_type>();
-        for (const auto& surface : detector.surfaces()) {
-            (*barcode_map)[surface.source] = surface.barcode();
-        }
-    } else {
-        // Construct a geometry object from the detector file.
-        surface_transforms = traccc::io::read_geometry(det_opts.detector_file);
-    }
+    // Read in the geometry.
+    auto [surface_transforms, barcode_map] = traccc::io::read_geometry(
+        det_opts.detector_file,
+        (det_opts.use_detray_detector ? traccc::data_format::json
+                                      : traccc::data_format::csv));
 
     // Read the digitization configuration file
     auto digi_cfg =
@@ -101,6 +66,9 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
 
     // Constant B field for the track finding and fitting
     const traccc::vector3 field_vec = {0.f, 0.f, finder_config.bFieldInZ};
+
+    // Memory resource used by the application.
+    vecmem::host_memory_resource host_mr;
 
     // Algorithms
     traccc::clusterization_algorithm ca(host_mr);

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,8 +14,6 @@
 // algorithms
 #include "traccc/clusterization/clusterization_algorithm.hpp"
 #include "traccc/clusterization/spacepoint_formation.hpp"
-#include "traccc/finding/finding_algorithm.hpp"
-#include "traccc/fitting/fitting_algorithm.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
 
@@ -25,18 +23,12 @@
 // options
 #include "traccc/options/common_options.hpp"
 #include "traccc/options/detector_input_options.hpp"
-#include "traccc/options/finding_input_options.hpp"
 #include "traccc/options/full_tracking_input_options.hpp"
 #include "traccc/options/handle_argument_errors.hpp"
-#include "traccc/options/propagation_options.hpp"
 
 // Detray include(s).
 #include "detray/core/detector.hpp"
-#include "detray/detectors/bfield.hpp"
-#include "detray/io/common/detector_reader.hpp"
-#include "detray/propagator/navigator.hpp"
-#include "detray/propagator/propagator.hpp"
-#include "detray/propagator/rk_stepper.hpp"
+#include "detray/io/frontend/detector_reader.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -46,39 +38,49 @@
 #include <exception>
 #include <iostream>
 #include <map>
+#include <memory>
 
 namespace po = boost::program_options;
 
 int seq_run(const traccc::full_tracking_input_options& i_cfg,
             const traccc::common_options& common_opts,
-            const traccc::detector_input_options& det_opts,
-            const traccc::finding_input_options& finding_opts,
-            const traccc::propagation_options& propagation_opts) {
+            const traccc::detector_input_options& det_opts) {
 
     // Memory resource used by the application.
     vecmem::host_memory_resource host_mr;
 
-    // Construct a detector object.
-    detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file(traccc::io::data_directory() + det_opts.detector_file);
-    if (!det_opts.material_file.empty()) {
+    // Construct a traccc::geometry object.
+    traccc::geometry surface_transforms;
+    using barcode_map_type = std::map<std::uint64_t, detray::geometry::barcode>;
+    std::unique_ptr<barcode_map_type> barcode_map;
+    if (det_opts.use_detray_detector) {
+
+        // Construct a detector object.
+        detray::io::detector_reader_config reader_cfg{};
         reader_cfg.add_file(traccc::io::data_directory() +
-                            det_opts.material_file);
-    }
-    if (!det_opts.grid_file.empty()) {
-        reader_cfg.add_file(traccc::io::data_directory() + det_opts.grid_file);
-    }
-    auto [detector, _] =
-        detray::io::read_detector<detray::detector<> >(host_mr, reader_cfg);
+                            det_opts.detector_file);
+        if (!det_opts.material_file.empty()) {
+            reader_cfg.add_file(traccc::io::data_directory() +
+                                det_opts.material_file);
+        }
+        if (!det_opts.grid_file.empty()) {
+            reader_cfg.add_file(traccc::io::data_directory() +
+                                det_opts.grid_file);
+        }
+        auto [detector, _] =
+            detray::io::read_detector<detray::detector<> >(host_mr, reader_cfg);
 
-    // Construct an "old style geometry" from the detector object.
-    traccc::geometry surface_transforms =
-        traccc::io::alt_read_geometry(detector);
+        // Construct an "old style geometry" from the detector object.
+        surface_transforms = traccc::io::alt_read_geometry(detector);
 
-    // Construct a map from Acts surface identifiers to Detray barcodes.
-    std::map<std::uint64_t, detray::geometry::barcode> barcode_map;
-    for (const auto& surface : detector.surface_lookup()) {
-        barcode_map[surface.source()] = surface.barcode();
+        // Construct a map from Acts surface identifiers to Detray barcodes.
+        barcode_map = std::make_unique<barcode_map_type>();
+        for (const auto& surface : detector.surfaces()) {
+            (*barcode_map)[surface.source] = surface.barcode();
+        }
+    } else {
+        // Construct a geometry object from the detector file.
+        surface_transforms = traccc::io::read_geometry(det_opts.detector_file);
     }
 
     // Read the digitization configuration file
@@ -91,47 +93,14 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
     uint64_t n_measurements = 0;
     uint64_t n_spacepoints = 0;
     uint64_t n_seeds = 0;
-    uint64_t n_found_tracks = 0;
-    uint64_t n_fitted_tracks = 0;
-
-    // Type definitions
-    using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
-                           detray::detector<>::transform3,
-                           detray::constrained_step<>>;
-    using navigator_type = detray::navigator<const detray::detector<>>;
-    using finding_algorithm =
-        traccc::finding_algorithm<stepper_type, navigator_type>;
-    using fitting_algorithm = traccc::fitting_algorithm<
-        traccc::kalman_fitter<stepper_type, navigator_type>>;
-
-    // Constant B field for the track finding and fitting
-    const traccc::vector3 field_vec = {0, 0,
-                                       2 * detray::unit<traccc::scalar>::T};
-    const detray::bfield::const_field_t field =
-        detray::bfield::create_const_field(field_vec);
 
     // Configs
     traccc::seedfinder_config finder_config;
     traccc::spacepoint_grid_config grid_config(finder_config);
     traccc::seedfilter_config filter_config;
 
-    finding_algorithm::config_type finding_config;
-    finding_config.min_track_candidates_per_track =
-        finding_opts.track_candidates_range[0];
-    finding_config.max_track_candidates_per_track =
-        finding_opts.track_candidates_range[1];
-    finding_config.chi2_max = finding_opts.chi2_max;
-    finding_config.step_constraint = propagation_opts.step_constraint;
-    finding_config.overstep_tolerance = propagation_opts.overstep_tolerance;
-    finding_config.mask_tolerance = propagation_opts.mask_tolerance;
-    finding_config.rk_tolerance = propagation_opts.rk_tolerance;
-
-    fitting_algorithm::config_type fitting_config;
-    fitting_config.step_constraint = propagation_opts.step_constraint;
-    fitting_config.overstep_tolerance = propagation_opts.overstep_tolerance;
-    fitting_config.mask_tolerance = propagation_opts.mask_tolerance;
-    fitting_config.rk_tolerance = propagation_opts.rk_tolerance;
+    // Constant B field for the track finding and fitting
+    const traccc::vector3 field_vec = {0.f, 0.f, finder_config.bFieldInZ};
 
     // Algorithms
     traccc::clusterization_algorithm ca(host_mr);
@@ -139,8 +108,6 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
     traccc::seeding_algorithm sa(finder_config, grid_config, filter_config,
                                  host_mr);
     traccc::track_params_estimation tp(host_mr);
-    finding_algorithm finding_alg(finding_config);
-    fitting_algorithm fitting_alg(fitting_config);
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
@@ -155,7 +122,8 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
         // Read the cells from the relevant event file
         traccc::io::read_cells(readOut, event, common_opts.input_directory,
                                common_opts.input_data_format,
-                               &surface_transforms, &digi_cfg, &barcode_map);
+                               &surface_transforms, &digi_cfg,
+                               barcode_map.get());
         traccc::cell_collection_types::host& cells_per_event = readOut.cells;
         traccc::cell_module_collection_types::host& modules_per_event =
             readOut.modules;
@@ -185,19 +153,6 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
 
         auto params = tp(spacepoints_per_event, seeds, field_vec);
 
-        /*-----------------------
-          Track finding
-          -----------------------*/
-
-        auto track_candidates =
-            finding_alg(detector, field, measurements_per_event, params);
-
-        /*-----------------------
-          Track fitting
-          -----------------------*/
-
-        auto track_states = fitting_alg(detector, field, track_candidates);
-
         /*----------------------------
           Statistics
           ----------------------------*/
@@ -207,8 +162,6 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
         n_measurements += measurements_per_event.size();
         n_spacepoints += spacepoints_per_event.size();
         n_seeds += seeds.size();
-        n_found_tracks += track_candidates.size();
-        n_fitted_tracks += track_states.size();
 
         /*------------
              Writer
@@ -238,8 +191,6 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
     std::cout << "- created " << n_spacepoints << " space points. "
               << std::endl;
     std::cout << "- created " << n_seeds << " seeds" << std::endl;
-    std::cout << "- found   " << n_found_tracks << " tracks" << std::endl;
-    std::cout << "- fitted  " << n_fitted_tracks << " tracks" << std::endl;
 
     return 0;
 }
@@ -255,8 +206,6 @@ int main(int argc, char* argv[]) {
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
     traccc::full_tracking_input_options full_tracking_input_cfg(desc);
-    traccc::finding_input_options finding_opts(desc);
-    traccc::propagation_options propagation_opts(desc);
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -268,18 +217,13 @@ int main(int argc, char* argv[]) {
     common_opts.read(vm);
     det_opts.read(vm);
     full_tracking_input_cfg.read(vm);
-    finding_opts.read(vm);
-    propagation_opts.read(vm);
 
     // Tell the user what's happening.
     std::cout << "\nRunning the full tracking chain on the host\n\n"
               << common_opts << "\n"
               << det_opts << "\n"
               << full_tracking_input_cfg << "\n"
-              << finding_opts << "\n"
-              << propagation_opts << "\n"
               << std::endl;
 
-    return seq_run(full_tracking_input_cfg, common_opts, det_opts, finding_opts,
-                   propagation_opts);
+    return seq_run(full_tracking_input_cfg, common_opts, det_opts);
 }

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -38,7 +38,8 @@ int seq_run(const traccc::seeding_input_options& /*i_cfg*/,
             const traccc::detector_input_options& det_opts, bool run_cpu) {
 
     // Read the surface transforms
-    auto surface_transforms = traccc::io::read_geometry(det_opts.detector_file);
+    auto [surface_transforms, _] =
+        traccc::io::read_geometry(det_opts.detector_file);
 
     // Output stats
     uint64_t n_modules = 0;

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,8 +39,11 @@ int par_run(const std::string &detector_file,
             const std::string &digi_config_file, const std::string &cells_dir,
             unsigned int events) {
 
-    // Read the surface transforms
-    auto surface_transforms = traccc::io::read_geometry(detector_file);
+    // Read the surface transforms. We can't use structured bindings for
+    // the return value of read_geometry(...), because the old Intel compiler
+    // used in the CI, when using OpenMP, crashes on such code. :-(
+    auto geom_pair = traccc::io::read_geometry(detector_file);
+    auto &surface_transforms = geom_pair.first;
 
     // Read the digitization configuration file
     auto digi_cfg = traccc::io::read_digitization_config(digi_config_file);

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -35,10 +35,6 @@
 #include "traccc/options/full_tracking_input_options.hpp"
 #include "traccc/options/handle_argument_errors.hpp"
 
-// Detray include(s).
-#include "detray/core/detector.hpp"
-#include "detray/io/frontend/detector_reader.hpp"
-
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
 #include <vecmem/memory/sycl/device_memory_resource.hpp>
@@ -73,43 +69,11 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts, bool run_cpu) {
 
-    // Memory resource used by the application.
-    vecmem::host_memory_resource host_mr;
-
-    // Construct a traccc::geometry object.
-    traccc::geometry surface_transforms;
-    using barcode_map_type = std::map<std::uint64_t, detray::geometry::barcode>;
-    std::unique_ptr<barcode_map_type> barcode_map;
-    if (det_opts.use_detray_detector) {
-
-        // Construct a detector object.
-        detray::io::detector_reader_config reader_cfg{};
-        reader_cfg.add_file(traccc::io::data_directory() +
-                            det_opts.detector_file);
-        if (!det_opts.material_file.empty()) {
-            reader_cfg.add_file(traccc::io::data_directory() +
-                                det_opts.material_file);
-        }
-        if (!det_opts.grid_file.empty()) {
-            reader_cfg.add_file(traccc::io::data_directory() +
-                                det_opts.grid_file);
-        }
-        auto [detector, _] =
-            detray::io::read_detector<detray::detector<>>(host_mr, reader_cfg);
-
-        // Construct an "old style geometry" from the detector object.
-        surface_transforms = traccc::io::alt_read_geometry(detector);
-
-        // Construct a map from Acts surface identifiers to Detray barcodes.
-        barcode_map = std::make_unique<barcode_map_type>();
-        for (const auto& surface : detector.surfaces()) {
-            (*barcode_map)[surface.source] = surface.barcode();
-        }
-
-    } else {
-        // Construct a geometry object from the detector file.
-        surface_transforms = traccc::io::read_geometry(det_opts.detector_file);
-    }
+    // Read in the geometry.
+    auto [surface_transforms, barcode_map] = traccc::io::read_geometry(
+        det_opts.detector_file,
+        (det_opts.use_detray_detector ? traccc::data_format::json
+                                      : traccc::data_format::csv));
 
     // Read the digitization configuration file
     auto digi_cfg =
@@ -139,6 +103,7 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
     const traccc::vector3 field_vec = {0.f, 0.f, finder_config.bFieldInZ};
 
     // Memory resources used by the application.
+    vecmem::host_memory_resource host_mr;
     vecmem::sycl::host_memory_resource sycl_host_mr{&q};
     vecmem::sycl::device_memory_resource device_mr{&q};
     traccc::memory_resource mr{device_mr, &sycl_host_mr};

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -1,6 +1,6 @@
 /* TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,6 +12,7 @@
 #include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_digitization_config.hpp"
 #include "traccc/io/read_geometry.hpp"
+#include "traccc/io/utils.hpp"
 
 // algorithms
 #include "traccc/clusterization/clusterization_algorithm.hpp"
@@ -34,6 +35,10 @@
 #include "traccc/options/full_tracking_input_options.hpp"
 #include "traccc/options/handle_argument_errors.hpp"
 
+// Detray include(s).
+#include "detray/core/detector.hpp"
+#include "detray/io/frontend/detector_reader.hpp"
+
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
 #include <vecmem/memory/sycl/device_memory_resource.hpp>
@@ -48,6 +53,7 @@
 #include <exception>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 
 namespace po = boost::program_options;
 
@@ -67,8 +73,43 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts, bool run_cpu) {
 
-    // Read the surface transforms
-    auto surface_transforms = traccc::io::read_geometry(det_opts.detector_file);
+    // Memory resource used by the application.
+    vecmem::host_memory_resource host_mr;
+
+    // Construct a traccc::geometry object.
+    traccc::geometry surface_transforms;
+    using barcode_map_type = std::map<std::uint64_t, detray::geometry::barcode>;
+    std::unique_ptr<barcode_map_type> barcode_map;
+    if (det_opts.use_detray_detector) {
+
+        // Construct a detector object.
+        detray::io::detector_reader_config reader_cfg{};
+        reader_cfg.add_file(traccc::io::data_directory() +
+                            det_opts.detector_file);
+        if (!det_opts.material_file.empty()) {
+            reader_cfg.add_file(traccc::io::data_directory() +
+                                det_opts.material_file);
+        }
+        if (!det_opts.grid_file.empty()) {
+            reader_cfg.add_file(traccc::io::data_directory() +
+                                det_opts.grid_file);
+        }
+        auto [detector, _] =
+            detray::io::read_detector<detray::detector<>>(host_mr, reader_cfg);
+
+        // Construct an "old style geometry" from the detector object.
+        surface_transforms = traccc::io::alt_read_geometry(detector);
+
+        // Construct a map from Acts surface identifiers to Detray barcodes.
+        barcode_map = std::make_unique<barcode_map_type>();
+        for (const auto& surface : detector.surfaces()) {
+            (*barcode_map)[surface.source] = surface.barcode();
+        }
+
+    } else {
+        // Construct a geometry object from the detector file.
+        surface_transforms = traccc::io::read_geometry(det_opts.detector_file);
+    }
 
     // Read the digitization configuration file
     auto digi_cfg =
@@ -86,7 +127,7 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
 
     // Creating SYCL queue object
     ::sycl::queue q(handle_async_error);
-    std::cout << "Running Seeding on device: "
+    std::cout << "Running on device: "
               << q.get_device().get_info<::sycl::info::device::name>() << "\n";
 
     // Configs
@@ -94,8 +135,10 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
     traccc::spacepoint_grid_config grid_config(finder_config);
     traccc::seedfilter_config filter_config;
 
+    // Constant B field for the track finding and fitting
+    const traccc::vector3 field_vec = {0.f, 0.f, finder_config.bFieldInZ};
+
     // Memory resources used by the application.
-    vecmem::host_memory_resource host_mr;
     vecmem::sycl::host_memory_resource sycl_host_mr{&q};
     vecmem::sycl::device_memory_resource device_mr{&q};
     traccc::memory_resource mr{device_mr, &sycl_host_mr};
@@ -145,10 +188,10 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
                 traccc::performance::timer t("File reading  (cpu)",
                                              elapsedTimes);
                 // Read the cells from the relevant event file into host memory.
-                traccc::io::read_cells(read_out_per_event, event,
-                                       common_opts.input_directory,
-                                       common_opts.input_data_format,
-                                       &surface_transforms, &digi_cfg);
+                traccc::io::read_cells(
+                    read_out_per_event, event, common_opts.input_directory,
+                    common_opts.input_data_format, &surface_transforms,
+                    &digi_cfg, barcode_map.get());
             }  // stop measuring file reading timer
 
             const traccc::cell_collection_types::host& cells_per_event =
@@ -228,9 +271,8 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
             {
                 traccc::performance::timer t("Track params (sycl)",
                                              elapsedTimes);
-                params_sycl_buffer =
-                    tp_sycl(spacepoints_sycl_buffer, seeds_sycl_buffer,
-                            {0.f, 0.f, finder_config.bFieldInZ});
+                params_sycl_buffer = tp_sycl(spacepoints_sycl_buffer,
+                                             seeds_sycl_buffer, field_vec);
                 q.wait_and_throw();
             }  // stop measuring track params timer
 
@@ -239,8 +281,7 @@ int seq_run(const traccc::full_tracking_input_options& i_cfg,
             if (run_cpu) {
                 traccc::performance::timer t("Track params  (cpu)",
                                              elapsedTimes);
-                params = tp(spacepoints_per_event, seeds,
-                            {0.f, 0.f, finder_config.bFieldInZ});
+                params = tp(spacepoints_per_event, seeds, field_vec);
             }  // stop measuring track params cpu timer
 
         }  // stop measuring wall time

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -69,14 +69,14 @@ traccc_add_library( traccc_io io TYPE SHARED
   "src/csv/read_measurements.hpp"
   "src/csv/read_measurements.cpp"
   "src/csv/make_measurement_hit_id_reader.cpp"
-  "src/csv/make_hit_reader.cpp"  
+  "src/csv/make_hit_reader.cpp"
   "src/csv/make_particle_reader.cpp"
   "src/csv/read_particles.hpp"
-  "src/csv/read_particles.cpp" 
+  "src/csv/read_particles.cpp"
   )
 target_link_libraries( traccc_io
   PUBLIC vecmem::core traccc::core ActsCore
-  PRIVATE dfelibs::dfelibs ActsPluginJson )
+  PRIVATE detray::core detray::io dfelibs::dfelibs ActsPluginJson )
 target_compile_definitions( traccc_io
   PRIVATE TRACCC_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/data" )
 if( OpenMP_CXX_FOUND )

--- a/io/include/traccc/io/read_cells.hpp
+++ b/io/include/traccc/io/read_cells.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,6 +18,8 @@
 
 // System include(s).
 #include <cstddef>
+#include <cstdint>
+#include <map>
 #include <string_view>
 
 namespace traccc::io {
@@ -33,12 +35,15 @@ namespace traccc::io {
 /// @param format The format of the cell data files (to read)
 /// @param geom The description of the detector geometry
 /// @param dconfig The detector's digitization configuration
+/// @param bardoce_map An object to perform barcode re-mapping with
+///                    (For Acts->Detray identifier re-mapping, if necessary)
 ///
-void read_cells(cell_reader_output &out, std::size_t event,
-                std::string_view directory,
-                data_format format = data_format::csv,
-                const geometry *geom = nullptr,
-                const digitization_config *dconfig = nullptr);
+void read_cells(
+    cell_reader_output &out, std::size_t event, std::string_view directory,
+    data_format format = data_format::csv, const geometry *geom = nullptr,
+    const digitization_config *dconfig = nullptr,
+    const std::map<std::uint64_t, detray::geometry::barcode> *barcode_map =
+        nullptr);
 
 /// Read cell data into memory
 ///
@@ -49,10 +54,14 @@ void read_cells(cell_reader_output &out, std::size_t event,
 /// @param format The format of the cell data files (to read)
 /// @param geom The description of the detector geometry
 /// @param dconfig The detector's digitization configuration
+/// @param bardoce_map An object to perform barcode re-mapping with
+///                    (For Acts->Detray identifier re-mapping, if necessary)
 ///
 void read_cells(cell_reader_output &out, std::string_view filename,
                 data_format format = data_format::csv,
                 const geometry *geom = nullptr,
-                const digitization_config *dconfig = nullptr);
+                const digitization_config *dconfig = nullptr,
+                const std::map<std::uint64_t, detray::geometry::barcode>
+                    *barcode_map = nullptr);
 
 }  // namespace traccc::io

--- a/io/include/traccc/io/read_geometry.hpp
+++ b/io/include/traccc/io/read_geometry.hpp
@@ -14,10 +14,15 @@
 #include "traccc/geometry/geometry.hpp"
 
 // Detray include(s).
-#include "detray/geometry/surface.hpp"
+#include <detray/geometry/barcode.hpp>
+#include <detray/geometry/surface.hpp>
 
 // System include(s).
+#include <cstdint>
+#include <map>
+#include <memory>
 #include <string_view>
+#include <utility>
 
 namespace traccc::io {
 
@@ -27,8 +32,9 @@ namespace traccc::io {
 /// @param format The format of the input file
 /// @return A description of the detector modules
 ///
-geometry read_geometry(std::string_view filename,
-                       data_format format = data_format::csv);
+std::pair<geometry,
+          std::unique_ptr<std::map<std::uint64_t, detray::geometry::barcode>>>
+read_geometry(std::string_view filename, data_format format = data_format::csv);
 
 /// Read in the detector geometry description from a detector object
 template <typename detector_t>

--- a/io/src/csv/read_cells.hpp
+++ b/io/src/csv/read_cells.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,6 +14,8 @@
 #include "traccc/io/reader_edm.hpp"
 
 // System include(s).
+#include <cstdint>
+#include <map>
 #include <string_view>
 
 namespace traccc::io::csv {
@@ -24,9 +26,12 @@ namespace traccc::io::csv {
 /// @param filename The file to read the cell data from
 /// @param geom The description of the detector geometry
 /// @param dconfig The detector's digitization configuration
+/// @param bardoce_map An object to perform barcode re-mapping with
 ///
 void read_cells(cell_reader_output& out, std::string_view filename,
                 const geometry* geom = nullptr,
-                const digitization_config* dconfig = nullptr);
+                const digitization_config* dconfig = nullptr,
+                const std::map<std::uint64_t, detray::geometry::barcode>*
+                    barcode_map = nullptr);
 
 }  // namespace traccc::io::csv

--- a/io/src/mapper.cpp
+++ b/io/src/mapper.cpp
@@ -199,7 +199,7 @@ generate_measurement_cell_map(std::size_t event,
     measurement_creation mc(resource);
 
     // Read the surface transforms
-    auto surface_transforms = io::read_geometry(detector_file);
+    auto [surface_transforms, _] = io::read_geometry(detector_file);
 
     // Read the digitization configuration file
     auto digi_cfg = io::read_digitization_config(digi_config_file);
@@ -266,7 +266,7 @@ measurement_particle_map generate_measurement_particle_map(
     measurement_particle_map result;
 
     // Read the surface transforms
-    auto surface_transforms = io::read_geometry(detector_file);
+    auto [surface_transforms, _] = io::read_geometry(detector_file);
 
     // Read the spacepoints from the relevant event file
     traccc::io::spacepoint_reader_output readOut(&resource);

--- a/io/src/read.cpp
+++ b/io/src/read.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -23,8 +23,11 @@ void read(demonstrator_input& out, std::size_t events,
           std::string_view directory, std::string_view detector_file,
           std::string_view digi_config_file, data_format format) {
 
-    // Read in the detector configuration.
-    const geometry geom = io::read_geometry(detector_file);
+    // Read in the detector configuration. We can't use structured bindings for
+    // the return value of read_geometry(...), because the old Intel compiler
+    // used in the CI, when using OpenMP, crashes on such code. :-(
+    const auto geom_pair = io::read_geometry(detector_file);
+    const auto& geom = geom_pair.first;
     const digitization_config digi_cfg =
         io::read_digitization_config(digi_config_file);
 

--- a/io/src/read_cells.cpp
+++ b/io/src/read_cells.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,16 +14,18 @@
 
 namespace traccc::io {
 
-void read_cells(cell_reader_output& out, std::size_t event,
-                std::string_view directory, data_format format,
-                const geometry* geom, const digitization_config* dconfig) {
+void read_cells(
+    cell_reader_output& out, std::size_t event, std::string_view directory,
+    data_format format, const geometry* geom,
+    const digitization_config* dconfig,
+    const std::map<std::uint64_t, detray::geometry::barcode>* barcode_map) {
 
     switch (format) {
         case data_format::csv: {
             read_cells(out,
                        data_directory() + directory.data() +
                            get_event_filename(event, "-cells.csv"),
-                       format, geom, dconfig);
+                       format, geom, dconfig, barcode_map);
             break;
         }
         case data_format::binary: {
@@ -40,13 +42,14 @@ void read_cells(cell_reader_output& out, std::size_t event,
     }
 }
 
-void read_cells(cell_reader_output& out, std::string_view filename,
-                data_format format, const geometry* geom,
-                const digitization_config* dconfig) {
+void read_cells(
+    cell_reader_output& out, std::string_view filename, data_format format,
+    const geometry* geom, const digitization_config* dconfig,
+    const std::map<std::uint64_t, detray::geometry::barcode>* barcode_map) {
 
     switch (format) {
         case data_format::csv:
-            return csv::read_cells(out, filename, geom, dconfig);
+            return csv::read_cells(out, filename, geom, dconfig, barcode_map);
 
         default:
             throw std::invalid_argument("Unsupported data format");

--- a/io/src/read_geometry.cpp
+++ b/io/src/read_geometry.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,16 +11,74 @@
 #include "traccc/io/details/read_surfaces.hpp"
 #include "traccc/io/utils.hpp"
 
+// Detray include(s).
+#include <detray/core/detector.hpp>
+#include <detray/io/frontend/detector_reader.hpp>
+
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// System include(s).
+#include <stdexcept>
+
+namespace {
+
+/// Helper function constructing @c traccc::geometry from Detray JSON
+std::pair<traccc::geometry,
+          std::unique_ptr<std::map<std::uint64_t, detray::geometry::barcode>>>
+read_json_geometry(std::string_view filename) {
+
+    // Memory resource used while reading the detector JSON.
+    vecmem::host_memory_resource host_mr;
+
+    // The result objects.
+    traccc::geometry surface_transforms;
+    std::unique_ptr<std::map<std::uint64_t, detray::geometry::barcode>>
+        barcode_map;
+
+    {
+        // Construct a detector object.
+        detray::io::detector_reader_config reader_cfg{};
+        reader_cfg.add_file(std::string{filename});
+        auto [detector, _] =
+            detray::io::read_detector<detray::detector<>>(host_mr, reader_cfg);
+
+        // Construct an "old style geometry" from the detector object.
+        surface_transforms = traccc::io::alt_read_geometry(detector);
+
+        // Construct a map from Acts surface identifiers to Detray barcodes.
+        barcode_map = std::make_unique<
+            std::map<std::uint64_t, detray::geometry::barcode>>();
+        for (const auto& surface : detector.surfaces()) {
+            (*barcode_map)[surface.source] = surface.barcode();
+        }
+    }
+
+    // Return the created objects.
+    return {surface_transforms, std::move(barcode_map)};
+}
+
+}  // namespace
+
 namespace traccc::io {
 
-geometry read_geometry(std::string_view filename, data_format format) {
+std::pair<geometry,
+          std::unique_ptr<std::map<std::uint64_t, detray::geometry::barcode>>>
+read_geometry(std::string_view filename, data_format format) {
 
     // Construct the full file name.
     const std::string full_filename = data_directory() + filename.data();
 
-    // Read the file using another function. Relying on the auto-conversion of
-    // the output type of that other function.
-    return details::read_surfaces(full_filename, format);
+    // Decide how to read the file.
+    switch (format) {
+        case data_format::csv:
+            return {geometry{details::read_surfaces(full_filename, format)},
+                    nullptr};
+        case data_format::json:
+            return ::read_json_geometry(full_filename);
+        default:
+            throw std::invalid_argument("Unsupported data format");
+    }
 }
 
 }  // namespace traccc::io

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -82,7 +82,7 @@ TEST_P(CompareWithActsSeedingTests, Run) {
     traccc::seed_finding sf(traccc_config, traccc::seedfilter_config());
 
     // Read the surface transforms
-    auto surface_transforms = traccc::io::read_geometry(detector_file);
+    auto [surface_transforms, _] = traccc::io::read_geometry(detector_file);
 
     // Read the hits from the relevant event file
     traccc::io::spacepoint_reader_output reader_output(&host_mr);

--- a/tests/cpu/test_clusterization_resolution.cpp
+++ b/tests/cpu/test_clusterization_resolution.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -32,7 +32,7 @@ TEST_P(SurfaceBinningTests, Run) {
     unsigned int event = std::get<3>(GetParam());
 
     // Read the surface transforms
-    auto surface_transforms = traccc::io::read_geometry(detector_file);
+    auto [surface_transforms, _] = traccc::io::read_geometry(detector_file);
 
     // Read the digitization configuration file
     auto digi_cfg = traccc::io::read_digitization_config(digi_config_file);

--- a/tests/io/test_binary.cpp
+++ b/tests/io/test_binary.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -35,7 +35,7 @@ TEST(io_binary, cell) {
     vecmem::host_memory_resource host_mr;
 
     // Read the surface transforms
-    auto surface_transforms =
+    auto [surface_transforms, _] =
         traccc::io::read_geometry("tml_detector/trackml-detector.csv");
 
     // Read the digitization configuration file
@@ -109,7 +109,7 @@ TEST(io_binary, spacepoint) {
     vecmem::host_memory_resource host_mr;
 
     // Read the surface transforms
-    auto surface_transforms =
+    auto [surface_transforms, _] =
         traccc::io::read_geometry("tml_detector/trackml-detector.csv");
 
     // Read csv file

--- a/tests/io/test_csv.cpp
+++ b/tests/io/test_csv.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -103,7 +103,7 @@ TEST_F(io, csv_read_tml_single_muon) {
     vecmem::host_memory_resource resource;
 
     // Read the surface transforms
-    auto surface_transforms =
+    auto [surface_transforms, _] =
         traccc::io::read_geometry("tml_detector/trackml-detector.csv");
 
     // Read the hits from the relevant event file


### PR DESCRIPTION
Made the CPU algorithm sequence use Detray geometries. This is needed for processing data produced for the ODD geometry.

To be able to read those files correctly, taught the CSV cell reading code how to switch from Acts to Detry identifiers in the cell module data on the fly. To make the simulation files usable with the identifiers generated by Detray.

This is all very much a hack at the moment, in order to try to make the full (host) chain work on the ODD geometry.