### PR TITLE
Remove use of deprecated `std::is_pod` type trait

### DIFF
--- a/core/include/traccc/utils/array_wrapper.hpp
+++ b/core/include/traccc/utils/array_wrapper.hpp
@@ -29,7 +29,8 @@ struct pod<> {};
 
 template <typename T, typename... Ts>
 struct pod<T, Ts...> {
-    static_assert(std::is_pod_v<T>, "Types in POD-tuple must each be POD.");
+    static_assert(std::is_standard_layout_v<T> && std::is_trivial_v<T>,
+                  "Types in POD-tuple must each be POD.");
 
     T v;
     pod<Ts...> r;


### PR DESCRIPTION
The `std::is_pod` type trait has been deprecated in C++20. This commit replaces that type trait with its recommended equivalent, namely a conjunction of `std::is_trivial` and `std::is_standard_layout`.