### PR TITLE
Command Line Options Cleanup, main branch (2024.03.05.)

### DIFF
--- a/examples/options/CMakeLists.txt
+++ b/examples/options/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022-2023 CERN for the benefit of the ACTS project
+# (c) 2022-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -9,23 +9,28 @@ traccc_add_library( traccc_options options TYPE SHARED
   # header files
   "include/traccc/options/common_options.hpp"
   "include/traccc/options/detector_input_options.hpp"
+  "include/traccc/options/finding_input_options.hpp"
+  "include/traccc/options/full_tracking_input_options.hpp"
   "include/traccc/options/handle_argument_errors.hpp"
   "include/traccc/options/mt_options.hpp"
   "include/traccc/options/options.hpp"
   "include/traccc/options/particle_gen_options.hpp"
   "include/traccc/options/propagation_options.hpp"
-  "include/traccc/options/finding_input_options.hpp"
   "include/traccc/options/seeding_input_options.hpp"
-  "include/traccc/options/full_tracking_input_options.hpp"   
+  "include/traccc/options/telescope_detector_options.hpp"
   "include/traccc/options/throughput_options.hpp"
   # source files
   "src/options/common_options.cpp"
   "src/options/detector_input_options.cpp"
+  "src/options/finding_input_options.cpp"
+  "src/options/full_tracking_input_options.cpp"
   "src/options/handle_argument_errors.cpp"
   "src/options/mt_options.cpp"
+  "src/options/particle_gen_options.cpp"
+  "src/options/propagation_options.cpp"
   "src/options/seeding_input_options.cpp"
-  "src/options/full_tracking_input_options.cpp"
+  "src/options/telescope_detector_options.cpp"
   "src/options/throughput_options.cpp"
   )
-target_link_libraries( traccc_options PUBLIC traccc::io 
+target_link_libraries( traccc_options PUBLIC traccc::io
                        traccc::performance Boost::program_options)

--- a/examples/options/include/traccc/options/common_options.hpp
+++ b/examples/options/include/traccc/options/common_options.hpp
@@ -8,24 +8,48 @@
 // Project include(s)
 #include "traccc/io/data_format.hpp"
 
-// Boost
+// Boost include(s).
 #include <boost/program_options.hpp>
+
+// System include(s).
+#include <iosfwd>
+#include <string>
 
 namespace traccc {
 
-namespace po = boost::program_options;
-
+/// Common options for the example applications
 struct common_options {
-    traccc::data_format input_data_format = traccc::data_format::csv;
-    std::string input_directory;
-    unsigned int events;
-    int skip;
-    unsigned short target_cells_per_partition;
-    bool check_performance;
-    bool perform_ambiguity_resolution;
 
-    common_options(po::options_description& desc);
-    void read(const po::variables_map& vm);
-};
+    /// The input data format
+    traccc::data_format input_data_format = traccc::data_format::csv;
+    /// The data input directory
+    std::string input_directory = "tml_full/ttbar_mu20/";
+    /// The number of events to process
+    unsigned int events = 1;
+    /// The number of events to skip
+    unsigned int skip = 0;
+    /// The number of cells to merge in a partition
+    unsigned short target_cells_per_partition = 1024;
+    /// Whether to check the reconstructions performance
+    bool check_performance = false;
+    /// Whether to perform ambiguity resolution
+    bool perform_ambiguity_resolution = true;
+
+    /// Constructor on top of a common @c program_options object
+    ///
+    /// @param desc The program options to add to
+    ///
+    common_options(boost::program_options::options_description& desc);
+
+    /// Read/process the command line options
+    ///
+    /// @param vm The command line options to interpret/read
+    ///
+    void read(const boost::program_options::variables_map& vm);
+
+};  // struct common_options
+
+/// Printout helper for @c traccc::common_options
+std::ostream& operator<<(std::ostream& out, const common_options& opt);
 
 }  // namespace traccc

--- a/examples/options/include/traccc/options/detector_input_options.hpp
+++ b/examples/options/include/traccc/options/detector_input_options.hpp
@@ -1,24 +1,46 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
-// Boost
+#pragma once
+
+// Boost include(s).
 #include <boost/program_options.hpp>
+
+// System include(s).
+#include <iosfwd>
+#include <string>
 
 namespace traccc {
 
-namespace po = boost::program_options;
-
+/// Options for the detector description
 struct detector_input_options {
-    std::string detector_file;
+
+    /// The file containing the detector description
+    std::string detector_file = "tml_detector/trackml-detector.csv";
+    /// The file containing the material description
     std::string material_file;
+    /// The file containing the surface grid description
     std::string grid_file;
 
-    detector_input_options(po::options_description& desc);
-    void read(const po::variables_map& vm);
-};
+    /// Constructor on top of a common @c program_options object
+    ///
+    /// @param desc The program options to add to
+    ///
+    detector_input_options(boost::program_options::options_description& desc);
+
+    /// Read/process the command line options
+    ///
+    /// @param vm The command line options to interpret/read
+    ///
+    void read(const boost::program_options::variables_map& vm);
+
+};  // struct detector_input_options
+
+/// Printout helper for @c traccc::detector_input_options
+std::ostream& operator<<(std::ostream& out, const detector_input_options& opt);
 
 }  // namespace traccc

--- a/examples/options/include/traccc/options/finding_input_options.hpp
+++ b/examples/options/include/traccc/options/finding_input_options.hpp
@@ -1,52 +1,49 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 // Project include(s).
 #include "traccc/options/options.hpp"
 
-// Boost
+// Boost include(s).
 #include <boost/program_options.hpp>
+
+// System include(s).
+#include <iosfwd>
+#include <limits>
 
 namespace traccc {
 
-namespace po = boost::program_options;
+/// Configuration for track finding
+struct finding_input_options {
 
-template <typename scalar_t>
-struct finding_input_config {
-    Reals<unsigned int, 2> track_candidates_range;
-    scalar_t chi2_max;
-    unsigned int nmax_per_seed;
+    /// Number of track candidates per seed
+    Reals<unsigned int, 2> track_candidates_range{3, 100};
+    /// Maximum chi2 for a measurement to be included in the track
+    float chi2_max = 30.f;
+    /// Maximum number of branches which each initial seed can have at a step
+    unsigned int nmax_per_seed = std::numeric_limits<unsigned int>::max();
 
-    finding_input_config(po::options_description& desc) {
+    /// Constructor on top of a common @c program_options object
+    ///
+    /// @param desc The program options to add to
+    ///
+    finding_input_options(boost::program_options::options_description& desc);
 
-        desc.add_options()("track-candidates-range",
-                           po::value<Reals<unsigned int, 2>>()
-                               ->value_name("MIN:MAX")
-                               ->default_value({3, 100}),
-                           "Range of track candidates number");
-        desc.add_options()(
-            "chi2-max",
-            po::value<scalar_t>()->value_name("chi2-max")->default_value(30.f),
-            "Maximum Chi suqare that measurements can be included in the "
-            "track");
-        desc.add_options()(
-            "nmax_per_seed",
-            po::value<unsigned int>()
-                ->value_name("nmax_per_seed")
-                ->default_value(std::numeric_limits<unsigned int>::max()),
-            "Maximum number of branches which each initial seed can have at a "
-            "step.");
-    }
-    void read(const po::variables_map& vm) {
-        track_candidates_range =
-            vm["track-candidates-range"].as<Reals<unsigned int, 2>>();
-        chi2_max = vm["chi2-max"].as<scalar_t>();
-        nmax_per_seed = vm["nmax_per_seed"].as<unsigned int>();
-    }
-};
+    /// Read/process the command line options
+    ///
+    /// @param vm The command line options to interpret/read
+    ///
+    void read(const boost::program_options::variables_map& vm);
+
+};  // struct finding_input_options
+
+/// Printout helper for @c traccc::finding_input_options
+std::ostream& operator<<(std::ostream& out, const finding_input_options& opt);
 
 }  // namespace traccc

--- a/examples/options/include/traccc/options/full_tracking_input_options.hpp
+++ b/examples/options/include/traccc/options/full_tracking_input_options.hpp
@@ -1,23 +1,45 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
-// Boost
+#pragma once
+
+// Boost include(s).
 #include <boost/program_options.hpp>
+
+// System include(s).
+#include <iosfwd>
+#include <string>
 
 namespace traccc {
 
-namespace po = boost::program_options;
+/// Configuration for a full tracking chain
+struct full_tracking_input_options {
 
-struct full_tracking_input_config {
-    std::string detector_file;
-    std::string digitization_config_file;
+    /// The digitization configuration file
+    std::string digitization_config_file =
+        "tml_detector/default-geometric-config-generic.json";
 
-    full_tracking_input_config(po::options_description& desc);
-    void read(const po::variables_map& vm);
-};
+    /// Constructor on top of a common @c program_options object
+    ///
+    /// @param desc The program options to add to
+    ///
+    full_tracking_input_options(
+        boost::program_options::options_description& desc);
+
+    /// Read/process the command line options
+    ///
+    /// @param vm The command line options to interpret/read
+    ///
+    void read(const boost::program_options::variables_map& vm);
+
+};  // struct full_tracking_input_config
+
+/// Printout helper for @c traccc::full_tracking_input_options
+std::ostream& operator<<(std::ostream& out,
+                         const full_tracking_input_options& opt);
 
 }  // namespace traccc

