### PR TITLE
ROOT Build Fix, main branch (2024.05.13.)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,7 +55,8 @@
          "inherits": ["base"],
          "cacheVariables": {
             "TRACCC_USE_ROOT" : "TRUE",
-            "TRACCC_USE_SYSTEM_TBB" : "TRUE"
+            "TRACCC_USE_SYSTEM_TBB" : "TRUE",
+            "ALGEBRA_PLUGINS_USE_SYSTEM_VC" : "TRUE"
          }
       },
       {


### PR DESCRIPTION
Made the [ROOT](https://root.cern/) build use "System VC".

Any modern version of [ROOT](https://root.cern/) comes with both [TBB](https://github.com/oneapi-src/oneTBB) and [Vc](https://github.com/VcDevel/Vc) included. So our project should not build either of those things, when using [ROOT](https://root.cern/).

I came across this a couple of times already, but working on #582 was the last straw to finally do something about it. :thinking: