### PR TITLE
Cell Reading Rewrite, main branch (2024.04.19.)

### DIFF
--- a/core/include/traccc/edm/cell.hpp
+++ b/core/include/traccc/edm/cell.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -37,6 +37,12 @@ struct cell_module {
 /// Declare all cell module collection types
 using cell_module_collection_types = collection_types<cell_module>;
 
+/// Comparison operator for cell modules
+TRACCC_HOST_DEVICE
+inline bool operator<(const cell_module& lhs, const cell_module& rhs) {
+    return lhs.surface_link < rhs.surface_link;
+}
+
 /// Equality operator for cell module
 TRACCC_HOST_DEVICE
 inline bool operator==(const cell_module& lhs, const cell_module& rhs) {
@@ -61,17 +67,16 @@ struct cell {
 /// Declare all cell collection types
 using cell_collection_types = collection_types<cell>;
 
+/// Comparison operator for cells
 TRACCC_HOST_DEVICE
 inline bool operator<(const cell& lhs, const cell& rhs) {
 
     if (lhs.module_link != rhs.module_link) {
         return lhs.module_link < rhs.module_link;
-    } else if (lhs.channel0 != rhs.channel0) {
-        return (lhs.channel0 < rhs.channel0);
     } else if (lhs.channel1 != rhs.channel1) {
         return (lhs.channel1 < rhs.channel1);
     } else {
-        return lhs.activation < rhs.activation;
+        return (lhs.channel0 < rhs.channel0);
     }
 }
 

--- a/core/include/traccc/edm/cell.hpp
+++ b/core/include/traccc/edm/cell.hpp
@@ -73,10 +73,12 @@ inline bool operator<(const cell& lhs, const cell& rhs) {
 
     if (lhs.module_link != rhs.module_link) {
         return lhs.module_link < rhs.module_link;
+    } else if (lhs.channel0 != rhs.channel0) {
+        return (lhs.channel0 < rhs.channel0);
     } else if (lhs.channel1 != rhs.channel1) {
         return (lhs.channel1 < rhs.channel1);
     } else {
-        return (lhs.channel0 < rhs.channel0);
+        return lhs.activation < rhs.activation;
     }
 }
 

--- a/io/include/traccc/io/read_cells.hpp
+++ b/io/include/traccc/io/read_cells.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -37,13 +37,15 @@ namespace traccc::io {
 /// @param dconfig The detector's digitization configuration
 /// @param bardoce_map An object to perform barcode re-mapping with
 ///                    (For Acts->Detray identifier re-mapping, if necessary)
+/// @param deduplicate Whether to deduplicate the cells
 ///
 void read_cells(
     cell_reader_output &out, std::size_t event, std::string_view directory,
     data_format format = data_format::csv, const geometry *geom = nullptr,
     const digitization_config *dconfig = nullptr,
     const std::map<std::uint64_t, detray::geometry::barcode> *barcode_map =
-        nullptr);
+        nullptr,
+    bool deduplicate = true);
 
 /// Read cell data into memory
 ///
@@ -56,12 +58,14 @@ void read_cells(
 /// @param dconfig The detector's digitization configuration
 /// @param bardoce_map An object to perform barcode re-mapping with
 ///                    (For Acts->Detray identifier re-mapping, if necessary)
+/// @param deduplicate Whether to deduplicate the cells
 ///
 void read_cells(cell_reader_output &out, std::string_view filename,
                 data_format format = data_format::csv,
                 const geometry *geom = nullptr,
                 const digitization_config *dconfig = nullptr,
                 const std::map<std::uint64_t, detray::geometry::barcode>
-                    *barcode_map = nullptr);
+                    *barcode_map = nullptr,
+                bool deduplicate = true);
 
 }  // namespace traccc::io

--- a/io/src/csv/read_cells.cpp
+++ b/io/src/csv/read_cells.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,30 +11,25 @@
 #include "traccc/io/csv/make_cell_reader.hpp"
 
 // System include(s).
-#include <algorithm>
 #include <cassert>
+#include <iostream>
+#include <map>
+#include <set>
 #include <stdexcept>
 #include <utility>
-#include <vector>
 
 namespace {
-
-/// Comparator used for sorting cells. This sorting is one of the assumptions
-/// made in the clusterization algorithm
-const auto comp = [](const traccc::cell& c1, const traccc::cell& c2) {
-    return c1.channel1 < c2.channel1;
-};
 
 /// Helper function which finds module from csv::cell in the geometry and
 /// digitization config, and initializes the modules limits with the cell's
 /// properties
-traccc::cell_module get_module(traccc::io::csv::cell c,
+traccc::cell_module get_module(const std::uint64_t geometry_id,
                                const traccc::geometry* geom,
                                const traccc::digitization_config* dconfig,
                                const std::uint64_t original_geometry_id) {
 
     traccc::cell_module result;
-    result.surface_link = detray::geometry::barcode{c.geometry_id};
+    result.surface_link = detray::geometry::barcode{geometry_id};
 
     // Find/set the 3D position of the detector module.
     if (geom != nullptr) {
@@ -81,105 +76,55 @@ void read_cells(
     const digitization_config* dconfig,
     const std::map<std::uint64_t, detray::geometry::barcode>* barcode_map) {
 
+    // Temporary storage for all the cells and modules.
+    std::map<std::uint64_t, std::set<traccc::cell> > cellsMap;
+
     // Construct the cell reader object.
     auto reader = make_cell_reader(filename);
 
-    // Create cell counter vector.
-    std::vector<unsigned int> cellCounts;
-    cellCounts.reserve(5000);
-
-    cell_module_collection_types::host& result_modules = out.modules;
-    result_modules.reserve(5000);
-
-    // Create a cell collection, which holds on to a flat list of all the cells
-    // and the position of their respective cell counter & module.
-    std::vector<std::pair<csv::cell, unsigned int>> allCells;
-    allCells.reserve(50000);
-
     // Read all cells from input file.
     csv::cell iocell;
+    unsigned int nduplicates = 0;
     while (reader.read(iocell)) {
 
-        // Modify the geometry ID of the cell if a barcode map is provided.
-        const std::uint64_t original_geometry_id = iocell.geometry_id;
+        // Add the cell to the module. At this point the module link of the
+        // cells is not set up correctly yet.
+        if (cellsMap[iocell.geometry_id]
+                .insert({iocell.channel0, iocell.channel1, iocell.value,
+                         iocell.timestamp, 0})
+                .second == false) {
+            ++nduplicates;
+        }
+    }
+    if (nduplicates > 0) {
+        std::cout << "WARNING: @traccc::io::csv::read_cells: " << nduplicates
+                  << " duplicate cells found in " << filename << std::endl;
+    }
+
+    // Fill the output containers with the ordered cells and modules.
+    for (const auto& [original_geometry_id, cells] : cellsMap) {
+
+        // Modify the geometry ID of the module if a barcode map is provided.
+        std::uint64_t geometry_id = original_geometry_id;
         if (barcode_map != nullptr) {
-            const auto it = barcode_map->find(iocell.geometry_id);
+            const auto it = barcode_map->find(geometry_id);
             if (it != barcode_map->end()) {
-                iocell.geometry_id = it->second.value();
+                geometry_id = it->second.value();
             } else {
                 throw std::runtime_error(
                     "Could not find barcode for geometry ID " +
-                    std::to_string(iocell.geometry_id));
+                    std::to_string(geometry_id));
             }
         }
 
-        // Look for current module in cell counter vector.
-        auto rit = std::find_if(result_modules.rbegin(), result_modules.rend(),
-                                [&iocell](const cell_module& mod) {
-                                    return mod.surface_link.value() ==
-                                           iocell.geometry_id;
-                                });
-        if (rit == result_modules.rend()) {
-            // Add new cell and new cell counter if a new module is found
-            const cell_module mod =
-                get_module(iocell, geom, dconfig, original_geometry_id);
-            allCells.push_back({iocell, result_modules.size()});
-            result_modules.push_back(mod);
-            cellCounts.push_back(1);
-        } else {
-            // Add a new cell and update cell counter if repeat module is found
-            const unsigned int pos =
-                std::distance(result_modules.begin(), rit.base()) - 1;
-            allCells.push_back({iocell, pos});
-            ++(cellCounts[pos]);
+        // Add the module and its cells to the output.
+        out.modules.push_back(
+            get_module(geometry_id, geom, dconfig, original_geometry_id));
+        for (auto& cell : cells) {
+            out.cells.push_back(cell);
+            // Set the module link.
+            out.cells.back().module_link = out.modules.size() - 1;
         }
-    }
-
-    // Transform the cellCounts vector into a prefix sum for accessing
-    // positions in the result vector.
-    std::partial_sum(cellCounts.begin(), cellCounts.end(), cellCounts.begin());
-
-    // The total number cells.
-    const unsigned int totalCells = allCells.size();
-
-    // Construct the result collection.
-    cell_collection_types::host& result_cells = out.cells;
-    result_cells.resize(totalCells);
-
-    // Member "-1" of the prefix sum vector
-    unsigned int nCellsZero = 0;
-    // Fill the result object with the read csv cells
-    for (unsigned int i = 0; i < totalCells; ++i) {
-        const csv::cell& c = allCells[i].first;
-
-        // The position of the cell counter this cell belongs to
-        const unsigned int& counterPos = allCells[i].second;
-
-        unsigned int& prefix_sum_previous =
-            counterPos == 0 ? nCellsZero : cellCounts[counterPos - 1];
-        result_cells[prefix_sum_previous++] = traccc::cell{
-            c.channel0, c.channel1, c.value, c.timestamp, counterPos};
-    }
-
-    if (cellCounts.size() == 0) {
-        return;
-    }
-    /* This is might look a bit overcomplicated, and could be made simpler by
-     * having a copy of the prefix sum vector before incrementing its value when
-     * filling the vector. however this seems more efficient, but requires
-     * manually setting the 1st & 2nd modules instead of just the 1st.
-     */
-
-    // Sort the cells belonging to the first module.
-    std::sort(result_cells.begin(), result_cells.begin() + nCellsZero, comp);
-    // Sort the cells belonging to the second module.
-    std::sort(result_cells.begin() + nCellsZero,
-              result_cells.begin() + cellCounts[0], comp);
-
-    // Sort cells belonging to all other modules.
-    for (unsigned int i = 1; i < cellCounts.size() - 1; ++i) {
-        std::sort(result_cells.begin() + cellCounts[i - 1],
-                  result_cells.begin() + cellCounts[i], comp);
     }
 }
 

--- a/io/src/csv/read_cells.hpp
+++ b/io/src/csv/read_cells.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -27,11 +27,13 @@ namespace traccc::io::csv {
 /// @param geom The description of the detector geometry
 /// @param dconfig The detector's digitization configuration
 /// @param bardoce_map An object to perform barcode re-mapping with
+/// @param deduplicate Whether to deduplicate the cells
 ///
 void read_cells(cell_reader_output& out, std::string_view filename,
                 const geometry* geom = nullptr,
                 const digitization_config* dconfig = nullptr,
                 const std::map<std::uint64_t, detray::geometry::barcode>*
-                    barcode_map = nullptr);
+                    barcode_map = nullptr,
+                bool deduplicate = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/mapper.cpp
+++ b/io/src/mapper.cpp
@@ -207,7 +207,7 @@ generate_measurement_cell_map(std::size_t event,
     // Read the cells from the relevant event file
     traccc::io::cell_reader_output readOut(&resource);
     io::read_cells(readOut, event, cells_dir, traccc::data_format::csv,
-                   &surface_transforms, &digi_cfg);
+                   &surface_transforms, &digi_cfg, nullptr, false);
     cell_collection_types::host& cells_per_event = readOut.cells;
     cell_module_collection_types::host& modules_per_event = readOut.modules;
 

--- a/io/src/read_cells.cpp
+++ b/io/src/read_cells.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,14 +18,15 @@ void read_cells(
     cell_reader_output& out, std::size_t event, std::string_view directory,
     data_format format, const geometry* geom,
     const digitization_config* dconfig,
-    const std::map<std::uint64_t, detray::geometry::barcode>* barcode_map) {
+    const std::map<std::uint64_t, detray::geometry::barcode>* barcode_map,
+    bool deduplicate) {
 
     switch (format) {
         case data_format::csv: {
             read_cells(out,
                        data_directory() + directory.data() +
                            get_event_filename(event, "-cells.csv"),
-                       format, geom, dconfig, barcode_map);
+                       format, geom, dconfig, barcode_map, deduplicate);
             break;
         }
         case data_format::binary: {
@@ -45,11 +46,13 @@ void read_cells(
 void read_cells(
     cell_reader_output& out, std::string_view filename, data_format format,
     const geometry* geom, const digitization_config* dconfig,
-    const std::map<std::uint64_t, detray::geometry::barcode>* barcode_map) {
+    const std::map<std::uint64_t, detray::geometry::barcode>* barcode_map,
+    bool deduplicate) {
 
     switch (format) {
         case data_format::csv:
-            return csv::read_cells(out, filename, geom, dconfig, barcode_map);
+            return csv::read_cells(out, filename, geom, dconfig, barcode_map,
+                                   deduplicate);
 
         default:
             throw std::invalid_argument("Unsupported data format");

--- a/tests/io/test_csv.cpp
+++ b/tests/io/test_csv.cpp
@@ -29,9 +29,9 @@ class io : public traccc::tests::data_test {};
 TEST_F(io, csv_read_single_module) {
 
     traccc::io::cell_reader_output single_module_cells;
-    traccc::io::read_cells(single_module_cells,
-                           get_datafile("single_module/cells.csv"),
-                           traccc::data_format::csv);
+    traccc::io::read_cells(
+        single_module_cells, get_datafile("single_module/cells.csv"),
+        traccc::data_format::csv, nullptr, nullptr, nullptr, false);
     auto& cells = single_module_cells.cells;
     auto& modules = single_module_cells.modules;
     ASSERT_EQ(cells.size(), 6u);
@@ -49,9 +49,9 @@ TEST_F(io, csv_read_single_module) {
 TEST_F(io, csv_read_two_modules) {
 
     traccc::io::cell_reader_output two_module_cells;
-    traccc::io::read_cells(two_module_cells,
-                           get_datafile("two_modules/cells.csv"),
-                           traccc::data_format::csv);
+    traccc::io::read_cells(
+        two_module_cells, get_datafile("two_modules/cells.csv"),
+        traccc::data_format::csv, nullptr, nullptr, nullptr, false);
     auto& cells = two_module_cells.cells;
     auto& modules = two_module_cells.modules;
     ASSERT_EQ(modules.size(), 2u);


### PR DESCRIPTION
This ended up being an alternative for #546. :thinking:

In here I made sure that proper comparison operators would exist for `traccc::cell` and `traccc::cell_module`, and then just relied on STL containers for ordering the cells and modules correctly in memory. Instead of the nigh unreadable current logic of the code.

We are looking at this with @stephenswat right now because of #527. Just as #546, this update also ensures that there would not be any duplicate cells read in from the CSV files. Which activates the same unit test failures.

But even more weirdly, this still doesn't answer the mystery that we've been struggling with Stephen for the last hour. You see, Stephen prepared some ODD files that would exclude the duplicated cells. But something really weird is going on with those files. Because the host seeding code does not find **any** seeds when reading those files. While it finds plenty with the files containing the duplicate cells.

But, even more weirdly, with this PR's code, I see the following using the CUDA test:

```
[bash][atspot01]:traccc > ./traccc/out/build/sycl/bin/traccc_seq_example_cuda --detector-file=geometries/odd/odd_geometry_detray.json --use-detray-detector --digitization-file=geometries/odd/odd-digi-geometric-config.json --input-directory=odd/muon100GeV-geant4/ --input-events=1 --compare-with-cpu

Running Full Tracking Chain Using CUDA

>>> Detector Options <<<
  Detector file       : geometries/odd/odd_geometry_detray.json
  Material file       : 
  Surface rid file    : 
  Use detray::detector: yes
  Digitization file   : geometries/odd/odd-digi-geometric-config.json
>>> Input Data Options <<<
  Input data format             : csv
  Input directory               : odd/muon100GeV-geant4/
  Number of input events        : 1
  Number of input events to skip: 0
>>> Clusterization Options <<<
  Target cells per partition: 1024
>>> Track Seeding Options <<<
  None
>>> Performance Measurement Options <<<
  Run performance checks: no
>>> Accelerator Options <<<
  Compare with CPU results: yes

WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: @traccc::io::csv::read_cells: 4500 duplicate cells found in /home/krasznaa/ATLAS/projects/traccc/traccc/data/odd/muon100GeV-geant4/event000000000-cells.csv
===>>> Event 0 <<<===
Number of spacepoints: 31587 (host), 31587 (device)
  Matching rate(s):
    - 98.167% at 0.01% uncertainty
    - 99.4998% at 0.1% uncertainty
    - 99.4998% at 1% uncertainty
    - 99.4998% at 5% uncertainty
Number of seeds: 5977 (host), 5977 (device)
  Matching rate(s):
    - 54.8268% at 0.01% uncertainty
    - 93.4583% at 0.1% uncertainty
    - 98.6783% at 1% uncertainty
    - 99.1467% at 5% uncertainty
Number of track parameters: 5977 (host), 5977 (device)
  Matching rate(s):
    - 71.1059% at 0.01% uncertainty
    - 96.4029% at 0.1% uncertainty
    - 99.3642% at 1% uncertainty
    - 99.6319% at 5% uncertainty
==> Statistics ... 
- read    77592 cells from 11131 modules
- created (cpu)  31587 measurements     
- created (cpu)  31587 spacepoints     
- created (cuda) 31587 spacepoints     
- created  (cpu) 5977 seeds
- created (cuda) 5977 seeds
==>Elapsed times...
           File reading  (cpu)  140 ms
         Clusterization (cuda)  4 ms
   Spacepoint formation (cuda)  2 ms
         Clusterization  (cpu)  4 ms
   Spacepoint formation  (cpu)  0 ms
                Seeding (cuda)  13 ms
                Seeding  (cpu)  81 ms
           Track params (cuda)  3 ms
           Track params  (cpu)  1 ms
                     Wall time  253 ms
[bash][atspot01]:traccc > ./traccc/out/build/sycl/bin/traccc_seq_example_cuda --detector-file=geometries/odd/odd_geometry_detray.json --use-detray-detector --digitization-file=geometries/odd/odd-digi-geometric-config.json --input-directory=v6/odd/muon100GeV-geant4/ --input-events=1 --compare-with-cpu

Running Full Tracking Chain Using CUDA

>>> Detector Options <<<
  Detector file       : geometries/odd/odd_geometry_detray.json
  Material file       : 
  Surface rid file    : 
  Use detray::detector: yes
  Digitization file   : geometries/odd/odd-digi-geometric-config.json
>>> Input Data Options <<<
  Input data format             : csv
  Input directory               : v6/odd/muon100GeV-geant4/
  Number of input events        : 1
  Number of input events to skip: 0
>>> Clusterization Options <<<
  Target cells per partition: 1024
>>> Track Seeding Options <<<
  None
>>> Performance Measurement Options <<<
  Run performance checks: no
>>> Accelerator Options <<<
  Compare with CPU results: yes

WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
===>>> Event 0 <<<===
Number of spacepoints: 31587 (host), 31587 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of seeds: 0 (host), 4247 (device)
  Matching rate(s):
    - 0% at 0.01% uncertainty
    - 0% at 0.1% uncertainty
    - 0% at 1% uncertainty
    - 0% at 5% uncertainty
Number of track parameters: 0 (host), 4247 (device)
  Matching rate(s):
    - 0% at 0.01% uncertainty
    - 0% at 0.1% uncertainty
    - 0% at 1% uncertainty
    - 0% at 5% uncertainty
==> Statistics ... 
- read    77592 cells from 11131 modules
- created (cpu)  31587 measurements     
- created (cpu)  31587 spacepoints     
- created (cuda) 31587 spacepoints     
- created  (cpu) 0 seeds
- created (cuda) 4247 seeds
==>Elapsed times...
           File reading  (cpu)  104 ms
         Clusterization (cuda)  8 ms
   Spacepoint formation (cuda)  6 ms
         Clusterization  (cpu)  4 ms
   Spacepoint formation  (cpu)  0 ms
                Seeding (cuda)  26 ms
                Seeding  (cpu)  0 ms
           Track params (cuda)  5 ms
           Track params  (cpu)  0 ms
                     Wall time  157 ms
[bash][atspot01]:traccc > 
```

  - The original file is reported to have 4500 duplicate cells. (A weirdly round number...)
  - Stephen's updated file reports no duplicates, and the same number of cells that remain from the original after duplicate removal.
  - As I wrote earlier, the host code **does not like** the updated CSV files. But the CUDA code still finds some seeds with those. Although noticeably fewer than with the original files.
  - When using the updated CSV files, we get a **100%** agreement between the host and CUDA clusterization. But not with the original files. (Since the comparison is made on the spacepoints, and not the clusters, floating point differences are accepted here.) I have no idea what to make of this. :confused:

So, something weird went wrong with the file updates, and I can just not figure out what. :confused: But at the same time, I think we should just go ahead with this deduplication in the code, and make sure that the tests would be made to work with the deduplication included. :thinking: