### PR TITLE
ODD ttbar Clusterization Fix, main branch (2024.05.04.)

### DIFF
--- a/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
+++ b/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
@@ -29,7 +29,7 @@ namespace details {
 using index_t = unsigned short;
 
 static constexpr int TARGET_CELLS_PER_THREAD = 8;
-static constexpr int MAX_CELLS_PER_THREAD = 12;
+static constexpr int MAX_CELLS_PER_THREAD = 32;
 
 /// Helper struct for calculating some of the input parameters of @c ccl_kernel
 struct ccl_kernel_helper {


### PR DESCRIPTION
Made high-$\mu$ ODD ttbar samples succeed with (device) clusterization.

As discussed in #565, with $\mu$ = 100 and higher, on the files that I generated as described in #561, I had to do this to avoid running into assertion errors from the clusterization code. :thinking:

I'm very open to discussions about why this is, but the code, with its current logic of how it splits the cells into partitions, does need this update for the highest pileup ODD simulations.