### PR TITLE
Double Precision Build Fix, main branch (2024.04.15.)

### DIFF
--- a/examples/options/include/traccc/options/track_propagation.hpp
+++ b/examples/options/include/traccc/options/track_propagation.hpp
@@ -37,6 +37,17 @@ class track_propagation : public interface {
     ///
     void read(const boost::program_options::variables_map& vm) override;
 
+    /// Set up a configuration object based on the command line options
+    ///
+    /// @param cfg The configuration object to fill
+    ///
+    void setup(detray::propagation::config<float>& cfg) const;
+    /// Set up a configuration object based on the command line options
+    ///
+    /// @param cfg The configuration object to fill
+    ///
+    void setup(detray::propagation::config<double>& cfg) const;
+
     private:
     /// Print the specific options of this class
     std::ostream& print_impl(std::ostream& out) const override;

--- a/examples/options/src/track_propagation.cpp
+++ b/examples/options/src/track_propagation.cpp
@@ -52,6 +52,34 @@ void track_propagation::read(const po::variables_map&) {
     config.navigation.search_window = m_search_window;
 }
 
+void track_propagation::setup(detray::propagation::config<float>& cfg) const {
+
+    cfg = config;
+    return;
+}
+
+void track_propagation::setup(detray::propagation::config<double>& cfg) const {
+
+    cfg.stepping.min_stepsize = config.stepping.min_stepsize;
+    cfg.stepping.rk_error_tol = config.stepping.rk_error_tol;
+    cfg.stepping.step_constraint = config.stepping.step_constraint;
+    cfg.stepping.path_limit = config.stepping.path_limit;
+    cfg.stepping.max_rk_updates = config.stepping.max_rk_updates;
+    cfg.stepping.use_mean_loss = config.stepping.use_mean_loss;
+    cfg.stepping.use_eloss_gradient = config.stepping.use_eloss_gradient;
+    cfg.stepping.use_field_gradient = config.stepping.use_field_gradient;
+    cfg.stepping.do_covariance_transport =
+        config.stepping.do_covariance_transport;
+
+    cfg.navigation.mask_tolerance = config.navigation.mask_tolerance;
+    cfg.navigation.on_surface_tolerance =
+        config.navigation.on_surface_tolerance;
+    cfg.navigation.overstep_tolerance = config.navigation.overstep_tolerance;
+    cfg.navigation.search_window[0] = config.navigation.search_window[0];
+    cfg.navigation.search_window[1] = config.navigation.search_window[1];
+    return;
+}
+
 std::ostream& track_propagation::print_impl(std::ostream& out) const {
 
     out << "  Constraint step size : "

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -139,14 +139,14 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     cfg.min_track_candidates_per_track = finding_opts.track_candidates_range[0];
     cfg.max_track_candidates_per_track = finding_opts.track_candidates_range[1];
     cfg.chi2_max = finding_opts.chi2_max;
-    cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(cfg.propagation);
 
     traccc::finding_algorithm<rk_stepper_type, host_navigator_type>
         host_finding(cfg);
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(fit_cfg.propagation);
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
 

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -133,10 +133,10 @@ int seq_run(const traccc::opts::input_data& input_opts,
     finding_cfg.max_track_candidates_per_track =
         finding_opts.track_candidates_range[1];
     finding_cfg.chi2_max = finding_opts.chi2_max;
-    finding_cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(finding_cfg.propagation);
 
     fitting_algorithm::config_type fitting_cfg;
-    fitting_cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(fitting_cfg.propagation);
 
     // Algorithms
     traccc::clusterization_algorithm ca(host_mr);

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -117,7 +117,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
     cfg.min_track_candidates_per_track = finding_opts.track_candidates_range[0];
     cfg.max_track_candidates_per_track = finding_opts.track_candidates_range[1];
     cfg.chi2_max = finding_opts.chi2_max;
-    cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(cfg.propagation);
 
     // Finding algorithm object
     traccc::finding_algorithm<rk_stepper_type, host_navigator_type>
@@ -125,7 +125,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(fit_cfg.propagation);
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
 

--- a/examples/run/cpu/truth_fitting_example.cpp
+++ b/examples/run/cpu/truth_fitting_example.cpp
@@ -116,7 +116,7 @@ int main(int argc, char* argv[]) {
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(fit_cfg.propagation);
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
 

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -186,7 +186,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     cfg.min_track_candidates_per_track = finding_opts.track_candidates_range[0];
     cfg.max_track_candidates_per_track = finding_opts.track_candidates_range[1];
     cfg.chi2_max = finding_opts.chi2_max;
-    cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(cfg.propagation);
 
     // Finding algorithm object
     traccc::finding_algorithm<rk_stepper_type, host_navigator_type>
@@ -196,7 +196,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(fit_cfg.propagation);
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
     traccc::cuda::fitting_algorithm<device_fitter_type> device_fitting(

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -161,7 +161,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
     cfg.min_track_candidates_per_track = finding_opts.track_candidates_range[0];
     cfg.max_track_candidates_per_track = finding_opts.track_candidates_range[1];
     cfg.chi2_max = finding_opts.chi2_max;
-    cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(cfg.propagation);
 
     // Finding algorithm object
     traccc::finding_algorithm<rk_stepper_type, host_navigator_type>
@@ -171,7 +171,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(fit_cfg.propagation);
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
     traccc::cuda::fitting_algorithm<device_fitter_type> device_fitting(

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -158,7 +158,7 @@ int main(int argc, char* argv[]) {
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    propagation_opts.setup(fit_cfg.propagation);
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
     traccc::cuda::fitting_algorithm<device_fitter_type> device_fitting(

--- a/examples/simulation/simulate.cpp
+++ b/examples/simulation/simulate.cpp
@@ -90,8 +90,12 @@ int main(int argc, char* argv[]) {
     // Origin of particles
     generator_type::configuration gen_cfg{};
     gen_cfg.n_tracks(generation_opts.gen_nparticles);
-    gen_cfg.origin(generation_opts.vertex);
-    gen_cfg.origin_stddev(generation_opts.vertex_stddev);
+    gen_cfg.origin(generator_type::point3{generation_opts.vertex[0],
+                                          generation_opts.vertex[1],
+                                          generation_opts.vertex[2]});
+    gen_cfg.origin_stddev(generator_type::point3{
+        generation_opts.vertex_stddev[0], generation_opts.vertex_stddev[1],
+        generation_opts.vertex_stddev[2]});
     gen_cfg.phi_range(generation_opts.phi_range[0],
                       generation_opts.phi_range[1]);
     gen_cfg.theta_range(generation_opts.theta_range[0],
@@ -121,7 +125,7 @@ int main(int argc, char* argv[]) {
         generation_opts.events, host_det, field, std::move(generator),
         std::move(smearer_writer_cfg), full_path);
 
-    sim.get_config().propagation = propagation_opts.config;
+    propagation_opts.setup(sim.get_config().propagation);
 
     sim.run();
 

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -99,8 +99,12 @@ int simulate(const traccc::opts::generation& generation_opts,
                                        uniform_gen_t>;
     generator_type::configuration gen_cfg{};
     gen_cfg.n_tracks(generation_opts.gen_nparticles);
-    gen_cfg.origin(generation_opts.vertex);
-    gen_cfg.origin_stddev(generation_opts.vertex_stddev);
+    gen_cfg.origin(generator_type::point3{generation_opts.vertex[0],
+                                          generation_opts.vertex[1],
+                                          generation_opts.vertex[2]});
+    gen_cfg.origin_stddev(generator_type::point3{
+        generation_opts.vertex_stddev[0], generation_opts.vertex_stddev[1],
+        generation_opts.vertex_stddev[2]});
     gen_cfg.phi_range(generation_opts.phi_range[0],
                       generation_opts.phi_range[1]);
     gen_cfg.theta_range(generation_opts.theta_range[0],
@@ -132,7 +136,7 @@ int simulate(const traccc::opts::generation& generation_opts,
                                  writer_type>(
         generation_opts.events, det, field, std::move(generator),
         std::move(smearer_writer_cfg), full_path);
-    sim.get_config().propagation = propagation_opts.config;
+    propagation_opts.setup(sim.get_config().propagation);
 
     sim.run();
 

--- a/examples/simulation/simulate_toy_detector.cpp
+++ b/examples/simulation/simulate_toy_detector.cpp
@@ -73,8 +73,12 @@ int simulate(const traccc::opts::generation& generation_opts,
                                        uniform_gen_t>;
     generator_type::configuration gen_cfg{};
     gen_cfg.n_tracks(generation_opts.gen_nparticles);
-    gen_cfg.origin(generation_opts.vertex);
-    gen_cfg.origin_stddev(generation_opts.vertex_stddev);
+    gen_cfg.origin(generator_type::point3{generation_opts.vertex[0],
+                                          generation_opts.vertex[1],
+                                          generation_opts.vertex[2]});
+    gen_cfg.origin_stddev(generator_type::point3{
+        generation_opts.vertex_stddev[0], generation_opts.vertex_stddev[1],
+        generation_opts.vertex_stddev[2]});
     gen_cfg.phi_range(generation_opts.phi_range[0],
                       generation_opts.phi_range[1]);
     gen_cfg.theta_range(generation_opts.theta_range[0],
@@ -104,7 +108,7 @@ int simulate(const traccc::opts::generation& generation_opts,
                                  writer_type>(
         generation_opts.events, det, field, std::move(generator),
         std::move(smearer_writer_cfg), full_path);
-    sim.get_config().propagation = propagation_opts.config;
+    propagation_opts.setup(sim.get_config().propagation);
 
     sim.run();
 

--- a/examples/simulation/simulate_wire_chamber.cpp
+++ b/examples/simulation/simulate_wire_chamber.cpp
@@ -74,8 +74,12 @@ int simulate(const traccc::opts::generation& generation_opts,
                                        uniform_gen_t>;
     generator_type::configuration gen_cfg{};
     gen_cfg.n_tracks(generation_opts.gen_nparticles);
-    gen_cfg.origin(generation_opts.vertex);
-    gen_cfg.origin_stddev(generation_opts.vertex_stddev);
+    gen_cfg.origin(generator_type::point3{generation_opts.vertex[0],
+                                          generation_opts.vertex[1],
+                                          generation_opts.vertex[2]});
+    gen_cfg.origin_stddev(generator_type::point3{
+        generation_opts.vertex_stddev[0], generation_opts.vertex_stddev[1],
+        generation_opts.vertex_stddev[2]});
     gen_cfg.phi_range(generation_opts.phi_range[0],
                       generation_opts.phi_range[1]);
     gen_cfg.theta_range(generation_opts.theta_range[0],
@@ -105,7 +109,7 @@ int simulate(const traccc::opts::generation& generation_opts,
                                  writer_type>(
         generation_opts.events, det, field, std::move(generator),
         std::move(smearer_writer_cfg), full_path);
-    sim.get_config().propagation = propagation_opts.config;
+    propagation_opts.setup(sim.get_config().propagation);
 
     sim.run();
 


### PR DESCRIPTION
Fixed the build of the project with double precision scalars. (Using `-DTRACCC_CUSTOM_SCALAR_TYPE=double` + `-DDETRAY_CUSTOM_SCALAR_TYPE=double`.)

This is to fix the issue described in #540. Which was introduced in #533.

It is only meant to be a temporary hack. The configuration types, much as @beomki-yeo proposed in #540, should become non-templated types in Detray in a future update. :thinking: