### PR TITLE
CUDA CI Update, main branch (2024.04.17.)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,39 +1,76 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022-2023 CERN for the benefit of the ACTS project
+# (c) 2022-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
+# Stages of the CI build.
 stages:
   - build
   - test
 
+# Job-wide variables.
+variables:
+  ALMA9_PACKAGES: make which wget tar atlas-devel curl-devel libX11-devel libXpm-devel libXft-devel libXext-devel libXi-devel openssl-devel glib2-devel glibc-devel gmp-devel rpm-build mesa-libGL-devel mesa-libGLU-devel mesa-libEGL-devel libuuid-devel man-db libxkbcommon-devel xz-devel libaio-devel expat-devel libtirpc-devel
+  UBUNTU_PACKAGES: git wget lsb-core libx11-dev libxpm-dev libxft-dev libxext-dev libxi-dev libssl-dev libgmp-dev libgl1-mesa-dev libglu1-mesa-dev libegl1-mesa-dev
 
-build_cuda:
-  tags: [docker]
+# Template for all build jobs.
+.build_template: &build_job
   stage: build
-  image: ghcr.io/acts-project/ubuntu2004_cuda:v30
-  artifacts:
-    paths:
-      - build
+  tags: [docker]
   script:
-      - git clone $CLONE_URL src
-      - git -C src checkout $HEAD_SHA
-      - cmake --preset cuda -DCMAKE_BUILD_TYPE=Release -S src -B build -G Ninja
-      - cmake --build build --parallel 2
+    - git clone $CLONE_URL traccc-src
+    - git -C traccc-src checkout $HEAD_SHA
+    - cmake ${CMAKE_ARGUMENTS} -S traccc-src -B traccc-build 2>&1 | tee cmake_config.log
+    - cmake --build traccc-build 2>&1 | tee cmake_build.log
+  artifacts:
+    when: always
+    expose_as: 'Build Artifacts'
+    paths:
+      - cmake_config.log
+      - cmake_build.log
+      - traccc-src/
+      - traccc-build/
+    expire_in: 1 week
 
-test_cuda:
+# Template for all test jobs.
+.test_template: &test_job
   stage: test
   tags: [docker-gpu-nvidia]
-  image: ghcr.io/acts-project/ubuntu2004_cuda:v30
-  needs:
-    - build_cuda
   script:
-    - git clone $CLONE_URL src
-    - cd src
-    - git checkout $HEAD_SHA
-    - data/traccc_data_get_files.sh
-    - cd ..
-    - cd build
     - nvidia-smi
-    - ctest --output-on-failure -E "^SeedingValidation/CompareWithActsSeedingTests.*"
+    - ./traccc-src/data/traccc_data_get_files.sh
+    - ctest ${CTEST_ARGUMENTS} --test-dir traccc-build --output-on-failure 2>&1 | tee cmake_ctest.log
+  artifacts:
+    when: always
+    expose_as: 'Test Artifacts'
+    paths:
+      - cmake_ctest.log
+    expire_in: 1 week
+
+# Template for all x86_64-el9-gcc11 CUDA jobs.
+.x86_64_el9_gcc11_cuda_template: &x86_64_el9_gcc11_cuda_job
+  image: gitlab-registry.cern.ch/linuxsupport/alma9-base:latest
+  before_script:
+    - dnf install -y ${ALMA9_PACKAGES}
+    - source /cvmfs/sft.cern.ch/lcg/views/${LCG_VERSION}/x86_64-el9-gcc11-opt/setup.sh
+    - source /cvmfs/sft.cern.ch/lcg/contrib/cuda/${CUDA_VERSION}/x86_64-centos7/setup.sh
+
+# x86_64-el9-gcc11 CUDA jobs.
+build:x86_64_el9_gcc11:cuda:
+  <<: *build_job
+  <<: *x86_64_el9_gcc11_cuda_job
+  variables:
+    LCG_VERSION: LCG_105a
+    CUDA_VERSION: 11.8
+    CMAKE_ARGUMENTS: --preset cuda
+    CMAKE_BUILD_PARALLEL_LEVEL: 2
+
+test:x86_64_el9_gcc11:cuda:
+  <<: *test_job
+  <<: *x86_64_el9_gcc11_cuda_job
+  variables:
+    LCG_VERSION: LCG_105a
+    CTEST_ARGUMENTS: -E "^SeedingValidation/CompareWithActsSeedingTests.*"
+  dependencies:
+    - build:x86_64_el9_gcc11:cuda


### PR DESCRIPTION
This is an attempt at bringing the CUDA runtime tests back into a working order. I don't expect the first try to succeed (CUDA 11.6 seems just as broken for these tests as 11.5), but I have some further ideas as well...