### PR TITLE
Make IO test mock data path absolute

### DIFF
--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -12,3 +12,9 @@ traccc_add_test( io
    "test_event_map.cpp"
    LINK_LIBRARIES GTest::gtest_main traccc_tests_common
                   traccc::core traccc::io )
+
+target_compile_definitions(
+  traccc_test_io
+  PRIVATE
+  TRACCC_TEST_IO_MOCK_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/mock_data"
+)

--- a/tests/io/test_mapper.cpp
+++ b/tests/io/test_mapper.cpp
@@ -19,9 +19,9 @@ std::size_t event = 0;
 std::string detector_file = "tml_detector/trackml-detector.csv";
 std::string digi_config_file =
     "tml_detector/default-geometric-config-generic.json";
-std::string hits_dir = "../tests/io/mock_data/";
-std::string cells_dir = "../tests/io/mock_data/";
-std::string particles_dir = "../tests/io/mock_data/";
+std::string hits_dir = TRACCC_TEST_IO_MOCK_DATA_DIR;
+std::string cells_dir = TRACCC_TEST_IO_MOCK_DATA_DIR;
+std::string particles_dir = TRACCC_TEST_IO_MOCK_DATA_DIR;
 
 /***
  * Mock data test


### PR DESCRIPTION
The current IO mock data path is relative, which breaks down if data is not stored in the `data/` directory. This commit makes the path absolute via some CMake code to ensure that it is treated as an absolute path.