### PR TITLE
Add sanity checks for contiguity and orderedness

### DIFF
--- a/core/include/traccc/finding/finding_algorithm.ipp
+++ b/core/include/traccc/finding/finding_algorithm.ipp
@@ -7,6 +7,8 @@
 
 // Project include(s).
 #include "traccc/finding/candidate_link.hpp"
+#include "traccc/sanity/contiguous_on.hpp"
+#include "traccc/utils/projections.hpp"
 
 // detray include(s).
 #include "detray/geometry/barcode.hpp"
@@ -28,6 +30,10 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
     /*****************************************************************
      * Measurement Operations
      *****************************************************************/
+
+    // Check contiguity of the measurements
+    assert(host::is_contiguous_on(measurement_module_projection(),
+                                  vecmem::get_data(measurements)));
 
     // Get copy of barcode uniques
     std::vector<measurement> uniques;

--- a/core/include/traccc/sanity/contiguous_on.hpp
+++ b/core/include/traccc/sanity/contiguous_on.hpp
@@ -1,0 +1,94 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/concepts.hpp"
+
+// VecMem include(s).
+#include <memory>
+#include <vecmem/containers/data/vector_view.hpp>
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/utils/copy.hpp>
+
+// System include
+#if __cpp_concepts >= 201907L
+#include <concepts>
+#endif
+#include <memory>
+#include <unordered_set>
+
+namespace traccc::host {
+/**
+ * @brief Sanity check that a given vector is contiguous on a given projection.
+ *
+ * For a vector $v$ to be contiguous on a projection $\pi$, it must be the case
+ * that for all indices $i$ and $j$, if $v_i = v_j$, then all indices $k$
+ * between $i$ and $j$, $v_i = v_j = v_k$.
+ *
+ * @note This function runs in O(n^2) time.
+ *
+ * @tparam P The type of projection $\pi$, a callable which returns some
+ * comparable type.
+ * @tparam T The type of the vector.
+ * @param projection A projection object of type `P`.
+ * @param mr A memory resource used for allocating intermediate memory.
+ * @param vector The vector which to check for contiguity.
+ * @return true If the vector is contiguous on `P`.
+ * @return false Otherwise.
+ */
+template <TRACCC_CONSTRAINT(std::semiregular) P,
+          TRACCC_CONSTRAINT(std::equality_comparable) T>
+#if __cpp_concepts >= 201907L
+requires std::regular_invocable<P, T>
+#endif
+    bool is_contiguous_on(P&& projection, vecmem::data::vector_view<T> vector) {
+    // Grab the number of elements in our vector.
+    uint32_t n = vector.size();
+
+    // Get the output type of the projection.
+    using projection_t = std::invoke_result_t<P, T>;
+
+    // Allocate memory for intermediate values and outputs, then set them up.
+    std::unique_ptr<projection_t[]> iout = std::make_unique<projection_t[]>(n);
+    uint32_t iout_size = 0;
+
+    // Create a device vector
+    vecmem::device_vector<T> in(vector);
+
+    // Compress adjacent elements
+    for (std::size_t i = 0; i < n; ++i) {
+        if (i == 0) {
+            iout[iout_size++] = projection(in.at(i));
+        } else {
+            projection_t v = projection(in.at(i));
+
+            if (v != iout[iout_size - 1]) {
+                iout[iout_size++] = v;
+            }
+        }
+    }
+
+    // Check whether all elements are unique
+    std::unordered_set<projection_t> seen;
+
+    for (std::size_t i = 0; i < iout_size; ++i) {
+        projection_t& v = iout[i];
+
+        if (seen.count(v) == 1) {
+            return false;
+        } else {
+            seen.insert(v);
+        }
+    }
+
+    return true;
+}
+}  // namespace traccc::host

--- a/core/include/traccc/utils/projections.hpp
+++ b/core/include/traccc/utils/projections.hpp
@@ -1,0 +1,29 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/cell.hpp"
+#include "traccc/edm/measurement.hpp"
+
+namespace traccc {
+struct [[maybe_unused]] cell_module_projection{
+    TRACCC_HOST_DEVICE [[maybe_unused]] auto operator()(const traccc::cell& m)
+        const {return m.module_link;
+}
+}
+;
+
+struct [[maybe_unused]] measurement_module_projection{
+    TRACCC_HOST_DEVICE auto operator()(const traccc::measurement& m)
+        const {return m.module_link;
+}
+}
+;
+}  // namespace traccc

--- a/core/include/traccc/utils/relations.hpp
+++ b/core/include/traccc/utils/relations.hpp
@@ -1,0 +1,34 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/cell.hpp"
+
+namespace traccc {
+struct [[maybe_unused]] channel0_major_cell_order_relation{
+    TRACCC_HOST_DEVICE [[maybe_unused]] bool operator()(const traccc::cell& a,
+                                                        const traccc::cell& b)
+        const {if (a.module_link ==
+                   b.module_link){if (a.channel1 <= b.channel1){return true;
+}
+else if (a.channel1 == b.channel1) {
+    return a.channel0 <= b.channel0;
+}
+else {
+    return false;
+}
+}
+else {
+    return true;
+}
+}
+}
+;
+}  // namespace traccc

--- a/core/src/clusterization/sparse_ccl_algorithm.cpp
+++ b/core/src/clusterization/sparse_ccl_algorithm.cpp
@@ -9,6 +9,10 @@
 #include "traccc/clusterization/sparse_ccl_algorithm.hpp"
 
 #include "traccc/clusterization/details/sparse_ccl.hpp"
+#include "traccc/sanity/contiguous_on.hpp"
+#include "traccc/sanity/ordered_on.hpp"
+#include "traccc/utils/projections.hpp"
+#include "traccc/utils/relations.hpp"
 
 // VecMem include(s).
 #include <vecmem/containers/device_vector.hpp>
