### PR TITLE
Data V7, main branch (2024.05.03.)

### DIFF
--- a/data/traccc_data_get_files.sh
+++ b/data/traccc_data_get_files.sh
@@ -27,7 +27,7 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v6"}
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v7"}
 TRACCC_WEB_DIRECTORY=${TRACCC_WEB_DIRECTORY:-"https://acts.web.cern.ch/traccc/data"}
 TRACCC_DATA_DIRECTORY=${TRACCC_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}
 TRACCC_CMAKE_EXECUTABLE=${TRACCC_CMAKE_EXECUTABLE:-cmake}

--- a/data/traccc_data_package_files.sh
+++ b/data/traccc_data_package_files.sh
@@ -27,7 +27,7 @@ usage() {
 }
 
 # Default script arguments.
-TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v7"}
+TRACCC_DATA_NAME=${TRACCC_DATA_NAME:-"traccc-data-v8"}
 TRACCC_DATA_DIRECTORY_NAMES=("cca_test" "detray_simulation" "geometries" "odd"
    "single_module" "tml_detector" "tml_full" "tml_pixel_barrel" "tml_pixels"
    "two_modules")


### PR DESCRIPTION
Switched to version 7 of the traccc data file.

It has 2 major updates:
  - The ODD geometry files have been updated to the "latest" ones generated by @asalzburger. (He since seems to have generated slightly newer ones, but I stuck with the ones that I tested the traccc code with already.)
  - Replaced the existing ODD Geant4 and Fatras simulation files with a new set of Geant4 files.

I did the latter with the code, and instructions from: https://github.com/acts-project/acts/pull/3169

As it is explained in that ticket, the current `main` branch of [acts](https://github.com/acts-project/acts) can run simulation on the ODD geometry out of the box. Which I did in the following way:
  - Cloned the HEAD of the Acts `main` branch;
    * Making sure that the ODD submodule of the repository would be set up correctly. (`git submodule init && git submodule update`)
  - Started a Docker container with the following command in the directory where I cloned Acts:

```
docker run -it --rm -v $PWD:$PWD -w $PWD ghcr.io/acts-project/ubuntu2204:v41
```

  - Inside the container, used the following BASH script to build the code, and run some specific simulations:

```sh
#!/bin/bash
#
# Script for running a set of ODD simulation jobs for traccc
# performance measurements.
#

# Stop on errors.
set -e

# Default script arguments.
ACTS_DIR="./acts"
BUILD_DIR="./build"

# Helper function for printing usage information for the script.
usage() {
    echo "Script for running ODD simulations for traccc using the"
    echo "ghcr.io/acts-project/ubuntu2204:v41 Docker image."
    echo ""
    echo "Usage: ${BASH_SOURCE[0]} [options]"
    echo "Options:"
    echo "  -h/--help:      Print this message."
    echo ""
    echo "  -a/--acts-dir:  Directory with the Acts sources"
    echo "                  [${ACTS_DIR}]"
    echo "  -b/--build-dir: Build directory for Acts"
    echo "                  [${BUILD_DIR}]"
    echo ""
}

# Parse the command line argument(s).
while [[ $# > 0 ]]
do
    case $1 in
	-a|--acts-dir)
	    ACTS_DIR=$2
	    shift
	    ;;
	-b|--build-dir)
	    BUILD_DIR=$2
	    shift
	    ;;
	-h|--help)
	    usage
	    exit 0
	    ;;
	*)
	    echo "ERROR: Unknown argument: $1"
	    echo ""
	    usage
	    exit 1
	    ;;
    esac
    shift
done

# Check if the Acts directory exists.
if [ ! -d "${ACTS_DIR}" ]
then
    echo "ERROR: Acts directory (${ACTS_DIR}) not found"
    exit 1
fi

# Check if the build directory exists. If not, make it.
if [ ! -d "${BUILD_DIR}" ]
then
    cmake -G Ninja \
	  -DCMAKE_BUILD_TYPE=Release \
	  -DCMAKE_CXX_STANDARD=17 \
	  -DACTS_ENABLE_LOG_FAILURE_THRESHOLD=ON \
	  -DACTS_BUILD_EVERYTHING=ON \
	  -DACTS_BUILD_ODD=ON \
	  -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON \
	  -S "${ACTS_DIR}" \
	  -B "${BUILD_DIR}"
    cmake --build "${BUILD_DIR}"
fi

# Set up the environment from the build directory.
source "${BUILD_DIR}/this_acts.sh"
source "${BUILD_DIR}/python/setup.sh"

# Make sure that the Geant4 datasets are downloaded.
geant4-config --install-datasets

# Run all the muon simulations.
for NMUON in 1 10
do
    for PT in 1 5 10 50 100
    do
	python3 "${ACTS_DIR}/Examples/Scripts/Python/sim_digi_odd.py" \
		--digi-config odd-digi-geometric-config.json \
		--geant4 \
		--gun-multiplicity ${NMUON} \
		--gun-pt-range ${PT} ${PT} \
		--events 100 \
		--output geant4_${NMUON}muon_${PT}GeV 2>&1 | \
	    tee geant4_${NMUON}muon_${PT}GeV.log
    done
done

# Run all ttbar simulations.
for MU in 20 40 60 80 100 140 200 300
do
    python3 "${ACTS_DIR}/Examples/Scripts/Python/sim_digi_odd.py" \
	    --digi-config odd-digi-geometric-config.json \
	    --geant4 \
	    --ttbar \
	    --ttbar-pu ${MU} \
	    --events 10 \
	    --output geant4_ttbar_mu${MU} 2>&1 | \
	tee geant4_ttbar_mu${MU}.log
done
```

(The `odd-digi-geometric-config.json` file used by the simulation is the same included in this PR's `v7` file as well.)

Unfortunately the ODD simulations turned out to be humongous. So I only included the muon simulations into the `v7` data file. Since the ttbar simulations, even with just 10 events each, look like this:

```
[bash][celeborn]:acts > du -sh geant4_ttbar_mu*/ | sort -h
2.0G	geant4_ttbar_mu20/
3.1G	geant4_ttbar_mu40/
4.0G	geant4_ttbar_mu60/
5.2G	geant4_ttbar_mu80/
6.4G	geant4_ttbar_mu100/
9.0G	geant4_ttbar_mu140/
13G	geant4_ttbar_mu200/
19G	geant4_ttbar_mu300/
[bash][celeborn]:acts >
```

So yeah, these are not going into the file that our CI setup uses... I'm currently compressing them, to put them on CERNBox.

But with the simulations being so humongous, we'll probably need to find some better way of storing these things. I think we'll have to consider putting them on EOS in such a way that inside of CERN we could use them without having to download them locally. I'm open to proposals on this front. :thinking:

Finally: While the current state of our reconstruction code swallows these files seemingly fine, performance checking doesn't work on them. :frowning: As I explained to @beomki-yeo already, the logic in our code does some funky stuff. Leading to the following crash:

```
[bash][celeborn]:traccc > gdb ./build/bin/traccc_seq_example
GNU gdb (Ubuntu 12.1-0ubuntu1~22.04) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./build/bin/traccc_seq_example...
(gdb) run --detector-file=geometries/odd/odd-detray_geometry_detray.json --grid-file=geometries/odd/odd-detray_surface_grids_detray.json --use-detray-detector --digitization-file=geometries/odd/odd-digi-geometric-config.json --input-directory=odd/geant4_1muon_1GeV/ --input-events=1 --check-performance
Starting program: /home/krasznaa/ATLAS/projects/traccc/build/bin/traccc_seq_example --detector-file=geometries/odd/odd-detray_geometry_detray.json --grid-file=geometries/odd/odd-detray_surface_grids_detray.json --use-detray-detector --digitization-file=geometries/odd/odd-digi-geometric-config.json --input-directory=odd/geant4_1muon_1GeV/ --input-events=1 --check-performance
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Running Full Tracking Chain on the Host

>>> Detector Options <<<
  Detector file       : geometries/odd/odd-detray_geometry_detray.json
  Material file       : 
  Surface rid file    : geometries/odd/odd-detray_surface_grids_detray.json
  Use detray::detector: yes
  Digitization file   : geometries/odd/odd-digi-geometric-config.json
>>> Input Data Options <<<
  Input data format             : csv
  Input directory               : odd/geant4_1muon_1GeV/
  Number of input events        : 1
  Number of input events to skip: 0
>>> Clusterization Options <<<
  Target cells per partition: 1024
>>> Track Seeding Options <<<
  None
>>> Track Finding Options <<<
  Track candidates range   : 3:100
  Minimum step length for the next surface: 0.5 [mm] 
  Maximum step counts for the next surface: 100
  Maximum Chi2             : 30
  Maximum branches per step: 4294967295
  Maximum number of skipped steps per candidates: 3
>>> Track Propagation Options <<<
  Constraint step size  : 3.40282e+38 [mm]
  Overstep tolerance    : -100 [um]
  Minimum mask tolerance: 1e-05 [mm]
  Maximum mask tolerance: 1 [mm]
  Search window         : 0 x 0
  Runge-Kutta tolerance : 0.0001
>>> Track Ambiguity Resolution Options <<<
  Run ambiguity resolution : yes
>>> Performance Measurement Options <<<
  Run performance checks: yes

WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: @traccc::io::csv::read_cells: 1 duplicate cells found in /home/krasznaa/ATLAS/projects/traccc/traccc/data/odd/geant4_1muon_1GeV/event000000000-cells.csv

Program received signal SIGSEGV, Segmentation fault.
traccc::event_map2::event_map2 (this=0x7fffffff9f50, event=<optimized out>, measurement_dir=..., hit_dir=..., particle_dir=...) at /home/krasznaa/ATLAS/projects/traccc/traccc/io/src/event_map2.cpp:90
90	        const auto csv_ptc = particles[csv_hit.particle_id];
(gdb) bt
#0  traccc::event_map2::event_map2 (this=0x7fffffff9f50, event=<optimized out>, measurement_dir=..., hit_dir=..., 
    particle_dir=...) at /home/krasznaa/ATLAS/projects/traccc/traccc/io/src/event_map2.cpp:90
#1  0x000000000044db6a in seq_run (input_opts=..., detector_opts=..., seeding_opts=..., finding_opts=..., propagation_opts=..., 
    resolution_opts=..., performance_opts=...)
    at /home/krasznaa/ATLAS/projects/traccc/traccc/examples/run/cpu/seq_example.cpp:295
#2  0x000000000044f906 in main (argc=<optimized out>, argv=<optimized out>)
    at /home/krasznaa/ATLAS/projects/traccc/traccc/examples/run/cpu/seq_example.cpp:368
(gdb)
```

Let's discuss this in either this PR, or on some other forum, because I don't even understand how that code is supposed to work exactly. :confused: Since the "particle IDs" used in the simulation are **very large** `uint64_t` numbers. They are not indices starting from `0`. :confused: (So we'll need to use something like a map in that code instead of a vector. :thinking:)