### PR TITLE
ODD CUDA Reconstruction, main branch (2024.04.23.)

### DIFF
--- a/examples/run/cuda/CMakeLists.txt
+++ b/examples/run/cuda/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package( CUDAToolkit REQUIRED )
 traccc_add_executable( seq_example_cuda "seq_example_cuda.cpp"
    LINK_LIBRARIES vecmem::core vecmem::cuda traccc::io traccc::performance
                   traccc::core traccc::device_common traccc::cuda
-                  traccc::options )
+                  traccc::options detray::utils detray::io )
 traccc_add_executable( seeding_example_cuda "seeding_example_cuda.cpp"
    LINK_LIBRARIES vecmem::core vecmem::cuda traccc::io traccc::performance
                   traccc::core traccc::device_common traccc::cuda

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -11,10 +11,15 @@
 #include "traccc/cuda/clusterization/clusterization_algorithm.hpp"
 #include "traccc/cuda/clusterization/measurement_sorting_algorithm.hpp"
 #include "traccc/cuda/clusterization/spacepoint_formation_algorithm.hpp"
+#include "traccc/cuda/finding/finding_algorithm.hpp"
+#include "traccc/cuda/fitting/fitting_algorithm.hpp"
 #include "traccc/cuda/seeding/seeding_algorithm.hpp"
 #include "traccc/cuda/seeding/track_params_estimation.hpp"
 #include "traccc/cuda/utils/stream.hpp"
+#include "traccc/device/container_d2h_copy_alg.hpp"
 #include "traccc/efficiency/seeding_performance_writer.hpp"
+#include "traccc/finding/finding_algorithm.hpp"
+#include "traccc/fitting/fitting_algorithm.hpp"
 #include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_digitization_config.hpp"
 #include "traccc/io/read_geometry.hpp"
@@ -25,12 +30,22 @@
 #include "traccc/options/input_data.hpp"
 #include "traccc/options/performance.hpp"
 #include "traccc/options/program_options.hpp"
+#include "traccc/options/track_finding.hpp"
+#include "traccc/options/track_propagation.hpp"
 #include "traccc/options/track_seeding.hpp"
 #include "traccc/performance/collection_comparator.hpp"
 #include "traccc/performance/container_comparator.hpp"
 #include "traccc/performance/timer.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
+
+// Detray include(s).
+#include "detray/core/detector.hpp"
+#include "detray/detectors/bfield.hpp"
+#include "detray/io/frontend/detector_reader.hpp"
+#include "detray/navigation/navigator.hpp"
+#include "detray/propagator/propagator.hpp"
+#include "detray/propagator/rk_stepper.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/cuda/device_memory_resource.hpp>
@@ -48,14 +63,60 @@ int seq_run(const traccc::opts::detector& detector_opts,
             const traccc::opts::input_data& input_opts,
             const traccc::opts::clusterization& clusterization_opts,
             const traccc::opts::track_seeding& seeding_opts,
+            const traccc::opts::track_finding& finding_opts,
+            const traccc::opts::track_propagation& propagation_opts,
             const traccc::opts::performance& performance_opts,
             const traccc::opts::accelerator& accelerator_opts) {
+
+    // Memory resources used by the application.
+    vecmem::host_memory_resource host_mr;
+    vecmem::cuda::host_memory_resource cuda_host_mr;
+    vecmem::cuda::device_memory_resource device_mr;
+    traccc::memory_resource mr{device_mr, &cuda_host_mr};
+
+    // CUDA types used.
+    traccc::cuda::stream stream;
+    vecmem::cuda::async_copy copy{stream.cudaStream()};
 
     // Read in the geometry.
     auto [surface_transforms, barcode_map] = traccc::io::read_geometry(
         detector_opts.detector_file,
         (detector_opts.use_detray_detector ? traccc::data_format::json
                                            : traccc::data_format::csv));
+
+    using host_detector_type = detray::detector<detray::default_metadata,
+                                                detray::host_container_types>;
+    using device_detector_type =
+        detray::detector<detray::default_metadata,
+                         detray::device_container_types>;
+
+    host_detector_type host_detector{host_mr};
+    host_detector_type::buffer_type device_detector;
+    host_detector_type::view_type device_detector_view;
+    if (detector_opts.use_detray_detector) {
+        // Set up the detector reader configuration.
+        detray::io::detector_reader_config cfg;
+        cfg.add_file(traccc::io::data_directory() +
+                     detector_opts.detector_file);
+        if (detector_opts.material_file.empty() == false) {
+            cfg.add_file(traccc::io::data_directory() +
+                         detector_opts.material_file);
+        }
+        if (detector_opts.grid_file.empty() == false) {
+            cfg.add_file(traccc::io::data_directory() +
+                         detector_opts.grid_file);
+        }
+
+        // Read the detector.
+        auto det = detray::io::read_detector<host_detector_type>(host_mr, cfg);
+        host_detector = std::move(det.first);
+
+        // Copy it to the device.
+        device_detector = detray::get_buffer(detray::get_data(host_detector),
+                                             device_mr, copy);
+        stream.synchronize();
+        device_detector_view = detray::get_data(device_detector);
+    }
 
     // Read the digitization configuration file
     auto digi_cfg =
@@ -64,22 +125,51 @@ int seq_run(const traccc::opts::detector& detector_opts,
     // Output stats
     uint64_t n_cells = 0;
     uint64_t n_modules = 0;
-    // uint64_t n_clusters = 0;
     uint64_t n_measurements = 0;
     uint64_t n_spacepoints = 0;
     uint64_t n_spacepoints_cuda = 0;
     uint64_t n_seeds = 0;
     uint64_t n_seeds_cuda = 0;
+    uint64_t n_found_tracks = 0;
+    uint64_t n_found_tracks_cuda = 0;
+    uint64_t n_fitted_tracks = 0;
+    uint64_t n_fitted_tracks_cuda = 0;
+
+    // Type definitions
+    using stepper_type =
+        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+                           host_detector_type::transform3,
+                           detray::constrained_step<>>;
+    using host_navigator_type = detray::navigator<const host_detector_type>;
+    using device_navigator_type = detray::navigator<const device_detector_type>;
+
+    using host_finding_algorithm =
+        traccc::finding_algorithm<stepper_type, host_navigator_type>;
+    using device_finding_algorithm =
+        traccc::cuda::finding_algorithm<stepper_type, device_navigator_type>;
+
+    using host_fitting_algorithm = traccc::fitting_algorithm<
+        traccc::kalman_fitter<stepper_type, host_navigator_type>>;
+    using device_fitting_algorithm = traccc::cuda::fitting_algorithm<
+        traccc::kalman_fitter<stepper_type, device_navigator_type>>;
+
+    // Algorithm configuration(s).
+    host_finding_algorithm::config_type finding_cfg;
+    finding_cfg.min_track_candidates_per_track =
+        finding_opts.track_candidates_range[0];
+    finding_cfg.max_track_candidates_per_track =
+        finding_opts.track_candidates_range[1];
+    finding_cfg.chi2_max = finding_opts.chi2_max;
+    propagation_opts.setup(finding_cfg.propagation);
+
+    host_fitting_algorithm::config_type fitting_cfg;
+    propagation_opts.setup(fitting_cfg.propagation);
 
     // Constant B field for the track finding and fitting
     const traccc::vector3 field_vec = {0.f, 0.f,
                                        seeding_opts.seedfinder.bFieldInZ};
-
-    // Memory resources used by the application.
-    vecmem::host_memory_resource host_mr;
-    vecmem::cuda::host_memory_resource cuda_host_mr;
-    vecmem::cuda::device_memory_resource device_mr;
-    traccc::memory_resource mr{device_mr, &cuda_host_mr};
+    const detray::bfield::const_field_t field =
+        detray::bfield::create_const_field(field_vec);
 
     traccc::host::clusterization_algorithm ca(host_mr);
     traccc::host::spacepoint_formation_algorithm sf(host_mr);
@@ -87,10 +177,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
                                  {seeding_opts.seedfinder},
                                  seeding_opts.seedfilter, host_mr);
     traccc::track_params_estimation tp(host_mr);
-
-    traccc::cuda::stream stream;
-
-    vecmem::cuda::async_copy copy{stream.cudaStream()};
+    host_finding_algorithm finding_alg(finding_cfg);
+    host_fitting_algorithm fitting_alg(fitting_cfg);
 
     traccc::cuda::clusterization_algorithm ca_cuda(
         mr, copy, stream, clusterization_opts.target_cells_per_partition);
@@ -100,6 +188,14 @@ int seq_run(const traccc::opts::detector& detector_opts,
         seeding_opts.seedfinder, {seeding_opts.seedfinder},
         seeding_opts.seedfilter, mr, copy, stream);
     traccc::cuda::track_params_estimation tp_cuda(mr, copy, stream);
+    device_finding_algorithm finding_alg_cuda(finding_cfg, mr, copy, stream);
+    device_fitting_algorithm fitting_alg_cuda(fitting_cfg, mr, copy, stream);
+
+    traccc::device::container_d2h_copy_alg<
+        traccc::track_candidate_container_types>
+        copy_track_candidates(mr, copy);
+    traccc::device::container_d2h_copy_alg<traccc::track_state_container_types>
+        copy_track_states(mr, copy);
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
@@ -119,6 +215,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
             spacepoints_per_event;
         traccc::seeding_algorithm::output_type seeds;
         traccc::track_params_estimation::output_type params;
+        host_finding_algorithm::output_type track_candidates;
+        host_fitting_algorithm::output_type track_states;
 
         // Instantiate cuda containers/collections
         traccc::measurement_collection_types::buffer measurements_cuda_buffer(
@@ -128,6 +226,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
         traccc::seed_collection_types::buffer seeds_cuda_buffer(0, *mr.host);
         traccc::bound_track_parameters_collection_types::buffer
             params_cuda_buffer(0, *mr.host);
+        traccc::track_candidate_container_types::buffer track_candidates_buffer;
+        traccc::track_state_container_types::buffer track_states_buffer;
 
         {
             traccc::performance::timer wall_t("Wall time", elapsedTimes);
@@ -244,6 +344,46 @@ int seq_run(const traccc::opts::detector& detector_opts,
                 params = tp(spacepoints_per_event, seeds, field_vec);
             }  // stop measuring track params cpu timer
 
+            // Perform track finding and fitting only when using a Detray
+            // geometry.
+            if (detector_opts.use_detray_detector) {
+                // CUDA
+                auto navigation_buffer = detray::create_candidates_buffer(
+                    host_detector,
+                    finding_cfg.max_num_branches_per_seed *
+                        copy.get_size(seeds_cuda_buffer),
+                    mr.main, mr.host);
+                {
+                    traccc::performance::timer timer{"Track finding (cuda)",
+                                                     elapsedTimes};
+                    track_candidates_buffer = finding_alg_cuda(
+                        device_detector_view, field, navigation_buffer,
+                        measurements_cuda_buffer, params_cuda_buffer);
+                }
+                // CPU
+                if (accelerator_opts.compare_with_cpu) {
+                    traccc::performance::timer timer{"Track finding (cpu)",
+                                                     elapsedTimes};
+                    track_candidates = finding_alg(
+                        host_detector, field, measurements_per_event, params);
+                }
+                // CUDA
+                {
+                    traccc::performance::timer timer{"Track fitting (cuda)",
+                                                     elapsedTimes};
+                    track_states_buffer = fitting_alg_cuda(
+                        device_detector_view, field, navigation_buffer,
+                        track_candidates_buffer);
+                }
+                // CPU
+                if (accelerator_opts.compare_with_cpu) {
+                    traccc::performance::timer timer{"Track fitting (cpu)",
+                                                     elapsedTimes};
+                    track_states =
+                        fitting_alg(host_detector, field, track_candidates);
+                }
+            }
+
         }  // Stop measuring wall time
 
         /*----------------------------------
@@ -257,6 +397,10 @@ int seq_run(const traccc::opts::detector& detector_opts,
         copy(spacepoints_cuda_buffer, spacepoints_per_event_cuda)->wait();
         copy(seeds_cuda_buffer, seeds_cuda)->wait();
         copy(params_cuda_buffer, params_cuda)->wait();
+        auto track_candidates_cuda =
+            copy_track_candidates(track_candidates_buffer);
+        auto track_states_cuda = copy_track_states(track_states_buffer);
+        stream.synchronize();
 
         if (accelerator_opts.compare_with_cpu) {
 
@@ -282,6 +426,22 @@ int seq_run(const traccc::opts::detector& detector_opts,
                 compare_track_parameters{"track parameters"};
             compare_track_parameters(vecmem::get_data(params),
                                      vecmem::get_data(params_cuda));
+
+            // Compare tracks found on the host and on the device.
+            traccc::collection_comparator<
+                traccc::track_candidate_container_types::host::header_type>
+                compare_track_candidates{"track candidates"};
+            compare_track_candidates(
+                vecmem::get_data(track_candidates.get_headers()),
+                vecmem::get_data(track_candidates_cuda.get_headers()));
+
+            // Compare tracks fitted on the host and on the device.
+            traccc::collection_comparator<
+                traccc::track_state_container_types::host::header_type>
+                compare_track_states{"track states"};
+            compare_track_states(
+                vecmem::get_data(track_states.get_headers()),
+                vecmem::get_data(track_states_cuda.get_headers()));
         }
         /// Statistics
         n_modules += read_out_per_event.modules.size();
@@ -291,6 +451,10 @@ int seq_run(const traccc::opts::detector& detector_opts,
         n_seeds += seeds.size();
         n_spacepoints_cuda += spacepoints_per_event_cuda.size();
         n_seeds_cuda += seeds_cuda.size();
+        n_found_tracks += track_candidates.size();
+        n_found_tracks_cuda += track_candidates_cuda.size();
+        n_fitted_tracks += track_states.size();
+        n_fitted_tracks_cuda += track_states_cuda.size();
 
         if (performance_opts.run) {
 
@@ -320,6 +484,14 @@ int seq_run(const traccc::opts::detector& detector_opts,
 
     std::cout << "- created  (cpu) " << n_seeds << " seeds" << std::endl;
     std::cout << "- created (cuda) " << n_seeds_cuda << " seeds" << std::endl;
+    std::cout << "- found (cpu)    " << n_found_tracks << " tracks"
+              << std::endl;
+    std::cout << "- found (cuda)   " << n_found_tracks_cuda << " tracks"
+              << std::endl;
+    std::cout << "- fitted (cpu)   " << n_fitted_tracks << " tracks"
+              << std::endl;
+    std::cout << "- fitted (cuda)  " << n_fitted_tracks_cuda << " tracks"
+              << std::endl;
     std::cout << "==>Elapsed times...\n" << elapsedTimes << std::endl;
 
     return 0;
@@ -334,16 +506,19 @@ int main(int argc, char* argv[]) {
     traccc::opts::input_data input_opts;
     traccc::opts::clusterization clusterization_opts;
     traccc::opts::track_seeding seeding_opts;
+    traccc::opts::track_finding finding_opts;
+    traccc::opts::track_propagation propagation_opts;
     traccc::opts::performance performance_opts;
     traccc::opts::accelerator accelerator_opts;
     traccc::opts::program_options program_opts{
         "Full Tracking Chain Using CUDA",
         {detector_opts, input_opts, clusterization_opts, seeding_opts,
-         performance_opts, accelerator_opts},
+         finding_opts, propagation_opts, performance_opts, accelerator_opts},
         argc,
         argv};
 
     // Run the application.
     return seq_run(detector_opts, input_opts, clusterization_opts, seeding_opts,
-                   performance_opts, accelerator_opts);
+                   finding_opts, propagation_opts, performance_opts,
+                   accelerator_opts);
 }


### PR DESCRIPTION
After the last ~2 weeks of developments, full-chain ODD reconstruction with CUDA is finally here. :partying_face:

Unfortunately it's not quite as perfect just yet as it should be. :frowning:

In order to get the code running, I had to generalize `traccc::cuda::finding_algorithm` a little. It was not exercised with a resizable measurement buffer so far, so it was doing an invalid access when I gave it a resizable container. (I had to deal with exactly this in #545 and #550 already, so it didn't take long to find the issue...)

Other than that, I "just" had to update `seq_example_cuda.cpp` to add track finding and track fitting to it. :thinking: With this PR's code, I now get:

```
[bash][atspot01]:traccc > ./out/build/sycl/bin/traccc_seq_example_cuda --detector-file=geometries/odd/odd_geometry_detray.json --use-detray-detector --digitization-file=geometries/odd/odd-digi-geometric-config.json --input-directory=odd/muon100GeV-geant4/ --input-events=3 --compare-with-cpu

Running Full Tracking Chain Using CUDA

>>> Detector Options <<<
  Detector file       : geometries/odd/odd_geometry_detray.json
  Material file       : 
  Surface rid file    : 
  Use detray::detector: yes
  Digitization file   : geometries/odd/odd-digi-geometric-config.json
>>> Input Data Options <<<
  Input data format             : csv
  Input directory               : odd/muon100GeV-geant4/
  Number of input events        : 3
  Number of input events to skip: 0
>>> Clusterization Options <<<
  Target cells per partition: 1024
>>> Track Seeding Options <<<
  None
>>> Track Finding Options <<<
  Track candidates range   : 3:100
  Maximum Chi2             : 30
  Maximum branches per step: 4294967295
>>> Track Propagation Options <<<
  Constraint step size : 3.40282e+38 [mm]
  Overstep tolerance   : -100 [um]
  Mask tolerance       : 15 [um]
  Search window        : 0 x 0
  Runge-Kutta tolerance: 0.0001
>>> Performance Measurement Options <<<
  Run performance checks: no
>>> Accelerator Options <<<
  Compare with CPU results: yes

WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: @traccc::io::csv::read_cells: 4500 duplicate cells found in /home/krasznaa/ATLAS/projects/traccc/traccc/data/odd/muon100GeV-geant4/event000000000-cells.csv
===>>> Event 0 <<<===
Number of spacepoints: 31587 (host), 31587 (device)
  Matching rate(s):
    - 98.1701% at 0.01% uncertainty
    - 99.503% at 0.1% uncertainty
    - 99.503% at 1% uncertainty
    - 99.503% at 5% uncertainty
Number of seeds: 5977 (host), 5977 (device)
  Matching rate(s):
    - 54.877% at 0.01% uncertainty
    - 93.4415% at 0.1% uncertainty
    - 98.6783% at 1% uncertainty
    - 99.1467% at 5% uncertainty
Number of track parameters: 5977 (host), 5977 (device)
  Matching rate(s):
    - 71.1226% at 0.01% uncertainty
    - 96.4196% at 0.1% uncertainty
    - 99.3642% at 1% uncertainty
    - 99.6319% at 5% uncertainty
Number of track candidates: 8145 (host), 4388 (device)
  Matching rate(s):
    - 33.2719% at 0.01% uncertainty
    - 61.5715% at 0.1% uncertainty
    - 64.4199% at 1% uncertainty
    - 64.7146% at 5% uncertainty
Number of track states: 8145 (host), 4388 (device)
  Matching rate(s):
    - 0.0245549% at 0.01% uncertainty
    - 1.01903% at 0.1% uncertainty
    - 18.7723% at 1% uncertainty
    - 40.356% at 5% uncertainty
WARNING: @traccc::io::csv::read_cells: 4170 duplicate cells found in /home/krasznaa/ATLAS/projects/traccc/traccc/data/odd/muon100GeV-geant4/event000000001-cells.csv
===>>> Event 1 <<<===
Number of spacepoints: 31923 (host), 31923 (device)
  Matching rate(s):
    - 98.2646% at 0.01% uncertainty
    - 99.5395% at 0.1% uncertainty
    - 99.5395% at 1% uncertainty
    - 99.5395% at 5% uncertainty
Number of seeds: 5829 (host), 5829 (device)
  Matching rate(s):
    - 54.3146% at 0.01% uncertainty
    - 93.3951% at 0.1% uncertainty
    - 98.9707% at 1% uncertainty
    - 99.4167% at 5% uncertainty
Number of track parameters: 5829 (host), 5829 (device)
  Matching rate(s):
    - 70.012% at 0.01% uncertainty
    - 96.1228% at 0.1% uncertainty
    - 99.3996% at 1% uncertainty
    - 99.7427% at 5% uncertainty
Number of track candidates: 7621 (host), 3719 (device)
  Matching rate(s):
    - 33.2371% at 0.01% uncertainty
    - 57.1447% at 0.1% uncertainty
    - 60.5301% at 1% uncertainty
    - 60.8188% at 5% uncertainty
Number of track states: 7621 (host), 3719 (device)
  Matching rate(s):
    - 0.0524866% at 0.01% uncertainty
    - 1.25968% at 0.1% uncertainty
    - 19.2363% at 1% uncertainty
    - 38.6301% at 5% uncertainty
WARNING: @traccc::io::csv::read_cells: 4711 duplicate cells found in /home/krasznaa/ATLAS/projects/traccc/traccc/data/odd/muon100GeV-geant4/event000000002-cells.csv
===>>> Event 2 <<<===
Number of spacepoints: 32088 (host), 32088 (device)
  Matching rate(s):
    - 98.2517% at 0.01% uncertainty
    - 99.5512% at 0.1% uncertainty
    - 99.5512% at 1% uncertainty
    - 99.5512% at 5% uncertainty
Number of seeds: 5789 (host), 5789 (device)
  Matching rate(s):
    - 55.7955% at 0.01% uncertainty
    - 93.4358% at 0.1% uncertainty
    - 98.9636% at 1% uncertainty
    - 99.4645% at 5% uncertainty
Number of track parameters: 5789 (host), 5789 (device)
  Matching rate(s):
    - 71.9468% at 0.01% uncertainty
    - 96.5797% at 0.1% uncertainty
    - 99.4818% at 1% uncertainty
    - 99.8273% at 5% uncertainty
Number of track candidates: 7186 (host), 3698 (device)
  Matching rate(s):
    - 35.4439% at 0.01% uncertainty
    - 59.435% at 0.1% uncertainty
    - 62.6078% at 1% uncertainty
    - 62.9557% at 5% uncertainty
Number of track states: 7186 (host), 3698 (device)
  Matching rate(s):
    - 0.0278319% at 0.01% uncertainty
    - 1.09936% at 0.1% uncertainty
    - 20.4843% at 1% uncertainty
    - 40.8572% at 5% uncertainty
==> Statistics ... 
- read    234267 cells from 33672 modules
- created (cpu)  95598 measurements     
- created (cpu)  95598 spacepoints     
- created (cuda) 95598 spacepoints     
- created  (cpu) 17595 seeds
- created (cuda) 17595 seeds
- found (cpu)    22952 tracks
- found (cuda)   11805 tracks
- fitted (cpu)   22952 tracks
- fitted (cuda)  11805 tracks
==>Elapsed times...
           File reading  (cpu)  451 ms
         Clusterization (cuda)  51 ms
   Spacepoint formation (cuda)  2 ms
         Clusterization  (cpu)  17 ms
   Spacepoint formation  (cpu)  1 ms
                Seeding (cuda)  12 ms
                Seeding  (cpu)  239 ms
           Track params (cuda)  2 ms
           Track params  (cpu)  3 ms
          Track finding (cuda)  484 ms
           Track finding (cpu)  6011 ms
          Track fitting (cuda)  181 ms
           Track fitting (cpu)  2001 ms
                     Wall time  9483 ms
[bash][atspot01]:traccc >
```

The **excellent** news is that the code techically runs. :grin: But CUDA finds way fewer tracks than the host does. And even the ones that it finds, have quite different fitted parameters than the ones found by the CPU. :thinking:

@beomki-yeo, I hope that some of it is "just" due to some mistake I'm doing with some sort of configuration parameter. But I'll need some help. :wink: