### PR TITLE
Alpaka: Build correct workDiv for HIP devices.

### DIFF
--- a/device/alpaka/src/utils/utils.hpp
+++ b/device/alpaka/src/utils/utils.hpp
@@ -40,7 +40,8 @@ static constexpr std::size_t warpSize =
 template <typename TAcc>
 inline WorkDiv makeWorkDiv(Idx blocksPerGrid,
                            Idx threadsPerBlockOrElementsPerThread) {
-    if constexpr (::alpaka::accMatchesTags<TAcc, ::alpaka::TagGpuCudaRt>) {
+    if constexpr (::alpaka::accMatchesTags<TAcc, ::alpaka::TagGpuCudaRt> ||
+                  ::alpaka::accMatchesTags<TAcc, ::alpaka::TagGpuHipRt>) {
         const auto elementsPerThread = Idx{1};
         return WorkDiv{blocksPerGrid, threadsPerBlockOrElementsPerThread,
                        elementsPerThread};


### PR DESCRIPTION
This is a tiny change that was missed as part of the Alpaka HIP work.

Without it, we'd be making `workDiv`s for the CPU and attempting to run them on the GPU...which isn't ideal and obviously broke lots of things (in testing the HIP code would run part of the seeding before crashing, due to incorrectly formed spacepoint binning).

With this change, we now have HIP-backed Alpaka results working!
This is on a machine with a few AMD Instinct MI210, and 2  AMD EPYC 7F72 CPUs.

```
==> Statistics ... 
- read    10472 spacepoints from 1598 modules
- created  (cpu)  12264 seeds
- created (alpaka)  12264 seeds
==>Elapsed times...
            Hit reading  (cpu)  245 ms
              Seeding (alpaka)  29 ms
                Seeding  (cpu)  252 ms
         Track params (alpaka)  2 ms
           Track params  (cpu)  3 ms
                     Wall time  754 ms
```

This is just from the `seeding_example` at the moment, but will look at integrating with my other PR (#558) to get some more realistic numbers soon.

There is still an instability, where if compiled for debugging there is a crash...which I'm hoping is the same sort of crash that I'm hitting every so often in the Alpaka-CUDA version, so will be debugging separately. 
