### PR TITLE
Spacepoint OBJ Writing, main branch (2024.05.05.)

### DIFF
--- a/examples/options/include/traccc/options/output_data.hpp
+++ b/examples/options/include/traccc/options/output_data.hpp
@@ -13,6 +13,7 @@
 
 // System include(s).
 #include <string>
+#include <string_view>
 
 namespace traccc::opts {
 
@@ -30,8 +31,13 @@ class output_data : public interface {
 
     /// @}
 
-    /// Constructor
-    output_data();
+    /// Constructor, with default arguments
+    ///
+    /// @param format The data format for the output
+    /// @param directory The directory for the output
+    ///
+    output_data(traccc::data_format format = data_format::csv,
+                std::string_view directory = "testing/");
 
     /// Read/process the command line options
     ///

--- a/examples/options/src/output_data.cpp
+++ b/examples/options/src/output_data.cpp
@@ -22,7 +22,8 @@ using data_format_type = std::string;
 /// Name of the data format option
 static const char* data_format_option = "output-data-format";
 
-output_data::output_data() : interface("Output Data Options") {
+output_data::output_data(traccc::data_format f, std::string_view d)
+    : interface("Output Data Options"), format(f), directory(d) {
 
     m_desc.add_options()(data_format_option,
                          po::value<data_format_type>()->default_value("csv"),
@@ -44,6 +45,8 @@ void output_data::read(const boost::program_options::variables_map& vm) {
             format = data_format::binary;
         } else if (input_format_string == "json") {
             format = data_format::json;
+        } else if (input_format_string == "obj") {
+            format = data_format::obj;
         } else {
             throw std::invalid_argument("Unknown input data format");
         }

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -10,6 +10,7 @@
 #include "traccc/io/read_digitization_config.hpp"
 #include "traccc/io/read_geometry.hpp"
 #include "traccc/io/utils.hpp"
+#include "traccc/io/write.hpp"
 
 // algorithms
 #include "traccc/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp"
@@ -30,6 +31,7 @@
 #include "traccc/options/clusterization.hpp"
 #include "traccc/options/detector.hpp"
 #include "traccc/options/input_data.hpp"
+#include "traccc/options/output_data.hpp"
 #include "traccc/options/performance.hpp"
 #include "traccc/options/program_options.hpp"
 #include "traccc/options/track_finding.hpp"
@@ -57,6 +59,7 @@
 #include <memory>
 
 int seq_run(const traccc::opts::input_data& input_opts,
+            const traccc::opts::output_data& output_opts,
             const traccc::opts::detector& detector_opts,
             const traccc::opts::clusterization& /*clusterization_opts*/,
             const traccc::opts::track_seeding& seeding_opts,
@@ -227,6 +230,12 @@ int seq_run(const traccc::opts::input_data& input_opts,
                     sf(vecmem::get_data(measurements_per_event),
                        vecmem::get_data(modules_per_event));
             }
+            if (output_opts.directory != "") {
+                traccc::io::write(event, output_opts.directory,
+                                  output_opts.format,
+                                  vecmem::get_data(spacepoints_per_event),
+                                  vecmem::get_data(modules_per_event));
+            }
 
             /*-----------------------
               Seeding algorithm
@@ -351,6 +360,7 @@ int main(int argc, char* argv[]) {
     // Program options.
     traccc::opts::detector detector_opts;
     traccc::opts::input_data input_opts;
+    traccc::opts::output_data output_opts{traccc::data_format::obj, ""};
     traccc::opts::clusterization clusterization_opts;
     traccc::opts::track_seeding seeding_opts;
     traccc::opts::track_finding finding_opts;
@@ -359,13 +369,14 @@ int main(int argc, char* argv[]) {
     traccc::opts::performance performance_opts;
     traccc::opts::program_options program_opts{
         "Full Tracking Chain on the Host",
-        {detector_opts, input_opts, clusterization_opts, seeding_opts,
-         finding_opts, propagation_opts, resolution_opts, performance_opts},
+        {detector_opts, input_opts, output_opts, clusterization_opts,
+         seeding_opts, finding_opts, propagation_opts, resolution_opts,
+         performance_opts},
         argc,
         argv};
 
     // Run the application.
-    return seq_run(input_opts, detector_opts, clusterization_opts, seeding_opts,
-                   finding_opts, propagation_opts, resolution_opts,
-                   performance_opts);
+    return seq_run(input_opts, output_opts, detector_opts, clusterization_opts,
+                   seeding_opts, finding_opts, propagation_opts,
+                   resolution_opts, performance_opts);
 }

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -73,6 +73,8 @@ traccc_add_library( traccc_io io TYPE SHARED
   "src/csv/make_particle_reader.cpp"
   "src/csv/read_particles.hpp"
   "src/csv/read_particles.cpp"
+  "src/obj/write_spacepoints.hpp"
+  "src/obj/write_spacepoints.cpp"
   )
 target_link_libraries( traccc_io
   PUBLIC vecmem::core traccc::core ActsCore

--- a/io/include/traccc/io/data_format.hpp
+++ b/io/include/traccc/io/data_format.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,9 +14,10 @@ namespace traccc {
 
 /// Format for an input or output file
 enum data_format : int {
-    csv = 0,
-    binary = 1,
-    json = 2,
+    csv = 0,     ///< Comma-separated values
+    binary = 1,  ///< Binary format
+    json = 2,    ///< JSON format
+    obj = 3,     ///< Wavefront OBJ format
 };
 
 /// Printout helper for @c traccc::data_format

--- a/io/include/traccc/io/utils.hpp
+++ b/io/include/traccc/io/utils.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -27,5 +27,16 @@ const std::string& data_directory();
 /// @return A standardized name for a data file to use as input.
 ///
 std::string get_event_filename(std::size_t event, std::string_view suffix);
+
+/// Get the absolute path to a file or directory
+///
+/// This function would just return the received path as-is if it is already
+/// an absolute path. Otherwise, it would prepend the traccc data directory
+/// to it.
+///
+/// @param path The path to get the absolute path for
+/// @return The absolute path to the file or directory
+///
+std::string get_absolute_path(std::string_view path);
 
 }  // namespace traccc::io

--- a/io/src/data_format.cpp
+++ b/io/src/data_format.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -24,6 +24,9 @@ std::ostream& operator<<(std::ostream& out, data_format format) {
             break;
         case data_format::json:
             out << "json";
+            break;
+        case data_format::obj:
+            out << "wavefront obj";
             break;
         default:
             out << "?!?unknown?!?";

--- a/io/src/obj/write_spacepoints.cpp
+++ b/io/src/obj/write_spacepoints.cpp
@@ -1,0 +1,37 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "write_spacepoints.hpp"
+
+// System include(s).
+#include <fstream>
+
+namespace traccc::io::obj {
+
+void write_spacepoints(
+    std::string_view filename,
+    traccc::spacepoint_collection_types::const_view spacepoints_view) {
+
+    // Open the output file.
+    std::ofstream file(filename.data());
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open file: " +
+                                 std::string(filename));
+    }
+
+    // Create a device collection around the spacepoint view.
+    traccc::spacepoint_collection_types::const_device spacepoints(
+        spacepoints_view);
+
+    // Write the spacepoints.
+    for (const traccc::spacepoint& sp : spacepoints) {
+        file << "v " << sp.x() << " " << sp.y() << " " << sp.z() << "\n";
+    }
+}
+
+}  // namespace traccc::io::obj

--- a/io/src/obj/write_spacepoints.hpp
+++ b/io/src/obj/write_spacepoints.hpp
@@ -1,0 +1,27 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/edm/spacepoint.hpp"
+
+// System include(s).
+#include <string_view>
+
+namespace traccc::io::obj {
+
+/// Write a spacepoint collection into a Wavefront OBJ file.
+///
+/// @param filename is the name of the output file
+/// @param spacepoints is the spacepoint collection to write
+///
+void write_spacepoints(
+    std::string_view filename,
+    traccc::spacepoint_collection_types::const_view spacepoints);
+
+}  // namespace traccc::io::obj

--- a/io/src/utils.cpp
+++ b/io/src/utils.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,7 @@
 
 // System include(s).
 #include <cstdlib>
+#include <filesystem>
 #include <iomanip>
 #include <sstream>
 
@@ -39,6 +40,18 @@ std::string get_event_filename(std::size_t event, std::string_view suffix) {
     std::ostringstream stream;
     stream << "event" << std::setfill('0') << std::setw(9) << event << suffix;
     return stream.str();
+}
+
+std::string get_absolute_path(std::string_view path) {
+
+    // Check if the path is already absolute.
+    if (std::filesystem::path(path).is_absolute()) {
+        return std::string{path};
+    }
+
+    // Otherwise, prepend the data directory to the path.
+    return std::filesystem::path(data_directory()) /
+           std::filesystem::path(path);
 }
 
 }  // namespace traccc::io

--- a/io/src/write.cpp
+++ b/io/src/write.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,8 +8,13 @@
 // Local include(s).
 #include "traccc/io/write.hpp"
 
+#include "obj/write_spacepoints.hpp"
 #include "traccc/io/utils.hpp"
 #include "write_binary.hpp"
+
+// System include(s).
+#include <filesystem>
+#include <stdexcept>
 
 namespace traccc::io {
 
@@ -21,12 +26,16 @@ void write(std::size_t event, std::string_view directory,
     switch (format) {
         case data_format::binary:
             details::write_binary_collection(
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-cells.dat"),
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(
+                                       get_event_filename(event, "-cells.dat")))
+                                      .native()),
                 traccc::cell_collection_types::const_device{cells});
             details::write_binary_collection(
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-modules.dat"),
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-modules.dat")))
+                                      .native()),
                 traccc::cell_module_collection_types::const_device{modules});
             break;
         default:
@@ -42,13 +51,25 @@ void write(std::size_t event, std::string_view directory,
     switch (format) {
         case data_format::binary:
             details::write_binary_collection(
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-hits.dat"),
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(
+                                       get_event_filename(event, "-hits.dat")))
+                                      .native()),
                 traccc::spacepoint_collection_types::const_device{spacepoints});
             details::write_binary_collection(
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-modules.dat"),
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-modules.dat")))
+                                      .native()),
                 traccc::cell_module_collection_types::const_device{modules});
+            break;
+        case data_format::obj:
+            obj::write_spacepoints(
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-spacepoints.obj")))
+                                      .native()),
+                spacepoints);
             break;
         default:
             throw std::invalid_argument("Unsupported data format");
@@ -63,13 +84,17 @@ void write(std::size_t event, std::string_view directory,
     switch (format) {
         case data_format::binary:
             details::write_binary_collection(
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-measurements.dat"),
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-measurements.dat")))
+                                      .native()),
                 traccc::measurement_collection_types::const_device{
                     measurements});
             details::write_binary_collection(
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-modules.dat"),
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-modules.dat")))
+                                      .native()),
                 traccc::cell_module_collection_types::const_device{modules});
             break;
         default:


### PR DESCRIPTION
I wanted to make the hacky thing that I've been doing over the last week, a bit more formal. Laying a foundation for saving even more complex meshes / paths / etc. later on for fancy visualization.

There's also a bit more of a fundamental thing that I'm introducing here. :thinking: Instead of having our code use `traccc::io::data_directory()` all over the place, I now introduced `traccc::io::get_absolute_path(...)`. The purpose of this function is to allow us to use absolute path names for our input/output files/directories if we so choose. Since doing this would've made my life a whole lot easier while experimenting with the ODD Geant4 simulation...

But I didn't want to go too crazy with this PR. Here I only allow `traccc::io::write(...)` to write to an absolute path, and not only under `$TRACCC_TEST_DATA_DIR`.

Finally, I taught `traccc_seq_example` to output its reconstructed spacepoints if you specify `--output-directory` among its arguments. (My idea is that later on we could output a whole bunch of other OBJ files as well if we choose.)

As a side-thing: It's now pretty clear to me that the "single muon" samples that I generated are far from being single muons. :confused: Since I tend to see 4 high-pt particles in each of those events.

![image](https://github.com/acts-project/traccc/assets/30694331/8c6c5a54-d021-430e-968b-b7e44550412e)

(The two different colours are from two separate events in this picture.)

Not a big problem at the moment, but something to debug with @asalzburger later on. :thinking: