### PR TITLE
Algebra Plugins Update, main branch (2024.05.30.)

### DIFF
--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -204,9 +204,9 @@ struct track_state {
     bound_matrix m_jacobian =
         matrix_operator().template zero<e_bound_size, e_bound_size>();
     bound_track_parameters_type m_predicted;
-    scalar_type m_filtered_chi2;
+    scalar_type m_filtered_chi2 = 0.f;
     bound_track_parameters_type m_filtered;
-    scalar_type m_smoothed_chi2;
+    scalar_type m_smoothed_chi2 = 0.f;
     bound_track_parameters_type m_smoothed;
 };
 

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,7 +18,7 @@ message( STATUS "Building Algebra Plugins as part of the TRACCC project" )
 
 # Declare where to get Algebra Plugins from.
 set( TRACCC_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.22.0.tar.gz;URL_MD5;42bcaad8d19a2c773993a974816dfdf5"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.24.0.tar.gz;URL_MD5;e9b4c531c61d9988aae6cab95f257948"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 
 mark_as_advanced( TRACCC_ALGEBRA_PLUGINS_SOURCE )


### PR DESCRIPTION
Updated to using [algebra-plugins-v0.24.0](https://github.com/acts-project/algebra-plugins/releases/tag/v0.24.0).

This will pick up the recent vectorization capabilities, and compatibility with oneAPI 2024.1.0. The full changelog is: https://github.com/acts-project/algebra-plugins/compare/v0.22.0...v0.24.0