### PR TITLE
Zero output in mutex and unique lock tests

### DIFF
--- a/tests/cuda/test_mutex.cu
+++ b/tests/cuda/test_mutex.cu
@@ -35,6 +35,7 @@ TEST(CUDAMutex, MassAdditionKernel) {
         vecmem::make_unique_alloc<uint32_t>(mr);
 
     TRACCC_CUDA_ERROR_CHECK(cudaMemset(lock.get(), 0, sizeof(uint32_t)));
+    TRACCC_CUDA_ERROR_CHECK(cudaMemset(out.get(), 0, sizeof(uint32_t)));
 
     uint32_t n_blocks = 262144;
     uint32_t n_threads = 32;

--- a/tests/cuda/test_unique_lock.cu
+++ b/tests/cuda/test_unique_lock.cu
@@ -70,6 +70,7 @@ TEST(CUDAUniqueLock, MassAdditionKernelTryLock) {
         vecmem::make_unique_alloc<uint32_t>(mr);
 
     TRACCC_CUDA_ERROR_CHECK(cudaMemset(lock.get(), 0, sizeof(uint32_t)));
+    TRACCC_CUDA_ERROR_CHECK(cudaMemset(out.get(), 0, sizeof(uint32_t)));
 
     uint32_t n_blocks = 262144;
     uint32_t n_threads = 32;
@@ -92,6 +93,7 @@ TEST(CUDAUniqueLock, MassAdditionKernelDeferLock) {
         vecmem::make_unique_alloc<uint32_t>(mr);
 
     TRACCC_CUDA_ERROR_CHECK(cudaMemset(lock.get(), 0, sizeof(uint32_t)));
+    TRACCC_CUDA_ERROR_CHECK(cudaMemset(out.get(), 0, sizeof(uint32_t)));
 
     uint32_t n_blocks = 262144;
     uint32_t n_threads = 32;
@@ -114,6 +116,7 @@ TEST(CUDAUniqueLock, MassAdditionKernelAdoptLock) {
         vecmem::make_unique_alloc<uint32_t>(mr);
 
     TRACCC_CUDA_ERROR_CHECK(cudaMemset(lock.get(), 0, sizeof(uint32_t)));
+    TRACCC_CUDA_ERROR_CHECK(cudaMemset(out.get(), 0, sizeof(uint32_t)));
 
     uint32_t n_blocks = 262144;
     uint32_t n_threads = 32;

--- a/tests/sycl/test_mutex.sycl
+++ b/tests/sycl/test_mutex.sycl
@@ -24,6 +24,7 @@ TEST(SYCLMutex, MassAdditionKernel) {
         vecmem::make_unique_alloc<uint32_t>(mr);
 
     queue.memset(lock.get(), 0, sizeof(uint32_t)).wait_and_throw();
+    queue.memset(out.get(), 0, sizeof(uint32_t)).wait_and_throw();
 
     uint32_t n_blocks = 262144;
     uint32_t n_threads = 32;

--- a/tests/sycl/test_unique_lock.sycl
+++ b/tests/sycl/test_unique_lock.sycl
@@ -25,6 +25,7 @@ TEST(SYCLUniqueLock, MassAdditionKernelTryLock) {
         vecmem::make_unique_alloc<uint32_t>(mr);
 
     queue.memset(lock.get(), 0, sizeof(uint32_t)).wait_and_throw();
+    queue.memset(out.get(), 0, sizeof(uint32_t)).wait_and_throw();
 
     uint32_t n_blocks = 262144;
     uint32_t n_threads = 32;
@@ -66,6 +67,7 @@ TEST(SYCLUniqueLock, MassAdditionKernelDeferLock) {
         vecmem::make_unique_alloc<uint32_t>(mr);
 
     queue.memset(lock.get(), 0, sizeof(uint32_t)).wait_and_throw();
+    queue.memset(out.get(), 0, sizeof(uint32_t)).wait_and_throw();
 
     uint32_t n_blocks = 262144;
     uint32_t n_threads = 32;
@@ -104,6 +106,7 @@ TEST(SYCLUniqueLock, MassAdditionKernelAdoptLock) {
         vecmem::make_unique_alloc<uint32_t>(mr);
 
     queue.memset(lock.get(), 0, sizeof(uint32_t)).wait_and_throw();
+    queue.memset(out.get(), 0, sizeof(uint32_t)).wait_and_throw();
 
     uint32_t n_blocks = 262144;
     uint32_t n_threads = 32;


### PR DESCRIPTION
Turns out that on the platforms we test for, memory allocations are zeroed out implicitly. If you try running the code on architectures that don't do this, though, the results are incorrect. To correct for this, this commit adds explicit zeroing for the output variables of the mutex and unique lock tests.