### PR TITLE
Kalman Fitter Step Aborter, main branch (2024.05.04.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -68,6 +68,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
   "include/traccc/fitting/kalman_filter/kalman_actor.hpp"
   "include/traccc/fitting/kalman_filter/kalman_fitter.hpp"
+  "include/traccc/fitting/kalman_filter/kalman_step_aborter.hpp"
   "include/traccc/fitting/kalman_filter/statistics_updater.hpp"
   "include/traccc/fitting/fitting_algorithm.hpp"
   # Seed finding algorithmic code.

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -15,6 +15,7 @@
 #include "traccc/fitting/fitting_config.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_smoother.hpp"
 #include "traccc/fitting/kalman_filter/kalman_actor.hpp"
+#include "traccc/fitting/kalman_filter/kalman_step_aborter.hpp"
 #include "traccc/fitting/kalman_filter/statistics_updater.hpp"
 
 // detray include(s).
@@ -66,7 +67,7 @@ class kalman_fitter {
 
     using actor_chain_type =
         detray::actor_chain<std::tuple, aborter, transporter, interactor,
-                            fit_actor, resetter>;
+                            fit_actor, resetter, kalman_step_aborter>;
 
     // Propagator type
     using propagator_type =
@@ -102,7 +103,7 @@ class kalman_fitter {
         typename actor_chain_type::state operator()() {
             return std::tie(m_aborter_state, m_transporter_state,
                             m_interactor_state, m_fit_actor_state,
-                            m_resetter_state);
+                            m_resetter_state, m_step_aborter_state);
         }
 
         /// Individual actor states
@@ -111,6 +112,7 @@ class kalman_fitter {
         typename interactor::state m_interactor_state{};
         typename fit_actor::state m_fit_actor_state;
         typename resetter::state m_resetter_state{};
+        kalman_step_aborter::state m_step_aborter_state{};
 
         /// Fitting result per track
         fitting_result<algebra_type> m_fit_res;

--- a/core/include/traccc/fitting/kalman_filter/kalman_step_aborter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_step_aborter.hpp
@@ -1,0 +1,65 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+
+// Detray include(s).
+#include "detray/propagator/base_actor.hpp"
+
+// VecMem include(s).
+#include <vecmem/utils/debug.hpp>
+
+namespace traccc {
+
+/// Aborter making sure that propagation would not exceed a certain step count
+///
+/// It is used mostly as a failsafe during the fitting stage. As long as
+/// everything works well, this aborter should never trigger. It is here to
+/// serve as a failsafe in case of a bug in the track finding / fitting
+/// algorithm.
+///
+struct kalman_step_aborter : public detray::actor {
+
+    /// The state of the aborter
+    struct state {
+        /// Maximum step count that a track can take to reach the next surface
+        unsigned int max_steps = 100u;
+        /// The current step count
+        unsigned int step = 0u;
+    };
+
+    /// The operator to be called by the propagator
+    ///
+    /// @tparam propagator_state_t The type of the propagator state
+    /// @param abrt_state The state of the aborter
+    /// @param prop_state The state of the propagator
+    ///
+    template <typename propagator_state_t>
+    TRACCC_HOST_DEVICE void operator()(state& abrt_state,
+                                       propagator_state_t& prop_state) const {
+
+        // Convenience reference to the navigation state.
+        auto& navigation = prop_state._navigation;
+
+        // Reset the step count if the track is on a sensitive surface.
+        if (navigation.is_on_sensitive()) {
+            abrt_state.step = 0u;
+        }
+
+        // Abort if the step count exceeds the maximum allowed
+        if (++(abrt_state.step) > abrt_state.max_steps) {
+            VECMEM_DEBUG_MSG(1, "Kalman fitter step aborter triggered");
+            prop_state._heartbeat &= navigation.abort();
+        }
+    }
+
+};  // struct kalman_step_aborter
+
+}  // namespace traccc


### PR DESCRIPTION
In order to address / work around the issue described in #569, added a "step count aborter" to the track fitting.

It is to prevent the track fitting from going into an endless loop. This simple failsafe will abort the propagation of a track if it cannot find the next detector surface in a maximal number of steps. (100 by default.)

Note that this is yet another reminder that we'll have to add some message logging facilities into this project. :thinking: For now I reused the [VECMEM_DEBUG_MSG](https://github.com/acts-project/vecmem/blob/main/core/include/vecmem/utils/debug.hpp) macro. But this is far from perfect. :frowning: (We can't just use `printf(...)` here, since SYCL doesn't support such output.)

From what I've seen with the ODD simulation files, 100 as the maximal number of steps seems to be a reasonable value. But I'm open for input on this. (100 is also what the CKF uses currently.)