### PR TITLE
Bump clang-format to version 18

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   format:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/format10:v11
+    container: ghcr.io/acts-project/format18:47
     steps:
       - uses: actions/checkout@v3
       - name: Check

--- a/core/include/traccc/utils/array_wrapper.hpp
+++ b/core/include/traccc/utils/array_wrapper.hpp
@@ -205,9 +205,12 @@ struct aos {
         constexpr std::size_t size() const { return _size; }
 
         constexpr const vecmem::unique_alloc_ptr<pod<Ts...>[]>& pointer()
-            const { return _ptr; }
+            const {
+            return _ptr;
+        }
 
-        private : std::size_t _size;
+        private:
+        std::size_t _size;
         vecmem::unique_alloc_ptr<pod<Ts...>[]> _ptr;
     };
 

--- a/device/futhark/include/traccc/futhark/wrapper.hpp
+++ b/device/futhark/include/traccc/futhark/wrapper.hpp
@@ -71,7 +71,7 @@ struct wrapper<T, std::tuple<IArgs...>, std::tuple<OArgs...>> {
 
     template <std::size_t... IIdxs, std::size_t... OIdxs>
     static output_t run_helper(struct futhark_context &ctx,
-                               std::vector<typename IArgs::cpp_t> &&... args,
+                               std::vector<typename IArgs::cpp_t> &&...args,
                                std::index_sequence<IIdxs...>,
                                std::index_sequence<OIdxs...>) {
         std::tuple<typename IArgs::futhark_t *...> futhark_inputs = {
@@ -145,7 +145,7 @@ struct wrapper<T, std::tuple<IArgs...>, std::tuple<OArgs...>> {
     }
 
     static std::tuple<std::vector<typename OArgs::cpp_t>...> run(
-        std::vector<typename IArgs::cpp_t> &&... args) {
+        std::vector<typename IArgs::cpp_t> &&...args) {
         return run_helper(
             get_context(),
             std::forward<std::vector<typename IArgs::cpp_t>>(args)...,


### PR DESCRIPTION
The version of clang-format that we use in this project is quite old (version 10) and it is no longer able to properly format all of the new stuff that has come into C++. See, for example, the formatting nightmares in #609 and #602. This commit bumps the formatter up to clang-format 18.