### PR TITLE
ref: Use angle from surface class instead of intersector

### DIFF
--- a/core/include/traccc/finding/finding_algorithm.ipp
+++ b/core/include/traccc/finding/finding_algorithm.ipp
@@ -11,9 +11,6 @@
 // detray include(s).
 #include "detray/geometry/barcode.hpp"
 #include "detray/geometry/surface.hpp"
-#include "detray/navigation/detail/ray.hpp"
-#include "detray/navigation/intersection/ray_intersector.hpp"
-#include "detray/navigation/intersection_kernel.hpp"
 
 // System include
 #include <algorithm>
@@ -129,40 +126,17 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
              *************************/
 
             // Get intersection at surface
-            const detray::surface<detector_type> sf{det,
-                                                    in_param.surface_link()};
+            const detray::surface sf{det, in_param.surface_link()};
 
             const cxt_t ctx{};
-            const auto free_vec =
-                sf.bound_to_free_vector(ctx, in_param.vector());
-            intersection_type sfi;
-
-            const auto sf_desc = det.surface(in_param.surface_link());
-            sfi.sf_desc = sf_desc;
-            sf.template visit_mask<
-                detray::intersection_update<detray::ray_intersector>>(
-                detray::detail::ray<transform3_type>(free_vec), sfi,
-                det.transform_store(),
-                sf.is_portal() ? 0.f : 50.f * unit<scalar_type>::um,
-                -100.f * unit<scalar_type>::um);
-
-            if (!(std::abs(sf.cos_angle(ctx, in_param.dir(),
-                                        in_param.bound_local()) -
-                           sfi.cos_incidence_angle) < 0.0001f)) {
-                std::cout << "finding alg" << std::endl;
-                std::cout << det.surface(in_param.surface_link()) << std::endl;
-                std::cout << sfi << std::endl;
-                std::cout << sf.cos_angle(ctx, in_param.dir(),
-                                          in_param.bound_local())
-                          << ", " << sfi.cos_incidence_angle << std::endl;
-            }
 
             // Apply interactor
             typename interactor_type::state interactor_state;
             interactor_type{}.update(
                 in_param, interactor_state,
                 static_cast<int>(detray::navigation::direction::e_forward), sf,
-                sfi.cos_incidence_angle);
+                std::abs(
+                    sf.cos_angle(ctx, in_param.dir(), in_param.bound_local())));
 
             /*************************
              * CKF

--- a/core/include/traccc/finding/finding_algorithm.ipp
+++ b/core/include/traccc/finding/finding_algorithm.ipp
@@ -142,7 +142,20 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
             sf.template visit_mask<
                 detray::intersection_update<detray::ray_intersector>>(
                 detray::detail::ray<transform3_type>(free_vec), sfi,
-                det.transform_store());
+                det.transform_store(),
+                sf.is_portal() ? 0.f : 50.f * unit<scalar_type>::um,
+                -100.f * unit<scalar_type>::um);
+
+            if (!(std::abs(sf.cos_angle(ctx, in_param.dir(),
+                                        in_param.bound_local()) -
+                           sfi.cos_incidence_angle) < 0.0001f)) {
+                std::cout << "finding alg" << std::endl;
+                std::cout << det.surface(in_param.surface_link()) << std::endl;
+                std::cout << sfi << std::endl;
+                std::cout << sf.cos_angle(ctx, in_param.dir(),
+                                          in_param.bound_local())
+                          << ", " << sfi.cos_incidence_angle << std::endl;
+            }
 
             // Apply interactor
             typename interactor_type::state interactor_state;

--- a/core/include/traccc/utils/seed_generator.hpp
+++ b/core/include/traccc/utils/seed_generator.hpp
@@ -65,6 +65,7 @@ struct seed_generator {
 
         // Type definitions
         using transform3_type = typename detector_t::transform3;
+        using scalar_type = typename detector_t::scalar_type;
         using intersection_type =
             detray::intersection2D<typename detector_t::surface_type,
                                    transform3_type>;
@@ -76,7 +77,20 @@ struct seed_generator {
         sf.template visit_mask<
             detray::intersection_update<detray::ray_intersector>>(
             detray::detail::ray<transform3_type>(free_param.vector()), sfi,
-            m_detector.transform_store());
+            m_detector.transform_store(),
+            sf.is_portal() ? 0.f : 50.f * unit<scalar_type>::um,
+            -100.f * unit<scalar_type>::um);
+
+        if (!(std::abs(std::abs(sf.cos_angle(ctx, bound_param.dir(),
+                                             bound_param.bound_local())) -
+                       sfi.cos_incidence_angle) < 0.0001f)) {
+            std::cout << "seed gen" << std::endl;
+            std::cout << m_detector.surface(surface_link) << std::endl;
+            std::cout << sfi << std::endl;
+            std::cout << sf.cos_angle(ctx, bound_param.dir(),
+                                      bound_param.bound_local())
+                      << ", " << sfi.cos_incidence_angle << std::endl;
+        }
 
         // Apply interactor
         typename interactor_type::state interactor_state;

--- a/device/common/include/traccc/finding/device/apply_interaction.hpp
+++ b/device/common/include/traccc/finding/device/apply_interaction.hpp
@@ -17,16 +17,12 @@ namespace traccc::device {
 ///
 /// @param[in] globalIndex     The index of the current thread
 /// @param[in] det_data        Detector view object
-/// @param[in] nav_candidates_buffer  Buffer for navigation candidates
 /// @param[in] n_params        The number of parameters (or tracks)
 /// @param[out] params_view    Collection of output bound track_parameters
 ///
 template <typename detector_t>
 TRACCC_DEVICE inline void apply_interaction(
     std::size_t globalIndex, typename detector_t::view_type det_data,
-    vecmem::data::jagged_vector_view<detray::intersection2D<
-        typename detector_t::surface_type, typename detector_t::transform3>>
-        nav_candidates_buffer,
     const int n_params,
     bound_track_parameters_collection_types::view params_view);
 

--- a/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
+++ b/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
@@ -54,13 +54,22 @@ TRACCC_DEVICE inline void apply_interaction(
     const cxt_t ctx{};
     const auto free_vec = sf.bound_to_free_vector(ctx, bound_param.vector());
 
+    using scalar_type = typename detector_t::scalar_type;
     const auto& mask_store = det.mask_store();
     intersection_type sfi;
     sfi.sf_desc = det.surface(bound_param.surface_link());
     sf.template visit_mask<
         detray::intersection_update<detray::ray_intersector>>(
         detray::detail::ray<transform3_type>(free_vec), sfi,
-        det.transform_store());
+        det.transform_store(),
+        sf.is_portal() ? 0.f : 15.f * unit<scalar_type>::um,
+        -100.f * unit<scalar_type>::um);
+
+    if (!(std::abs(
+              sf.cos_angle(ctx, bound_param.dir(), bound_param.bound_local()) -
+              sfi.cos_incidence_angle) < 0.000001f)) {
+        printf("Problem");
+    }
 
     // Apply interactor
     typename interactor_type::state interactor_state;

--- a/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
+++ b/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
@@ -9,35 +9,22 @@
 
 // Detray include(s).
 #include "detray/geometry/surface.hpp"
-#include "detray/navigation/intersection/intersection.hpp"
-#include "detray/navigation/intersection/ray_intersector.hpp"
-#include "detray/navigation/intersection_kernel.hpp"
 
 namespace traccc::device {
 
 template <typename detector_t>
 TRACCC_DEVICE inline void apply_interaction(
     std::size_t globalIndex, typename detector_t::view_type det_data,
-    vecmem::data::jagged_vector_view<detray::intersection2D<
-        typename detector_t::surface_type, typename detector_t::transform3>>
-        nav_candidates_buffer,
     const int n_params,
     bound_track_parameters_collection_types::view params_view) {
 
     // Type definitions
     using transform3_type = typename detector_t::transform3;
-    using intersection_type =
-        detray::intersection2D<typename detector_t::surface_type,
-                               transform3_type>;
     using interactor_type =
         detray::pointwise_material_interactor<transform3_type>;
 
     // Detector
     detector_t det(det_data);
-
-    // Navigation candidate buffer
-    vecmem::jagged_device_vector<intersection_type> nav_candidates(
-        nav_candidates_buffer);
 
     // in param
     bound_track_parameters_collection_types::device params(params_view);
@@ -49,34 +36,16 @@ TRACCC_DEVICE inline void apply_interaction(
     auto& bound_param = params.at(globalIndex);
 
     // Get intersection at surface
-    const detray::surface<detector_t> sf{det, bound_param.surface_link()};
-    using cxt_t = typename detector_t::geometry_context;
-    const cxt_t ctx{};
-    const auto free_vec = sf.bound_to_free_vector(ctx, bound_param.vector());
-
-    using scalar_type = typename detector_t::scalar_type;
-    const auto& mask_store = det.mask_store();
-    intersection_type sfi;
-    sfi.sf_desc = det.surface(bound_param.surface_link());
-    sf.template visit_mask<
-        detray::intersection_update<detray::ray_intersector>>(
-        detray::detail::ray<transform3_type>(free_vec), sfi,
-        det.transform_store(),
-        sf.is_portal() ? 0.f : 15.f * unit<scalar_type>::um,
-        -100.f * unit<scalar_type>::um);
-
-    if (!(std::abs(
-              sf.cos_angle(ctx, bound_param.dir(), bound_param.bound_local()) -
-              sfi.cos_incidence_angle) < 0.000001f)) {
-        printf("Problem");
-    }
+    const detray::surface sf{det, bound_param.surface_link()};
+    const typename detector_t::geometry_context ctx{};
 
     // Apply interactor
     typename interactor_type::state interactor_state;
     interactor_type{}.update(
         bound_param, interactor_state,
         static_cast<int>(detray::navigation::direction::e_forward), sf,
-        sfi.cos_incidence_angle);
+        std::abs(
+            sf.cos_angle(ctx, bound_param.dir(), bound_param.bound_local())));
 }
 
 }  // namespace traccc::device

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -60,17 +60,12 @@ __global__ void make_barcode_sequence(
 /// CUDA kernel for running @c traccc::device::apply_interaction
 template <typename detector_t>
 __global__ void apply_interaction(
-    typename detector_t::view_type det_data,
-    vecmem::data::jagged_vector_view<detray::intersection2D<
-        typename detector_t::surface_type, typename detector_t::transform3>>
-        nav_candidates_buffer,
-    const int n_params,
+    typename detector_t::view_type det_data, const int n_params,
     bound_track_parameters_collection_types::view params_view) {
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
 
-    device::apply_interaction<detector_t>(gid, det_data, nav_candidates_buffer,
-                                          n_params, params_view);
+    device::apply_interaction<detector_t>(gid, det_data, n_params, params_view);
 }
 
 /// CUDA kernel for running @c traccc::device::count_measurements
@@ -295,8 +290,8 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
         nThreads = m_warp_size * 2;
         nBlocks = (n_in_params + nThreads - 1) / nThreads;
         kernels::apply_interaction<detector_type>
-            <<<nBlocks, nThreads, 0, stream>>>(det_view, navigation_buffer,
-                                               n_in_params, in_params_buffer);
+            <<<nBlocks, nThreads, 0, stream>>>(det_view, n_in_params,
+                                               in_params_buffer);
         TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 
         /*****************************************************************


### PR DESCRIPTION
While debugging the detray update I found that in the ```seed_generator``` the cosine of the incidence angle on the intersection is quite often invalid, because the mask tolerance and overstepping tolerance that are given to the ```intersection_update``` call do not match what the navigator used to find the track parameters on surface. This leads to essentially a zero path through the material (thickness gets divided by the cosine). Because putting the navigation configuration in there to set all of the tolerances is a bit awkward, I used the angle calculation of the surface directly. I cleaned that interface up a bit in acts-project/detray#723