### PR TITLE
Improve numerical stability of CCA variance

### DIFF
--- a/core/src/clusterization/measurement_creation_algorithm.cpp
+++ b/core/src/clusterization/measurement_creation_algorithm.cpp
@@ -32,16 +32,6 @@ measurement_creation_algorithm::operator()(
 
     // Process the clusters one-by-one.
     for (std::size_t i = 0; i < clusters.size(); ++i) {
-        // To calculate the mean and variance with high numerical stability
-        // we use a weighted variant of Welford's algorithm. This is a
-        // single-pass online algorithm that works well for large numbers
-        // of samples, as well as samples with very high values.
-        //
-        // To learn more about this algorithm please refer to:
-        // [1] https://doi.org/10.1080/00401706.1962.10490022
-        // [2] The Art of Computer Programming, Donald E. Knuth, second
-        //     edition, chapter 4.2.2.
-
         // Get the cluster.
         cluster_container_types::device::item_vector::const_reference cluster =
             clusters.get_items()[i];

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -25,16 +25,42 @@ inline void aggregate_cluster(
     vecmem::device_vector<unsigned int> cell_links_device(cell_links);
 
     /*
-     * Now, we iterate over all other cells to check if they belong
-     * to our cluster. Note that we can start at the current index
-     * because no cell is ever a child of a cluster owned by a cell
-     * with a higher ID.
+     * Now, we iterate over all other cells to check if they belong to our
+     * cluster. Note that we can start at the current index because no cell is
+     * ever a child of a cluster owned by a cell with a higher ID.
+     *
+     * Implemented here is a weighted version of Welford's algorithm. To read
+     * more about this algorithm, see the following sources:
+     *
+     * [1] https://doi.org/10.1080/00401706.1962.10490022
+     * [2] The Art of Computer Programming, Donald E. Knuth, second edition,
+     * chapter 4.2.2.
+     *
+     * The core idea of Welford's algorithm is to use the recurrence relation
+     *
+     * $$\sigma^2_n = (1 - \frac{w_n}{W_n}) \sigma^2_{n-1} + \frac{w_n}{W_n}
+     * (x_n - \mu_n) (x_n - \mu_{n-1})$$
+     *
+     * Which makes the algorithm less prone to catastrophic cancellation and
+     * other unwanted effects. In addition, we offset the entire computation
+     * by the first cell in the cluster, which brings the entire computation
+     * closer to zero where floating point precision is higher. This relies on
+     * the following:
+     *
+     * $$\mu(x_1, \ldots, x_n) = \mu(x_1 - C, \ldots, x_n - C) + C$$
+     *
+     * and
+     *
+     * $$\sigma^2(x_1, \ldots, x_n) = \sigma^2(x_1 - C, \ldots, x_n - C)$$
      */
     scalar totalWeight = 0.;
-    point2 mean{0., 0.}, var{0., 0.};
+    point2 mean{0., 0.}, var{0., 0.}, offset{0., 0.};
+
     const auto module_link = cells[cid + start].module_link;
     const cell_module this_module = modules.at(module_link);
     const unsigned short partition_size = end - start;
+
+    bool first_processed = false;
 
     channel_id maxChannel1 = std::numeric_limits<channel_id>::min();
 
@@ -67,15 +93,26 @@ inline void aggregate_cluster(
 
             if (weight > this_module.threshold) {
                 totalWeight += weight;
-                const point2 cell_position =
-                    traccc::details::position_from_cell(this_cell, this_module);
-                const point2 prev = mean;
-                const point2 diff = cell_position - prev;
+                scalar weight_factor = weight / totalWeight;
 
-                mean = prev + (weight / totalWeight) * diff;
-                for (char i = 0; i < 2; ++i) {
-                    var[i] += weight * (diff[i]) * (cell_position[i] - mean[i]);
+                point2 cell_position =
+                    traccc::details::position_from_cell(this_cell, this_module);
+
+                if (!first_processed) {
+                    offset = cell_position;
+                    first_processed = true;
                 }
+
+                cell_position = cell_position - offset;
+
+                const point2 diff_old = cell_position - mean;
+                mean = mean + diff_old * weight_factor;
+                const point2 diff_new = cell_position - mean;
+
+                var[0] = (1.f - weight_factor) * var[0] +
+                         weight_factor * (diff_old[0] * diff_new[0]);
+                var[1] = (1.f - weight_factor) * var[1] +
+                         weight_factor * (diff_old[1] * diff_new[1]);
             }
 
             cell_links_device.at(pos) = link;
@@ -89,20 +126,15 @@ inline void aggregate_cluster(
             break;
         }
     }
-    if (totalWeight > static_cast<scalar>(0.)) {
-#pragma unroll
-        for (char i = 0; i < 2; ++i) {
-            var[i] /= totalWeight;
-        }
-        const auto pitch = this_module.pixel.get_pitch();
-        var = var + point2{pitch[0] * pitch[0] / static_cast<scalar>(12.),
-                           pitch[1] * pitch[1] / static_cast<scalar>(12.)};
-    }
+
+    const auto pitch = this_module.pixel.get_pitch();
+    var = var + point2{pitch[0] * pitch[0] / static_cast<scalar>(12.),
+                       pitch[1] * pitch[1] / static_cast<scalar>(12.)};
 
     /*
      * Fill output vector with calculated cluster properties
      */
-    out.local = mean;
+    out.local = mean + offset;
     out.variance = var;
     out.surface_link = this_module.surface_link;
     out.module_link = module_link;


### PR DESCRIPTION
I noticed that, at some point, a factor of $\frac{1}{12}$ was added to the variance of measurements and this slipped through because the tolerance on the variance test was extremely large, i.e. no smaller than 0.1. This is an unacceptably high tolerance, and so I decided that the variance computation was in need of an update. I decided to adopt two strategies to do this. The first is the implementation of Welford's online algorithm, which relies on the following recurrence relation:

$$\sigma^2_n = \left(1 - \frac{w_n}{W_n}\right) \sigma^2_{n-1} + \frac{w_n}{W_n} (x_n - \mu_n) (x_n - \mu_{n-1})$$

This is significantly less prone to catastrophic cancellation. Second, I shifted the entire computation by the position of the first cell, which brings the computation closer to zero where floating point computation is more accurate. This depends on two equivalences:

$$\mu(x_1, \ldots, x_n) = \mu(x_1 - C, \ldots, x_n - C) + C$$

and

$$\sigma^2(x_1, \ldots, x_n) = \sigma^2(x_1 - C, \ldots, x_n - C)$$

Combined, these factors allow me to drop the tolerance in the tests from a _minimum_ of 0.1 to a fixed value of 0.0001.