### PR TITLE
Require multiple threads for Alpaka CCL code

### DIFF
--- a/device/alpaka/src/clusterization/clusterization_algorithm.cpp
+++ b/device/alpaka/src/clusterization/clusterization_algorithm.cpp
@@ -99,6 +99,9 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     // Launch ccl kernel. Each thread will handle a single cell.
     const device::details::ccl_kernel_helper helper{
         m_target_cells_per_partition, num_cells};
+    static_assert(accSupportsMultiThreadBlocks<Acc>(),
+                  "Clustering algorithm must be compiled for an accelerator "
+                  "with support for multi-thread blocks.");
     auto workDiv =
         makeWorkDiv<Acc>(helper.num_partitions, helper.threads_per_partition);
 

--- a/device/alpaka/src/utils/utils.hpp
+++ b/device/alpaka/src/utils/utils.hpp
@@ -38,10 +38,21 @@ static constexpr std::size_t warpSize =
 #endif
 
 template <typename TAcc>
+constexpr bool accSupportsMultiThreadBlocks() {
+    if constexpr (::alpaka::accMatchesTags<TAcc, ::alpaka::TagGpuCudaRt> ||
+                  ::alpaka::accMatchesTags<TAcc, ::alpaka::TagGpuHipRt> ||
+                  ::alpaka::accMatchesTags<TAcc, ::alpaka::TagCpuOmp2Threads> ||
+                  ::alpaka::accMatchesTags<TAcc, ::alpaka::TagCpuThreads>) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+template <typename TAcc>
 inline WorkDiv makeWorkDiv(Idx blocks, Idx threadsOrElements) {
     const Idx blocksPerGrid = std::max(Idx{1}, blocks);
-    if constexpr (::alpaka::accMatchesTags<TAcc, ::alpaka::TagGpuCudaRt> ||
-                  ::alpaka::accMatchesTags<TAcc, ::alpaka::TagGpuHipRt>) {
+    if constexpr (accSupportsMultiThreadBlocks<TAcc>()) {
         const Idx threadsPerBlock(threadsOrElements);
         const Idx elementsPerThread = Idx{1};
         return WorkDiv{blocksPerGrid, threadsPerBlock, elementsPerThread};


### PR DESCRIPTION
The CCL code currently does not support running with a single thread per block; it has to be run with multiple threads per block by design. In order to require this, I have added a new function that asserts this about a device (note that in Alpaka 1.2.0 there is `IsMultiThreadAcc`, but we cannot use this yet). I have also added a static assertion for this.