### PR TITLE
ODD Strip Module Handling, main branch (2024.05.08.)

### DIFF
--- a/core/include/traccc/clusterization/impl/measurement_creation.ipp
+++ b/core/include/traccc/clusterization/impl/measurement_creation.ipp
@@ -98,7 +98,7 @@ TRACCC_HOST_DEVICE inline void fill_measurement(
         if (module.pixel.dimension == 1) {
             m.meas_dim = 1;
             m.local[1] = 0.f;
-            m.variance[1] = 1000.f;
+            m.variance[1] = module.pixel.variance_y;
         }
     }
 }

--- a/core/include/traccc/clusterization/impl/measurement_creation.ipp
+++ b/core/include/traccc/clusterization/impl/measurement_creation.ipp
@@ -93,6 +93,13 @@ TRACCC_HOST_DEVICE inline void fill_measurement(
 
         // For the ambiguity resolution algorithm, give a unique measurement ID
         m.measurement_id = measurement_index;
+
+        // Adjust the measurement object for 1D surfaces.
+        if (module.pixel.dimension == 1) {
+            m.meas_dim = 1;
+            m.local[1] = 0.f;
+            m.variance[1] = 1000.f;
+        }
     }
 }
 

--- a/core/include/traccc/geometry/pixel_data.hpp
+++ b/core/include/traccc/geometry/pixel_data.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -23,6 +23,7 @@ struct pixel_data {
     scalar min_center_y = 0.;
     scalar pitch_x = 1.;
     scalar pitch_y = 1.;
+    char dimension = 2;
 
     TRACCC_HOST_DEVICE
     vector2 get_pitch() const { return {pitch_x, pitch_y}; };

--- a/core/include/traccc/geometry/pixel_data.hpp
+++ b/core/include/traccc/geometry/pixel_data.hpp
@@ -19,11 +19,12 @@ namespace traccc {
 /// No checking on out of bounds done
 struct pixel_data {
 
-    scalar min_center_x = 0.;
-    scalar min_center_y = 0.;
-    scalar pitch_x = 1.;
-    scalar pitch_y = 1.;
+    scalar min_center_x = 0.f;
+    scalar min_center_y = 0.f;
+    scalar pitch_x = 1.f;
+    scalar pitch_y = 1.f;
     char dimension = 2;
+    scalar variance_y = 0.f;
 
     TRACCC_HOST_DEVICE
     vector2 get_pitch() const { return {pitch_x, pitch_y}; };

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -106,10 +106,16 @@ inline void aggregate_cluster(
     out.variance = var;
     out.surface_link = this_module.surface_link;
     out.module_link = module_link;
-    // The following will need to be filled properly "soon".
-    out.meas_dim = 2u;
     // Set a unique identifier for the measurement.
     out.measurement_id = link;
+    // Adjust the output object for 1D surfaces.
+    if (this_module.pixel.dimension == 1) {
+        out.meas_dim = 1;
+        out.local[1] = 0.f;
+        out.variance[1] = 1000.f;
+    } else {
+        out.meas_dim = 2;
+    }
 }
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -112,7 +112,7 @@ inline void aggregate_cluster(
     if (this_module.pixel.dimension == 1) {
         out.meas_dim = 1;
         out.local[1] = 0.f;
-        out.variance[1] = 1000.f;
+        out.variance[1] = this_module.pixel.variance_y;
     } else {
         out.meas_dim = 2;
     }

--- a/io/include/traccc/io/digitization_config.hpp
+++ b/io/include/traccc/io/digitization_config.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,6 +16,7 @@ namespace traccc {
 /// Type describing the digitization configuration of a detector module
 struct module_digitization_config {
     Acts::BinUtility segmentation;
+    char dimensions = 2;
 };
 
 /// Type describing the digitization configuration for the whole detector

--- a/io/include/traccc/io/digitization_config.hpp
+++ b/io/include/traccc/io/digitization_config.hpp
@@ -17,6 +17,7 @@ namespace traccc {
 struct module_digitization_config {
     Acts::BinUtility segmentation;
     char dimensions = 2;
+    float variance_y = 0.f;
 };
 
 /// Type describing the digitization configuration for the whole detector

--- a/io/src/csv/read_cells.cpp
+++ b/io/src/csv/read_cells.cpp
@@ -75,9 +75,14 @@ traccc::cell_module get_module(const std::uint64_t geometry_id,
 
         // Set the value on the module description.
         const auto& binning_data = geo_it->segmentation.binningData();
-        assert(binning_data.size() >= 2);
-        result.pixel = {binning_data[0].min, binning_data[1].min,
-                        binning_data[0].step, binning_data[1].step};
+        assert(binning_data.size() > 0);
+        result.pixel.min_center_x = binning_data[0].min;
+        result.pixel.pitch_x = binning_data[0].step;
+        if (binning_data.size() > 1) {
+            result.pixel.min_center_y = binning_data[1].min;
+            result.pixel.pitch_y = binning_data[1].step;
+        }
+        result.pixel.dimension = geo_it->dimensions;
     }
 
     return result;

--- a/io/src/csv/read_cells.cpp
+++ b/io/src/csv/read_cells.cpp
@@ -83,6 +83,7 @@ traccc::cell_module get_module(const std::uint64_t geometry_id,
             result.pixel.pitch_y = binning_data[1].step;
         }
         result.pixel.dimension = geo_it->dimensions;
+        result.pixel.variance_y = geo_it->variance_y;
     }
 
     return result;

--- a/io/src/read_digitization_config.cpp
+++ b/io/src/read_digitization_config.cpp
@@ -16,6 +16,7 @@
 #include <Acts/Plugins/Json/UtilitiesJsonConverter.hpp>
 
 // System include(s).
+#include <algorithm>
 #include <fstream>
 #include <string>
 
@@ -48,11 +49,13 @@ void from_json(const nlohmann::json& json, module_digitization_config& cfg) {
                 for (const auto& rms : jdata["rms"]) {
                     // A large RMS value associated to the second index happens
                     // to mean that this is a strip detector...
-                    if (rms > 1.0f) {
+                    const float frms = rms.get<float>();
+                    if (frms > 1.0f) {
                         cfg.dimensions = 1;
-                        return;
+                        cfg.variance_y = std::max(frms, cfg.variance_y);
                     }
                 }
+                break;
             }
         }
     }


### PR DESCRIPTION
As discussed many times recently, currently we are handling all modules / surfaces as pixels when reconstructing ODD data. Which leads to some funky behaviour in its short and long strips.

As discussed on Mattermost, we can use a sort of hacky way to determine which modules / surfaces are 1D and 2D, by looking at the variations assigned to their 2 dimensions. Since the digitization config always describes 2 dimensions for the surfaces, even for strip modules. (It's a long story...)

With the info added to `traccc::digitization_config` and then to `traccc::cell_module`, I could make the host and device measurement creation algorithms take this information into account.

It did not cause any significant changes in our host<->device agreement numbers, those just moved around a tiny bit. But also, this did not seem to break anything either... :wink:
