### PR TITLE
Fix chi2 calculation for annulus measurements

### DIFF
--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -77,10 +77,10 @@ struct track_state {
                       "The measurement dimension should be 1 or 2");
 
         matrix_type<D, 1> ret;
-	if(m_measurement.subs.get_indices()[0]==0)	
-	  matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
-	else
-	  matrix_operator().element(ret, 0, 0) = m_measurement.local[1];
+        if (m_measurement.subs.get_indices()[0] == 0)
+            matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
+        else
+            matrix_operator().element(ret, 0, 0) = m_measurement.local[1];
 
         if constexpr (D == 2u) {
             matrix_operator().element(ret, 1, 0) = m_measurement.local[1];
@@ -95,10 +95,10 @@ struct track_state {
                       "The measurement dimension should be 1 or 2");
 
         matrix_type<D, D> ret;
-	if(m_measurement.subs.get_indices()[0]==0)	
-	  matrix_operator().element(ret, 0, 0) = m_measurement.variance[0];
-	else
-	  matrix_operator().element(ret, 0, 0) = m_measurement.variance[1];
+        if (m_measurement.subs.get_indices()[0] == 0)
+            matrix_operator().element(ret, 0, 0) = m_measurement.variance[0];
+        else
+            matrix_operator().element(ret, 0, 0) = m_measurement.variance[1];
 
         if constexpr (D == 2u) {
             matrix_operator().element(ret, 0, 1) = 0.f;

--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -91,6 +91,10 @@ struct track_state {
             assert(
                 "The measurement index out of e_bound_loc0 and e_bound_loc1 "
                 "should not happen.");
+            matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
+            if constexpr (D == 2u) {
+                matrix_operator().element(ret, 1, 0) = m_measurement.local[1];
+            }
         }
 
         return ret;
@@ -126,6 +130,13 @@ struct track_state {
             assert(
                 "The measurement index out of e_bound_loc0 and e_bound_loc1 "
                 "should not happen.");
+            matrix_operator().element(ret, 0, 0) = m_measurement.variance[0];
+            if constexpr (D == 2u) {
+                matrix_operator().element(ret, 0, 1) = 0.f;
+                matrix_operator().element(ret, 1, 0) = 0.f;
+                matrix_operator().element(ret, 1, 1) =
+                    m_measurement.variance[1];
+            }
         }
         return ret;
     }

--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -77,7 +77,11 @@ struct track_state {
                       "The measurement dimension should be 1 or 2");
 
         matrix_type<D, 1> ret;
-        matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
+	if(m_measurement.subs.get_indices()[0]==0)	
+	  matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
+	else
+	  matrix_operator().element(ret, 0, 0) = m_measurement.local[1];
+
         if constexpr (D == 2u) {
             matrix_operator().element(ret, 1, 0) = m_measurement.local[1];
         }
@@ -91,7 +95,11 @@ struct track_state {
                       "The measurement dimension should be 1 or 2");
 
         matrix_type<D, D> ret;
-        matrix_operator().element(ret, 0, 0) = m_measurement.variance[0];
+	if(m_measurement.subs.get_indices()[0]==0)	
+	  matrix_operator().element(ret, 0, 0) = m_measurement.variance[0];
+	else
+	  matrix_operator().element(ret, 0, 0) = m_measurement.variance[1];
+
         if constexpr (D == 2u) {
             matrix_operator().element(ret, 0, 1) = 0.f;
             matrix_operator().element(ret, 1, 0) = 0.f;

--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -77,13 +77,16 @@ struct track_state {
                       "The measurement dimension should be 1 or 2");
 
         matrix_type<D, 1> ret;
-        if (m_measurement.subs.get_indices()[0] == 0)
+        if (m_measurement.subs.get_indices()[0] == e_bound_loc0) {
             matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
-        else
+            if constexpr (D == 2u) {
+                matrix_operator().element(ret, 1, 0) = m_measurement.local[1];
+            }
+        } else if (m_measurement.subs.get_indices()[0] == e_bound_loc1) {
             matrix_operator().element(ret, 0, 0) = m_measurement.local[1];
-
-        if constexpr (D == 2u) {
-            matrix_operator().element(ret, 1, 0) = m_measurement.local[1];
+            if constexpr (D == 2u) {
+                matrix_operator().element(ret, 1, 0) = m_measurement.local[0];
+            }
         }
         return ret;
     }
@@ -95,15 +98,25 @@ struct track_state {
                       "The measurement dimension should be 1 or 2");
 
         matrix_type<D, D> ret;
-        if (m_measurement.subs.get_indices()[0] == 0)
-            matrix_operator().element(ret, 0, 0) = m_measurement.variance[0];
-        else
-            matrix_operator().element(ret, 0, 0) = m_measurement.variance[1];
+        if (m_measurement.subs.get_indices()[0] == e_bound_loc0) {
 
-        if constexpr (D == 2u) {
-            matrix_operator().element(ret, 0, 1) = 0.f;
-            matrix_operator().element(ret, 1, 0) = 0.f;
-            matrix_operator().element(ret, 1, 1) = m_measurement.variance[1];
+            matrix_operator().element(ret, 0, 0) = m_measurement.variance[0];
+            if constexpr (D == 2u) {
+                matrix_operator().element(ret, 0, 1) = 0.f;
+                matrix_operator().element(ret, 1, 0) = 0.f;
+                matrix_operator().element(ret, 1, 1) =
+                    m_measurement.variance[1];
+            }
+
+        } else if (m_measurement.subs.get_indices()[0] == e_bound_loc1) {
+
+            matrix_operator().element(ret, 0, 0) = m_measurement.variance[1];
+            if constexpr (D == 2u) {
+                matrix_operator().element(ret, 0, 1) = 0.f;
+                matrix_operator().element(ret, 1, 0) = 0.f;
+                matrix_operator().element(ret, 1, 1) =
+                    m_measurement.variance[0];
+            }
         }
         return ret;
     }

--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -87,11 +87,10 @@ struct track_state {
             if constexpr (D == 2u) {
                 matrix_operator().element(ret, 1, 0) = m_measurement.local[0];
             }
-        } else {  // same as e_bound_loc0
-            matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
-            if constexpr (D == 2u) {
-                matrix_operator().element(ret, 1, 0) = m_measurement.local[1];
-            }
+        } else {
+            assert(
+                "The measurement index out of e_bound_loc0 and e_bound_loc1 "
+                "should not happen.");
         }
 
         return ret;
@@ -123,15 +122,10 @@ struct track_state {
                 matrix_operator().element(ret, 1, 1) =
                     m_measurement.variance[0];
             }
-        } else {  // same as e_bound_loc0
-
-            matrix_operator().element(ret, 0, 0) = m_measurement.variance[0];
-            if constexpr (D == 2u) {
-                matrix_operator().element(ret, 0, 1) = 0.f;
-                matrix_operator().element(ret, 1, 0) = 0.f;
-                matrix_operator().element(ret, 1, 1) =
-                    m_measurement.variance[1];
-            }
+        } else {
+            assert(
+                "The measurement index out of e_bound_loc0 and e_bound_loc1 "
+                "should not happen.");
         }
         return ret;
     }

--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -87,7 +87,13 @@ struct track_state {
             if constexpr (D == 2u) {
                 matrix_operator().element(ret, 1, 0) = m_measurement.local[0];
             }
+        } else {  // same as e_bound_loc0
+            matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
+            if constexpr (D == 2u) {
+                matrix_operator().element(ret, 1, 0) = m_measurement.local[1];
+            }
         }
+
         return ret;
     }
 
@@ -116,6 +122,15 @@ struct track_state {
                 matrix_operator().element(ret, 1, 0) = 0.f;
                 matrix_operator().element(ret, 1, 1) =
                     m_measurement.variance[0];
+            }
+        } else {  // same as e_bound_loc0
+
+            matrix_operator().element(ret, 0, 0) = m_measurement.variance[0];
+            if constexpr (D == 2u) {
+                matrix_operator().element(ret, 0, 1) = 0.f;
+                matrix_operator().element(ret, 1, 0) = 0.f;
+                matrix_operator().element(ret, 1, 1) =
+                    m_measurement.variance[1];
             }
         }
         return ret;


### PR DESCRIPTION
Update of `track_state.hpp` to get annulus measurements properly in track_state, otherwise chi2 is always zero for annulus measurements. 