### PR TITLE
Fix the default value of maxmimum number of branches per seed

### DIFF
--- a/examples/options/include/traccc/options/track_finding.hpp
+++ b/examples/options/include/traccc/options/track_finding.hpp
@@ -37,7 +37,7 @@ class track_finding : public interface {
     /// Maximum chi2 for a measurement to be included in the track
     float chi2_max = 30.f;
     /// Maximum number of branches which each initial seed can have at a step
-    unsigned int nmax_per_seed = std::numeric_limits<unsigned int>::max();
+    unsigned int nmax_per_seed = 10;
     /// Maximum allowed number of skipped steps per candidate
     unsigned int max_num_skipping_per_cand = 3;
 


### PR DESCRIPTION
This is important parameter for GPU CKF and it is not supposed to be the max of `unsigned int`. 

May not impact the performance  a lot now I think :thinking: But it is pretty error prone with current default value