### PR TITLE
Add CLI options to configuration type conversion

### DIFF
--- a/examples/options/include/traccc/options/clusterization.hpp
+++ b/examples/options/include/traccc/options/clusterization.hpp
@@ -8,26 +8,29 @@
 #pragma once
 
 // Local include(s).
+#include "traccc/options/details/config_provider.hpp"
 #include "traccc/options/details/interface.hpp"
 
 namespace traccc::opts {
 
 /// Options for the cell clusterization algorithm(s)
-class clusterization : public interface {
+class clusterization : public interface,
+                       public config_provider<unsigned short> {
 
     public:
-    /// @name Options
-    /// @{
-
-    /// The number of cells to merge in a partition
-    unsigned short target_cells_per_partition = 1024;
-
-    /// @}
-
     /// Constructor
     clusterization();
 
+    /// Configuration conversion
+    operator unsigned short() const override;
+
     private:
+    /// @name Options
+    /// @{
+    /// The number of cells to merge in a partition
+    unsigned short target_cells_per_partition = 1024;
+    /// @}
+
     /// Print the specific options of this class
     std::ostream& print_impl(std::ostream& out) const override;
 

--- a/examples/options/include/traccc/options/details/config_provider.hpp
+++ b/examples/options/include/traccc/options/details/config_provider.hpp
@@ -1,0 +1,24 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::opts {
+/**
+ * @brief Mixin type to indicate that some set of program options can be
+ * converted to some configuration type.
+ *
+ * @tparam Config The config type to which this can be converted
+ */
+template <typename Config>
+class config_provider {
+    public:
+    using config_type = Config;
+
+    virtual operator config_type() const = 0;
+};
+}  // namespace traccc::opts

--- a/examples/options/include/traccc/options/track_finding.hpp
+++ b/examples/options/include/traccc/options/track_finding.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/finding/finding_config.hpp"
+#include "traccc/options/details/config_provider.hpp"
 #include "traccc/options/details/interface.hpp"
 #include "traccc/options/details/value_array.hpp"
 
@@ -20,12 +22,21 @@
 namespace traccc::opts {
 
 /// Configuration for track finding
-class track_finding : public interface {
+class track_finding : public interface,
+                      public config_provider<finding_config<float>>,
+                      public config_provider<finding_config<double>> {
 
     public:
+    /// Constructor
+    track_finding();
+
+    /// Configuration conversion operators
+    operator finding_config<float>() const override;
+    operator finding_config<double>() const override;
+
+    private:
     /// @name Options
     /// @{
-
     /// Number of track candidates per seed
     opts::value_array<unsigned int, 2> track_candidates_range{3, 100};
     /// Minimum step length that track should make to reach the next surface. It
@@ -40,13 +51,8 @@ class track_finding : public interface {
     unsigned int nmax_per_seed = 10;
     /// Maximum allowed number of skipped steps per candidate
     unsigned int max_num_skipping_per_cand = 3;
-
     /// @}
 
-    /// Constructor
-    track_finding();
-
-    private:
     /// Print the specific options of this class
     std::ostream& print_impl(std::ostream& out) const override;
 

--- a/examples/options/include/traccc/options/track_propagation.hpp
+++ b/examples/options/include/traccc/options/track_propagation.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Local include(s).
+#include "traccc/options/details/config_provider.hpp"
 #include "traccc/options/details/interface.hpp"
 #include "traccc/options/details/value_array.hpp"
 
@@ -17,17 +18,10 @@
 namespace traccc::opts {
 
 /// Command line options used in the propagation tests
-class track_propagation : public interface {
+class track_propagation : public interface,
+                          public config_provider<detray::propagation::config> {
 
     public:
-    /// @name Options
-    /// @{
-
-    /// Propagation configuration object
-    detray::propagation::config config;
-
-    /// @}
-
     /// Constructor
     track_propagation();
 
@@ -37,7 +31,16 @@ class track_propagation : public interface {
     ///
     void read(const boost::program_options::variables_map& vm) override;
 
+    /// Configuration provider
+    operator detray::propagation::config() const override;
+
     private:
+    /// @name Options
+    /// @{
+    /// Propagation configuration object
+    detray::propagation::config config;
+    /// @}
+
     /// Print the specific options of this class
     std::ostream& print_impl(std::ostream& out) const override;
 

--- a/examples/options/src/clusterization.cpp
+++ b/examples/options/src/clusterization.cpp
@@ -22,6 +22,10 @@ clusterization::clusterization() : interface("Clusterization Options") {
         "The number of cells to merge in a partition");
 }
 
+clusterization::operator unsigned short() const {
+    return target_cells_per_partition;
+}
+
 std::ostream& clusterization::print_impl(std::ostream& out) const {
 
     out << "  Target cells per partition: " << target_cells_per_partition;

--- a/examples/options/src/track_finding.cpp
+++ b/examples/options/src/track_finding.cpp
@@ -50,6 +50,30 @@ track_finding::track_finding() : interface("Track Finding Options") {
         "Maximum allowed number of skipped steps per candidate");
 }
 
+track_finding::operator finding_config<float>() const {
+    finding_config<float> out;
+    out.min_track_candidates_per_track = track_candidates_range[0];
+    out.max_track_candidates_per_track = track_candidates_range[1];
+    out.min_step_length_for_next_surface = min_step_length_for_next_surface;
+    out.max_step_counts_for_next_surface = max_step_counts_for_next_surface;
+    out.chi2_max = chi2_max;
+    out.max_num_branches_per_seed = nmax_per_seed;
+    out.max_num_skipping_per_cand = max_num_skipping_per_cand;
+    return out;
+}
+
+track_finding::operator finding_config<double>() const {
+    finding_config<double> out;
+    out.min_track_candidates_per_track = track_candidates_range[0];
+    out.max_track_candidates_per_track = track_candidates_range[1];
+    out.min_step_length_for_next_surface = min_step_length_for_next_surface;
+    out.max_step_counts_for_next_surface = max_step_counts_for_next_surface;
+    out.chi2_max = chi2_max;
+    out.max_num_branches_per_seed = nmax_per_seed;
+    out.max_num_skipping_per_cand = max_num_skipping_per_cand;
+    return out;
+}
+
 std::ostream& track_finding::print_impl(std::ostream& out) const {
 
     out << "  Track candidates range   : " << track_candidates_range << "\n"

--- a/examples/options/src/track_propagation.cpp
+++ b/examples/options/src/track_propagation.cpp
@@ -57,6 +57,10 @@ void track_propagation::read(const po::variables_map&) {
     config.navigation.search_window = m_search_window;
 }
 
+track_propagation::operator detray::propagation::config() const {
+    return config;
+}
+
 std::ostream& track_propagation::print_impl(std::ostream& out) const {
 
     out << config;

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -137,23 +137,13 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
         cached_host_mrs{threading_opts.threads + 1};
 
     // Algorithm configuration(s).
-    typename FULL_CHAIN_ALG::finding_algorithm::config_type finding_cfg;
-    finding_cfg.min_track_candidates_per_track =
-        finding_opts.track_candidates_range[0];
-    finding_cfg.max_track_candidates_per_track =
-        finding_opts.track_candidates_range[1];
-    finding_cfg.min_step_length_for_next_surface =
-        finding_opts.min_step_length_for_next_surface;
-    finding_cfg.max_step_counts_for_next_surface =
-        finding_opts.max_step_counts_for_next_surface;
-    finding_cfg.chi2_max = finding_opts.chi2_max;
-    finding_cfg.max_num_branches_per_seed = finding_opts.nmax_per_seed;
-    finding_cfg.max_num_skipping_per_cand =
-        finding_opts.max_num_skipping_per_cand;
-    finding_cfg.propagation = propagation_opts.config;
+    detray::propagation::config propagation_config(propagation_opts);
+    typename FULL_CHAIN_ALG::finding_algorithm::config_type finding_cfg(
+        finding_opts);
+    finding_cfg.propagation = propagation_config;
 
     typename FULL_CHAIN_ALG::fitting_algorithm::config_type fitting_cfg;
-    fitting_cfg.propagation = propagation_opts.config;
+    fitting_cfg.propagation = propagation_config;
 
     // Set up the full-chain algorithm(s). One for each thread.
     std::vector<FULL_CHAIN_ALG> algs;
@@ -170,7 +160,7 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
                 : static_cast<vecmem::memory_resource&>(uncached_host_mr);
         algs.push_back(
             {alg_host_mr,
-             clusterization_opts.target_cells_per_partition,
+             clusterization_opts,
              seeding_opts.seedfinder,
              {seeding_opts.seedfinder},
              seeding_opts.seedfilter,
@@ -267,7 +257,6 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
                 << "," << threading_opts.threads << "," << input_opts.events
                 << "," << throughput_opts.cold_run_events << ","
                 << throughput_opts.processed_events << ","
-                << clusterization_opts.target_cells_per_partition << ","
                 << times.get_time("Warm-up processing").count() << ","
                 << times.get_time("Event processing").count() << std::endl;
         logFile.close();

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -122,28 +122,17 @@ int throughput_st(std::string_view description, int argc, char* argv[],
     }
 
     // Algorithm configuration(s).
-    typename FULL_CHAIN_ALG::finding_algorithm::config_type finding_cfg;
-    finding_cfg.min_track_candidates_per_track =
-        finding_opts.track_candidates_range[0];
-    finding_cfg.max_track_candidates_per_track =
-        finding_opts.track_candidates_range[1];
-    finding_cfg.min_step_length_for_next_surface =
-        finding_opts.min_step_length_for_next_surface;
-    finding_cfg.max_step_counts_for_next_surface =
-        finding_opts.max_step_counts_for_next_surface;
-    finding_cfg.chi2_max = finding_opts.chi2_max;
-    finding_cfg.max_num_branches_per_seed = finding_opts.nmax_per_seed;
-    finding_cfg.max_num_skipping_per_cand =
-        finding_opts.max_num_skipping_per_cand;
-    finding_cfg.propagation = propagation_opts.config;
+    detray::propagation::config propagation_config(propagation_opts);
+    typename FULL_CHAIN_ALG::finding_algorithm::config_type finding_cfg(
+        finding_opts);
+    finding_cfg.propagation = propagation_config;
 
     typename FULL_CHAIN_ALG::fitting_algorithm::config_type fitting_cfg;
-    fitting_cfg.propagation = propagation_opts.config;
+    fitting_cfg.propagation = propagation_config;
 
     // Set up the full-chain algorithm.
     std::unique_ptr<FULL_CHAIN_ALG> alg = std::make_unique<FULL_CHAIN_ALG>(
-        alg_host_mr, clusterization_opts.target_cells_per_partition,
-        seeding_opts.seedfinder,
+        alg_host_mr, clusterization_opts, seeding_opts.seedfinder,
         spacepoint_grid_config{seeding_opts.seedfinder},
         seeding_opts.seedfilter, finding_cfg, fitting_cfg,
         (detector_opts.use_detray_detector ? &detector : nullptr));

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -132,27 +132,21 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                                  seeding_opts.seedfilter, host_mr);
     traccc::track_params_estimation tp(host_mr);
 
-    // Finding algorithm configuration
-    typename traccc::finding_algorithm<rk_stepper_type,
-                                       host_navigator_type>::config_type cfg;
+    // Propagation configuration
+    detray::propagation::config propagation_config(propagation_opts);
 
-    cfg.min_track_candidates_per_track = finding_opts.track_candidates_range[0];
-    cfg.max_track_candidates_per_track = finding_opts.track_candidates_range[1];
-    cfg.min_step_length_for_next_surface =
-        finding_opts.min_step_length_for_next_surface;
-    cfg.max_step_counts_for_next_surface =
-        finding_opts.max_step_counts_for_next_surface;
-    cfg.chi2_max = finding_opts.chi2_max;
-    cfg.max_num_branches_per_seed = finding_opts.nmax_per_seed;
-    cfg.max_num_skipping_per_cand = finding_opts.max_num_skipping_per_cand;
-    cfg.propagation = propagation_opts.config;
+    // Finding algorithm configuration
+    typename traccc::finding_algorithm<
+        rk_stepper_type, host_navigator_type>::config_type cfg(finding_opts);
+
+    cfg.propagation = propagation_config;
 
     traccc::finding_algorithm<rk_stepper_type, host_navigator_type>
         host_finding(cfg);
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    fit_cfg.propagation = propagation_config;
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
 

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -131,23 +131,13 @@ int seq_run(const traccc::opts::input_data& input_opts,
         detray::bfield::create_const_field(field_vec);
 
     // Algorithm configuration(s).
-    finding_algorithm::config_type finding_cfg;
-    finding_cfg.min_track_candidates_per_track =
-        finding_opts.track_candidates_range[0];
-    finding_cfg.max_track_candidates_per_track =
-        finding_opts.track_candidates_range[1];
-    finding_cfg.min_step_length_for_next_surface =
-        finding_opts.min_step_length_for_next_surface;
-    finding_cfg.max_step_counts_for_next_surface =
-        finding_opts.max_step_counts_for_next_surface;
-    finding_cfg.chi2_max = finding_opts.chi2_max;
-    finding_cfg.max_num_branches_per_seed = finding_opts.nmax_per_seed;
-    finding_cfg.max_num_skipping_per_cand =
-        finding_opts.max_num_skipping_per_cand;
-    finding_cfg.propagation = propagation_opts.config;
+    detray::propagation::config propagation_config(propagation_opts);
+
+    finding_algorithm::config_type finding_cfg(finding_opts);
+    finding_cfg.propagation = propagation_config;
 
     fitting_algorithm::config_type fitting_cfg;
-    fitting_cfg.propagation = propagation_opts.config;
+    fitting_cfg.propagation = propagation_config;
 
     // Algorithms
     traccc::host::clusterization_algorithm ca(host_mr);

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -111,19 +111,13 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
          1e-4 / detray::unit<traccc::scalar>::GeV,
          1e-4 * detray::unit<traccc::scalar>::ns};
 
+    // Propagation configuration
+    detray::propagation::config propagation_config(propagation_opts);
+
     // Finding algorithm configuration
-    typename traccc::finding_algorithm<rk_stepper_type,
-                                       host_navigator_type>::config_type cfg;
-    cfg.min_track_candidates_per_track = finding_opts.track_candidates_range[0];
-    cfg.max_track_candidates_per_track = finding_opts.track_candidates_range[1];
-    cfg.min_step_length_for_next_surface =
-        finding_opts.min_step_length_for_next_surface;
-    cfg.max_step_counts_for_next_surface =
-        finding_opts.max_step_counts_for_next_surface;
-    cfg.chi2_max = finding_opts.chi2_max;
-    cfg.max_num_branches_per_seed = finding_opts.nmax_per_seed;
-    cfg.max_num_skipping_per_cand = finding_opts.max_num_skipping_per_cand;
-    cfg.propagation = propagation_opts.config;
+    typename traccc::finding_algorithm<
+        rk_stepper_type, host_navigator_type>::config_type cfg(finding_opts);
+    cfg.propagation = propagation_config;
 
     // Finding algorithm object
     traccc::finding_algorithm<rk_stepper_type, host_navigator_type>
@@ -131,7 +125,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    fit_cfg.propagation = propagation_config;
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
 

--- a/examples/run/cpu/truth_fitting_example.cpp
+++ b/examples/run/cpu/truth_fitting_example.cpp
@@ -116,7 +116,7 @@ int main(int argc, char* argv[]) {
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    fit_cfg.propagation = propagation_opts;
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
 

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -180,19 +180,13 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                                             stream};
     traccc::cuda::track_params_estimation tp_cuda{mr, async_copy, stream};
 
+    // Propagation configuration
+    detray::propagation::config propagation_config(propagation_opts);
+
     // Finding algorithm configuration
     typename traccc::cuda::finding_algorithm<
-        rk_stepper_type, device_navigator_type>::config_type cfg;
-    cfg.min_track_candidates_per_track = finding_opts.track_candidates_range[0];
-    cfg.max_track_candidates_per_track = finding_opts.track_candidates_range[1];
-    cfg.min_step_length_for_next_surface =
-        finding_opts.min_step_length_for_next_surface;
-    cfg.max_step_counts_for_next_surface =
-        finding_opts.max_step_counts_for_next_surface;
-    cfg.chi2_max = finding_opts.chi2_max;
-    cfg.max_num_branches_per_seed = finding_opts.nmax_per_seed;
-    cfg.max_num_skipping_per_cand = finding_opts.max_num_skipping_per_cand;
-    cfg.propagation = propagation_opts.config;
+        rk_stepper_type, device_navigator_type>::config_type cfg(finding_opts);
+    cfg.propagation = propagation_config;
 
     // Finding algorithm object
     traccc::finding_algorithm<rk_stepper_type, host_navigator_type>
@@ -202,7 +196,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    fit_cfg.propagation = propagation_config;
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
     traccc::cuda::fitting_algorithm<device_fitter_type> device_fitting(

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -155,23 +155,13 @@ int seq_run(const traccc::opts::detector& detector_opts,
         traccc::kalman_fitter<stepper_type, device_navigator_type>>;
 
     // Algorithm configuration(s).
-    host_finding_algorithm::config_type finding_cfg;
-    finding_cfg.min_track_candidates_per_track =
-        finding_opts.track_candidates_range[0];
-    finding_cfg.max_track_candidates_per_track =
-        finding_opts.track_candidates_range[1];
-    finding_cfg.min_step_length_for_next_surface =
-        finding_opts.min_step_length_for_next_surface;
-    finding_cfg.max_step_counts_for_next_surface =
-        finding_opts.max_step_counts_for_next_surface;
-    finding_cfg.chi2_max = finding_opts.chi2_max;
-    finding_cfg.max_num_branches_per_seed = finding_opts.nmax_per_seed;
-    finding_cfg.max_num_skipping_per_cand =
-        finding_opts.max_num_skipping_per_cand;
-    finding_cfg.propagation = propagation_opts.config;
+    detray::propagation::config propagation_config(propagation_opts);
+
+    host_finding_algorithm::config_type finding_cfg(finding_opts);
+    finding_cfg.propagation = propagation_config;
 
     host_fitting_algorithm::config_type fitting_cfg;
-    fitting_cfg.propagation = propagation_opts.config;
+    fitting_cfg.propagation = propagation_config;
 
     // Constant B field for the track finding and fitting
     const traccc::vector3 field_vec = {0.f, 0.f,
@@ -188,8 +178,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
     host_finding_algorithm finding_alg(finding_cfg);
     host_fitting_algorithm fitting_alg(fitting_cfg);
 
-    traccc::cuda::clusterization_algorithm ca_cuda(
-        mr, copy, stream, clusterization_opts.target_cells_per_partition);
+    traccc::cuda::clusterization_algorithm ca_cuda(mr, copy, stream,
+                                                   clusterization_opts);
     traccc::cuda::measurement_sorting_algorithm ms_cuda(copy, stream);
     traccc::cuda::spacepoint_formation_algorithm sf_cuda(mr, copy, stream);
     traccc::cuda::seeding_algorithm sa_cuda(

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -155,19 +155,13 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
          1e-4 / detray::unit<traccc::scalar>::GeV,
          1e-4 * detray::unit<traccc::scalar>::ns};
 
+    // Propagation configuration
+    detray::propagation::config propagation_config(propagation_opts);
+
     // Finding algorithm configuration
     typename traccc::cuda::finding_algorithm<
-        rk_stepper_type, device_navigator_type>::config_type cfg;
-    cfg.min_track_candidates_per_track = finding_opts.track_candidates_range[0];
-    cfg.max_track_candidates_per_track = finding_opts.track_candidates_range[1];
-    cfg.min_step_length_for_next_surface =
-        finding_opts.min_step_length_for_next_surface;
-    cfg.max_step_counts_for_next_surface =
-        finding_opts.max_step_counts_for_next_surface;
-    cfg.chi2_max = finding_opts.chi2_max;
-    cfg.max_num_branches_per_seed = finding_opts.nmax_per_seed;
-    cfg.max_num_skipping_per_cand = finding_opts.max_num_skipping_per_cand;
-    cfg.propagation = propagation_opts.config;
+        rk_stepper_type, device_navigator_type>::config_type cfg(finding_opts);
+    cfg.propagation = propagation_config;
 
     // Finding algorithm object
     traccc::finding_algorithm<rk_stepper_type, host_navigator_type>
@@ -177,7 +171,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    fit_cfg.propagation = propagation_config;
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
     traccc::cuda::fitting_algorithm<device_fitter_type> device_fitting(

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -158,7 +158,7 @@ int main(int argc, char* argv[]) {
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
-    fit_cfg.propagation = propagation_opts.config;
+    fit_cfg.propagation = propagation_opts;
 
     traccc::fitting_algorithm<host_fitter_type> host_fitting(fit_cfg);
     traccc::cuda::fitting_algorithm<device_fitter_type> device_fitting(

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -118,8 +118,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
 
     vecmem::sycl::async_copy copy{&q};
 
-    traccc::sycl::clusterization_algorithm ca_sycl(
-        mr, copy, &q, clusterization_opts.target_cells_per_partition);
+    traccc::sycl::clusterization_algorithm ca_sycl(mr, copy, &q,
+                                                   clusterization_opts);
     traccc::sycl::spacepoint_formation_algorithm sf_sycl(mr, copy, &q);
     traccc::sycl::seeding_algorithm sa_sycl(
         seeding_opts.seedfinder, {seeding_opts.seedfinder},

--- a/examples/simulation/simulate.cpp
+++ b/examples/simulation/simulate.cpp
@@ -122,7 +122,7 @@ int main(int argc, char* argv[]) {
         generation_opts.events, host_det, field, std::move(generator),
         std::move(smearer_writer_cfg), full_path);
 
-    sim.get_config().propagation = propagation_opts.config;
+    sim.get_config().propagation = propagation_opts;
 
     sim.run();
 

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -133,7 +133,7 @@ int simulate(const traccc::opts::generation& generation_opts,
                                  writer_type>(
         generation_opts.events, det, field, std::move(generator),
         std::move(smearer_writer_cfg), full_path);
-    sim.get_config().propagation = propagation_opts.config;
+    sim.get_config().propagation = propagation_opts;
 
     sim.run();
 

--- a/examples/simulation/simulate_toy_detector.cpp
+++ b/examples/simulation/simulate_toy_detector.cpp
@@ -105,7 +105,7 @@ int simulate(const traccc::opts::generation& generation_opts,
                                  writer_type>(
         generation_opts.events, det, field, std::move(generator),
         std::move(smearer_writer_cfg), full_path);
-    sim.get_config().propagation = propagation_opts.config;
+    sim.get_config().propagation = propagation_opts;
 
     sim.run();
 

--- a/examples/simulation/simulate_wire_chamber.cpp
+++ b/examples/simulation/simulate_wire_chamber.cpp
@@ -106,7 +106,7 @@ int simulate(const traccc::opts::generation& generation_opts,
                                  writer_type>(
         generation_opts.events, det, field, std::move(generator),
         std::move(smearer_writer_cfg), full_path);
-    sim.get_config().propagation = propagation_opts.config;
+    sim.get_config().propagation = propagation_opts;
 
     sim.run();
 


### PR DESCRIPTION
As I am finalizing #595, I am noticing that it is really quite a task to update the configuration of our algorithms. Not only do you need to update the configuration type and the ways your algorithm uses it, but you also need to update the way the CLI options are translated into those configuration files across _many_ executables.

In this commit I am trying to make this process a little easier by specifying the `config_provider` mixin for command line options classes. This allows us to specify only once how options should be translated to configuration types, making the process easier and less prone to bugs.