### PR TITLE
Add infrastructure for working with concepts

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -35,7 +35,7 @@ jobs:
           - name: CPU
             container: ghcr.io/acts-project/ubuntu2404:48
             cxx_standard: "20"
-            options: -DTRACCC_USE_ROOT=FALSE
+            options: -DTRACCC_USE_ROOT=FALSE -DTRACCC_ENFORCE_CONCEPTS=TRUE
           - name: HIP
             container: ghcr.io/acts-project/ubuntu2004_rocm:47
             cxx_standard: "17"
@@ -47,7 +47,7 @@ jobs:
           - name: CUDA
             container: ghcr.io/acts-project/ubuntu2204_cuda:48
             cxx_standard: "20"
-            options: -DTRACCC_BUILD_CUDA=TRUE -DTRACCC_USE_ROOT=FALSE
+            options: -DTRACCC_BUILD_CUDA=TRUE -DTRACCC_USE_ROOT=FALSE -DTRACCC_ENFORCE_CONCEPTS=TRUE -DCMAKE_CUDA_FLAGS="-std=c++20"
           - name: SYCL
             container: ghcr.io/acts-project/ubuntu2004_oneapi:47
             cxx_standard: "17"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ option( TRACCC_BUILD_EXAMPLES "Build the examples of traccc" TRUE )
 option( TRACCC_USE_SYSTEM_LIBS "Use system libraries be default" FALSE )
 option( TRACCC_USE_ROOT "Use ROOT in the build (if needed)" TRUE )
 
+# Flag enforcing concept usage.
+option( TRACCC_ENFORCE_CONCEPTS "Throw an error if concepts are not available" FALSE )
+
 # Clean up.
 unset( TRACCC_BUILD_CUDA_DEFAULT )
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -110,3 +110,11 @@ target_link_libraries( traccc_core
 # CUDA or HIP backend with SYCL.
 target_compile_definitions( traccc_core
   PUBLIC $<$<COMPILE_LANGUAGE:SYCL>:EIGEN_NO_CUDA EIGEN_NO_HIP> )
+
+if ( TRACCC_ENFORCE_CONCEPTS )
+  target_compile_definitions(
+    traccc_core
+    PUBLIC
+    TRACCC_ENFORCE_CONCEPTS
+  )
+endif ()

--- a/core/include/traccc/definitions/concepts.hpp
+++ b/core/include/traccc/definitions/concepts.hpp
@@ -1,0 +1,18 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#if __cpp_concepts >= 201907L
+#define TRACCC_CONSTRAINT(...) __VA_ARGS__
+#elif defined(TRACCC_ENFORCE_CONCEPTS)
+#error \
+    "`TRACCC_ENFORCE_CONCEPTS` is set, but concepts are not available. This constitutes a fatal error."
+#else
+#define TRACCC_CONSTRAINT(...) typename
+#endif


### PR DESCRIPTION
This commit adds the `TRACCC_CONSTRAINT` macro which acts as a concept in C++20 builds, and simply acts as the `typename` keyword in builds with older standards. It also adds the `TRACCC_ENFORCE_CONCEPTS` CMake flag which will throw an error if concepts are not available.