### PR TITLE
Enable thread backend for all Alpaka builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,10 @@ option( TRACCC_USE_SYSTEM_ALPAKA
    "Pick up an existing installation of Alpaka from the build environment"
    ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_ALPAKA )
+   # Default options for the Alpaka build.
+   set( alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE TRUE CACHE BOOL
+      "Enable the serial backend of Alpaka" )
+
    if( TRACCC_USE_SYSTEM_ALPAKA )
       find_package( alpaka REQUIRED )
    else()

--- a/extern/alpaka/CMakeLists.txt
+++ b/extern/alpaka/CMakeLists.txt
@@ -23,10 +23,6 @@ set( TRACCC_ALPAKA_SOURCE
 mark_as_advanced( TRACCC_ALPAKA_SOURCE )
 FetchContent_Declare( Alpaka ${TRACCC_ALPAKA_SOURCE} )
 
-# Default options for the Alpaka build.
-set( alpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE TRUE CACHE BOOL
-   "Enable the serial backend of Alpaka" )
-
 #Turn off build testing
 if( DEFINED CACHE{BUILD_TESTING} )
    set( _buildTestingValue ${BUILD_TESTING} )


### PR DESCRIPTION
Currently, the serial CPU backend is enabled in Alpaka only if you download Alpaka using FetchContent. When using a preinstalled version of Alpaka, the default backend is not correctly set. In this PR, I move the default backend configuration from a file which is only loaded for FetchContent usage to the main CMakeLists.txt file, allowing it to be used in all builds.