--- a/examples/options/include/traccc/options/mt_options.hpp
+++ b/examples/options/include/traccc/options/mt_options.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -28,7 +28,7 @@ struct mt_options {
     ///
     mt_options(boost::program_options::options_description& desc);
 
-    /// Read the command line options
+    /// Read/process the command line options
     ///
     /// @param vm The command line options to interpret/read
     ///

--- a/examples/options/include/traccc/options/particle_gen_options.hpp
+++ b/examples/options/include/traccc/options/particle_gen_options.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,75 +9,48 @@
 
 // Project include(s).
 #include "traccc/options/options.hpp"
-#include "traccc/utils/ranges.hpp"
 
-// Detray include(s).
-#include "detray/definitions/units.hpp"
-
-// Boost
+// Boost include(s).
 #include <boost/program_options.hpp>
+
+// System include(s).
+#include <iosfwd>
 
 namespace traccc {
 
-namespace po = boost::program_options;
-
-template <typename scalar_t>
+/// Configuration for particle generation
 struct particle_gen_options {
-    unsigned int gen_nparticles{1};
-    Reals<scalar_t, 3> vertex{0., 0., 0.};
-    Reals<scalar_t, 3> vertex_stddev{0., 0., 0.};
-    Reals<scalar_t, 2> mom_range{1., 1.};
-    Reals<scalar_t, 2> phi_range{0., 0.};
-    Reals<scalar_t, 2> theta_range{0., 0.};
-    scalar_t charge{-1.f};
 
-    particle_gen_options(po::options_description& desc) {
-        desc.add_options()("gen-nparticles",
-                           po::value<unsigned int>()->default_value(1),
-                           "The number of particles to generate per event");
-        desc.add_options()(
-            "gen-vertex-xyz-mm",
-            po::value<Reals<scalar_t, 3>>()->value_name("X:Y:Z")->default_value(
-                {{0.f, 0.f, 0.f}}),
-            "Vertex [mm]");
-        desc.add_options()(
-            "gen-vertex-xyz-std-mm",
-            po::value<Reals<scalar_t, 3>>()->value_name("X:Y:Z")->default_value(
-                {{0.f, 0.f, 0.f}}),
-            "Standard deviation of the vertex [mm]");
-        desc.add_options()("gen-mom-gev",
-                           po::value<Reals<scalar_t, 2>>()
-                               ->value_name("MIN:MAX")
-                               ->default_value({1.f, 1.f}),
-                           "Range of momentum [GeV]");
-        desc.add_options()("gen-phi-degree",
-                           po::value<Reals<scalar_t, 2>>()
-                               ->value_name("MIN:MAX")
-                               ->default_value({0.f, 0.f}),
-                           "Range of phi [Degree]");
-        desc.add_options()("gen-eta",
-                           po::value<Reals<scalar_t, 2>>()
-                               ->value_name("MIN:MAX")
-                               ->default_value({0.f, 0.f}),
-                           "Range of eta");
-        desc.add_options()(
-            "charge",
-            po::value<scalar_t>()->value_name("charge")->default_value(-1.f),
-            "Charge of particles");
-    }
-    void read(const po::variables_map& vm) {
-        gen_nparticles = vm["gen-nparticles"].as<unsigned int>();
-        vertex = vm["gen-vertex-xyz-mm"].as<Reals<scalar_t, 3>>();
-        vertex_stddev = vm["gen-vertex-xyz-std-mm"].as<Reals<scalar_t, 3>>();
-        mom_range = vm["gen-mom-gev"].as<Reals<scalar_t, 2>>();
-        const auto phi_range_degree =
-            vm["gen-phi-degree"].as<Reals<scalar_t, 2>>();
-        const auto eta_range = vm["gen-eta"].as<Reals<scalar_t, 2>>();
-        theta_range = eta_to_theta_range(eta_range);
-        phi_range = {phi_range_degree[0] * detray::unit<scalar_t>::degree,
-                     phi_range_degree[1] * detray::unit<scalar_t>::degree};
-        charge = vm["charge"].as<scalar_t>();
-    }
-};
+    /// The number of particles to generate per event
+    unsigned int gen_nparticles{1u};
+    /// Vertex position [mm]
+    Reals<float, 3> vertex{0., 0., 0.};
+    /// Standard deviation of the vertex position [mm]
+    Reals<float, 3> vertex_stddev{0., 0., 0.};
+    /// Range of momentum [GeV]
+    Reals<float, 2> mom_range{1., 1.};
+    /// Range of phi [rad]
+    Reals<float, 2> phi_range{0., 0.};
+    /// Range of theta [rad]
+    Reals<float, 2> theta_range{0., 0.};
+    /// Charge of particles
+    float charge{-1.f};
+
+    /// Constructor on top of a common @c program_options object
+    ///
+    /// @param desc The program options to add to
+    ///
+    particle_gen_options(boost::program_options::options_description& desc);
+
+    /// Read/process the command line options
+    ///
+    /// @param vm The command line options to interpret/read
+    ///
+    void read(const boost::program_options::variables_map& vm);
+
+};  // struct particle_gen_options
+
+/// Printout helper for @c traccc::particle_gen_options
+std::ostream& operator<<(std::ostream& out, const particle_gen_options& opt);
 
 }  // namespace traccc

--- a/examples/options/include/traccc/options/propagation_options.hpp
+++ b/examples/options/include/traccc/options/propagation_options.hpp
@@ -7,73 +7,38 @@
 
 #pragma once
 
-// Project include(s).
-#include "traccc/options/options.hpp"
-
 // Detray include(s).
-#include "detray/definitions/units.hpp"
 #include "detray/propagator/propagation_config.hpp"
 
-// Boost
+// Boost include(s).
 #include <boost/program_options.hpp>
 
-// System
-#include <limits>
+// System include(s).
+#include <iosfwd>
 
 namespace traccc {
 
-namespace po = boost::program_options;
-
-template <typename scalar_t>
+/// Command line options used in the propagation tests
 struct propagation_options {
 
-    detray::propagation::config<scalar_t> propagation{};
+    /// Propagation configuration object
+    detray::propagation::config<float> propagation;
 
-    propagation_options(po::options_description& desc) {
-        desc.add_options()("constraint-step-size-mm",
-                           po::value<scalar_t>()->default_value(
-                               std::numeric_limits<scalar>::max()),
-                           "The constrained step size [mm]");
-        desc.add_options()("overstep-tolerance-um",
-                           po::value<scalar_t>()->default_value(-100.f),
-                           "The overstep tolerance [um]");
-        desc.add_options()("mask-tolerance-um",
-                           po::value<scalar_t>()->default_value(15.f),
-                           "The mask tolerance [um]");
-        desc.add_options()("search_window",
-                           po::value<std::vector<unsigned int>>()->multitoken(),
-                           "Size of the grid surface search window");
-        desc.add_options()("rk-tolerance",
-                           po::value<scalar_t>()->default_value(1e-4),
-                           "The Runge-Kutta stepper tolerance");
-    }
+    /// Constructor on top of a common @c program_options object
+    ///
+    /// @param desc The program options to add to
+    ///
+    propagation_options(boost::program_options::options_description& desc);
 
-    void read(const po::variables_map& vm) {
-        propagation.stepping.step_constraint =
-            vm["constraint-step-size-mm"].as<scalar_t>() *
-            detray::unit<scalar_t>::mm;
-        propagation.navigation.overstep_tolerance =
-            vm["overstep-tolerance-um"].as<scalar_t>() *
-            detray::unit<scalar_t>::um;
-        propagation.navigation.mask_tolerance =
-            vm["mask-tolerance-um"].as<scalar_t>() * detray::unit<scalar_t>::um;
-        propagation.stepping.rk_error_tol = vm["rk-tolerance"].as<scalar_t>();
+    /// Read/process the command line options
+    ///
+    /// @param vm The command line options to interpret/read
+    ///
+    void read(const boost::program_options::variables_map& vm);
 
-        // Grid neighborhood size
-        if (vm.count("search_window")) {
-            const auto window =
-                vm["search_window"].as<std::vector<unsigned int>>();
-            if (window.size() != 2u) {
-                throw std::invalid_argument(
-                    "Incorrect surface grid search window. Please provide two "
-                    "integer distances.");
-            }
-            propagation.navigation.search_window = {window[0], window[1]};
-        } else {
-            // default
-            propagation.navigation.search_window = {0u, 0u};
-        }
-    }
-};
+};  // struct propagation_options
+
+/// Printout helper for @c traccc::propagation_options
+std::ostream& operator<<(std::ostream& out, const propagation_options& opt);
 
 }  // namespace traccc

