### PR TITLE
Add a simple spinlock mutex type

### DIFF
--- a/device/common/include/traccc/device/impl/mutex.ipp
+++ b/device/common/include/traccc/device/impl/mutex.ipp
@@ -1,0 +1,48 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cassert>
+#include <vecmem/memory/device_atomic_ref.hpp>
+
+namespace traccc::device {
+template <typename T>
+mutex<T>::mutex(T& p) : m_atomic(p) {}
+
+template <typename T>
+mutex<T>::mutex(const vecmem::device_atomic_ref<T>& r) : m_atomic(r) {}
+
+template <typename T>
+void mutex<T>::lock() {
+    while (!try_lock())
+        ;
+}
+
+template <typename T>
+bool mutex<T>::try_lock() {
+    assert(!m_is_locked);
+
+    T false_v = static_cast<T>(false);
+    bool s = m_atomic.compare_exchange_strong(false_v, static_cast<T>(true),
+                                              vecmem::memory_order::acquire);
+
+#ifndef NDEBUG
+    m_is_locked |= s;
+#endif
+
+    return s;
+}
+
+template <typename T>
+void mutex<T>::unlock() {
+    assert(m_is_locked);
+
+    m_atomic.store(static_cast<T>(false), vecmem::memory_order::release);
+}
+}  // namespace traccc::device

--- a/device/common/include/traccc/device/impl/unique_lock.ipp
+++ b/device/common/include/traccc/device/impl/unique_lock.ipp
@@ -1,0 +1,65 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::device {
+template <typename Mutex>
+TRACCC_HOST_DEVICE unique_lock<Mutex>::unique_lock(mutex_type& m,
+                                                   std::defer_lock_t) {
+    m_mutex_ptr = &m;
+    m_owns_lock = false;
+}
+
+template <typename Mutex>
+TRACCC_HOST_DEVICE unique_lock<Mutex>::unique_lock(mutex_type& m,
+                                                   std::try_to_lock_t) {
+    m_mutex_ptr = &m;
+    m_owns_lock = m_mutex_ptr->try_lock();
+}
+
+template <typename Mutex>
+TRACCC_HOST_DEVICE unique_lock<Mutex>::unique_lock(mutex_type& m,
+                                                   std::adopt_lock_t) {
+    m_mutex_ptr = &m;
+    m_owns_lock = true;
+}
+
+template <typename Mutex>
+TRACCC_HOST_DEVICE unique_lock<Mutex>::~unique_lock() {
+    if (m_owns_lock) {
+        m_mutex_ptr->unlock();
+    }
+}
+
+template <typename Mutex>
+TRACCC_HOST_DEVICE void unique_lock<Mutex>::lock() {
+    assert(!m_owns_lock);
+    m_mutex_ptr->lock();
+    m_owns_lock = true;
+}
+
+template <typename Mutex>
+TRACCC_HOST_DEVICE bool unique_lock<Mutex>::try_lock() {
+    assert(!m_owns_lock);
+    m_owns_lock = m_mutex_ptr->try_lock();
+    return m_owns_lock;
+}
+
+template <typename Mutex>
+TRACCC_HOST_DEVICE void unique_lock<Mutex>::unlock() {
+    assert(m_owns_lock);
+    m_mutex_ptr->unlock();
+    m_owns_lock = false;
+}
+
+template <typename Mutex>
+TRACCC_HOST_DEVICE bool unique_lock<Mutex>::owns_lock() const {
+    return m_owns_lock;
+}
+}  // namespace traccc::device

