### PR TITLE
Add missing ACTS JSON dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ option( TRACCC_USE_SYSTEM_ACTS
    ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_ACTS )
    if( TRACCC_USE_SYSTEM_ACTS )
-      find_package( Acts REQUIRED )
+      find_package( Acts REQUIRED COMPONENTS PluginJson )
    else()
       add_subdirectory( extern/acts )
    endif()


### PR DESCRIPTION
As it stands, our CMake configuration imports ACTS without the JSON plugin component while our code depends on it. This can lead to some nasty build errors. This commit fixes the issue by correctly adding the JSON plugin dependency, allowing the build to fail early at configuration time.