--- a/examples/options/include/traccc/options/seeding_input_options.hpp
+++ b/examples/options/include/traccc/options/seeding_input_options.hpp
@@ -1,20 +1,38 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
-// Boost
+#pragma once
+
+// Boost include(s).
 #include <boost/program_options.hpp>
+
+// System include(s).
+#include <iosfwd>
 
 namespace traccc {
 
-namespace po = boost::program_options;
+/// Command line options used in the seeding input tests
+struct seeding_input_options {
 
-struct seeding_input_config {
-    seeding_input_config(po::options_description& desc);
-    void read(const po::variables_map& vm);
-};
+    /// Constructor on top of a common @c program_options object
+    ///
+    /// @param desc The program options to add to
+    ///
+    seeding_input_options(boost::program_options::options_description& desc);
+
+    /// Read/process the command line options
+    ///
+    /// @param vm The command line options to interpret/read
+    ///
+    void read(const boost::program_options::variables_map& vm);
+
+};  // struct seeding_input_options
+
+/// Printout helper for @c traccc::seeding_input_options
+std::ostream& operator<<(std::ostream& out, const seeding_input_options& opt);
 
 }  // namespace traccc

--- a/examples/options/include/traccc/options/telescope_detector_options.hpp
+++ b/examples/options/include/traccc/options/telescope_detector_options.hpp
@@ -1,64 +1,53 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
-// Project include(s).
-#include "traccc/options/options.hpp"
+#pragma once
 
-// Detray include(s).
-#include "detray/definitions/units.hpp"
-
-// Boost
+// Boost include(s).
 #include <boost/program_options.hpp>
+
+// System include(s).
+#include <iosfwd>
 
 namespace traccc {
 
-namespace po = boost::program_options;
-
-template <typename scalar_t>
+/// Command line options used in the telescope detector tests
 struct telescope_detector_options {
-    bool empty_material;
-    unsigned int n_planes;
-    scalar_t thickness;
-    scalar_t spacing;
-    scalar_t smearing;
-    scalar_t half_length;
 
-    telescope_detector_options(po::options_description& desc) {
-        desc.add_options()("empty-material",
-                           po::value<bool>()->default_value(false),
-                           "Build detector without materials");
-        desc.add_options()("n-planes",
-                           po::value<unsigned int>()->default_value(9),
-                           "Number of planes");
-        desc.add_options()("thickness-mm",
-                           po::value<scalar_t>()->default_value(0.5f),
-                           "Slab thickness in [mm]");
-        desc.add_options()("spacing",
-                           po::value<scalar_t>()->default_value(20.f),
-                           "Space between planes in [mm]");
-        desc.add_options()("smearing-um",
-                           po::value<scalar_t>()->default_value(50.f),
-                           "Measurement smearing in [um]");
-        desc.add_options()("half-length-mm",
-                           po::value<scalar_t>()->default_value(1000000.f),
-                           "Half length of plane [mm]");
-    }
+    /// Build detector without materials
+    bool empty_material = false;
+    /// Number of planes
+    unsigned int n_planes = 9;
+    /// Slab thickness in [mm]
+    float thickness = 0.5f;
+    /// Space between planes in [mm]
+    float spacing = 20.f;
+    /// Measurement smearing in [um]
+    float smearing = 50.f;
+    /// Half length of plane [mm]
+    float half_length = 1000000.f;
 
-    void read(const po::variables_map& vm) {
-        empty_material = vm["empty-material"].as<bool>();
-        n_planes = vm["n-planes"].as<unsigned int>();
-        thickness =
-            vm["thickness-mm"].as<scalar_t>() * detray::unit<scalar_t>::mm;
-        spacing = vm["spacing-mm"].as<scalar_t>() * detray::unit<scalar_t>::mm;
-        smearing =
-            vm["smearing-um"].as<scalar_t>() * detray::unit<scalar_t>::um;
-        half_length =
-            vm["half-length-mm"].as<scalar_t>() * detray::unit<scalar_t>::mm;
-    }
-};
+    /// Constructor on top of a common @c program_options object
+    ///
+    /// @param desc The program options to add to
+    ///
+    telescope_detector_options(
+        boost::program_options::options_description& desc);
+
+    /// Read/process the command line options
+    ///
+    /// @param vm The command line options to interpret/read
+    ///
+    void read(const boost::program_options::variables_map& vm);
+
+};  // struct telescope_detector_options
+
+/// Printout helper for @c traccc::telescope_detector_options
+std::ostream& operator<<(std::ostream& out,
+                         const telescope_detector_options& opt);
 
 }  // namespace traccc