--- a/device/common/include/traccc/device/mutex.hpp
+++ b/device/common/include/traccc/device/mutex.hpp
@@ -1,0 +1,77 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vecmem/memory/device_atomic_ref.hpp>
+
+#include "traccc/definitions/qualifiers.hpp"
+
+namespace traccc::device {
+/*
+ * A mutex object over type T.
+ *
+ * @warning This class assumes that the value is written to _only_ by mutex
+ * class objects. Writing to the given pointers or atomic references in any
+ * other way is undefined behaviour. Furthermore, it is assumed that the
+ * initial value of the underlying pointer is false.
+ *
+ * @warning This is a spinlock. Do not use when more efficient implementations
+ * are available.
+ */
+template <typename T = uint32_t>
+class mutex {
+    public:
+    /*
+     * Construct a mutex from a pointer.
+     */
+    TRACCC_HOST_DEVICE
+    mutex(T &);
+
+    /*
+     * Construct a mutex from a vecmem atomic reference.
+     */
+    TRACCC_HOST_DEVICE
+    mutex(const vecmem::device_atomic_ref<T> &);
+
+    /*
+     * Attempt to acquire a lock on the mutex. This method spins until a lock
+     * is acquired.
+     *
+     * @warning On lockstep devices, only one thread per thread group (e.g.
+     * warp) should call this function!
+     */
+    TRACCC_HOST_DEVICE
+    void lock();
+
+    /*
+     * Try to acquire a lock on the mutex, returning whether the operation
+     * succeeded or not. */
+    TRACCC_HOST_DEVICE
+    bool try_lock();
+
+    /*
+     * Unlock the mutex.
+     *
+     * @warning Using this method on a mutex that is not locked is undefined
+     * behaviour.
+     */
+    TRACCC_HOST_DEVICE
+    void unlock();
+
+    private:
+    const vecmem::device_atomic_ref<T> m_atomic;
+
+#ifndef NDEBUG
+    bool m_is_locked = false;
+#endif
+};
+}  // namespace traccc::device
+
+#include "impl/mutex.ipp"

