### PR TITLE
build: include tbb as a system library and add compile flag `-Wfloat-conversion`

### DIFF
--- a/cmake/traccc-compiler-options-cpp.cmake
+++ b/cmake/traccc-compiler-options-cpp.cmake
@@ -23,6 +23,7 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wshadow" )
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wunused-local-typedefs" )
    traccc_add_flag( CMAKE_CXX_FLAGS "-pedantic" )
+   traccc_add_fkag( CMAKE_CXX_FLAGS "-Wfloat-conversion" )
 
    # Fail on warnings, if asked for that behaviour.
    if( TRACCC_FAIL_ON_WARNINGS )

--- a/cmake/traccc-compiler-options-cpp.cmake
+++ b/cmake/traccc-compiler-options-cpp.cmake
@@ -23,7 +23,7 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wshadow" )
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wunused-local-typedefs" )
    traccc_add_flag( CMAKE_CXX_FLAGS "-pedantic" )
-   traccc_add_fkag( CMAKE_CXX_FLAGS "-Wfloat-conversion" )
+   traccc_add_flag( CMAKE_CXX_FLAGS "-Wfloat-conversion" )
 
    # Fail on warnings, if asked for that behaviour.
    if( TRACCC_FAIL_ON_WARNINGS )

--- a/extern/tbb/CMakeLists.txt
+++ b/extern/tbb/CMakeLists.txt
@@ -29,9 +29,9 @@ set( TBB_STRICT FALSE CACHE BOOL "Do not throw errors on compiler warnings" )
 
 # Treat the TBB headers as "system headers", to avoid getting warnings from
 # them.
-get_target_property( _incDirs tbb INTERFACE_INCLUDE_DIRECTORIES )
+get_target_property( _incDirs tbb INCLUDE_DIRECTORIES )
 target_include_directories( tbb
-   SYSTEM INTERFACE ${_incDirs} )
+   SYSTEM PUBLIC ${_incDirs} )
 unset( _incDirs )
 
 

--- a/extern/tbb/CMakeLists.txt
+++ b/extern/tbb/CMakeLists.txt
@@ -29,8 +29,8 @@ set( TBB_STRICT FALSE CACHE BOOL "Do not throw errors on compiler warnings" )
 
 # Treat the TBB headers as "system headers", to avoid getting warnings from
 # them.
-get_target_property( _incDirs TBB::tbb INTERFACE_INCLUDE_DIRECTORIES )
-target_include_directories( eigen
+get_target_property( _incDirs tbb INTERFACE_INCLUDE_DIRECTORIES )
+target_include_directories( tbb
    SYSTEM INTERFACE ${_incDirs} )
 unset( _incDirs )
 

--- a/extern/tbb/CMakeLists.txt
+++ b/extern/tbb/CMakeLists.txt
@@ -27,5 +27,13 @@ FetchContent_Declare( TBB ${TRACCC_TBB_SOURCE} )
 set( TBB_TEST FALSE CACHE BOOL "Turn off the TBB tests" )
 set( TBB_STRICT FALSE CACHE BOOL "Do not throw errors on compiler warnings" )
 
+# Treat the TBB headers as "system headers", to avoid getting warnings from
+# them.
+get_target_property( _incDirs TBB::tbb INTERFACE_INCLUDE_DIRECTORIES )
+target_include_directories( eigen
+   SYSTEM INTERFACE ${_incDirs} )
+unset( _incDirs )
+
+
 # Get it into the current directory.
 FetchContent_MakeAvailable( TBB )


### PR DESCRIPTION
These changes are needed for traccc to be included in ACTS (without the changes the clang-tidy CI fails because of the warnings in tbb). The code added to tbb is based on the code in the eigen cmake. Furthermore, I added the compiler flag "-Wfloat-conversion" to align the compiler flags with ACTS.