### PR TITLE
Hip updates main

### DIFF
--- a/core/include/traccc/definitions/qualifiers.hpp
+++ b/core/include/traccc/definitions/qualifiers.hpp
@@ -8,25 +8,25 @@
 
 #pragma once
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIP__)
 #define TRACCC_DEVICE __device__
 #else
 #define TRACCC_DEVICE
 #endif
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIP__)
 #define TRACCC_HOST __host__
 #else
 #define TRACCC_HOST
 #endif
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIP__)
 #define TRACCC_HOST_DEVICE __host__ __device__
 #else
 #define TRACCC_HOST_DEVICE
 #endif
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIP__)
 #define TRACCC_ALIGN(x) __align__(x)
 #else
 #define TRACCC_ALIGN(x) alignas(x)

--- a/core/include/traccc/seeding/doublet_finding_helper.hpp
+++ b/core/include/traccc/seeding/doublet_finding_helper.hpp
@@ -47,7 +47,7 @@ struct doublet_finding_helper {
 };
 
 template <details::spacepoint_type otherSpType>
-bool doublet_finding_helper::isCompatible(
+bool TRACCC_HOST_DEVICE doublet_finding_helper::isCompatible(
     const internal_spacepoint<spacepoint>& sp1,
     const internal_spacepoint<spacepoint>& sp2,
     const seedfinder_config& config) {
@@ -86,7 +86,7 @@ bool doublet_finding_helper::isCompatible(
 }
 
 template <details::spacepoint_type otherSpType>
-lin_circle doublet_finding_helper::transform_coordinates(
+lin_circle TRACCC_HOST_DEVICE doublet_finding_helper::transform_coordinates(
     const internal_spacepoint<spacepoint>& sp1,
     const internal_spacepoint<spacepoint>& sp2) {
 

--- a/core/include/traccc/seeding/doublet_finding_helper.hpp
+++ b/core/include/traccc/seeding/doublet_finding_helper.hpp
@@ -47,10 +47,10 @@ struct doublet_finding_helper {
 };
 
 template <details::spacepoint_type otherSpType>
-bool TRACCC_HOST_DEVICE doublet_finding_helper::isCompatible(
-    const internal_spacepoint<spacepoint>& sp1,
-    const internal_spacepoint<spacepoint>& sp2,
-    const seedfinder_config& config) {
+bool TRACCC_HOST_DEVICE
+doublet_finding_helper::isCompatible(const internal_spacepoint<spacepoint>& sp1,
+                                     const internal_spacepoint<spacepoint>& sp2,
+                                     const seedfinder_config& config) {
 
     static_assert(otherSpType == details::spacepoint_type::bottom ||
                   otherSpType == details::spacepoint_type::top);

--- a/core/include/traccc/seeding/triplet_finding_helper.hpp
+++ b/core/include/traccc/seeding/triplet_finding_helper.hpp
@@ -36,7 +36,7 @@ struct triplet_finding_helper {
         scalar& curvature, scalar& impact_parameter);
 };
 
-bool triplet_finding_helper::isCompatible(
+bool TRACCC_HOST_DEVICE triplet_finding_helper::isCompatible(
     const internal_spacepoint<spacepoint>& spM, const lin_circle& lb,
     const lin_circle& lt, const seedfinder_config& config,
     const scalar& iSinTheta2, const scalar& scatteringInRegion2,


### PR DESCRIPTION
As proposed by @krasznaa in https://github.com/acts-project/vecmem/pull/261, extend the __host__ and __device__ macros for HIP.

Clang wanted TRACCC_HOST_DEVICE to be added to the function definition as well in a couple of places. I could not get compilation to work with gcc. Wasn't clear to me if this was supported at all.

I now get as far as a puzzling linker error:
```
[100%] Linking CXX executable ../../../bin/traccc_seeding_example_alpaka
/cvmfs/sft.cern.ch/lcg/releases/binutils/2.39-393d1/x86_64-centos7/bin/ld: CMakeFiles/traccc_seeding_example_alpaka.dir/seeding_example_alpaka.cpp.o: relocation R_X86_64_32S against symbol `_ZTVN6vecmem4copyE' can not be used when making a PIE object; recompile with -fPIE
/cvmfs/sft.cern.ch/lcg/releases/binutils/2.39-393d1/x86_64-centos7/bin/ld: failed to set dynamic section sizes: bad value
```
but I think this is separate and that these changes are safe.