--- a/device/common/include/traccc/device/unique_lock.hpp
+++ b/device/common/include/traccc/device/unique_lock.hpp
@@ -1,0 +1,75 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <mutex>
+
+#include "traccc/definitions/qualifiers.hpp"
+
+namespace traccc::device {
+template <typename Mutex>
+class unique_lock {
+    public:
+    using mutex_type = Mutex;
+
+    /*
+     * Construct a unique lock without locking.
+     */
+    TRACCC_HOST_DEVICE
+    unique_lock(mutex_type& m, std::defer_lock_t);
+
+    /*
+     * Construct a unique lock, attempting to lock it.
+     */
+    TRACCC_HOST_DEVICE
+    unique_lock(mutex_type& m, std::try_to_lock_t);
+
+    /*
+     * Construct a unique lock which was previously locked.
+     */
+    TRACCC_HOST_DEVICE
+    unique_lock(mutex_type& m, std::adopt_lock_t);
+
+    /*
+     * Destroy a lock, freeing the underlying mutex.
+     */
+    TRACCC_HOST_DEVICE
+    ~unique_lock();
+
+    /*
+     * Lock the lock, blocking until the operation succeeds.
+     */
+    TRACCC_HOST_DEVICE
+    void lock();
+
+    /*
+     * Try to lock the lock without blocking.
+     */
+    TRACCC_HOST_DEVICE
+    bool try_lock();
+
+    /*
+     * Explicitly lock the underlying lock.
+     */
+    TRACCC_HOST_DEVICE
+    void unlock();
+
+    /*
+     * Check if the lock is locked by this object.
+     */
+    TRACCC_HOST_DEVICE
+    bool owns_lock() const;
+
+    private:
+    mutex_type* m_mutex_ptr = nullptr;
+    bool m_owns_lock;
+};
+}  // namespace traccc::device
+
+#include "impl/unique_lock.ipp"

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -40,6 +40,8 @@ traccc_add_test(
     test_thrust.cu
     test_sync.cu
     test_array_wrapper.cu
+    test_mutex.cu
+    test_unique_lock.cu
 
     LINK_LIBRARIES
     CUDA::cudart

--- a/tests/cuda/test_mutex.cu
+++ b/tests/cuda/test_mutex.cu
@@ -1,0 +1,48 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <vecmem/memory/cuda/managed_memory_resource.hpp>
+#include <vecmem/memory/unique_ptr.hpp>
+
+#include "../../device/cuda/src/utils/cuda_error_handling.hpp"
+#include "traccc/device/mutex.hpp"
+
+__global__ void mutex_add_kernel(uint32_t *out, uint32_t *lock) {
+    traccc::device::mutex m(*lock);
+
+    if (threadIdx.x == 0) {
+        m.lock();
+        uint32_t tmp = *out;
+        tmp += 1;
+        *out = tmp;
+        m.unlock();
+    }
+}
+
+TEST(CUDAMutex, MassAdditionKernel) {
+    vecmem::cuda::managed_memory_resource mr;
+
+    vecmem::unique_alloc_ptr<uint32_t> out =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+    vecmem::unique_alloc_ptr<uint32_t> lock =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+
+    TRACCC_CUDA_ERROR_CHECK(cudaMemset(lock.get(), 0, sizeof(uint32_t)));
+
+    uint32_t n_blocks = 262144;
+    uint32_t n_threads = 32;
+
+    mutex_add_kernel<<<n_blocks, n_threads>>>(out.get(), lock.get());
+
+    TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+    TRACCC_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+
+    EXPECT_EQ(n_blocks, *out.get());
+}

--- a/tests/cuda/test_unique_lock.cu
+++ b/tests/cuda/test_unique_lock.cu
@@ -1,0 +1,128 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <mutex>
+#include <vecmem/memory/cuda/managed_memory_resource.hpp>
+#include <vecmem/memory/unique_ptr.hpp>
+
+#include "../../device/cuda/src/utils/cuda_error_handling.hpp"
+#include "traccc/device/mutex.hpp"
+#include "traccc/device/unique_lock.hpp"
+
+__global__ void unique_lock_add_kernel_try_lock(uint32_t *out,
+                                                uint32_t *_lock) {
+    traccc::device::mutex m(*_lock);
+
+    if (threadIdx.x == 0) {
+        traccc::device::unique_lock lock(m, std::try_to_lock);
+
+        if (!lock.owns_lock()) {
+            lock.lock();
+        }
+
+        uint32_t tmp = *out;
+        tmp += 1;
+        *out = tmp;
+    }
+}
+
+__global__ void unique_lock_add_kernel_defer_lock(uint32_t *out,
+                                                  uint32_t *_lock) {
+    traccc::device::mutex m(*_lock);
+    traccc::device::unique_lock lock(m, std::defer_lock);
+
+    if (threadIdx.x == 0) {
+        lock.lock();
+
+        uint32_t tmp = *out;
+        tmp += 1;
+        *out = tmp;
+    }
+}
+
+__global__ void unique_lock_add_kernel_adopt_lock(uint32_t *out,
+                                                  uint32_t *_lock) {
+    traccc::device::mutex m(*_lock);
+
+    if (threadIdx.x == 0) {
+        m.lock();
+        traccc::device::unique_lock lock(m, std::adopt_lock);
+
+        uint32_t tmp = *out;
+        tmp += 1;
+        *out = tmp;
+    }
+}
+
+TEST(CUDAUniqueLock, MassAdditionKernelTryLock) {
+    vecmem::cuda::managed_memory_resource mr;
+
+    vecmem::unique_alloc_ptr<uint32_t> out =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+    vecmem::unique_alloc_ptr<uint32_t> lock =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+
+    TRACCC_CUDA_ERROR_CHECK(cudaMemset(lock.get(), 0, sizeof(uint32_t)));
+
+    uint32_t n_blocks = 262144;
+    uint32_t n_threads = 32;
+
+    unique_lock_add_kernel_try_lock<<<n_blocks, n_threads>>>(out.get(),
+                                                             lock.get());
+
+    TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+    TRACCC_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+
+    EXPECT_EQ(n_blocks, *out.get());
+}
+
+TEST(CUDAUniqueLock, MassAdditionKernelDeferLock) {
+    vecmem::cuda::managed_memory_resource mr;
+
+    vecmem::unique_alloc_ptr<uint32_t> out =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+    vecmem::unique_alloc_ptr<uint32_t> lock =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+
+    TRACCC_CUDA_ERROR_CHECK(cudaMemset(lock.get(), 0, sizeof(uint32_t)));
+
+    uint32_t n_blocks = 262144;
+    uint32_t n_threads = 32;
+
+    unique_lock_add_kernel_defer_lock<<<n_blocks, n_threads>>>(out.get(),
+                                                               lock.get());
+
+    TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+    TRACCC_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+
+    EXPECT_EQ(n_blocks, *out.get());
+}
+
+TEST(CUDAUniqueLock, MassAdditionKernelAdoptLock) {
+    vecmem::cuda::managed_memory_resource mr;
+
+    vecmem::unique_alloc_ptr<uint32_t> out =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+    vecmem::unique_alloc_ptr<uint32_t> lock =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+
+    TRACCC_CUDA_ERROR_CHECK(cudaMemset(lock.get(), 0, sizeof(uint32_t)));
+
+    uint32_t n_blocks = 262144;
+    uint32_t n_threads = 32;
+
+    unique_lock_add_kernel_adopt_lock<<<n_blocks, n_threads>>>(out.get(),
+                                                               lock.get());
+
+    TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+    TRACCC_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+
+    EXPECT_EQ(n_blocks, *out.get());
+}

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -16,6 +16,8 @@ traccc_add_test(
     test_clusterization.sycl
     test_spacepoint_formation.sycl
     test_barrier.sycl
+    test_mutex.sycl
+    test_unique_lock.sycl
 
     LINK_LIBRARIES
     GTest::gtest_main

--- a/tests/sycl/test_mutex.sycl
+++ b/tests/sycl/test_mutex.sycl
@@ -1,0 +1,52 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <CL/sycl.hpp>
+#include <vecmem/memory/sycl/shared_memory_resource.hpp>
+#include <vecmem/memory/unique_ptr.hpp>
+
+#include "traccc/device/mutex.hpp"
+
+TEST(SYCLMutex, MassAdditionKernel) {
+    vecmem::sycl::shared_memory_resource mr;
+    cl::sycl::queue queue;
+
+    vecmem::unique_alloc_ptr<uint32_t> out =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+    vecmem::unique_alloc_ptr<uint32_t> lock =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+
+    queue.memset(lock.get(), 0, sizeof(uint32_t)).wait_and_throw();
+
+    uint32_t n_blocks = 262144;
+    uint32_t n_threads = 32;
+
+    cl::sycl::nd_range test_range(cl::sycl::range<1>(n_blocks * n_threads),
+                                  cl::sycl::range<1>(n_threads));
+
+    queue
+        .submit([&, out = out.get(), lock = lock.get()](cl::sycl::handler &h) {
+            h.parallel_for<class MassAdditionTest>(
+                test_range, [=](cl::sycl::nd_item<1> item) {
+                    traccc::device::mutex m(*lock);
+
+                    if (item.get_local_id() == 0) {
+                        m.lock();
+                        uint32_t tmp = *out;
+                        tmp += 1;
+                        *out = tmp;
+                        m.unlock();
+                    }
+                });
+        })
+        .wait_and_throw();
+
+    EXPECT_EQ(n_blocks, *out.get());
+}

--- a/tests/sycl/test_unique_lock.sycl
+++ b/tests/sycl/test_unique_lock.sycl
@@ -1,0 +1,133 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <CL/sycl.hpp>
+#include <vecmem/memory/sycl/shared_memory_resource.hpp>
+#include <vecmem/memory/unique_ptr.hpp>
+
+#include "traccc/device/mutex.hpp"
+#include "traccc/device/unique_lock.hpp"
+
+TEST(SYCLUniqueLock, MassAdditionKernelTryLock) {
+    vecmem::sycl::shared_memory_resource mr;
+    cl::sycl::queue queue;
+
+    vecmem::unique_alloc_ptr<uint32_t> out =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+    vecmem::unique_alloc_ptr<uint32_t> lock =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+
+    queue.memset(lock.get(), 0, sizeof(uint32_t)).wait_and_throw();
+
+    uint32_t n_blocks = 262144;
+    uint32_t n_threads = 32;
+
+    cl::sycl::nd_range test_range(cl::sycl::range<1>(n_blocks * n_threads),
+                                  cl::sycl::range<1>(n_threads));
+
+    queue
+        .submit([&, out = out.get(), _lock = lock.get()](cl::sycl::handler &h) {
+            h.parallel_for<class MassAdditionTryLockTest>(
+                test_range, [=](cl::sycl::nd_item<1> item) {
+                    traccc::device::mutex m(*_lock);
+
+                    if (item.get_local_id() == 0) {
+                        traccc::device::unique_lock lock(m, std::try_to_lock);
+
+                        if (!lock.owns_lock()) {
+                            lock.lock();
+                        }
+
+                        uint32_t tmp = *out;
+                        tmp += 1;
+                        *out = tmp;
+                    }
+                });
+        })
+        .wait_and_throw();
+
+    EXPECT_EQ(n_blocks, *out.get());
+}
+
+TEST(SYCLUniqueLock, MassAdditionKernelDeferLock) {
+    vecmem::sycl::shared_memory_resource mr;
+    cl::sycl::queue queue;
+
+    vecmem::unique_alloc_ptr<uint32_t> out =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+    vecmem::unique_alloc_ptr<uint32_t> lock =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+
+    queue.memset(lock.get(), 0, sizeof(uint32_t)).wait_and_throw();
+
+    uint32_t n_blocks = 262144;
+    uint32_t n_threads = 32;
+
+    cl::sycl::nd_range test_range(cl::sycl::range<1>(n_blocks * n_threads),
+                                  cl::sycl::range<1>(n_threads));
+
+    queue
+        .submit([&, out = out.get(), _lock = lock.get()](cl::sycl::handler &h) {
+            h.parallel_for<class MassAdditionDeferLockTest>(
+                test_range, [=](cl::sycl::nd_item<1> item) {
+                    traccc::device::mutex m(*_lock);
+                    traccc::device::unique_lock lock(m, std::defer_lock);
+
+                    if (item.get_local_id() == 0) {
+                        lock.lock();
+
+                        uint32_t tmp = *out;
+                        tmp += 1;
+                        *out = tmp;
+                    }
+                });
+        })
+        .wait_and_throw();
+
+    EXPECT_EQ(n_blocks, *out.get());
+}
+
+TEST(SYCLUniqueLock, MassAdditionKernelAdoptLock) {
+    vecmem::sycl::shared_memory_resource mr;
+    cl::sycl::queue queue;
+
+    vecmem::unique_alloc_ptr<uint32_t> out =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+    vecmem::unique_alloc_ptr<uint32_t> lock =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+
+    queue.memset(lock.get(), 0, sizeof(uint32_t)).wait_and_throw();
+
+    uint32_t n_blocks = 262144;
+    uint32_t n_threads = 32;
+
+    cl::sycl::nd_range test_range(cl::sycl::range<1>(n_blocks * n_threads),
+                                  cl::sycl::range<1>(n_threads));
+
+    queue
+        .submit([&, out = out.get(), _lock = lock.get()](cl::sycl::handler &h) {
+            h.parallel_for<class MassAdditionAdoptLockTest>(
+                test_range, [=](cl::sycl::nd_item<1> item) {
+                    traccc::device::mutex m(*_lock);
+
+                    if (item.get_local_id() == 0) {
+                        m.lock();
+                        traccc::device::unique_lock lock(m, std::adopt_lock);
+
+                        uint32_t tmp = *out;
+                        tmp += 1;
+                        *out = tmp;
+                    }
+                });
+        })
+        .wait_and_throw();
+
+    EXPECT_EQ(n_blocks, *out.get());
+}


### PR DESCRIPTION
In order to facilitate some edge case handling in device code, this commit adds a very simple spinlock-type mutex using vecmem atomic references.