### PR TITLE
Thrust Update, main branch (2024.03.12.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -117,13 +117,6 @@ set( TRACCC_THRUST_OPTIONS "" CACHE STRING
    "Extra options for configuring how Thrust should be used" )
 mark_as_advanced( TRACCC_THRUST_OPTIONS )
 thrust_create_target( traccc::Thrust ${TRACCC_THRUST_OPTIONS} )
-# Make sure that Thrust/CUB headers are treated as system headers.
-get_target_property( _thrustIncludeDir Thrust::Thrust INTERFACE_INCLUDE_DIRECTORIES )
-get_target_property( _cubIncludeDir CUB::CUB INTERFACE_INCLUDE_DIRECTORIES )
-target_include_directories( traccc::Thrust
-   SYSTEM INTERFACE ${_thrustIncludeDir} ${_cubIncludeDir} )
-unset( _thrustIncludeDir )
-unset( _cubIncludeDir )
 
 # Set up TBB.
 option( TRACCC_SETUP_TBB

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -87,4 +87,12 @@ target_compile_options( traccc_cuda
   PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr> )
 target_link_libraries( traccc_cuda
   PUBLIC traccc::core detray::core detray::utils vecmem::core covfie::core
-  PRIVATE CUDA::cudart traccc::device_common vecmem::cuda )
+  PRIVATE CUDA::cudart traccc::Thrust traccc::device_common vecmem::cuda )
+
+# For CUDA 11 turn on separable compilation. This is necessary for using
+# Thrust 2.1.0.
+if( ( "${CMAKE_CUDA_COMPILER_ID}" STREQUAL "NVIDIA" ) AND
+    ( "${CMAKE_CUDA_COMPILER_VERSION}" VERSION_LESS "12.0" ) )
+  set_target_properties( traccc_cuda PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON )
+endif()

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -38,6 +38,7 @@
 #include <thrust/fill.h>
 #include <thrust/scan.h>
 #include <thrust/sort.h>
+#include <thrust/unique.h>
 
 // System include(s).
 #include <vector>

--- a/extern/thrust/CMakeLists.txt
+++ b/extern/thrust/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,7 +18,7 @@ message( STATUS "Building Thrust as part of the TRACCC project" )
 
 # Declare where to get Thrust from.
 set( TRACCC_THRUST_SOURCE
-   "GIT_REPOSITORY;https://github.com/NVIDIA/thrust.git;GIT_TAG;1.15.0"
+   "GIT_REPOSITORY;https://github.com/NVIDIA/thrust.git;GIT_TAG;2.1.0"
    CACHE STRING "Source for Thrust, when built as part of this project" )
 mark_as_advanced( TRACCC_THRUST_SOURCE )
 FetchContent_Declare( Thrust ${TRACCC_THRUST_SOURCE} )

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -41,6 +41,7 @@ traccc_add_test(
 
     LINK_LIBRARIES
     CUDA::cudart
+    traccc::Thrust
     GTest::gtest
     vecmem::cuda
     detray::core
@@ -55,3 +56,11 @@ traccc_add_test(
     traccc_tests_cuda_main
     traccc_tests_common
 )
+
+# For CUDA 11 turn on separable compilation. This is necessary for using
+# Thrust 2.1.0.
+if( ( "${CMAKE_CUDA_COMPILER_ID}" STREQUAL "NVIDIA" ) AND
+    ( "${CMAKE_CUDA_COMPILER_VERSION}" VERSION_LESS "12.0" ) )
+    set_target_properties( traccc_test_cuda PROPERTIES
+        CUDA_SEPARABLE_COMPILATION ON )
+endif()


### PR DESCRIPTION
While trying to build the project on Ubuntu 22.04 with CUDA 12.4 + oneAPI 2024.0.1, I ran into the following issues:

```
[ 95%] Building CUDA object tests/cuda/CMakeFiles/traccc_test_cuda.dir/test_copy.cu.o
/home/krasznaa/software/cuda/12.4.0/x86_64-ubuntu2204/targets/x86_64-linux/include/cuda/std/detail/libcxx/include/__iterator/unreachable_sentinel.h:49:1: error: an attribute list cannot appear here
   49 | [[nodiscard]] friend constexpr bool 
      | ^~~~~~~~~~~~~
/home/krasznaa/software/cuda/12.4.0/x86_64-ubuntu2204/targets/x86_64-linux/include/cuda/std/detail/libcxx/include/__iterator/unreachable_sentinel.h:57:1: error: an attribute list cannot appear here
   57 | [[nodiscard]] friend constexpr bool 
      | ^~~~~~~~~~~~~
/home/krasznaa/software/cuda/12.4.0/x86_64-ubuntu2204/targets/x86_64-linux/include/cuda/std/detail/libcxx/include/__iterator/unreachable_sentinel.h:64:1: error: an attribute list cannot appear here
   64 | [[nodiscard]] friend constexpr bool 
      | ^~~~~~~~~~~~~
/home/krasznaa/software/cuda/12.4.0/x86_64-ubuntu2204/targets/x86_64-linux/include/cuda/std/detail/libcxx/include/__iterator/unreachable_sentinel.h:71:1: error: an attribute list cannot appear here
   71 | [[nodiscard]] friend constexpr bool 
      | ^~~~~~~~~~~~~
4 errors generated.
```

After some amount of debugging, I found that [Thrust 1.5.0](https://github.com/NVIDIA/thrust/releases/tag/1.15.0), which we use at the moment by default, cannot work with these compilers anymore. :frowning: In the end it's not super unexpected, since that version of Thrust was released back in 2021. :thinking:

When updating to [Thrust 2.1.0](https://github.com/NVIDIA/thrust/releases/tag/2.1.0), the current latest version, I had to change the following:
  - The tweaks in [CMakeLists.txt](CMakeLists.txt) for making sure that the Thrust headers would be treated as system headers, are very much tinkered around the exact CMake configuration of Thrust 1.15.0. I tried to update these at first, but since even with Clang I was not seeing any warnings from Thrust 2.1.0, in the end I just removed the tweaks all together. :thinking:
  - [finding_algorithm.cu](device/cuda/src/finding/finding_algorithm.cu) was missing an include, which didn't show up as an issue with the previous Thrust version.
  - Any CUDA source file that uses Thrust (2.1.0) needs to be built with [CUDA_SEPARABLE_COMPILATION](https://cmake.org/cmake/help/latest/prop_tgt/CUDA_SEPARABLE_COMPILATION.html) enabled when using CUDA 11.X. So added this property on `traccc::cuda` and `traccc_test_cuda`. :thinking: