### PR TITLE
GPU CI Updates, main branch (2024.05.31.)

### DIFF
--- a/.github/ci_setup.sh
+++ b/.github/ci_setup.sh
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022-2023 CERN for the benefit of the ACTS project
+# (c) 2022-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 #
@@ -13,6 +13,14 @@
 # The platform name.
 PLATFORM_NAME=$1
 
-# Make sure that GNU Make and CTest would use all available cores.
-export MAKEFLAGS="-j`nproc`"
-export CTEST_PARALLEL_LEVEL=`nproc`
+# Make sure that the build and CTest would use all available cores.
+export CMAKE_BUILD_PARALLEL_LEVEL=`nproc`
+export CTEST_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL}
+export MAKEFLAGS="-j${CMAKE_BUILD_PARALLEL_LEVEL}"
+
+# Set up the correct environment for the SYCL tests.
+if [ "${PLATFORM_NAME}" = "SYCL" ]; then
+   if [ -f "/opt/intel/oneapi/setvars.sh" ]; then
+      source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+   fi
+fi

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -31,11 +31,14 @@ jobs:
             container: ghcr.io/acts-project/ubuntu2004:v30
             options: -DTRACCC_USE_ROOT=FALSE
           - name: HIP
-            container: ghcr.io/acts-project/ubuntu2004_rocm:v42
+            container: ghcr.io/acts-project/ubuntu2004_rocm:47
             options: -DTRACCC_BUILD_HIP=TRUE -DTRACCC_SETUP_ROCTHRUST=TRUE
           - name: CUDA
-            container: ghcr.io/acts-project/ubuntu2004_cuda:v30
-            options: -DTRACCC_BUILD_CUDA=TRUE
+            container: ghcr.io/acts-project/ubuntu2004_cuda:47
+            options: -DTRACCC_BUILD_CUDA=TRUE -DTRACCC_ENABLE_NVTX_PROFILING=TRUE
+          - name: SYCL
+            container: ghcr.io/acts-project/ubuntu2004_oneapi:47
+            options: -DTRACCC_BUILD_SYCL=TRUE
           - name: KOKKOS
             container: ghcr.io/acts-project/ubuntu2004:v30
             options: -DTRACCC_BUILD_KOKKOS=TRUE
@@ -48,18 +51,13 @@ jobs:
         include:
           - platform:
               name: "SYCL"
-              container: "ghcr.io/acts-project/ubuntu2004_cuda_oneapi:v37"
+              container: ghcr.io/acts-project/ubuntu2004_cuda_oneapi:47
               options: -DTRACCC_BUILD_SYCL=TRUE -DTRACCC_BUILD_CUDA=FALSE -DVECMEM_BUILD_CUDA_LIBRARY=FALSE
             build: Release
           - platform:
               name: "SYCL"
-              container: "ghcr.io/acts-project/ubuntu2004_rocm_oneapi:v37"
+              container: ghcr.io/acts-project/ubuntu2004_rocm_oneapi:47
               options: -DTRACCC_BUILD_SYCL=TRUE -DVECMEM_BUILD_HIP_LIBRARY=FALSE
-            build: Release
-          - platform:
-              name: "CUDA"
-              container: ghcr.io/acts-project/ubuntu2004_cuda:v30
-              options: -DTRACCC_BUILD_CUDA=TRUE -DTRACCC_ENABLE_NVTX_PROFILING=TRUE
             build: Release
     # Use BASH as the shell from the images.
     defaults:


### PR DESCRIPTION
Switched the "GPU builds" to the latest Acts Docker images. At the same time I removed a CUDA build that I just didn't understand why we had. :confused: I just enabled `-DTRACCC_ENABLE_NVTX_PROFILING=TRUE` for our "standard" Release and Debug CUDA build instead.

I instead added a oneAPI based build with an Intel backend. Since until now we've only been testing the build for NVIDIA and AMD backends in the CI for some reason. :confused: While the Intel backend allows us to do both Release and Debug builds, which should be good for the CI's test coverage. :thinking: (The NVIDIA and AMD backends still have issues with `assert(...)` calls unfortunately. :frowning: Making Debug builds impossible with them.)

The big goal here is to finally revive #442, which should (hopefully...) start working with this new setup. :thinking: