### PR TITLE
Update algebra-plugins and vecmem versions

### DIFF
--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Algebra Plugins as part of the TRACCC project" )
 
 # Declare where to get Algebra Plugins from.
 set( TRACCC_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.19.0.tar.gz;URL_MD5;8357b024b1bcdb70350d8a378055cfee"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.22.0.tar.gz;URL_MD5;42bcaad8d19a2c773993a974816dfdf5"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 
 mark_as_advanced( TRACCC_ALGEBRA_PLUGINS_SOURCE )

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.26.0.tar.gz;URL_MD5;3162c26ced6bb7ce25a5873002e8a2b4"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.3.0.tar.gz;URL_MD5;0ba29e2c5db4aaab02aeb93fc0900e3b"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.3.0.tar.gz;URL_MD5;0ba29e2c5db4aaab02aeb93fc0900e3b"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.3.1.tar.gz;URL_MD5;3356c4db427e1b176e2f71d7f060ecd7"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Update algebra-plugins and vecmem to latest tags. Largely important for Alpaka HIP developments.