### PR TITLE
Download data files after build in CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -82,8 +82,6 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v3
-      - name: Download data files
-        run: data/traccc_data_get_files.sh
       - name: Configure
         run: |
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
@@ -101,6 +99,9 @@ jobs:
         run: |
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
           cmake --build build
+      - name: Download data files
+        if: "matrix.platform.name == 'CPU'"
+        run: data/traccc_data_get_files.sh
       - name: Test
         if: "matrix.platform.name == 'CPU'"
         run: |


### PR DESCRIPTION
As it stands right now, we download all the data files before we ever even build the traccc project. This is a bit wasteful, as a failed build will render all that downloading useless. This commit moves the data downloading step to after the build step, and also makes it conditional on whether the tests will actually be run.