@@ -21,6 +25,9 @@ sparse_ccl_algorithm::sparse_ccl_algorithm(vecmem::memory_resource& mr)
 
 sparse_ccl_algorithm::output_type sparse_ccl_algorithm::operator()(
     const cell_collection_types::const_view& cells_view) const {
+
+    assert(is_contiguous_on(cell_module_projection(), cells_view));
+    assert(is_ordered_on(channel0_major_cell_order_relation(), cells_view));
 
     // Run SparseCCL to fill CCL indices.
     const cell_collection_types::const_device cells{cells_view};

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -28,6 +28,8 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/utils/opaque_stream.cpp"
   "src/utils/utils.hpp"
   "src/utils/utils.cpp"
+  "src/sanity/contiguous_on.cuh"
+  "src/sanity/ordered_on.cuh"
   # Seed finding code.
   "include/traccc/cuda/seeding/track_params_estimation.hpp"
   "src/seeding/track_params_estimation.cu"

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -6,10 +6,14 @@
  */
 
 // CUDA Library include(s).
+#include "../sanity/contiguous_on.cuh"
+#include "../sanity/ordered_on.cuh"
 #include "../utils/barrier.hpp"
 #include "../utils/cuda_error_handling.hpp"
 #include "../utils/utils.hpp"
 #include "traccc/cuda/clusterization/clusterization_algorithm.hpp"
+#include "traccc/utils/projections.hpp"
+#include "traccc/utils/relations.hpp"
 
 // Project include(s)
 #include "traccc/clusterization/device/ccl_kernel.hpp"
@@ -59,6 +63,11 @@ clusterization_algorithm::clusterization_algorithm(
 clusterization_algorithm::output_type clusterization_algorithm::operator()(
     const cell_collection_types::const_view& cells,
     const cell_module_collection_types::const_view& modules) const {
+
+    assert(is_contiguous_on(cell_module_projection(), m_mr.main, m_copy,
+                            m_stream, cells));
+    assert(is_ordered_on(channel0_major_cell_order_relation(), m_mr.main,
+                         m_copy, m_stream, cells));
 
     // Get a convenience variable for the stream that we'll be using.
     cudaStream_t stream = details::get_stream(m_stream);

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -6,10 +6,12 @@
  */
 
 // Project include(s).
+#include "../sanity/contiguous_on.cuh"
 #include "../utils/cuda_error_handling.hpp"
 #include "../utils/utils.hpp"
 #include "traccc/cuda/finding/finding_algorithm.hpp"
 #include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/device/finding_global_counter.hpp"
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/finding/device/add_links_for_holes.hpp"
@@ -20,6 +22,7 @@
 #include "traccc/finding/device/make_barcode_sequence.hpp"
 #include "traccc/finding/device/propagate_to_next_surface.hpp"
 #include "traccc/finding/device/prune_tracks.hpp"
+#include "traccc/utils/projections.hpp"
 
 // detray include(s).
 #include "detray/core/detector.hpp"
@@ -43,10 +46,10 @@
 #include <thrust/unique.h>
 
 // System include(s).
+#include <cassert>
 #include <vector>
 
 namespace traccc::cuda {
-
 namespace kernels {
 
 /// CUDA kernel for running @c traccc::device::make_barcode_sequence
@@ -269,6 +272,9 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 
     measurement_collection_types::const_view::size_type n_measurements =
         m_copy.get_size(measurements);
+
+    assert(is_contiguous_on(measurement_module_projection(), m_mr.main, m_copy,
+                            m_stream, measurements));
 
     // Get copy of barcode uniques
     measurement_collection_types::buffer uniques_buffer{n_measurements,

--- a/device/cuda/src/sanity/contiguous_on.cuh
+++ b/device/cuda/src/sanity/contiguous_on.cuh
@@ -1,0 +1,162 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "../utils/cuda_error_handling.hpp"
+#include "traccc/cuda/utils/stream.hpp"
+#include "traccc/definitions/concepts.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/memory/unique_ptr.hpp>
+#include <vecmem/utils/copy.hpp>
+
+// CUDA include
+#include <cuda_runtime.h>
+
+// System include
+#if __cpp_concepts >= 201907L
+#include <concepts>
+#endif
+
+namespace traccc::cuda {
+namespace kernels {
+template <TRACCC_CONSTRAINT(std::semiregular) P, typename T, typename S>
+#if __cpp_concepts >= 201907L
+requires std::regular_invocable<P, T>
+#endif
+    __global__ void compress_adjacent(P projection,
+                                      vecmem::data::vector_view<T> _in, S* out,
+                                      uint32_t* out_size) {
+    int tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+    vecmem::device_vector<T> in(_in);
+
+    if (tid > 0 && tid < in.size()) {
+        std::invoke_result_t<P, T> v1 = projection(in.at(tid - 1));
+        std::invoke_result_t<P, T> v2 = projection(in.at(tid));
+
+        if (v1 != v2) {
+            out[atomicAdd(out_size, 1u)] = v2;
+        }
+    } else if (tid == 0) {
+        out[atomicAdd(out_size, 1u)] = projection(in.at(tid));
+    }
+}
+
+template <TRACCC_CONSTRAINT(std::equality_comparable) T>
+__global__ void all_unique(const T* in, const size_t n, bool* out) {
+    int tid_x = threadIdx.x + blockIdx.x * blockDim.x;
+    int tid_y = threadIdx.y + blockIdx.y * blockDim.y;
+
+    if (tid_x < n && tid_y < n && tid_x != tid_y && in[tid_x] == in[tid_y]) {
+        *out = false;
+    }
+}
+}  // namespace kernels
+
+/**
+ * @brief Sanity check that a given vector is contiguous on a given projection.
+ *
+ * For a vector $v$ to be contiguous on a projection $\pi$, it must be the case
+ * that for all indices $i$ and $j$, if $v_i = v_j$, then all indices $k$
+ * between $i$ and $j$, $v_i = v_j = v_k$.
+ *
+ * @note This function runs in O(n^2) time.
+ *
+ * @tparam P The type of projection $\pi$, a callable which returns some
+ * comparable type.
+ * @tparam T The type of the vector.
+ * @param projection A projection object of type `P`.
+ * @param mr A memory resource used for allocating intermediate memory.
+ * @param vector The vector which to check for contiguity.
+ * @return true If the vector is contiguous on `P`.
+ * @return false Otherwise.
+ */
+template <TRACCC_CONSTRAINT(std::semiregular) P,
+          TRACCC_CONSTRAINT(std::equality_comparable) T>
+#if __cpp_concepts >= 201907L
+requires std::regular_invocable<P, T>
+#endif
+    bool is_contiguous_on(P&& projection, vecmem::memory_resource& mr,
+                          vecmem::copy& copy, stream& stream,
+                          vecmem::data::vector_view<T> vector) {
+    // This should never be a performance-critical step, so we can keep the
+    // block size fixed.
+    constexpr int block_size = 512;
+    constexpr int block_size_2d = 32;
+
+    cudaStream_t cuda_stream =
+        reinterpret_cast<cudaStream_t>(stream.cudaStream());
+
+    // Grab the number of elements in our vector.
+    uint32_t n = copy.get_size(vector);
+
+    // Get the output type of the projection.
+    using projection_t = std::invoke_result_t<P, T>;
+
+    // Allocate memory for intermediate values and outputs, then set them up.
+    vecmem::unique_alloc_ptr<projection_t[]> iout =
+        vecmem::make_unique_alloc<projection_t[]>(mr, n);
+    vecmem::unique_alloc_ptr<uint32_t> iout_size =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+    vecmem::unique_alloc_ptr<bool> out = vecmem::make_unique_alloc<bool>(mr);
+
+    uint32_t initial_iout_size = 0;
+    bool initial_out = true;
+
+    TRACCC_CUDA_ERROR_CHECK(
+        cudaMemcpyAsync(iout_size.get(), &initial_iout_size, sizeof(uint32_t),
+                        cudaMemcpyHostToDevice, cuda_stream));
+    TRACCC_CUDA_ERROR_CHECK(
+        cudaMemcpyAsync(out.get(), &initial_out, sizeof(bool),
+                        cudaMemcpyHostToDevice, cuda_stream));
+
+    // Launch the first kernel, which will squash consecutive equal elements
+    // into one element.
+    kernels::compress_adjacent<P, T, projection_t>
+        <<<(n + block_size - 1) / block_size, block_size, 0, cuda_stream>>>(
+            projection, vector, iout.get(), iout_size.get());
+
+    TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+
+    // Copy the total number of squashed elements, e.g. the size of the
+    // resulting vector.
+    uint32_t host_iout_size;
+
+    TRACCC_CUDA_ERROR_CHECK(
+        cudaMemcpyAsync(&host_iout_size, iout_size.get(), sizeof(uint32_t),
+                        cudaMemcpyDeviceToHost, cuda_stream));
+
+    // Launch the second kernel, which will check if the values are unique.
+    uint32_t grid_size_rd =
+        (host_iout_size + block_size_2d - 1) / block_size_2d;
+    dim3 all_unique_grid_size(grid_size_rd, grid_size_rd);
+    dim3 all_unique_block_size(block_size_2d, block_size_2d);
+
+    kernels::all_unique<<<all_unique_grid_size, all_unique_block_size, 0,
+                          cuda_stream>>>(iout.get(), host_iout_size, out.get());
+
+    TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+
+    // Get the result from the device and return it.
+    bool host_out;
+
+    TRACCC_CUDA_ERROR_CHECK(cudaMemcpyAsync(&host_out, out.get(), sizeof(bool),
+                                            cudaMemcpyDeviceToHost,
+                                            cuda_stream));
+
+    stream.synchronize();
+
+    return host_out;
+}
+}  // namespace traccc::cuda

--- a/device/cuda/src/sanity/ordered_on.cuh
+++ b/device/cuda/src/sanity/ordered_on.cuh
@@ -1,0 +1,117 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "../utils/cuda_error_handling.hpp"
+#include "traccc/cuda/utils/stream.hpp"
+#include "traccc/definitions/concepts.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/memory/unique_ptr.hpp>
+#include <vecmem/utils/copy.hpp>
+
+// CUDA include
+#include <cuda_runtime.h>
+
+// System include
+#if __cpp_concepts >= 201907L
+#include <concepts>
+#endif
+
+namespace traccc::cuda {
+namespace kernels {
+template <TRACCC_CONSTRAINT(std::semiregular) R, typename T>
+#if __cpp_concepts >= 201907L
+requires std::relation<R, T, T>
+#endif
+    __global__ void is_ordered_on_kernel(R relation,
+                                         vecmem::data::vector_view<T> _in,
+                                         bool* out) {
+    int tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+    vecmem::device_vector<T> in(_in);
+
+    if (tid > 0 && tid < in.size()) {
+        if (!relation(in.at(tid - 1), in.at(tid))) {
+            *out = false;
+        }
+    }
+}
+}  // namespace kernels
+
+/**
+ * @brief Sanity check that a given vector is ordered on a given relation.
+ *
+ * For a vector $v$ to be ordered on a relation $R$, it must be the case that
+ * for all indices $i$ and $j$, if $i < j$, then $R(i, j)$.
+ *
+ * @note This function runs in O(n) time.
+ *
+ * @note Although functions like `std::sort` requires the relation to be strict
+ * weak order, this function is more lax in its requirements. Rather, the
+ * relation should be a total preorder, i.e. a non-strict weak order.
+ *
+ * @note For any strict weak order $R$, `is_ordered_on(sort(R, v))` is true.
+ *
+ * @tparam R The type of relation $R$, a callable which returns a bool if the
+ * first argument can be immediately before the second type.
+ * @tparam T The type of the vector.
+ * @param relation A relation object of type `R`.
+ * @param mr A memory resource used for allocating intermediate memory.
+ * @param vector The vector which to check for ordering.
+ * @return true If the vector is ordered on `R`.
+ * @return false Otherwise.
+ */
+template <TRACCC_CONSTRAINT(std::semiregular) R, typename T>
+#if __cpp_concepts >= 201907L
+requires std::relation<R, T, T>
+#endif
+    bool is_ordered_on(R relation, vecmem::memory_resource& mr,
+                       vecmem::copy& copy, stream& stream,
+                       vecmem::data::vector_view<T> vector) {
+    // This should never be a performance-critical step, so we can keep the
+    // block size fixed.
+    constexpr int block_size = 512;
+
+    cudaStream_t cuda_stream =
+        reinterpret_cast<cudaStream_t>(stream.cudaStream());
+
+    // Grab the number of elements in our vector.
+    uint32_t n = copy.get_size(vector);
+
+    // Initialize the output boolean.
+    vecmem::unique_alloc_ptr<bool> out = vecmem::make_unique_alloc<bool>(mr);
+    bool initial_out = true;
+    TRACCC_CUDA_ERROR_CHECK(
+        cudaMemcpyAsync(out.get(), &initial_out, sizeof(bool),
+                        cudaMemcpyHostToDevice, cuda_stream));
+
+    // Launch the kernel which will write its result to the `out` boolean.
+    kernels::is_ordered_on_kernel<<<(n + block_size - 1) / block_size,
+                                    block_size, 0, cuda_stream>>>(
+        relation, vector, out.get());
+
+    TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+
+    // Copy the output to host, then return it.
+    bool host_out;
+
+    TRACCC_CUDA_ERROR_CHECK(cudaMemcpyAsync(&host_out, out.get(), sizeof(bool),
+                                            cudaMemcpyDeviceToHost,
+                                            cuda_stream));
+
+    stream.synchronize();
+
+    return host_out;
+}
+}  // namespace traccc::cuda

--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -39,7 +39,10 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
   "src/utils/get_queue.sycl"
   "src/utils/queue_wrapper.cpp"
   "src/utils/calculate1DimNdRange.sycl"
-  "src/utils/make_prefix_sum_buff.sycl" )
+  "src/utils/make_prefix_sum_buff.sycl"
+  "src/sanity/contiguous_on.hpp"
+  "src/sanity/ordered_on.hpp"
+)
 target_link_libraries( traccc_sycl
   PUBLIC traccc::core detray::core detray::utils vecmem::core covfie::core
   PRIVATE traccc::device_common vecmem::sycl )

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -6,9 +6,13 @@
  */
 
 // Local include(s).
+#include "../sanity/contiguous_on.hpp"
+#include "../sanity/ordered_on.hpp"
 #include "../utils/barrier.hpp"
 #include "../utils/get_queue.hpp"
 #include "traccc/sycl/clusterization/clusterization_algorithm.hpp"
+#include "traccc/utils/projections.hpp"
+#include "traccc/utils/relations.hpp"
 
 // Project include(s)
 #include "traccc/clusterization/device/ccl_kernel.hpp"
@@ -36,6 +40,11 @@ clusterization_algorithm::clusterization_algorithm(
 clusterization_algorithm::output_type clusterization_algorithm::operator()(
     const cell_collection_types::const_view& cells_view,
     const cell_module_collection_types::const_view& modules_view) const {
+
+    assert(is_contiguous_on(cell_module_projection(), m_mr.main, m_copy,
+                            m_queue, cells_view));
+    assert(is_ordered_on(channel0_major_cell_order_relation(), m_mr.main,
+                         m_copy, m_queue, cells_view));
 
     // Get the number of cells
     const cell_collection_types::view::size_type num_cells =

--- a/device/sycl/src/sanity/contiguous_on.hpp
+++ b/device/sycl/src/sanity/contiguous_on.hpp
@@ -1,0 +1,165 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include <traccc/definitions/concepts.hpp>
+#include <traccc/sycl/utils/queue_wrapper.hpp>
+
+#include "../utils/get_queue.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/memory/device_atomic_ref.hpp>
+#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/memory/unique_ptr.hpp>
+#include <vecmem/utils/copy.hpp>
+
+// SYCL include
+#include <CL/sycl.hpp>
+
+// System include
+#if __cpp_concepts >= 201907L
+#include <concepts>
+#endif
+
+namespace traccc::sycl {
+namespace kernels {
+template <typename P, typename T, typename S>
+class IsContiguousOnCompressAdjacent {};
+
+template <typename T>
+class IsContiguousOnAllUnique {};
+}  // namespace kernels
+
+/**
+ * @brief Sanity check that a given vector is contiguous on a given projection.
+ *
+ * For a vector $v$ to be contiguous on a projection $\pi$, it must be the case
+ * that for all indices $i$ and $j$, if $v_i = v_j$, then all indices $k$
+ * between $i$ and $j$, $v_i = v_j = v_k$.
+ *
+ * @note This function runs in O(n^2) time.
+ *
+ * @tparam P The type of projection $\pi$, a callable which returns some
+ * comparable type.
+ * @tparam T The type of the vector.
+ * @param projection A projection object of type `P`.
+ * @param mr A memory resource used for allocating intermediate memory.
+ * @param vector The vector which to check for contiguity.
+ * @return true If the vector is contiguous on `P`.
+ * @return false Otherwise.
+ */
+template <TRACCC_CONSTRAINT(std::semiregular) P,
+          TRACCC_CONSTRAINT(std::equality_comparable) T>
+#if __cpp_concepts >= 201907L
+requires std::regular_invocable<P, T>
+#endif
+    bool is_contiguous_on(P&& projection, vecmem::memory_resource& mr,
+                          vecmem::copy& copy, queue_wrapper& queue_wrapper,
+                          vecmem::data::vector_view<T> vector) {
+    // This should never be a performance-critical step, so we can keep the
+    // block size fixed.
+    constexpr int block_size = 512;
+
+    cl::sycl::queue& queue = details::get_queue(queue_wrapper);
+
+    // Grab the number of elements in our vector.
+    uint32_t n = copy.get_size(vector);
+
+    // Get the output type of the projection.
+    using projection_t = std::invoke_result_t<P, T>;
+
+    // Allocate memory for intermediate values and outputs, then set them up.
+    vecmem::unique_alloc_ptr<projection_t[]> iout =
+        vecmem::make_unique_alloc<projection_t[]>(mr, n);
+    vecmem::unique_alloc_ptr<uint32_t> iout_size =
+        vecmem::make_unique_alloc<uint32_t>(mr);
+    vecmem::unique_alloc_ptr<bool> out = vecmem::make_unique_alloc<bool>(mr);
+
+    uint32_t initial_iout_size = 0;
+    bool initial_out = true;
+
+    cl::sycl::event kernel1_memcpy1_evt =
+        queue.copy(&initial_iout_size, iout_size.get(), 1);
+    cl::sycl::event kernel2_memcpy1_evt =
+        queue.copy(&initial_out, out.get(), 1);
+
+    cl::sycl::nd_range<1> compress_adjacent_range{
+        cl::sycl::range<1>(((n + block_size - 1) / block_size) * block_size),
+        cl::sycl::range<1>(block_size)};
+
+    // Launch the first kernel, which will squash consecutive equal elements
+    // into one element.
+    cl::sycl::event kernel1_evt = queue.submit([&](cl::sycl::handler& h) {
+        h.depends_on(kernel1_memcpy1_evt);
+        h.parallel_for<
+            kernels::IsContiguousOnCompressAdjacent<P, T, projection_t>>(
+            compress_adjacent_range,
+            [vector, projection, out = iout.get(),
+             out_size = iout_size.get()](cl::sycl::nd_item<1> item) {
+                std::size_t tid = item.get_global_linear_id();
+
+                vecmem::device_vector<T> in(vector);
+                vecmem::device_atomic_ref<uint32_t> out_siz_atm(*out_size);
+
+                if (tid > 0 && tid < in.size()) {
+                    std::invoke_result_t<P, T> v1 = projection(in.at(tid - 1));
+                    std::invoke_result_t<P, T> v2 = projection(in.at(tid));
+
+                    if (v1 != v2) {
+                        out[out_siz_atm.fetch_add(1)] = v2;
+                    }
+                } else if (tid == 0) {
+                    out[out_siz_atm.fetch_add(1)] = projection(in.at(tid));
+                }
+            });
+    });
+
+    // Copy the total number of squashed elements, e.g. the size of the
+    // resulting vector.
+    uint32_t host_iout_size;
+
+    queue
+        .memcpy(&host_iout_size, iout_size.get(), sizeof(uint32_t),
+                {kernel1_evt})
+        .wait_and_throw();
+
+    uint32_t grid_size_rd = (host_iout_size + block_size - 1) / block_size;
+
+    cl::sycl::nd_range<2> all_unique_range{
+        cl::sycl::range<2>(grid_size_rd * block_size, host_iout_size),
+        cl::sycl::range<2>(block_size, 1)};
+
+    // Launch the second kernel, which will check if the values are unique.
+    cl::sycl::event kernel2_evt = queue.submit([&](cl::sycl::handler& h) {
+        h.depends_on(kernel2_memcpy1_evt);
+        h.parallel_for<kernels::IsContiguousOnAllUnique<T>>(
+            all_unique_range, [n = host_iout_size, in = iout.get(),
+                               out = out.get()](cl::sycl::nd_item<2> item) {
+                std::size_t tid_x = item.get_global_id(0);
+                std::size_t tid_y = item.get_global_id(1);
+
+                if (tid_x < n && tid_y < n && tid_x != tid_y &&
+                    in[tid_x] == in[tid_y]) {
+                    *out = false;
+                }
+            });
+    });
+
+    // Get the result from the device and return it.
+    bool host_out;
+
+    queue.memcpy(&host_out, out.get(), sizeof(bool), {kernel2_evt})
+        .wait_and_throw();
+
+    return host_out;
+}
+}  // namespace traccc::sycl

--- a/device/sycl/src/sanity/ordered_on.hpp
+++ b/device/sycl/src/sanity/ordered_on.hpp
@@ -1,0 +1,112 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include <traccc/definitions/concepts.hpp>
+#include <traccc/sycl/utils/queue_wrapper.hpp>
+
+#include "../utils/get_queue.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/memory/unique_ptr.hpp>
+#include <vecmem/utils/copy.hpp>
+
+// SYCL include
+#include <CL/sycl.hpp>
+
+// System include
+#if __cpp_concepts >= 201907L
+#include <concepts>
+#endif
+
+namespace traccc::sycl {
+namespace kernels {
+template <typename R, typename T>
+class IsOrderedOn {};
+}  // namespace kernels
+
+/**
+ * @brief Sanity check that a given vector is ordered on a given relation.
+ *
+ * For a vector $v$ to be ordered on a relation $R$, it must be the case that
+ * for all indices $i$ and $j$, if $i < j$, then $R(i, j)$.
+ *
+ * @note This function runs in O(n) time.
+ *
+ * @note Although functions like `std::sort` requires the relation to be strict
+ * weak order, this function is more lax in its requirements. Rather, the
+ * relation should be a total preorder, i.e. a non-strict weak order.
+ *
+ * @note For any strict weak order $R$, `is_ordered_on(sort(R, v))` is true.
+ *
+ * @tparam R The type of relation $R$, a callable which returns a bool if the
+ * first argument can be immediately before the second type.
+ * @tparam T The type of the vector.
+ * @param relation A relation object of type `R`.
+ * @param mr A memory resource used for allocating intermediate memory.
+ * @param vector The vector which to check for ordering.
+ * @return true If the vector is ordered on `R`.
+ * @return false Otherwise.
+ */
+template <TRACCC_CONSTRAINT(std::semiregular) R, typename T>
+#if __cpp_concepts >= 201907L
+requires std::relation<R, T, T>
+#endif
+    bool is_ordered_on(R relation, vecmem::memory_resource& mr,
+                       vecmem::copy& copy, queue_wrapper& queue_wrapper,
+                       vecmem::data::vector_view<T> vector) {
+    // This should never be a performance-critical step, so we can keep the
+    // block size fixed.
+    constexpr int block_size = 512;
+
+    cl::sycl::queue& queue = details::get_queue(queue_wrapper);
+
+    // Grab the number of elements in our vector.
+    uint32_t n = copy.get_size(vector);
+
+    // Initialize the output boolean.
+    vecmem::unique_alloc_ptr<bool> out = vecmem::make_unique_alloc<bool>(mr);
+    bool initial_out = true;
+
+    cl::sycl::event kernel1_memcpy1 =
+        queue.memcpy(out.get(), &initial_out, sizeof(bool));
+
+    cl::sycl::nd_range<1> kernel_range{
+        cl::sycl::range<1>(((n + block_size - 1) / block_size) * block_size),
+        cl::sycl::range<1>(block_size)};
+
+    cl::sycl::event kernel1 = queue.submit([&](cl::sycl::handler& h) {
+        h.depends_on(kernel1_memcpy1);
+        h.parallel_for<kernels::IsOrderedOn<R, T>>(
+            kernel_range, [=, out = out.get()](cl::sycl::nd_item<1> item) {
+                std::size_t tid = item.get_global_linear_id();
+
+                vecmem::device_vector<T> in(vector);
+
+                if (tid > 0 && tid < in.size()) {
+                    if (!relation(in.at(tid - 1), in.at(tid))) {
+                        *out = false;
+                    }
+                }
+            });
+    });
+
+    // Copy the output to host, then return it.
+    bool host_out;
+
+    queue.memcpy(&host_out, out.get(), sizeof(bool), {kernel1})
+        .wait_and_throw();
+
+    return host_out;
+}
+}  // namespace traccc::sycl

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -20,6 +20,8 @@ traccc_add_test(cpu
     "test_simulation.cpp"
     "test_spacepoint_formation.cpp"
     "test_track_params_estimation.cpp"
+    "test_sanity_ordered_on.cpp"
+    "test_sanity_contiguous_on.cpp"
     LINK_LIBRARIES GTest::gtest_main vecmem::core 
     traccc_tests_common traccc::core traccc::io traccc::performance 
     traccc::simulation detray::core detray::utils covfie::core )

--- a/tests/cpu/test_sanity_contiguous_on.cpp
+++ b/tests/cpu/test_sanity_contiguous_on.cpp
@@ -1,0 +1,142 @@
+/*
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// vecmem includes
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// traccc includes
+#include <traccc/definitions/qualifiers.hpp>
+#include <traccc/sanity/contiguous_on.hpp>
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+struct int_identity_projection {
+    TRACCC_HOST_DEVICE
+    int operator()(const int& v) const { return v; }
+};
+
+class CPUSanityContiguousOn : public testing::Test {
+    protected:
+    CPUSanityContiguousOn() {}
+};
+
+TEST_F(CPUSanityContiguousOn, TrueOrdered) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_TRUE(
+        traccc::host::is_contiguous_on(int_identity_projection(), device_data));
+}
+
+TEST_F(CPUSanityContiguousOn, TrueRandom) {
+    std::vector<int> host_vector;
+
+    for (int i : {603, 6432, 1, 3, 67, 2, 1111}) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_TRUE(
+        traccc::host::is_contiguous_on(int_identity_projection(), device_data));
+}
+
+TEST_F(CPUSanityContiguousOn, FalseOrdered) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        if (i == 105) {
+            host_vector.push_back(5);
+        } else {
+            for (int j = 0; j < i; ++j) {
+                host_vector.push_back(i);
+            }
+        }
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_FALSE(
+        traccc::host::is_contiguous_on(int_identity_projection(), device_data));
+}
+
+TEST_F(CPUSanityContiguousOn, FalseOrderedPathologicalFirst) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(4000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_FALSE(
+        traccc::host::is_contiguous_on(int_identity_projection(), device_data));
+}
+
+TEST_F(CPUSanityContiguousOn, TrueOrderedPathologicalFirst) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(6000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_TRUE(
+        traccc::host::is_contiguous_on(int_identity_projection(), device_data));
+}
+
+TEST_F(CPUSanityContiguousOn, FalseOrderedPathologicalLast) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    host_vector.push_back(2);
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_FALSE(
+        traccc::host::is_contiguous_on(int_identity_projection(), device_data));
+}
+
+TEST_F(CPUSanityContiguousOn, FalseRandom) {
+    std::vector<int> host_vector;
+
+    for (int i : {603, 6432, 1, 3, 67, 1, 1111}) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_FALSE(
+        traccc::host::is_contiguous_on(int_identity_projection(), device_data));
+}

--- a/tests/cpu/test_sanity_ordered_on.cpp
+++ b/tests/cpu/test_sanity_ordered_on.cpp
@@ -1,0 +1,116 @@
+/*
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// vecmem includes
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// traccc includes
+#include <traccc/definitions/qualifiers.hpp>
+#include <traccc/sanity/ordered_on.hpp>
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+struct int_lt_relation {
+    TRACCC_HOST_DEVICE
+    bool operator()(const int& a, const int& b) const { return a < b; }
+};
+
+struct int_leq_relation {
+    TRACCC_HOST_DEVICE
+    bool operator()(const int& a, const int& b) const { return a <= b; }
+};
+
+class CPUSanityOrderedOn : public testing::Test {
+    protected:
+    CPUSanityOrderedOn() {}
+};
+
+TEST_F(CPUSanityOrderedOn, TrueConsecutiveNoRepeatsLeq) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 500000; ++i) {
+        host_vector.push_back(i);
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_TRUE(traccc::host::is_ordered_on(int_leq_relation(), device_data));
+}
+
+TEST_F(CPUSanityOrderedOn, TrueConsecutiveNoRepeatsLt) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 500000; ++i) {
+        host_vector.push_back(i);
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_TRUE(traccc::host::is_ordered_on(int_lt_relation(), device_data));
+}
+
+TEST_F(CPUSanityOrderedOn, TrueConsecutiveRepeatsLeq) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_TRUE(traccc::host::is_ordered_on(int_leq_relation(), device_data));
+}
+
+TEST_F(CPUSanityOrderedOn, FalseConsecutiveRepeatLt) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_FALSE(traccc::host::is_ordered_on(int_lt_relation(), device_data));
+}
+
+TEST_F(CPUSanityOrderedOn, TrueConsecutivePathologicalFirstLeq) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(4000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_FALSE(traccc::host::is_ordered_on(int_leq_relation(), device_data));
+}
+
+TEST_F(CPUSanityOrderedOn, TrueConsecutivePathologicalLastLeq) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(2000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = vecmem::get_data(host_vector);
+
+    ASSERT_FALSE(traccc::host::is_ordered_on(int_leq_relation(), device_data));
+}

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -42,6 +42,8 @@ traccc_add_test(
     test_array_wrapper.cu
     test_mutex.cu
     test_unique_lock.cu
+    test_sanity_contiguous_on.cu
+    test_sanity_ordered_on.cu
 
     LINK_LIBRARIES
     CUDA::cudart

--- a/tests/cuda/test_sanity_contiguous_on.cu
+++ b/tests/cuda/test_sanity_contiguous_on.cu
@@ -1,0 +1,155 @@
+/*
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// vecmem includes
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/utils/cuda/async_copy.hpp>
+
+// traccc includes
+#include <traccc/definitions/qualifiers.hpp>
+
+#include "../../device/cuda/src/sanity/contiguous_on.cuh"
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+struct int_identity_projection {
+    TRACCC_HOST_DEVICE
+    int operator()(const int& v) const { return v; }
+};
+
+class CUDASanityContiguousOn : public testing::Test {
+    protected:
+    CUDASanityContiguousOn() : copy(stream.cudaStream()) {}
+
+    vecmem::cuda::device_memory_resource mr;
+    traccc::cuda::stream stream;
+    vecmem::cuda::async_copy copy;
+};
+
+TEST_F(CUDASanityContiguousOn, TrueOrdered) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::cuda::is_contiguous_on(int_identity_projection(), mr,
+                                               copy, stream, device_data));
+}
+
+TEST_F(CUDASanityContiguousOn, TrueRandom) {
+    std::vector<int> host_vector;
+
+    for (int i : {603, 6432, 1, 3, 67, 2, 1111}) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::cuda::is_contiguous_on(int_identity_projection(), mr,
+                                               copy, stream, device_data));
+}
+
+TEST_F(CUDASanityContiguousOn, FalseOrdered) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        if (i == 105) {
+            host_vector.push_back(5);
+        } else {
+            for (int j = 0; j < i; ++j) {
+                host_vector.push_back(i);
+            }
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::cuda::is_contiguous_on(int_identity_projection(), mr,
+                                                copy, stream, device_data));
+}
+
+TEST_F(CUDASanityContiguousOn, FalseOrderedPathologicalFirst) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(4000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::cuda::is_contiguous_on(int_identity_projection(), mr,
+                                                copy, stream, device_data));
+}
+
+TEST_F(CUDASanityContiguousOn, TrueOrderedPathologicalFirst) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(6000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::cuda::is_contiguous_on(int_identity_projection(), mr,
+                                               copy, stream, device_data));
+}
+
+TEST_F(CUDASanityContiguousOn, FalseOrderedPathologicalLast) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    host_vector.push_back(2);
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::cuda::is_contiguous_on(int_identity_projection(), mr,
+                                                copy, stream, device_data));
+}
+
+TEST_F(CUDASanityContiguousOn, FalseRandom) {
+    std::vector<int> host_vector;
+
+    for (int i : {603, 6432, 1, 3, 67, 1, 1111}) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::cuda::is_contiguous_on(int_identity_projection(), mr,
+                                                copy, stream, device_data));
+}

--- a/tests/cuda/test_sanity_ordered_on.cu
+++ b/tests/cuda/test_sanity_ordered_on.cu
@@ -1,0 +1,134 @@
+/*
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// vecmem includes
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/utils/cuda/async_copy.hpp>
+
+// traccc includes
+#include <traccc/definitions/qualifiers.hpp>
+
+#include "../../device/cuda/src/sanity/ordered_on.cuh"
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+struct int_lt_relation {
+    TRACCC_HOST_DEVICE
+    bool operator()(const int& a, const int& b) const { return a < b; }
+};
+
+struct int_leq_relation {
+    TRACCC_HOST_DEVICE
+    bool operator()(const int& a, const int& b) const { return a <= b; }
+};
+
+class CUDASanityOrderedOn : public testing::Test {
+    protected:
+    CUDASanityOrderedOn() : copy(stream.cudaStream()) {}
+
+    vecmem::cuda::device_memory_resource mr;
+    traccc::cuda::stream stream;
+    vecmem::cuda::async_copy copy;
+};
+
+TEST_F(CUDASanityOrderedOn, TrueConsecutiveNoRepeatsLeq) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 500000; ++i) {
+        host_vector.push_back(i);
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::cuda::is_ordered_on(int_leq_relation(), mr, copy,
+                                            stream, device_data));
+}
+
+TEST_F(CUDASanityOrderedOn, TrueConsecutiveNoRepeatsLt) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 500000; ++i) {
+        host_vector.push_back(i);
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::cuda::is_ordered_on(int_lt_relation(), mr, copy, stream,
+                                            device_data));
+}
+
+TEST_F(CUDASanityOrderedOn, TrueConsecutiveRepeatsLeq) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::cuda::is_ordered_on(int_leq_relation(), mr, copy,
+                                            stream, device_data));
+}
+
+TEST_F(CUDASanityOrderedOn, FalseConsecutiveRepeatLt) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::cuda::is_ordered_on(int_lt_relation(), mr, copy,
+                                             stream, device_data));
+}
+
+TEST_F(CUDASanityOrderedOn, TrueConsecutivePathologicalFirstLeq) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(4000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::cuda::is_ordered_on(int_leq_relation(), mr, copy,
+                                             stream, device_data));
+}
+
+TEST_F(CUDASanityOrderedOn, TrueConsecutivePathologicalLastLeq) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(2000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::cuda::is_ordered_on(int_leq_relation(), mr, copy,
+                                             stream, device_data));
+}

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -19,6 +19,8 @@ traccc_add_test(
     test_mutex.sycl
     test_unique_lock.sycl
     test_cca.sycl
+    test_sanity_contiguous_on.sycl
+    test_sanity_ordered_on.sycl
 
     LINK_LIBRARIES
     GTest::gtest_main

--- a/tests/sycl/test_sanity_contiguous_on.sycl
+++ b/tests/sycl/test_sanity_contiguous_on.sycl
@@ -1,0 +1,159 @@
+/*
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// vecmem includes
+#include <vecmem/memory/sycl/device_memory_resource.hpp>
+#include <vecmem/utils/sycl/async_copy.hpp>
+
+// traccc includes
+#include <traccc/definitions/qualifiers.hpp>
+
+#include "../../device/sycl/src/sanity/contiguous_on.hpp"
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+// System include
+#include <CL/sycl.hpp>
+
+struct int_identity_projection {
+    TRACCC_HOST_DEVICE
+    int operator()(const int& v) const { return v; }
+};
+
+class SYCLSanityContiguousOn : public testing::Test {
+    protected:
+    SYCLSanityContiguousOn() : queue_wrapper(&queue), copy(&queue) {}
+
+    vecmem::sycl::device_memory_resource mr;
+    cl::sycl::queue queue;
+    traccc::sycl::queue_wrapper queue_wrapper;
+    vecmem::sycl::async_copy copy;
+};
+
+TEST_F(SYCLSanityContiguousOn, TrueOrdered) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::sycl::is_contiguous_on(
+        int_identity_projection(), mr, copy, queue_wrapper, device_data));
+}
+
+TEST_F(SYCLSanityContiguousOn, TrueRandom) {
+    std::vector<int> host_vector;
+
+    for (int i : {603, 6432, 1, 3, 67, 2, 1111}) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::sycl::is_contiguous_on(
+        int_identity_projection(), mr, copy, queue_wrapper, device_data));
+}
+
+TEST_F(SYCLSanityContiguousOn, FalseOrdered) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        if (i == 105) {
+            host_vector.push_back(5);
+        } else {
+            for (int j = 0; j < i; ++j) {
+                host_vector.push_back(i);
+            }
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::sycl::is_contiguous_on(
+        int_identity_projection(), mr, copy, queue_wrapper, device_data));
+}
+
+TEST_F(SYCLSanityContiguousOn, FalseOrderedPathologicalFirst) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(4000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::sycl::is_contiguous_on(
+        int_identity_projection(), mr, copy, queue_wrapper, device_data));
+}
+
+TEST_F(SYCLSanityContiguousOn, TrueOrderedPathologicalFirst) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(6000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::sycl::is_contiguous_on(
+        int_identity_projection(), mr, copy, queue_wrapper, device_data));
+}
+
+TEST_F(SYCLSanityContiguousOn, FalseOrderedPathologicalLast) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    host_vector.push_back(2);
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::sycl::is_contiguous_on(
+        int_identity_projection(), mr, copy, queue_wrapper, device_data));
+}
+
+TEST_F(SYCLSanityContiguousOn, FalseRandom) {
+    std::vector<int> host_vector;
+
+    for (int i : {603, 6432, 1, 3, 67, 1, 1111}) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::sycl::is_contiguous_on(
+        int_identity_projection(), mr, copy, queue_wrapper, device_data));
+}

--- a/tests/sycl/test_sanity_ordered_on.sycl
+++ b/tests/sycl/test_sanity_ordered_on.sycl
@@ -1,0 +1,139 @@
+/*
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// vecmem includes
+#include <vecmem/memory/sycl/device_memory_resource.hpp>
+#include <vecmem/utils/sycl/async_copy.hpp>
+
+// traccc includes
+#include <traccc/definitions/qualifiers.hpp>
+
+#include "../../device/sycl/src/sanity/ordered_on.hpp"
+#include "traccc/sycl/utils/queue_wrapper.hpp"
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+// System include
+#include <CL/sycl.hpp>
+
+struct int_lt_relation {
+    TRACCC_HOST_DEVICE
+    bool operator()(const int& a, const int& b) const { return a < b; }
+};
+
+struct int_leq_relation {
+    TRACCC_HOST_DEVICE
+    bool operator()(const int& a, const int& b) const { return a <= b; }
+};
+
+class SYCLSanityOrderedOn : public testing::Test {
+    protected:
+    SYCLSanityOrderedOn() : queue_wrapper(&queue), copy(&queue) {}
+
+    vecmem::sycl::device_memory_resource mr;
+    cl::sycl::queue queue;
+    traccc::sycl::queue_wrapper queue_wrapper;
+    vecmem::sycl::async_copy copy;
+};
+
+TEST_F(SYCLSanityOrderedOn, TrueConsecutiveNoRepeatsLeq) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 500000; ++i) {
+        host_vector.push_back(i);
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::sycl::is_ordered_on(int_leq_relation(), mr, copy,
+                                            queue_wrapper, device_data));
+}
+
+TEST_F(SYCLSanityOrderedOn, TrueConsecutiveNoRepeatsLt) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 500000; ++i) {
+        host_vector.push_back(i);
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::sycl::is_ordered_on(int_lt_relation(), mr, copy,
+                                            queue_wrapper, device_data));
+}
+
+TEST_F(SYCLSanityOrderedOn, TrueConsecutiveRepeatsLeq) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_TRUE(traccc::sycl::is_ordered_on(int_leq_relation(), mr, copy,
+                                            queue_wrapper, device_data));
+}
+
+TEST_F(SYCLSanityOrderedOn, FalseConsecutiveRepeatLt) {
+    std::vector<int> host_vector;
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::sycl::is_ordered_on(int_lt_relation(), mr, copy,
+                                             queue_wrapper, device_data));
+}
+
+TEST_F(SYCLSanityOrderedOn, TrueConsecutivePathologicalFirstLeq) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(4000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::sycl::is_ordered_on(int_leq_relation(), mr, copy,
+                                             queue_wrapper, device_data));
+}
+
+TEST_F(SYCLSanityOrderedOn, TrueConsecutivePathologicalLastLeq) {
+    std::vector<int> host_vector;
+
+    host_vector.push_back(2000);
+
+    for (int i = 0; i < 5000; ++i) {
+        for (int j = 0; j < i; ++j) {
+            host_vector.push_back(i);
+        }
+    }
+
+    auto device_data = copy.to(vecmem::get_data(host_vector), mr,
+                               vecmem::copy::type::host_to_device);
+
+    ASSERT_FALSE(traccc::sycl::is_ordered_on(int_leq_relation(), mr, copy,
+                                             queue_wrapper, device_data));
+}


### PR DESCRIPTION
In some places, we rely on certain properties of our inputs. For one, we rely on our measurements being contiguous (with respect to the module identifiers) in the fitting code, and we rely on our cells being ordered in some way in the clustering code. I aim to emit properly contiguous elements from the CCL code in the future, but I want to make this process foolproof. To that end, I have added two new sanity checks which aim to find problems with input. One of them checks whether elements are contiguous (according to some projection function) and the other checks whether the elements are in some order. This commit also employs these checks for debug builds in some places.