### PR TITLE
Add missing wait statements to CCA testing code

### DIFF
--- a/tests/cuda/test_cca.cpp
+++ b/tests/cuda/test_cca.cpp
@@ -34,15 +34,15 @@ cca_function_t f = [](const traccc::cell_collection_types::host& cells,
         static_cast<traccc::cell_collection_types::buffer::size_type>(
             cells.size()),
         device_mr};
-    copy.setup(cells_buffer);
-    copy(vecmem::get_data(cells), cells_buffer)->ignore();
+    copy.setup(cells_buffer)->wait();
+    copy(vecmem::get_data(cells), cells_buffer)->wait();
 
     traccc::cell_module_collection_types::buffer modules_buffer{
         static_cast<traccc::cell_module_collection_types::buffer::size_type>(
             modules.size()),
         device_mr};
-    copy.setup(modules_buffer);
-    copy(vecmem::get_data(modules), modules_buffer)->ignore();
+    copy.setup(modules_buffer)->wait();
+    copy(vecmem::get_data(modules), modules_buffer)->wait();
 
     auto measurements_buffer = cc(cells_buffer, modules_buffer);
     traccc::measurement_collection_types::host measurements{&host_mr};

--- a/tests/sycl/test_cca.sycl
+++ b/tests/sycl/test_cca.sycl
@@ -34,15 +34,15 @@ cca_function_t f = [](const traccc::cell_collection_types::host& cells,
         static_cast<traccc::cell_collection_types::buffer::size_type>(
             cells.size()),
         device_mr};
-    copy.setup(cells_buffer);
-    copy(vecmem::get_data(cells), cells_buffer)->ignore();
+    copy.setup(cells_buffer)->wait();
+    copy(vecmem::get_data(cells), cells_buffer)->wait();
 
     traccc::cell_module_collection_types::buffer modules_buffer{
         static_cast<traccc::cell_module_collection_types::buffer::size_type>(
             modules.size()),
         device_mr};
-    copy.setup(modules_buffer);
-    copy(vecmem::get_data(modules), modules_buffer)->ignore();
+    copy.setup(modules_buffer)->wait();
+    copy(vecmem::get_data(modules), modules_buffer)->wait();
 
     auto measurements_buffer = cc(cells_buffer, modules_buffer);
     traccc::measurement_collection_types::host measurements{&host_mr};


### PR DESCRIPTION
The current CCA testing code for CUDA and SYCL is missing some necessary wait statements, which are causing me issues in #609. This commit fixes the problem by adding the missing waits.