### PR TITLE
CUDA Throughput Improvement, main branch (2024.05.06.)

### DIFF
--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -16,7 +16,6 @@
 #include "traccc/cuda/seeding/seeding_algorithm.hpp"
 #include "traccc/cuda/seeding/track_params_estimation.hpp"
 #include "traccc/cuda/utils/stream.hpp"
-#include "traccc/device/container_d2h_copy_alg.hpp"
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/track_state.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
@@ -30,6 +29,7 @@
 #include "detray/propagator/rk_stepper.hpp"
 
 // VecMem include(s).
+#include <vecmem/containers/vector.hpp>
 #include <vecmem/memory/binary_page_memory_resource.hpp>
 #include <vecmem/memory/cuda/device_memory_resource.hpp>
 #include <vecmem/memory/memory_resource.hpp>
@@ -44,9 +44,10 @@ namespace traccc::cuda {
 ///
 /// At least as much as is implemented in the project at any given moment.
 ///
-class full_chain_algorithm : public algorithm<track_state_container_types::host(
-                                 const cell_collection_types::host&,
-                                 const cell_module_collection_types::host&)> {
+class full_chain_algorithm
+    : public algorithm<vecmem::vector<fitting_result<default_algebra>>(
+          const cell_collection_types::host&,
+          const cell_module_collection_types::host&)> {
 
     public:
     /// @name Type declaration(s)
@@ -160,9 +161,6 @@ class full_chain_algorithm : public algorithm<track_state_container_types::host(
     finding_algorithm m_finding;
     /// Track fitting algorithm
     fitting_algorithm m_fitting;
-
-    /// Algorithm copying the result container back to the host
-    device::container_d2h_copy_alg<track_state_container_types> m_result_copy;
 
     /// @}
 

--- a/io/src/event_map2.cpp
+++ b/io/src/event_map2.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,6 +13,10 @@
 #include "traccc/io/csv/make_measurement_reader.hpp"
 #include "traccc/io/csv/make_particle_reader.hpp"
 #include "traccc/io/utils.hpp"
+
+// System include(s).
+#include <filesystem>
+
 namespace traccc {
 
 event_map2::event_map2(std::size_t event, const std::string& measurement_dir,
@@ -20,19 +24,26 @@ event_map2::event_map2(std::size_t event, const std::string& measurement_dir,
                        const std::string particle_dir) {
 
     std::string io_measurement_hit_id_file =
-        io::data_directory() + hit_dir +
-        io::get_event_filename(event, "-measurement-simhit-map.csv");
+        io::get_absolute_path((std::filesystem::path(hit_dir) /
+                               std::filesystem::path(io::get_event_filename(
+                                   event, "-measurement-simhit-map.csv")))
+                                  .native());
 
-    std::string io_particle_file =
-        io::data_directory() + particle_dir +
-        io::get_event_filename(event, "-particles.csv");
+    std::string io_particle_file = io::get_absolute_path(
+        (std::filesystem::path(particle_dir) /
+         std::filesystem::path(io::get_event_filename(event, "-particles.csv")))
+            .native());
 
-    std::string io_hit_file = io::data_directory() + hit_dir +
-                              io::get_event_filename(event, "-hits.csv");
+    std::string io_hit_file = io::get_absolute_path(
+        (std::filesystem::path(hit_dir) /
+         std::filesystem::path(io::get_event_filename(event, "-hits.csv")))
+            .native());
 
     std::string io_measurement_file =
-        io::data_directory() + measurement_dir +
-        io::get_event_filename(event, "-measurements.csv");
+        io::get_absolute_path((std::filesystem::path(measurement_dir) /
+                               std::filesystem::path(io::get_event_filename(
+                                   event, "-measurements.csv")))
+                                  .native());
 
     auto mreader = io::csv::make_measurement_reader(io_measurement_file);
 

--- a/io/src/mapper.cpp
+++ b/io/src/mapper.cpp
@@ -22,6 +22,9 @@
 #include "traccc/clusterization/measurement_creation_algorithm.hpp"
 #include "traccc/clusterization/sparse_ccl_algorithm.hpp"
 
+// System include(s).
+#include <filesystem>
+
 namespace traccc {
 
 particle_map generate_particle_map(std::size_t event,
@@ -31,8 +34,10 @@ particle_map generate_particle_map(std::size_t event,
 
     // Read the particles from the relevant event file
     std::string io_particles_file =
-        io::data_directory() + particle_dir +
-        io::get_event_filename(event, "-particles_initial.csv");
+        io::get_absolute_path((std::filesystem::path(particle_dir) /
+                               std::filesystem::path(io::get_event_filename(
+                                   event, "-particles_initial.csv")))
+                                  .native());
 
     auto preader = io::csv::make_particle_reader(io_particles_file);
 
@@ -61,8 +66,10 @@ hit_particle_map generate_hit_particle_map(std::size_t event,
     auto pmap = generate_particle_map(event, particle_dir);
 
     // Read the hits from the relevant event file
-    std::string io_hits_file = io::data_directory() + hits_dir +
-                               io::get_event_filename(event, "-hits.csv");
+    std::string io_hits_file = io::get_absolute_path(
+        (std::filesystem::path(hits_dir) /
+         std::filesystem::path(io::get_event_filename(event, "-hits.csv")))
+            .native());
 
     auto hreader = io::csv::make_hit_reader(io_hits_file);
 
@@ -93,8 +100,10 @@ hit_map generate_hit_map(std::size_t event, const std::string& hits_dir) {
     hit_map result;
 
     // Read the hits from the relevant event file
-    std::string io_hits_file = io::data_directory() + hits_dir +
-                               io::get_event_filename(event, "-hits.csv");
+    std::string io_hits_file = io::get_absolute_path(
+        (std::filesystem::path(hits_dir) /
+         std::filesystem::path(io::get_event_filename(event, "-hits.csv")))
+            .native());
 
     auto hreader = io::csv::make_hit_reader(io_hits_file);
 
@@ -102,8 +111,10 @@ hit_map generate_hit_map(std::size_t event, const std::string& hits_dir) {
 
     // Read the hits from the relevant event file
     std::string io_measurement_hit_id_file =
-        io::data_directory() + hits_dir +
-        io::get_event_filename(event, "-measurement-simhit-map.csv");
+        io::get_absolute_path((std::filesystem::path(hits_dir) /
+                               std::filesystem::path(io::get_event_filename(
+                                   event, "-measurement-simhit-map.csv")))
+                                  .native());
 
     auto mhid_reader =
         io::csv::make_measurement_hit_id_reader(io_measurement_hit_id_file);
@@ -141,8 +152,10 @@ hit_cell_map generate_hit_cell_map(std::size_t event,
     auto hmap = generate_hit_map(event, hits_dir);
 
     // Read the cells from the relevant event file
-    std::string io_cells_file = io::data_directory() + cells_dir +
-                                io::get_event_filename(event, "-cells.csv");
+    std::string io_cells_file = io::get_absolute_path(
+        (std::filesystem::path(cells_dir) /
+         std::filesystem::path(io::get_event_filename(event, "-cells.csv")))
+            .native());
 
     auto creader = io::csv::make_cell_reader(io_cells_file);
 

--- a/io/src/read_cells.cpp
+++ b/io/src/read_cells.cpp
@@ -12,6 +12,9 @@
 #include "read_binary.hpp"
 #include "traccc/io/utils.hpp"
 
+// System include(s).
+#include <filesystem>
+
 namespace traccc::io {
 
 void read_cells(
@@ -23,19 +26,28 @@ void read_cells(
 
     switch (format) {
         case data_format::csv: {
-            read_cells(out,
-                       data_directory() + directory.data() +
-                           get_event_filename(event, "-cells.csv"),
-                       format, geom, dconfig, barcode_map, deduplicate);
+            read_cells(
+                out,
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(
+                                       get_event_filename(event, "-cells.csv")))
+                                      .native()),
+                format, geom, dconfig, barcode_map, deduplicate);
             break;
         }
         case data_format::binary: {
             details::read_binary_collection<cell_collection_types::host>(
-                out.cells, data_directory() + directory.data() +
-                               get_event_filename(event, "-cells.dat"));
+                out.cells,
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(
+                                       get_event_filename(event, "-cells.dat")))
+                                      .native()));
             details::read_binary_collection<cell_module_collection_types::host>(
-                out.modules, data_directory() + directory.data() +
-                                 get_event_filename(event, "-modules.dat"));
+                out.modules,
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-modules.dat")))
+                                      .native()));
             break;
         }
         default:

--- a/io/src/read_digitization_config.cpp
+++ b/io/src/read_digitization_config.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -64,7 +64,7 @@ digitization_config read_digitization_config(std::string_view filename,
                                              data_format format) {
 
     // Construct the full filename.
-    std::string full_filename = data_directory() + filename.data();
+    std::string full_filename = get_absolute_path(filename);
 
     // Decide how to read the file.
     switch (format) {

--- a/io/src/read_geometry.cpp
+++ b/io/src/read_geometry.cpp
@@ -67,7 +67,7 @@ std::pair<geometry,
 read_geometry(std::string_view filename, data_format format) {
 
     // Construct the full file name.
-    const std::string full_filename = data_directory() + filename.data();
+    const std::string full_filename = get_absolute_path(filename);
 
     // Decide how to read the file.
     switch (format) {

--- a/io/src/read_measurements.cpp
+++ b/io/src/read_measurements.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,6 +12,9 @@
 #include "read_binary.hpp"
 #include "traccc/io/utils.hpp"
 
+// System include(s).
+#include <filesystem>
+
 namespace traccc::io {
 
 void read_measurements(measurement_reader_output& out, std::size_t event,
@@ -21,8 +24,10 @@ void read_measurements(measurement_reader_output& out, std::size_t event,
         case data_format::csv: {
             read_measurements(
                 out,
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-measurements.csv"),
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-measurements.csv")))
+                                      .native()),
                 format);
             break;
         }
@@ -30,11 +35,16 @@ void read_measurements(measurement_reader_output& out, std::size_t event,
 
             details::read_binary_collection<measurement_collection_types::host>(
                 out.measurements,
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-measurements.dat"));
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-measurements.dat")))
+                                      .native()));
             details::read_binary_collection<cell_module_collection_types::host>(
-                out.modules, data_directory() + directory.data() +
-                                 get_event_filename(event, "-modules.dat"));
+                out.modules,
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-modules.dat")))
+                                      .native()));
             break;
         }
         default:

--- a/io/src/read_particles.cpp
+++ b/io/src/read_particles.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,9 @@
 
 #include "csv/read_particles.hpp"
 #include "traccc/io/utils.hpp"
+
+// System include(s).
+#include <filesystem>
 
 namespace traccc::io {
 
@@ -21,8 +24,10 @@ particle_collection_types::host read_particles(std::size_t event,
     switch (format) {
         case data_format::csv:
             return read_particles(
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-particles.csv"),
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-particles.csv")))
+                                      .native()),
                 format, mr);
         default:
             throw std::invalid_argument("Unsupported data format");

--- a/io/src/read_spacepoints.cpp
+++ b/io/src/read_spacepoints.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,6 +12,9 @@
 #include "read_binary.hpp"
 #include "traccc/io/utils.hpp"
 
+// System include(s).
+#include <filesystem>
+
 namespace traccc::io {
 
 void read_spacepoints(spacepoint_reader_output& out, std::size_t event,
@@ -22,22 +25,34 @@ void read_spacepoints(spacepoint_reader_output& out, std::size_t event,
         case data_format::csv: {
             read_spacepoints(
                 out,
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-hits.csv"),
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-measurements.csv"),
-                data_directory() + directory.data() +
-                    get_event_filename(event, "-measurement-simhit-map.csv"),
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(
+                                       get_event_filename(event, "-hits.csv")))
+                                      .native()),
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-measurements.csv")))
+                                      .native()),
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-measurement-simhit-map.csv")))
+                                      .native()),
                 geom, format);
             break;
         }
         case data_format::binary: {
             details::read_binary_collection<spacepoint_collection_types::host>(
-                out.spacepoints, data_directory() + directory.data() +
-                                     get_event_filename(event, "-hits.dat"));
+                out.spacepoints,
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(
+                                       get_event_filename(event, "-hits.dat")))
+                                      .native()));
             details::read_binary_collection<cell_module_collection_types::host>(
-                out.modules, data_directory() + directory.data() +
-                                 get_event_filename(event, "-modules.dat"));
+                out.modules,
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-modules.dat")))
+                                      .native()));
             break;
         }
         default:

--- a/performance/src/performance/details/is_same_object.cpp
+++ b/performance/src/performance/details/is_same_object.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -141,8 +141,7 @@ bool is_same_object<fitting_result<traccc::default_algebra>>::operator()(
 
     return (is_same_object<bound_track_parameters>(m_ref.get().fit_params,
                                                    m_unc)(obj.fit_params) &&
-            is_same_angle(obj.ndf, m_ref.get().ndf, m_unc) &&
-            is_same_angle(obj.chi2, m_ref.get().chi2, m_unc));
+            is_same_scalar(obj.ndf, m_ref.get().ndf, m_unc));
 }
 
 /// @}

--- a/tests/io/test_mapper.cpp
+++ b/tests/io/test_mapper.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,9 +16,9 @@
 
 std::size_t event = 0;
 
-std::string detector_file = "/tml_detector/trackml-detector.csv";
+std::string detector_file = "tml_detector/trackml-detector.csv";
 std::string digi_config_file =
-    "/tml_detector/default-geometric-config-generic.json";
+    "tml_detector/default-geometric-config-generic.json";
 std::string hits_dir = "../tests/io/mock_data/";
 std::string cells_dir = "../tests/io/mock_data/";
 std::string particles_dir = "../tests/io/mock_data/";


### PR DESCRIPTION
This is built on top of #574. We'll need to merge that one in before this one.

As discussed in #572, the CUDA throughput measurements are fairly poor right now. With the absolute biggest bottleneck being the copy of a jagged vector of track states back to the host. While I have some ideas on how we can make that more efficient in the future, for now I decided to skip copying the jagged vector back to the host. And only copy the fitting results of the tracks. Which is a much smaller, 1D vector.

With this setup, on our "serious" GPU, I get:

```
[bash][pcadp04]:traccc > ./build/bin/traccc_throughput_mt_cuda --detector-file=geometries/odd/odd-detray_geometry_detray.json --grid-file=geometries/odd/odd-detray_surface_grids_detray.json --use-detray-detector --digitization-file=geometries/odd/odd-digi-geometric-config.json --input-directory=/data/Acts/odd-simulations-20240506/geant4_ttbar_mu200 --input-events=10 --processed-events=100 --cpu-threads=2

Running Multi-threaded CUDA GPU throughput tests

>>> Detector Options <<<
  Detector file       : geometries/odd/odd-detray_geometry_detray.json
  Material file       : 
  Surface grid file   : geometries/odd/odd-detray_surface_grids_detray.json
  Use detray::detector: yes
  Digitization file   : geometries/odd/odd-digi-geometric-config.json
>>> Input Data Options <<<
  Input data format             : csv
  Input directory               : /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200
  Number of input events        : 10
  Number of input events to skip: 0
>>> Clusterization Options <<<
  Target cells per partition: 1024
>>> Track Seeding Options <<<
  None
>>> Track Finding Options <<<
  Track candidates range   : 3:100
  Minimum step length for the next surface: 0.5 [mm] 
  Maximum step counts for the next surface: 100
  Maximum Chi2             : 30
  Maximum branches per step: 10
  Maximum number of skipped steps per candidates: 3
>>> Track Propagation Options <<<
  Constraint step size  : 3.40282e+38 [mm]
  Overstep tolerance    : -100 [um]
  Minimum mask tolerance: 1e-05 [mm]
  Maximum mask tolerance: 1 [mm]
  Search window         : 0 x 0
  Runge-Kutta tolerance : 0.0001
>>> Throughput Measurement Options <<<
  Cold run event(s) : 10
  Processed event(s): 100
  Log file          : 
>>> Multi-Threading Options <<<
  CPU threads: 2

WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: @traccc::io::csv::read_cells: 19157 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000000-cells.csv
WARNING: @traccc::io::csv::read_cells: 24524 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000001-cells.csv
WARNING: @traccc::io::csv::read_cells: 17547 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000002-cells.csv
WARNING: @traccc::io::csv::read_cells: 20889 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000003-cells.csv
WARNING: @traccc::io::csv::read_cells: 15151 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000004-cells.csv
WARNING: @traccc::io::csv::read_cells: 21299 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000005-cells.csv
WARNING: @traccc::io::csv::read_cells: 20111 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000006-cells.csv
WARNING: @traccc::io::csv::read_cells: 17117 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000007-cells.csv
WARNING: @traccc::io::csv::read_cells: 14836 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000008-cells.csv
WARNING: @traccc::io::csv::read_cells: 14147 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000009-cells.csv
Using CUDA device: NVIDIA RTX A5000 [id: 0, bus: 1, device: 0]
Using CUDA device: NVIDIA RTX A5000 [id: 0, bus: 1, device: 0]
Using CUDA device: NVIDIA RTX A5000 [id: 0, bus: 1, device: 0]
Reconstructed track parameters: 2713685
Time totals:
                  File reading  7585 ms
            Warm-up processing  1029 ms
              Event processing  8102 ms
Throughput:
            Warm-up processing  102.956 ms/event, 9.71287 events/s
              Event processing  81.0205 ms/event, 12.3426 events/s
[bash][pcadp04]:traccc >
```

While the EPYC CPU hosting that GPU can do the following:

```
[bash][pcadp04]:traccc > ./build/bin/traccc_throughput_mt --detector-file=geometries/odd/odd-detray_geometry_detray.json --grid-file=geometries/odd/odd-detray_surface_grids_detray.json --use-detray-detector --digitization-file=geometries/odd/odd-digi-geometric-config.json --input-directory=/data/Acts/odd-simulations-20240506/geant4_ttbar_mu200 --input-events=10 --processed-events=100 --cpu-threads=48

Running Multi-threaded host-only throughput tests

>>> Detector Options <<<
  Detector file       : geometries/odd/odd-detray_geometry_detray.json
  Material file       : 
  Surface grid file   : geometries/odd/odd-detray_surface_grids_detray.json
  Use detray::detector: yes
  Digitization file   : geometries/odd/odd-digi-geometric-config.json
>>> Input Data Options <<<
  Input data format             : csv
  Input directory               : /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200
  Number of input events        : 10
  Number of input events to skip: 0
>>> Clusterization Options <<<
  Target cells per partition: 1024
>>> Track Seeding Options <<<
  None
>>> Track Finding Options <<<
  Track candidates range   : 3:100
  Minimum step length for the next surface: 0.5 [mm] 
  Maximum step counts for the next surface: 100
  Maximum Chi2             : 30
  Maximum branches per step: 10
  Maximum number of skipped steps per candidates: 3
>>> Track Propagation Options <<<
  Constraint step size  : 3.40282e+38 [mm]
  Overstep tolerance    : -100 [um]
  Minimum mask tolerance: 1e-05 [mm]
  Maximum mask tolerance: 1 [mm]
  Search window         : 0 x 0
  Runge-Kutta tolerance : 0.0001
>>> Throughput Measurement Options <<<
  Cold run event(s) : 10
  Processed event(s): 100
  Log file          : 
>>> Multi-Threading Options <<<
  CPU threads: 48

WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: No material in detector
WARNING: No entries in volume finder
Detector check: OK
WARNING: @traccc::io::csv::read_cells: 19157 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000000-cells.csv
WARNING: @traccc::io::csv::read_cells: 24524 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000001-cells.csv
WARNING: @traccc::io::csv::read_cells: 17547 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000002-cells.csv
WARNING: @traccc::io::csv::read_cells: 20889 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000003-cells.csv
WARNING: @traccc::io::csv::read_cells: 15151 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000004-cells.csv
WARNING: @traccc::io::csv::read_cells: 21299 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000005-cells.csv
WARNING: @traccc::io::csv::read_cells: 20111 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000006-cells.csv
WARNING: @traccc::io::csv::read_cells: 17117 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000007-cells.csv
WARNING: @traccc::io::csv::read_cells: 14836 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000008-cells.csv
WARNING: @traccc::io::csv::read_cells: 14147 duplicate cells found in /data/Acts/odd-simulations-20240506/geant4_ttbar_mu200/event000000009-cells.csv
Reconstructed track parameters: 2695399
Time totals:
                  File reading  7442 ms
            Warm-up processing  4692 ms
              Event processing  17069 ms
Throughput:
            Warm-up processing  469.22 ms/event, 2.1312 events/s
              Event processing  170.696 ms/event, 5.85838 events/s
[bash][pcadp04]:traccc >
```

This is still a bit of a "Jonathan" vs. "Pink Lady" apple comparison. But it's not quite a matter of apples vs. oranges. :stuck_out_tongue:

You can also notice in these logs why I made the I/O updates that are also in this PR. So that I could pick up the humoungous ODD Geant4 files easily from outside of the `traccc` source directory.