### PR TITLE
Data V6, main branch (2024.04.24.)

### DIFF
--- a/data/traccc_data_get_files.sh
+++ b/data/traccc_data_get_files.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# (c) 2023 CERN for the benefit of the ACTS project
+# (c) 2023-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 #
@@ -27,7 +27,7 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v5"}
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v6"}
 TRACCC_WEB_DIRECTORY=${TRACCC_WEB_DIRECTORY:-"https://acts.web.cern.ch/traccc/data"}
 TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}
 TRACCC_CMAKE_EXECUTABLE=${TRACCC_CMAKE_EXECUTABLE:-cmake}

--- a/data/traccc_data_package_files.sh
+++ b/data/traccc_data_package_files.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# (c) 2023 CERN for the benefit of the ACTS project
+# (c) 2023-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 #
@@ -27,7 +27,7 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v6"}
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v7"}
 TRACCC_DATA_DIRECTORY_NAMES=("cca_test" "detray_simulation" "geometries" "odd"
    "single_module" "tml_detector" "tml_full" "tml_pixel_barrel" "tml_pixels"
    "two_modules")


### PR DESCRIPTION
Switched to `v6` of the data file(s).
  - https://acts.web.cern.ch/traccc/data/traccc-data-v6.tar.bz2
  - https://acts.web.cern.ch/traccc/data/traccc-data-v6.md5

The new file comes just with a single update wrt. `v5`. The ODD grid file was updated with the one that @niermann999 produced yesterday. :smile:

The new file seems to work fine. Producing seemingly the same output that we get when not using a grid at all, with some speedup. The totally non-scientific findings are:

| Step | no grid file [ms] | new grid file [ms] |
|-|-|-|
| CPU Track Finding | 7040 | 2148 |
| CPU Track Fitting | 2546 | 970 |
| CUDA Track Finding | 804 | 199 |
| CUDA Track Fitting | 342 | 67 |

The CUDA results I got with #552. So they don't mean terribly much right now, only that the code doesn't crash with the grid file, and that it produces the same, albeit imperfect output. In all cases I executed the "sequence example executables" with the following options:
  - No grid file: `--detector-file=geometries/odd/odd_geometry_detray.json --use-detray-detector --digitization-file=geometries/odd/odd-digi-geometric-config.json --input-directory=odd/muon100GeV-geant4/ --input-events=5`
  - New grid file: `--detector-file=geometries/odd/odd_geometry_detray.json --grid-file=geometries/odd/odd_surface_grids_detray.json --use-detray-detector --digitization-file=geometries/odd/odd-digi-geometric-config.json --input-directory=odd/muon100GeV-geant4/ --input-events=5`

P.S. @stephenswat I overwrote your earlier `v6` file on EOS. I consider that effort abandoned for now, for removing the cell duplicates from the CSV files themselves.