### PR TITLE
ref: Update to detray version 0.65.0

### DIFF
--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.64.1.tar.gz;URL_MD5;28b9a1a761a37536fe0b9ee3502a0aba"
+"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.65.0.tar.gz;URL_MD5;4bb0e3a489fea8e460223def1fcd01be"
    CACHE STRING "Source for Detray, when built as part of this project" )
 
 mark_as_advanced( TRACCC_DETRAY_SOURCE )


### PR DESCRIPTION
Mainly removes a few instances of too strict checking for the material and the stepper, as well as removing the transform for concentric cylinders and setting their boundary values correctly.

The material maps should now run by just adding the material map file to the detector reader