### PR TITLE
Bump detray version to v0.67.0

### DIFF
--- a/examples/simulation/simulate.cpp
+++ b/examples/simulation/simulate.cpp
@@ -54,7 +54,8 @@ int main(int argc, char* argv[]) {
     /// Type declarations
     using host_detector_type = detray::detector<>;
     using uniform_gen_t =
-        detray::random_numbers<scalar, std::uniform_real_distribution<scalar>>;
+        detray::detail::random_numbers<scalar,
+                                       std::uniform_real_distribution<scalar>>;
     using generator_type =
         detray::random_track_generator<traccc::free_track_parameters,
                                        uniform_gen_t>;

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -43,7 +43,8 @@ int simulate(const traccc::opts::generation& generation_opts,
 
     // Use deterministic random number generator for testing
     using uniform_gen_t =
-        detray::random_numbers<scalar, std::uniform_real_distribution<scalar>>;
+        detray::detail::random_numbers<scalar,
+                                       std::uniform_real_distribution<scalar>>;
 
     // Memory resource
     vecmem::host_memory_resource host_mr;

--- a/examples/simulation/simulate_toy_detector.cpp
+++ b/examples/simulation/simulate_toy_detector.cpp
@@ -37,7 +37,8 @@ int simulate(const traccc::opts::generation& generation_opts,
 
     // Use deterministic random number generator for testing
     using uniform_gen_t =
-        detray::random_numbers<scalar, std::uniform_real_distribution<scalar>>;
+        detray::detail::random_numbers<scalar,
+                                       std::uniform_real_distribution<scalar>>;
 
     // Memory resource
     vecmem::host_memory_resource host_mr;

--- a/examples/simulation/simulate_wire_chamber.cpp
+++ b/examples/simulation/simulate_wire_chamber.cpp
@@ -37,7 +37,8 @@ int simulate(const traccc::opts::generation& generation_opts,
 
     // Use deterministic random number generator for testing
     using uniform_gen_t =
-        detray::random_numbers<scalar, std::uniform_real_distribution<scalar>>;
+        detray::detail::random_numbers<scalar,
+                                       std::uniform_real_distribution<scalar>>;
 
     // Memory resource
     vecmem::host_memory_resource host_mr;

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.66.1.tar.gz;URL_MD5;000a0a36f953f74466c9e889261dd166"
+"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.67.0.tar.gz;URL_MD5;e874ea4299bdfa55b74df1ad71fae066"
    CACHE STRING "Source for Detray, when built as part of this project" )
 
 mark_as_advanced( TRACCC_DETRAY_SOURCE )

--- a/tests/common/tests/kalman_fitting_test.hpp
+++ b/tests/common/tests/kalman_fitting_test.hpp
@@ -69,7 +69,8 @@ class KalmanFittingTests
 
     // Use deterministic random number generator for testing
     using uniform_gen_t =
-        detray::random_numbers<scalar, std::uniform_real_distribution<scalar>>;
+        detray::detail::random_numbers<scalar,
+                                       std::uniform_real_distribution<scalar>>;
 
     /// Verify that pull distribtions follow the normal distribution
     ///

--- a/tests/cpu/test_simulation.cpp
+++ b/tests/cpu/test_simulation.cpp
@@ -85,7 +85,8 @@ GTEST_TEST(traccc_simulation, toy_detector_simulation) {
 
     // Create track generator
     using uniform_gen_t =
-        detray::random_numbers<scalar, std::uniform_real_distribution<scalar>>;
+        detray::detail::random_numbers<scalar,
+                                       std::uniform_real_distribution<scalar>>;
     using generator_type =
         detray::random_track_generator<traccc::free_track_parameters,
                                        uniform_gen_t>;


### PR DESCRIPTION
This commit bumps the detray version to v0.67.0, accounting for a small breaking change in how detray handles its random number generation.