### PR TITLE
Fix ambiguity resolution algorithm: add unique measurement_id

### DIFF
--- a/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
+++ b/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
@@ -78,12 +78,11 @@ TRACCC_HOST inline void calc_cluster_properties(
 /// @param[in] cluster is the input cell vector
 /// @param[in] module is the cell module where the cluster belongs to
 /// @param[in] module_link is the module index
-/// @param[in] unique_mid unique measurement id, for ambiguity resolution
 ///
 TRACCC_HOST inline void fill_measurement(
     measurement_collection_types::host& measurements,
     const cell_collection_types::host& cluster, const cell_module& module,
-    const unsigned int module_link, std::size_t unique_mid) {
+    const unsigned int module_link) {
 
     // To calculate the mean and variance with high numerical stability
     // we use a weighted variant of Welford's algorithm. This is a
@@ -117,7 +116,7 @@ TRACCC_HOST inline void fill_measurement(
         // @todo add variance estimation
 
         // For the ambiguity resolution algorithm, give a unique measurement ID
-        m.measurement_id = unique_mid;
+        m.measurement_id = measurements.size();
 
         measurements.push_back(std::move(m));
     }

--- a/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
+++ b/core/include/traccc/clusterization/detail/measurement_creation_helper.hpp
@@ -78,11 +78,12 @@ TRACCC_HOST inline void calc_cluster_properties(
 /// @param[in] cluster is the input cell vector
 /// @param[in] module is the cell module where the cluster belongs to
 /// @param[in] module_link is the module index
+/// @param[in] unique_mid unique measurement id, for ambiguity resolution
 ///
 TRACCC_HOST inline void fill_measurement(
     measurement_collection_types::host& measurements,
     const cell_collection_types::host& cluster, const cell_module& module,
-    const unsigned int module_link) {
+    const unsigned int module_link, std::size_t unique_mid) {
 
     // To calculate the mean and variance with high numerical stability
     // we use a weighted variant of Welford's algorithm. This is a
@@ -114,6 +115,9 @@ TRACCC_HOST inline void fill_measurement(
             m.variance + point2{pitch[0] * pitch[0] / static_cast<scalar>(12.),
                                 pitch[1] * pitch[1] / static_cast<scalar>(12.)};
         // @todo add variance estimation
+
+        // For the ambiguity resolution algorithm, give a unique measurement ID
+        m.measurement_id = unique_mid;
 
         measurements.push_back(std::move(m));
     }

--- a/core/src/clusterization/measurement_creation.cpp
+++ b/core/src/clusterization/measurement_creation.cpp
@@ -24,8 +24,6 @@ measurement_creation::output_type measurement_creation::operator()(
     output_type result(&(m_mr.get()));
     result.reserve(clusters.size());
 
-    std::size_t unique_measurement_id = 0;
-
     // Process the clusters one-by-one.
     for (std::size_t i = 0; i < clusters.size(); ++i) {
         // To calculate the mean and variance with high numerical stability
@@ -50,10 +48,7 @@ measurement_creation::output_type measurement_creation::operator()(
         const auto &module = modules.at(module_link);
 
         // Fill measurement from cluster
-        // Give each measurement a unique ID, for the ambiguity resolution
-        // algorithm
-        detail::fill_measurement(result, cluster, module, module_link,
-                                 ++unique_measurement_id);
+        detail::fill_measurement(result, cluster, module, module_link);
     }
 
     return result;

--- a/core/src/clusterization/measurement_creation.cpp
+++ b/core/src/clusterization/measurement_creation.cpp
@@ -24,6 +24,8 @@ measurement_creation::output_type measurement_creation::operator()(
     output_type result(&(m_mr.get()));
     result.reserve(clusters.size());
 
+    std::size_t unique_measurement_id = 0;
+
     // Process the clusters one-by-one.
     for (std::size_t i = 0; i < clusters.size(); ++i) {
         // To calculate the mean and variance with high numerical stability
@@ -48,7 +50,10 @@ measurement_creation::output_type measurement_creation::operator()(
         const auto &module = modules.at(module_link);
 
         // Fill measurement from cluster
-        detail::fill_measurement(result, cluster, module, module_link);
+        // Give each measurement a unique ID, for the ambiguity resolution
+        // algorithm
+        detail::fill_measurement(result, cluster, module, module_link,
+                                 ++unique_measurement_id);
     }
 
     return result;


### PR DESCRIPTION
This is a fix for @krasznaa PR  [ODD Full Chain Reconstruction, main branch (2024.04.09.) #534](https://github.com/acts-project/traccc/pull/534).

The ambiguity resolution algorithm failed because every `measurement_id` were equal to zero, as they were not initialized when created from clusters during `measurement_creation`.

Since we are running sequentially on the CPU, I think iteratively giving a unique measurement id by incrementing a variable may be okay?

Output example:
```
Running Full Tracking Chain on the Host

>>> Detector Options <<<
  Detector file       : geometries/odd/odd_geometry_detray.json
  Material file       : 
  Surface rid file    : 
  Use detray::detector: yes
  Digitization file   : geometries/odd/odd-digi-geometric-config.json
>>> Input Data Options <<<
  Input data format             : csv
  Input directory               : odd/muon100GeV-geant4/
  Number of input events        : 2
  Number of input events to skip: 0
>>> Clusterization Options <<<
  Target cells per partition: 1024
>>> Track Seeding Options <<<
  None
>>> Track Finding Options <<<
  Track candidates range   : 3:100
  Maximum Chi2             : 30
  Maximum branches per step: 4294967295
>>> Track Propagation Options <<<
  Constraint step size : 3.40282e+38 [mm]
  Overstep tolerance   : -100 [um]
  Mask tolerance       : 15 [um]
  Search window        : 0 x 0
  Runge-Kutta tolerance: 0.0001
>>> Track Ambiguity Resolution Options <<<
  Run ambiguity resolution : yes
>>> Performance Measurement Options <<<
  Run performance checks: no

WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
@greedy_ambiguity_resolution_algorithm: Iteration_count: 6417
@greedy_ambiguity_resolution_algorithm: Checking result validity...
@greedy_ambiguity_resolution_algorithm: OK 1/2: every removed track had at least one commun measurement with another track.
@greedy_ambiguity_resolution_algorithm: OK 2/2: each selected_track shares at most (_config.maximum_shared_hits - 1)(=0) measurement(s)
@greedy_ambiguity_resolution_algorithm: state.selected_tracks.size() = 1728
@greedy_ambiguity_resolution_algorithm: Iteration_count: 5869
@greedy_ambiguity_resolution_algorithm: Checking result validity...
@greedy_ambiguity_resolution_algorithm: OK 1/2: every removed track had at least one commun measurement with another track.
@greedy_ambiguity_resolution_algorithm: OK 2/2: each selected_track shares at most (_config.maximum_shared_hits - 1)(=0) measurement(s)
@greedy_ambiguity_resolution_algorithm: state.selected_tracks.size() = 1751
==> Statistics ... 
- read     163156 cells from 22437 modules
- created  63510 measurements. 
- created  63510 space points. 
- created  11806 seeds
- found    15765 tracks
- fitted   15765 tracks
- resolved 3479 tracks
```