### PR TITLE
Add concepts for barrier-like types

### DIFF
--- a/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
+++ b/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "traccc/definitions/hints.hpp"
 #include "traccc/definitions/qualifiers.hpp"
+#include "traccc/device/concepts/barrier.hpp"
 #include "traccc/edm/cell.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/edm/spacepoint.hpp"
@@ -86,7 +87,7 @@ struct ccl_kernel_helper {
 /// @param[out] measurements_view collection of measurements
 /// @param[out] cell_links    collection of links to measurements each cell is
 /// put into
-template <typename barrier_t>
+template <TRACCC_CONSTRAINT(device::concepts::barrier) barrier_t>
 TRACCC_DEVICE inline void ccl_kernel(
     details::index_t threadId, details::index_t blckDim, unsigned int blockId,
     const cell_collection_types::const_view cells_view,

--- a/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
@@ -32,7 +32,7 @@ namespace traccc::device {
 ///                     iteration.
 /// @param[in] barrier  A generic object for block-wide synchronisation
 ///
-template <typename barrier_t>
+template <TRACCC_CONSTRAINT(device::concepts::barrier) barrier_t>
 TRACCC_DEVICE void fast_sv_1(
     vecmem::device_vector<details::index_t>& f,
     vecmem::device_vector<details::index_t>& gf,
@@ -125,7 +125,7 @@ TRACCC_DEVICE void fast_sv_1(
     } while (barrier.blockOr(gf_changed));
 }
 
-template <typename barrier_t>
+template <TRACCC_CONSTRAINT(device::concepts::barrier) barrier_t>
 TRACCC_DEVICE inline void ccl_kernel(
     const details::index_t threadId, const details::index_t blckDim,
     const unsigned int blockId,

--- a/device/common/include/traccc/device/concepts/barrier.hpp
+++ b/device/common/include/traccc/device/concepts/barrier.hpp
@@ -1,0 +1,61 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/definitions/concepts.hpp"
+
+#if __cpp_concepts >= 201907L
+#include <concepts>
+#endif
+
+namespace traccc::device::concepts {
+#if __cpp_concepts >= 201907L
+/**
+ * @brief Concept to ensure that a type is barrier-like, i.e. it can
+ * synchronize threads in a compute block.
+ *
+ * @tparam T The barrier-like type.
+ */
+template <typename T>
+concept barrier = requires(T& b) {
+    /*
+     * Check for the general, nulary barrier function which simply synchronizes
+     * threads without return value.
+     */
+    { b.blockBarrier() }
+    ->std::same_as<void>;
+
+    /*
+     * Check for the unary boolean-argument synchronization functions.
+     */
+    requires requires(bool p) {
+        /*
+         * `blockOr` should return true iff one or more of the threads in the
+         * block issues the call with a truthful argument.
+         */
+        { b.blockOr(p) }
+        ->std::same_as<bool>;
+
+        /*
+         * `blockAnd` should return true iff all of the threads in the block
+         * issue the call with a truthful argument.
+         */
+        { b.blockAnd(p) }
+        ->std::same_as<bool>;
+
+        /*
+         * `blockCount` should return the number of threads subject to the
+         * barrier that issued the call with a truthful argument.
+         */
+        { b.blockCount(p) }
+        ->std::integral;
+    };
+};
+#endif
+}  // namespace traccc::device::concepts


### PR DESCRIPTION
This commit continues my eternal crusade against unconstrained template types. It lays the groundwork for using concepts in traccc, and it adds a concept for barrier-like objects which are used in the CCL kernels as well as, possibly, other kernels in the future.