--- a/examples/options/include/traccc/options/throughput_options.hpp
+++ b/examples/options/include/traccc/options/throughput_options.hpp
@@ -26,17 +26,18 @@ struct throughput_options {
     /// The data format of the input files
     data_format input_data_format = data_format::csv;
     /// Directory of the input files
-    std::string input_directory;
+    std::string input_directory = "tml_full/ttbar_mu20/";
     /// The file describing the detector geometry
-    std::string detector_file;
+    std::string detector_file = "tml_detector/trackml-detector.csv";
     /// The file describing the detector digitization configuration
-    std::string digitization_config_file;
+    std::string digitization_config_file =
+        "tml_detector/default-geometric-config-generic.json";
 
     /// The average number of cells in each partition.
     /// Equal to the number of threads in the clusterization kernels multiplied
     /// by CELLS_PER_THREAD defined in clusterization. Adapt to different GPUs'
     /// capabilities.
-    unsigned short target_cells_per_partition;
+    unsigned short target_cells_per_partition = 1024;
 
     /// The number of input events to load into memory
     std::size_t loaded_events = 10;
@@ -55,7 +56,7 @@ struct throughput_options {
     ///
     throughput_options(boost::program_options::options_description& desc);
 
-    /// Read the command line options
+    /// Read/process the command line options
     ///
     /// @param vm The command line options to interpret/read
     ///

--- a/examples/options/src/options/common_options.cpp
+++ b/examples/options/src/options/common_options.cpp
@@ -1,49 +1,82 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
-// options
+// Project include(s).
 #include "traccc/options/common_options.hpp"
+
+// System include(s).
+#include <iostream>
+
+namespace traccc {
+
+/// Convenience namespace shorthand
+namespace po = boost::program_options;
+
+/// Type alias for the data format enumeration
+using data_format_type = std::string;
+/// Name of the data format option
+static const char* data_format_option = "input-data-format";
 
 traccc::common_options::common_options(po::options_description& desc) {
 
-    desc.add_options()("input-csv", "Use csv input file");
-    desc.add_options()("input-binary", "Use binary input file");
-    desc.add_options()("input-directory", po::value<std::string>()->required(),
-                       "specify the directory of input data");
-    desc.add_options()("events", po::value<unsigned int>()->required(),
+    desc.add_options()(data_format_option,
+                       po::value<data_format_type>()->default_value("csv"),
+                       "Format of the input file(s)");
+    desc.add_options()(
+        "input-directory",
+        po::value(&input_directory)->default_value(input_directory),
+        "specify the directory of input data");
+    desc.add_options()("events", po::value(&events)->default_value(events),
                        "number of events");
-    desc.add_options()("skip", po::value<int>()->default_value(0),
+    desc.add_options()("skip", po::value(&skip)->default_value(skip),
                        "number of events to skip");
     desc.add_options()("target-cells-per-partition",
-                       po::value<unsigned short>()->default_value(1024),
+                       po::value(&target_cells_per_partition)
+                           ->default_value(target_cells_per_partition),
                        "Number of cells to merge in a partition. Equal to the "
                        "number of threads multiplied by CELLS_PER_THREAD "
                        "defined in clusterization.");
-    desc.add_options()("check-performance",
-                       po::value<bool>()->default_value(false),
+    desc.add_options()("check-performance", po::bool_switch(&check_performance),
                        "generate performance result");
     desc.add_options()("perform-ambiguity-resolution",
-                       po::value<bool>()->default_value(true),
+                       po::value(&perform_ambiguity_resolution)
+                           ->default_value(perform_ambiguity_resolution),
                        "perform ambiguity resolution");
 }
 
 void traccc::common_options::read(const po::variables_map& vm) {
 
-    if (vm.count("input-csv")) {
-        input_data_format = traccc::data_format::csv;
-    } else if (vm.count("input-binary")) {
-        input_data_format = traccc::data_format::binary;
+    // Set the input data format.
+    if (vm.count(data_format_option)) {
+        const auto input_format_string =
+            vm[data_format_option].as<data_format_type>();
+        if (input_format_string == "csv") {
+            input_data_format = data_format::csv;
+        } else if (input_format_string == "binary") {
+            input_data_format = data_format::binary;
+        } else {
+            throw std::invalid_argument("Invalid input data format specified");
+        }
     }
-    input_directory = vm["input-directory"].as<std::string>();
-    events = vm["events"].as<unsigned int>();
-    skip = vm["skip"].as<int>();
-    target_cells_per_partition =
-        vm["target-cells-per-partition"].as<unsigned short>();
-    check_performance = vm["check-performance"].as<bool>();
-    perform_ambiguity_resolution =
-        vm["perform-ambiguity-resolution"].as<bool>();
 }
+
+std::ostream& operator<<(std::ostream& out, const common_options& opt) {
+
+    out << ">>> Common options <<<\n"
+        << "  Input data format            : " << opt.input_data_format << "\n"
+        << "  Input directory              : " << opt.input_directory << "\n"
+        << "  Events                       : " << opt.events << "\n"
+        << "  Skipped events               : " << opt.skip << "\n"
+        << "  Target cells per partition   : " << opt.target_cells_per_partition
+        << "\n"
+        << "  Check performance            : " << opt.check_performance << "\n"
+        << "  Perform ambiguity resolution : "
+        << opt.perform_ambiguity_resolution;
+    return out;
+}
+
+}  // namespace traccc

--- a/examples/options/src/options/detector_input_options.cpp
+++ b/examples/options/src/options/detector_input_options.cpp
@@ -1,31 +1,44 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
-// options
+// Project include(s).
 #include "traccc/options/detector_input_options.hpp"
+
+// System include(s).
+#include <iostream>
+
+namespace traccc {
+
+/// Convenience namespace shorthand
+namespace po = boost::program_options;
 
 traccc::detector_input_options::detector_input_options(
     po::options_description& desc) {
-    desc.add_options()("detector-file", po::value<std::string>()->required(),
+
+    desc.add_options()("detector-file",
+                       po::value(&detector_file)->default_value(detector_file),
                        "specify detector file");
     desc.add_options()("material-file",
-                       po::value<std::string>()->default_value(""),
+                       po::value(&material_file)->default_value(material_file),
                        "specify material file");
-    desc.add_options()("grid-file", po::value<std::string>()->default_value(""),
+    desc.add_options()("grid-file",
+                       po::value(&grid_file)->default_value(grid_file),
                        "specify surface grid file");
 }
 
-void traccc::detector_input_options::read(const po::variables_map& vm) {
+void traccc::detector_input_options::read(const po::variables_map&) {}
 
-    detector_file = vm["detector-file"].as<std::string>();
-    if (vm.count("material-file")) {
-        material_file = vm["material-file"].as<std::string>();
-    }
-    if (vm.count("grid-file")) {
-        grid_file = vm["grid-file"].as<std::string>();
-    }
+std::ostream& operator<<(std::ostream& out, const detector_input_options& opt) {
+
+    out << ">>> Detector options <<<\n"
+        << "  Detector file : " << opt.detector_file << "\n"
+        << "  Material file : " << opt.material_file << "\n"
+        << "  Grid file     : " << opt.grid_file;
+    return out;
 }
+
+}  // namespace traccc

--- a/examples/options/src/options/finding_input_options.cpp
+++ b/examples/options/src/options/finding_input_options.cpp
@@ -1,0 +1,45 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/options/finding_input_options.hpp"
+
+namespace traccc {
+
+/// Convenience namespace shorthand
+namespace po = boost::program_options;
+
+finding_input_options::finding_input_options(po::options_description& desc) {
+
+    desc.add_options()("track-candidates-range",
+                       po::value(&track_candidates_range)
+                           ->value_name("MIN:MAX")
+                           ->default_value(track_candidates_range),
+                       "Range of track candidates number");
+    desc.add_options()(
+        "chi2-max", po::value(&chi2_max)->default_value(chi2_max),
+        "Maximum Chi suqare that measurements can be included in the track");
+    desc.add_options()(
+        "nmax_per_seed",
+        po::value<unsigned int>(&nmax_per_seed)->default_value(nmax_per_seed),
+        "Maximum number of branches which each initial seed can have at a "
+        "step.");
+}
+
+void finding_input_options::read(const po::variables_map&) {}
+
+std::ostream& operator<<(std::ostream& out, const finding_input_options& opt) {
+
+    out << ">>> Track finding options <<<\n"
+        << "  Track candidates range    : " << opt.track_candidates_range
+        << "\n"
+        << "  Maximum Chi2              : " << opt.chi2_max << "\n"
+        << "  Maximum branches per step : " << opt.nmax_per_seed;
+    return out;
+}
+
+}  // namespace traccc

--- a/examples/options/src/options/full_tracking_input_options.cpp
+++ b/examples/options/src/options/full_tracking_input_options.cpp
@@ -1,20 +1,39 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
-// options
+// Project include(s).
 #include "traccc/options/full_tracking_input_options.hpp"
 
-traccc::full_tracking_input_config::full_tracking_input_config(
+// System include(s).
+#include <iostream>
+
+namespace traccc {
+
+/// Convenience namespace shorthand
+namespace po = boost::program_options;
+
+full_tracking_input_options::full_tracking_input_options(
     po::options_description& desc) {
+
     desc.add_options()("digitization-config-file",
-                       po::value<std::string>()->required(),
+                       po::value(&digitization_config_file)
+                           ->default_value(digitization_config_file),
                        "specify the digitization configuration file");
 }
 
-void traccc::full_tracking_input_config::read(const po::variables_map& vm) {
-    digitization_config_file = vm["digitization-config-file"].as<std::string>();
+void full_tracking_input_options::read(const po::variables_map&) {}
+
+std::ostream& operator<<(std::ostream& out,
+                         const full_tracking_input_options& opt) {
+
+    out << ">>> Full tracking chain options <<<\n"
+        << "  Digitization configuration file: "
+        << opt.digitization_config_file;
+    return out;
 }
+
+}  // namespace traccc

--- a/examples/options/src/options/mt_options.cpp
+++ b/examples/options/src/options/mt_options.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,13 +18,12 @@ mt_options::mt_options(boost::program_options::options_description& desc) {
 
     desc.add_options()(
         "threads",
-        boost::program_options::value<std::size_t>()->default_value(1),
+        boost::program_options::value(&threads)->default_value(threads),
         "The number of CPU threads to use");
 }
 
-void mt_options::read(const boost::program_options::variables_map& vm) {
+void mt_options::read(const boost::program_options::variables_map&) {
 
-    threads = vm["threads"].as<std::size_t>();
     if (threads == 0) {
         throw std::invalid_argument{"Must use threads>0"};
     }
@@ -33,7 +32,7 @@ void mt_options::read(const boost::program_options::variables_map& vm) {
 std::ostream& operator<<(std::ostream& out, const mt_options& opt) {
 
     out << ">>> Multi-threading options <<<\n"
-        << "CPU threads: " << opt.threads;
+        << "  CPU threads: " << opt.threads;
     return out;
 }
 

--- a/examples/options/src/options/particle_gen_options.cpp
+++ b/examples/options/src/options/particle_gen_options.cpp
@@ -1,0 +1,79 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/options/particle_gen_options.hpp"
+
+#include "traccc/utils/ranges.hpp"
+
+// Detray include(s).
+#include "detray/definitions/units.hpp"
+
+namespace traccc {
+
+/// Convenience namespace shorthand
+namespace po = boost::program_options;
+
+/// Type alias for the eta range argument
+using eta_range_type = Reals<float, 2>;
+/// Name of the eta range option
+static const char* eta_range_option = "gen-eta";
+
+particle_gen_options::particle_gen_options(po::options_description& desc) {
+
+    desc.add_options()(
+        "gen-nparticles",
+        po::value(&gen_nparticles)->default_value(gen_nparticles),
+        "The number of particles to generate per event");
+    desc.add_options()(
+        "gen-vertex-xyz-mm",
+        po::value(&vertex)->value_name("X:Y:Z")->default_value(vertex),
+        "Vertex [mm]");
+    desc.add_options()("gen-vertex-xyz-std-mm",
+                       po::value(&vertex_stddev)
+                           ->value_name("X:Y:Z")
+                           ->default_value(vertex_stddev),
+                       "Standard deviation of the vertex [mm]");
+    desc.add_options()(
+        "gen-mom-gev",
+        po::value(&mom_range)->value_name("MIN:MAX")->default_value(mom_range),
+        "Range of momentum [GeV]");
+    desc.add_options()(
+        "gen-phi-degree",
+        po::value(&phi_range)->value_name("MIN:MAX")->default_value(phi_range),
+        "Range of phi [Degree]");
+    desc.add_options()(
+        eta_range_option,
+        po::value<eta_range_type>()->value_name("MIN:MAX")->default_value(
+            {0.f, 0.f}),
+        "Range of eta");
+    desc.add_options()("charge", po::value(&charge)->default_value(charge),
+                       "Charge of particles");
+}
+
+void particle_gen_options::read(const po::variables_map& vm) {
+
+    phi_range[0] *= detray::unit<float>::degree;
+    phi_range[1] *= detray::unit<float>::degree;
+    theta_range = eta_to_theta_range(vm[eta_range_option].as<eta_range_type>());
+}
+
+std::ostream& operator<<(std::ostream& out, const particle_gen_options& opt) {
+
+    out << ">>> Particle generation options: <<<\n"
+        << "  Number of particles to generate : " << opt.gen_nparticles << "\n"
+        << "  Vertex                          : " << opt.vertex << " mm\n"
+        << "  Vertex standard deviation       : " << opt.vertex_stddev
+        << " mm\n"
+        << "  Momentum range                  : " << opt.mom_range << " GeV\n"
+        << "  Phi range                       : " << opt.phi_range << " rad\n"
+        << "  Theta range                     : " << opt.theta_range << " rad\n"
+        << "  Charge                          : " << opt.charge << "\n";
+    return out;
+}
+
+}  // namespace traccc

--- a/examples/options/src/options/propagation_options.cpp
+++ b/examples/options/src/options/propagation_options.cpp
@@ -1,0 +1,94 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/options/propagation_options.hpp"
+
+// Detray include(s).
+#include "detray/definitions/units.hpp"
+
+// System include(s).
+#include <limits>
+#include <stdexcept>
+
+namespace traccc {
+
+/// Convenience namespace shorthand
+namespace po = boost::program_options;
+
+/// Type alias for the search window argument
+using search_window_argument_type = std::vector<unsigned int>;
+/// Name of the search window option
+static const char* search_window_option = "search-window";
+
+propagation_options::propagation_options(po::options_description& desc) {
+
+    desc.add_options()("constraint-step-size-mm",
+                       po::value(&(propagation.stepping.step_constraint))
+                           ->default_value(std::numeric_limits<float>::max()),
+                       "The constrained step size [mm]");
+    desc.add_options()("overstep-tolerance-um",
+                       po::value(&(propagation.navigation.overstep_tolerance))
+                           ->default_value(-100.f),
+                       "The overstep tolerance [um]");
+    desc.add_options()("mask-tolerance-um",
+                       po::value(&(propagation.navigation.mask_tolerance))
+                           ->default_value(15.f),
+                       "The mask tolerance [um]");
+    desc.add_options()(search_window_option,
+                       po::value<search_window_argument_type>()->multitoken(),
+                       "Size of the grid surface search window");
+    desc.add_options()(
+        "rk-tolerance",
+        po::value(&(propagation.stepping.rk_error_tol))->default_value(1e-4),
+        "The Runge-Kutta stepper tolerance");
+}
+
+void propagation_options::read(const po::variables_map& vm) {
+
+    propagation.stepping.step_constraint *= detray::unit<float>::mm;
+    propagation.navigation.overstep_tolerance *= detray::unit<float>::um;
+    propagation.navigation.mask_tolerance *= detray::unit<float>::um;
+
+    // Set the search window parameter by hand, since boost::program_options
+    // does not support std::array options directly.
+    if (vm.count(search_window_option)) {
+        const auto window =
+            vm[search_window_option].as<search_window_argument_type>();
+        if (window.size() != 2u) {
+            throw std::invalid_argument(
+                "Incorrect surface grid search window. Please provide two "
+                "integer distances.");
+        }
+        propagation.navigation.search_window = {window[0], window[1]};
+    } else {
+        propagation.navigation.search_window = {0u, 0u};
+    }
+}
+
+std::ostream& operator<<(std::ostream& out, const propagation_options& opt) {
+
+    out << ">>> Propagation options <<<\n"
+        << "  Constraint step size  : "
+        << opt.propagation.stepping.step_constraint / detray::unit<float>::mm
+        << " [mm]\n"
+        << "  Overstep tolerance    : "
+        << opt.propagation.navigation.overstep_tolerance /
+               detray::unit<float>::um
+        << " [um]\n"
+        << "  Mask tolerance        : "
+        << opt.propagation.navigation.mask_tolerance / detray::unit<float>::um
+        << " [um]\n"
+        << "  Search window         : "
+        << opt.propagation.navigation.search_window[0] << " x "
+        << opt.propagation.navigation.search_window[1] << "\n"
+        << "  Runge-Kutta tolerance : " << opt.propagation.stepping.rk_error_tol
+        << "\n";
+    return out;
+}
+
+}  // namespace traccc

--- a/examples/options/src/options/seeding_input_options.cpp
+++ b/examples/options/src/options/seeding_input_options.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,7 +8,22 @@
 // options
 #include "traccc/options/seeding_input_options.hpp"
 
-traccc::seeding_input_config::seeding_input_config(
-    po::options_description& /*desc*/) {}
+// System include(s).
+#include <iostream>
 
-void traccc::seeding_input_config::read(const po::variables_map& /*vm*/) {}
+namespace traccc {
+
+/// Convenience namespace shorthand
+namespace po = boost::program_options;
+
+seeding_input_options::seeding_input_options(po::options_description&) {}
+
+void seeding_input_options::read(const po::variables_map&) {}
+
+std::ostream& operator<<(std::ostream& out, const seeding_input_options&) {
+
+    out << ">>> Seeding input options <<<";
+    return out;
+}
+
+}  // namespace traccc

--- a/examples/options/src/options/telescope_detector_options.cpp
+++ b/examples/options/src/options/telescope_detector_options.cpp
@@ -1,0 +1,69 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/options/telescope_detector_options.hpp"
+
+// Detray include(s).
+#include "detray/definitions/units.hpp"
+
+// System include(s).
+#include <iostream>
+
+namespace traccc {
+
+/// Convenience namespace shorthand
+namespace po = boost::program_options;
+
+telescope_detector_options::telescope_detector_options(
+    po::options_description& desc) {
+
+    desc.add_options()("empty-material", po::bool_switch(&empty_material),
+                       "Build detector without materials");
+    desc.add_options()("n-planes",
+                       po::value(&n_planes)->default_value(n_planes),
+                       "Number of planes");
+    desc.add_options()("thickness-mm",
+                       po::value(&thickness)->default_value(thickness),
+                       "Slab thickness in [mm]");
+    desc.add_options()("spacing", po::value(&spacing)->default_value(spacing),
+                       "Space between planes in [mm]");
+    desc.add_options()("smearing-um",
+                       po::value(&smearing)->default_value(smearing),
+                       "Measurement smearing in [um]");
+    desc.add_options()("half-length-mm",
+                       po::value(&half_length)->default_value(half_length),
+                       "Half length of plane [mm]");
+}
+
+void telescope_detector_options::read(const po::variables_map&) {
+
+    thickness *= detray::unit<float>::mm;
+    spacing *= detray::unit<float>::mm;
+    smearing *= detray::unit<float>::um;
+    half_length *= detray::unit<float>::mm;
+}
+
+std::ostream& operator<<(std::ostream& out,
+                         const telescope_detector_options& opt) {
+
+    out << ">>> Telescope detector options <<<\n"
+        << "  Empty material   : " << (opt.empty_material ? "true" : "false")
+        << "\n"
+        << "  Number of planes : " << opt.n_planes << "\n"
+        << "  Slab thickness   : " << opt.thickness / detray::unit<float>::mm
+        << " [mm]\n"
+        << "  Spacing          : " << opt.spacing / detray::unit<float>::mm
+        << " [mm]\n"
+        << "  Smearing         : " << opt.smearing / detray::unit<float>::um
+        << " [um]\n"
+        << "  Half length      : " << opt.half_length / detray::unit<float>::mm
+        << " [mm]";
+    return out;
+}
+
+}  // namespace traccc

--- a/examples/options/src/options/throughput_options.cpp
+++ b/examples/options/src/options/throughput_options.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,47 +14,59 @@
 
 namespace traccc {
 
+/// Convenience namespace shorthand
 namespace po = boost::program_options;
+
+/// Type alias for the data format enumeration
+using data_format_type = std::string;
+/// Name of the data format option
+static const char* data_format_option = "input-data-format";
 
 throughput_options::throughput_options(po::options_description& desc) {
 
-    desc.add_options()("input-data-format",
-                       po::value<std::string>()->default_value("csv"),
+    desc.add_options()(data_format_option,
+                       po::value<data_format_type>()->default_value("csv"),
                        "Format of the input file(s)");
-    desc.add_options()("input_directory", po::value<std::string>()->required(),
-                       "Directory holding the input files");
-    desc.add_options()("detector-file", po::value<std::string>()->required(),
+    desc.add_options()(
+        "input-directory",
+        po::value(&input_directory)->default_value(input_directory),
+        "Directory holding the input files");
+    desc.add_options()("detector-file",
+                       po::value(&detector_file)->default_value(detector_file),
                        "Detector geometry description file");
     desc.add_options()("digitization-config-file",
-                       po::value<std::string>()->required(),
+                       po::value(&digitization_config_file)
+                           ->default_value(digitization_config_file),
                        "Digitization configuration file");
     desc.add_options()(
         "target-cells-per-partition",
-        po::value<unsigned short>()->default_value(1024),
+        po::value(&target_cells_per_partition)
+            ->default_value(target_cells_per_partition),
         "Average number of cells in a partition. Equal to the number of "
         "threads in the clusterization kernels multiplied by CELLS_PER_THREAD "
         "defined in clusterization.");
     desc.add_options()("loaded-events",
-                       po::value<std::size_t>()->default_value(10),
+                       po::value(&loaded_events)->default_value(loaded_events),
                        "Number of input events to load");
-    desc.add_options()("processed-events",
-                       po::value<std::size_t>()->default_value(100),
-                       "Number of events to process");
-    desc.add_options()("cold-run-events",
-                       po::value<std::size_t>()->default_value(10),
-                       "Number of events to run 'cold'");
     desc.add_options()(
-        "log-file",
-        po::value<std::string>()->default_value(
-            "\0", "File where result logs will be printed (in append mode)."));
+        "processed-events",
+        po::value(&processed_events)->default_value(processed_events),
+        "Number of events to process");
+    desc.add_options()(
+        "cold-run-events",
+        po::value(&cold_run_events)->default_value(cold_run_events),
+        "Number of events to run 'cold'");
+    desc.add_options()(
+        "log-file", po::value(&log_file),
+        "File where result logs will be printed (in append mode).");
 }
 
 void throughput_options::read(const po::variables_map& vm) {
 
     // Set the input data format.
-    if (vm.count("input-data-format")) {
-        const std::string input_format_string =
-            vm["input-data-format"].as<std::string>();
+    if (vm.count(data_format_option)) {
+        const auto input_format_string =
+            vm[data_format_option].as<data_format_type>();
         if (input_format_string == "csv") {
             input_data_format = data_format::csv;
         } else if (input_format_string == "binary") {
@@ -63,33 +75,22 @@ void throughput_options::read(const po::variables_map& vm) {
             throw std::invalid_argument("Invalid input data format specified");
         }
     }
-
-    // Set the rest of the options.
-    input_directory = vm["input-directory"].as<std::string>();
-    detector_file = vm["detector-file"].as<std::string>();
-    digitization_config_file = vm["digitization-config-file"].as<std::string>();
-    target_cells_per_partition =
-        vm["target-cells-per-partition"].as<unsigned short>();
-    loaded_events = vm["loaded-events"].as<std::size_t>();
-    processed_events = vm["processed-events"].as<std::size_t>();
-    cold_run_events = vm["cold-run-events"].as<std::size_t>();
-    log_file = vm["log-file"].as<std::string>();
 }
 
 std::ostream& operator<<(std::ostream& out, const throughput_options& opt) {
 
     out << ">>> Throughput options <<<\n"
-        << "Input data format          : " << opt.input_data_format << "\n"
-        << "Input directory            : " << opt.input_directory << "\n"
-        << "Detector geometry          : " << opt.detector_file << "\n"
-        << "Digitization config        : " << opt.digitization_config_file
+        << "  Input data format          : " << opt.input_data_format << "\n"
+        << "  Input directory            : " << opt.input_directory << "\n"
+        << "  Detector geometry          : " << opt.detector_file << "\n"
+        << "  Digitization config        : " << opt.digitization_config_file
         << "\n"
-        << "Target cells per partition : " << opt.target_cells_per_partition
+        << "  Target cells per partition : " << opt.target_cells_per_partition
         << "\n"
-        << "Loaded event(s)            : " << opt.loaded_events << "\n"
-        << "Cold run event(s)          : " << opt.cold_run_events << "\n"
-        << "Processed event(s)         : " << opt.processed_events << "\n"
-        << "Log_file                   : " << opt.log_file;
+        << "  Loaded event(s)            : " << opt.loaded_events << "\n"
+        << "  Cold run event(s)          : " << opt.cold_run_events << "\n"
+        << "  Processed event(s)         : " << opt.processed_events << "\n"
+        << "  Log_file                   : " << opt.log_file;
     return out;
 }
 

--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -61,12 +61,11 @@
 using namespace traccc;
 namespace po = boost::program_options;
 
-int seq_run(
-    const traccc::seeding_input_config& /*i_cfg*/,
-    const traccc::finding_input_config<traccc::scalar>& /*finding_cfg*/,
-    const traccc::propagation_options<traccc::scalar>& /*propagation_opts*/,
-    const traccc::common_options& common_opts,
-    const traccc::detector_input_options& det_opts, bool run_cpu) {
+int seq_run(const traccc::seeding_input_options& /*i_cfg*/,
+            const traccc::finding_input_options& /*finding_cfg*/,
+            const traccc::propagation_options& /*propagation_opts*/,
+            const traccc::common_options& common_opts,
+            const traccc::detector_input_options& det_opts, bool run_cpu) {
 
     using host_detector_type = detray::detector<>;
 
@@ -318,9 +317,9 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::seeding_input_config seeding_input_cfg(desc);
-    traccc::finding_input_config<traccc::scalar> finding_input_cfg(desc);
-    traccc::propagation_options<traccc::scalar> propagation_opts(desc);
+    traccc::seeding_input_options seeding_input_cfg(desc);
+    traccc::finding_input_options finding_input_cfg(desc);
+    traccc::propagation_options propagation_opts(desc);
     desc.add_options()("run-cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
@@ -334,12 +333,17 @@ int main(int argc, char* argv[]) {
     common_opts.read(vm);
     det_opts.read(vm);
     seeding_input_cfg.read(vm);
-    // finding_input_cfg.read(vm);
-    // propagation_opts.read(vm);
+    finding_input_cfg.read(vm);
+    propagation_opts.read(vm);
     auto run_cpu = vm["run-cpu"].as<bool>();
 
-    std::cout << "Running " << argv[0] << " " << det_opts.detector_file << " "
-              << common_opts.input_directory << " " << common_opts.events
+    // Tell the user what's happening.
+    std::cout << "\nRunning the tracking chain using Alpaka\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << seeding_input_cfg << "\n"
+              << finding_input_cfg << "\n"
+              << propagation_opts << "\n"
               << std::endl;
 
     return seq_run(seeding_input_cfg, finding_input_cfg, propagation_opts,

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -53,9 +53,9 @@
 using namespace traccc;
 namespace po = boost::program_options;
 
-int seq_run(const traccc::seeding_input_config& /*i_cfg*/,
-            const traccc::finding_input_config<traccc::scalar>& finding_cfg,
-            const traccc::propagation_options<traccc::scalar>& propagation_opts,
+int seq_run(const traccc::seeding_input_options& /*i_cfg*/,
+            const traccc::finding_input_options& finding_cfg,
+            const traccc::propagation_options& propagation_opts,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts) {
 
@@ -272,9 +272,9 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::seeding_input_config seeding_input_cfg(desc);
-    traccc::finding_input_config<traccc::scalar> finding_input_cfg(desc);
-    traccc::propagation_options<traccc::scalar> propagation_opts(desc);
+    traccc::seeding_input_options seeding_input_cfg(desc);
+    traccc::finding_input_options finding_input_cfg(desc);
+    traccc::propagation_options propagation_opts(desc);
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -289,8 +289,13 @@ int main(int argc, char* argv[]) {
     finding_input_cfg.read(vm);
     propagation_opts.read(vm);
 
-    std::cout << "Running " << argv[0] << " " << det_opts.detector_file << " "
-              << common_opts.input_directory << " " << common_opts.events
+    // Tell the user what's happening.
+    std::cout << "\nRunning the tracking chain on the host\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << seeding_input_cfg << "\n"
+              << finding_input_cfg << "\n"
+              << propagation_opts << "\n"
               << std::endl;
 
     return seq_run(seeding_input_cfg, finding_input_cfg, propagation_opts,

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -34,7 +34,7 @@
 
 namespace po = boost::program_options;
 
-int seq_run(const traccc::full_tracking_input_config& i_cfg,
+int seq_run(const traccc::full_tracking_input_options& i_cfg,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts) {
 
@@ -162,7 +162,7 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::full_tracking_input_config full_tracking_input_cfg(desc);
+    traccc::full_tracking_input_options full_tracking_input_cfg(desc);
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -175,9 +175,11 @@ int main(int argc, char* argv[]) {
     det_opts.read(vm);
     full_tracking_input_cfg.read(vm);
 
-    std::cout << "Running " << argv[0] << " "
-              << full_tracking_input_cfg.detector_file << " "
-              << common_opts.input_directory << " " << common_opts.events
+    // Tell the user what's happening.
+    std::cout << "\nRunning the full tracking chain on the host\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << full_tracking_input_cfg << "\n"
               << std::endl;
 
     return seq_run(full_tracking_input_cfg, common_opts, det_opts);

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -43,8 +43,8 @@
 using namespace traccc;
 namespace po = boost::program_options;
 
-int seq_run(const traccc::finding_input_config<traccc::scalar>& i_cfg,
-            const traccc::propagation_options<scalar>& propagation_opts,
+int seq_run(const traccc::finding_input_options& i_cfg,
+            const traccc::propagation_options& propagation_opts,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts) {
 
@@ -203,8 +203,8 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::finding_input_config<traccc::scalar> finding_input_cfg(desc);
-    traccc::propagation_options<scalar> propagation_opts(desc);
+    traccc::finding_input_options finding_input_cfg(desc);
+    traccc::propagation_options propagation_opts(desc);
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -218,8 +218,13 @@ int main(int argc, char* argv[]) {
     finding_input_cfg.read(vm);
     propagation_opts.read(vm);
 
-    std::cout << "Running " << argv[0] << " " << common_opts.input_directory
-              << " " << common_opts.events << std::endl;
+    // Tell the user what's happening.
+    std::cout << "\nRunning truth track finding on the host\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << finding_input_cfg << "\n"
+              << propagation_opts << "\n"
+              << std::endl;
 
     return seq_run(finding_input_cfg, propagation_opts, common_opts, det_opts);
 }

--- a/examples/run/cpu/truth_fitting_example.cpp
+++ b/examples/run/cpu/truth_fitting_example.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::propagation_options<scalar> propagation_opts(desc);
+    traccc::propagation_options propagation_opts(desc);
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -64,8 +64,12 @@ int main(int argc, char* argv[]) {
 
     propagation_opts.read(vm);
 
-    std::cout << "Running " << argv[0] << " " << common_opts.input_directory
-              << " " << common_opts.events << std::endl;
+    // Tell the user what's happening.
+    std::cout << "\nRunning truth track fitting on the host\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << propagation_opts << "\n"
+              << std::endl;
 
     /// Type declarations
     using host_detector_type = detray::detector<detray::default_metadata,

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -60,9 +60,9 @@
 using namespace traccc;
 namespace po = boost::program_options;
 
-int seq_run(const traccc::seeding_input_config& /*i_cfg*/,
-            const traccc::finding_input_config<traccc::scalar>& finding_cfg,
-            const traccc::propagation_options<traccc::scalar>& propagation_opts,
+int seq_run(const traccc::seeding_input_options& /*i_cfg*/,
+            const traccc::finding_input_options& finding_cfg,
+            const traccc::propagation_options& propagation_opts,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts, bool run_cpu) {
 
@@ -485,9 +485,9 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::seeding_input_config seeding_input_cfg(desc);
-    traccc::finding_input_config<traccc::scalar> finding_input_cfg(desc);
-    traccc::propagation_options<traccc::scalar> propagation_opts(desc);
+    traccc::seeding_input_options seeding_input_cfg(desc);
+    traccc::finding_input_options finding_input_cfg(desc);
+    traccc::propagation_options propagation_opts(desc);
     desc.add_options()("run-cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
@@ -505,8 +505,13 @@ int main(int argc, char* argv[]) {
     propagation_opts.read(vm);
     auto run_cpu = vm["run-cpu"].as<bool>();
 
-    std::cout << "Running " << argv[0] << " " << det_opts.detector_file << " "
-              << common_opts.input_directory << " " << common_opts.events
+    // Tell the user what's happening.
+    std::cout << "\nRunning the tracking chain using CUDA\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << seeding_input_cfg << "\n"
+              << finding_input_cfg << "\n"
+              << propagation_opts << "\n"
               << std::endl;
 
     return seq_run(seeding_input_cfg, finding_input_cfg, propagation_opts,

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -39,7 +39,7 @@
 
 namespace po = boost::program_options;
 
-int seq_run(const traccc::full_tracking_input_config& i_cfg,
+int seq_run(const traccc::full_tracking_input_options& i_cfg,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts, bool run_cpu) {
 
@@ -308,7 +308,7 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::full_tracking_input_config full_tracking_input_cfg(desc);
+    traccc::full_tracking_input_options full_tracking_input_cfg(desc);
     desc.add_options()("run-cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
@@ -324,9 +324,11 @@ int main(int argc, char* argv[]) {
     full_tracking_input_cfg.read(vm);
     auto run_cpu = vm["run-cpu"].as<bool>();
 
-    std::cout << "Running " << argv[0] << " "
-              << full_tracking_input_cfg.detector_file << " "
-              << common_opts.input_directory << " " << common_opts.events
+    // Tell the user what's happening.
+    std::cout << "\nRunning the full tracking chain using CUDA\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << full_tracking_input_cfg << "\n"
               << std::endl;
 
     return seq_run(full_tracking_input_cfg, common_opts, det_opts, run_cpu);

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -55,8 +55,8 @@
 using namespace traccc;
 namespace po = boost::program_options;
 
-int seq_run(const traccc::finding_input_config<traccc::scalar>& i_cfg,
-            const traccc::propagation_options<scalar>& propagation_opts,
+int seq_run(const traccc::finding_input_options& i_cfg,
+            const traccc::propagation_options& propagation_opts,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts, bool run_cpu) {
 
@@ -360,8 +360,8 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::finding_input_config<traccc::scalar> finding_input_cfg(desc);
-    traccc::propagation_options<scalar> propagation_opts(desc);
+    traccc::finding_input_options finding_input_cfg(desc);
+    traccc::propagation_options propagation_opts(desc);
     desc.add_options()("run-cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
@@ -379,8 +379,13 @@ int main(int argc, char* argv[]) {
     propagation_opts.read(vm);
     auto run_cpu = vm["run-cpu"].as<bool>();
 
-    std::cout << "Running " << argv[0] << " " << common_opts.input_directory
-              << " " << common_opts.events << std::endl;
+    // Tell the user what's happening.
+    std::cout << "\nRunning truth track finding using CUDA\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << finding_input_cfg << "\n"
+              << propagation_opts << "\n"
+              << std::endl;
 
     return seq_run(finding_input_cfg, propagation_opts, common_opts, det_opts,
                    run_cpu);

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::propagation_options<scalar> propagation_opts(desc);
+    traccc::propagation_options propagation_opts(desc);
     desc.add_options()("run-cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
@@ -78,8 +78,12 @@ int main(int argc, char* argv[]) {
     propagation_opts.read(vm);
     auto run_cpu = vm["run-cpu"].as<bool>();
 
-    std::cout << "Running " << argv[0] << " " << common_opts.input_directory
-              << " " << common_opts.events << std::endl;
+    // Tell the user what's happening.
+    std::cout << "\nRunning truth track fitting using CUDA\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << propagation_opts << "\n"
+              << std::endl;
 
     /// Type declarations
     using host_detector_type = detray::detector<detray::default_metadata,

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -33,7 +33,7 @@
 
 namespace po = boost::program_options;
 
-int seq_run(const traccc::seeding_input_config& /*i_cfg*/,
+int seq_run(const traccc::seeding_input_options& /*i_cfg*/,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts, bool run_cpu) {
 
@@ -156,7 +156,7 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::seeding_input_config seeding_input_cfg(desc);
+    traccc::seeding_input_options seeding_input_cfg(desc);
     desc.add_options()("run-cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
@@ -173,8 +173,11 @@ int main(int argc, char* argv[]) {
     seeding_input_cfg.read(vm);
     auto run_cpu = vm["run-cpu"].as<bool>();
 
-    std::cout << "Running " << argv[0] << " " << det_opts.detector_file << " "
-              << common_opts.input_directory << " " << common_opts.events
+    // Tell the user what's happening.
+    std::cout << "\nRunning the tracking chain using Kokkos\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << seeding_input_cfg << "\n"
               << std::endl;
 
     int ret = seq_run(seeding_input_cfg, common_opts, det_opts, run_cpu);

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -50,7 +50,7 @@
 
 namespace po = boost::program_options;
 
-int seq_run(const traccc::seeding_input_config& /*i_cfg*/,
+int seq_run(const traccc::seeding_input_options& /*i_cfg*/,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts, bool run_cpu) {
 
@@ -279,7 +279,7 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::seeding_input_config seeding_input_cfg(desc);
+    traccc::seeding_input_options seeding_input_cfg(desc);
     desc.add_options()("run-cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
@@ -296,8 +296,11 @@ int main(int argc, char* argv[]) {
     seeding_input_cfg.read(vm);
     auto run_cpu = vm["run-cpu"].as<bool>();
 
-    std::cout << "Running " << argv[0] << " " << det_opts.detector_file << " "
-              << common_opts.input_directory << " " << common_opts.events
+    // Tell the user what's happening.
+    std::cout << "\nRunning the tracking chain using SYCL\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << seeding_input_cfg << "\n"
               << std::endl;
 
     return seq_run(seeding_input_cfg, common_opts, det_opts, run_cpu);

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -63,7 +63,7 @@ auto handle_async_error = [](::sycl::exception_list elist) {
     }
 };
 
-int seq_run(const traccc::full_tracking_input_config& i_cfg,
+int seq_run(const traccc::full_tracking_input_options& i_cfg,
             const traccc::common_options& common_opts,
             const traccc::detector_input_options& det_opts, bool run_cpu) {
 
@@ -334,7 +334,7 @@ int main(int argc, char* argv[]) {
     desc.add_options()("help,h", "Give some help with the program's options");
     traccc::common_options common_opts(desc);
     traccc::detector_input_options det_opts(desc);
-    traccc::full_tracking_input_config full_tracking_input_cfg(desc);
+    traccc::full_tracking_input_options full_tracking_input_cfg(desc);
     desc.add_options()("run-cpu", po::value<bool>()->default_value(false),
                        "run cpu tracking as well");
 
@@ -350,9 +350,11 @@ int main(int argc, char* argv[]) {
     full_tracking_input_cfg.read(vm);
     auto run_cpu = vm["run-cpu"].as<bool>();
 
-    std::cout << "Running " << argv[0] << " "
-              << full_tracking_input_cfg.detector_file << " "
-              << common_opts.input_directory << " " << common_opts.events
+    // Tell the user what's happening.
+    std::cout << "\nRunning the full tracking chain using SYCL\n\n"
+              << common_opts << "\n"
+              << det_opts << "\n"
+              << full_tracking_input_cfg << "\n"
               << std::endl;
 
     return seq_run(full_tracking_input_cfg, common_opts, det_opts, run_cpu);

--- a/examples/simulation/simulate.cpp
+++ b/examples/simulation/simulate.cpp
@@ -52,8 +52,8 @@ int main(int argc, char* argv[]) {
     desc.add_options()("events", po::value<unsigned int>()->required(),
                        "number of events");
     traccc::detector_input_options det_opts(desc);
-    traccc::particle_gen_options<scalar> pg_opts(desc);
-    traccc::propagation_options<scalar> propagation_opts(desc);
+    traccc::particle_gen_options pg_opts(desc);
+    traccc::propagation_options propagation_opts(desc);
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -39,9 +39,9 @@ using namespace traccc;
 namespace po = boost::program_options;
 
 int simulate(std::string output_directory, unsigned int events,
-             const traccc::particle_gen_options<scalar>& pg_opts,
-             const traccc::propagation_options<scalar>& propagation_opts,
-             const traccc::telescope_detector_options<scalar>& telescope_opts) {
+             const traccc::particle_gen_options& pg_opts,
+             const traccc::propagation_options& propagation_opts,
+             const traccc::telescope_detector_options& telescope_opts) {
 
     // Use deterministic random number generator for testing
     using uniform_gen_t =
@@ -156,9 +156,9 @@ int main(int argc, char* argv[]) {
                        "specify the directory of output data");
     desc.add_options()("events", po::value<unsigned int>()->required(),
                        "number of events");
-    traccc::particle_gen_options<scalar> pg_opts(desc);
-    traccc::propagation_options<scalar> propagation_opts(desc);
-    traccc::telescope_detector_options<scalar> telescope_opts(desc);
+    traccc::particle_gen_options pg_opts(desc);
+    traccc::propagation_options propagation_opts(desc);
+    traccc::telescope_detector_options telescope_opts(desc);
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);

--- a/examples/simulation/simulate_toy_detector.cpp
+++ b/examples/simulation/simulate_toy_detector.cpp
@@ -34,8 +34,8 @@ using namespace traccc;
 namespace po = boost::program_options;
 
 int simulate(std::string output_directory, unsigned int events,
-             const traccc::particle_gen_options<scalar>& pg_opts,
-             const traccc::propagation_options<scalar>& propagation_opts) {
+             const traccc::particle_gen_options& pg_opts,
+             const traccc::propagation_options& propagation_opts) {
 
     // Use deterministic random number generator for testing
     using uniform_gen_t =
@@ -124,8 +124,8 @@ int main(int argc, char* argv[]) {
                        "specify the directory of output data");
     desc.add_options()("events", po::value<unsigned int>()->required(),
                        "number of events");
-    traccc::particle_gen_options<scalar> pg_opts(desc);
-    traccc::propagation_options<scalar> propagation_opts(desc);
+    traccc::particle_gen_options pg_opts(desc);
+    traccc::propagation_options propagation_opts(desc);
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);

--- a/examples/simulation/simulate_wire_chamber.cpp
+++ b/examples/simulation/simulate_wire_chamber.cpp
@@ -34,8 +34,8 @@ using namespace traccc;
 namespace po = boost::program_options;
 
 int simulate(std::string output_directory, unsigned int events,
-             const traccc::particle_gen_options<scalar>& pg_opts,
-             const traccc::propagation_options<scalar>& propagation_opts) {
+             const traccc::particle_gen_options& pg_opts,
+             const traccc::propagation_options& propagation_opts) {
 
     // Use deterministic random number generator for testing
     using uniform_gen_t =
@@ -129,8 +129,8 @@ int main(int argc, char* argv[]) {
                        "specify the directory of output data");
     desc.add_options()("events", po::value<unsigned int>()->required(),
                        "number of events");
-    traccc::particle_gen_options<scalar> pg_opts(desc);
-    traccc::propagation_options<scalar> propagation_opts(desc);
+    traccc::particle_gen_options pg_opts(desc);
+    traccc::propagation_options propagation_opts(desc);
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);


### PR DESCRIPTION
This all started out from a report on Mattermost that the throughput measuring executables are not working at the moment. But instead of merely fixing a typo in the "options code", I decided that it was time to do a thorough cleanup of it.

I did a number of things:
  - Got rid of all templating from the "options structs". I do not believe that we would have any need for using either `float` or `double` precision when specifying runtime parameters on the command line. So these options are always just specified as `float`-s, and then those configuration parameters may be used in `double` precision calculations later on.
  - Changed the name of some of the structs. Weirdly enough the names of the source files were in all cases how I wanted to call the structs themselves. So this was a pretty unfortunate inconsistency in the code so far. :frowning:
  - Switched all of the structs to a formalism where they would make `boost::program_options` write the configured parameters into C\+\+ variables "directly". Instead of declaring the option first, and then extracting the option ourselves later on.
    * I still kept all of the `read(...)` functions, since in a few cases we still need to do some non-trivial operations while interpreting the user-provided arguments. Though much of the code from these `read(...)` functions could be removed.
    * This is mainly to reduce code repetition. Which was the reason for the typo in the first place. :thinking:
  - Introduced "output operators" for all of the options structs. Similar to what we had already for a few of them.
    * Then updated all of the example applications to print their configured parameters using these helper operators. So that they would present a slightly more uniform look-and-feel. Like:

```
[bash][atspot01]:traccc > ./out/build/sycl/bin/traccc_seq_example_sycl --detector-file=tml_detector/trackml-detector.csv --digitization-config-file=tml_detector/default-geometric-config-generic.json --input-directory=tml_full/ttbar_mu20/ --events=2

Running the full tracking chain using SYCL

>>> Common options <<<
  Input data format            : csv
  Input directory              : tml_full/ttbar_mu20/
  Events                       : 2
  Skip                         : 0
  Target cells per partition   : 1024
  Check performance            : 0
  Perform ambiguity resolution : 1
>>> Detector options <<<
  Detector file : tml_detector/trackml-detector.csv
  Material file : 
  Grid file     : 
>>> Full tracking chain options <<<
  Digitization configuration file: tml_detector/default-geometric-config-generic.json

Running Seeding on device: NVIDIA GeForce RTX 2060
==> Statistics ... 
- read    95678 cells from 12529 modules
- created (cpu)  0 measurements
- created (cpu)  0 spacepoints
- created (sycl) 27862 spacepoints     
- created  (cpu) 0 seeds
- created (sycl) 3924 seeds
==>Elapsed times...
           File reading  (cpu)  228 ms
         Clusterization (sycl)  4 ms
                Seeding (sycl)  4 ms
           Track params (sycl)  0 ms
                     Wall time  238 ms
[bash][atspot01]:traccc >
```

This whole cleanup, I believe, was in the end very useful. Since I now have a new idea for why track finding in #509 would not be working. :thinking: