### PR TITLE
Make Kokkos code compatible with C++20

### DIFF
--- a/device/kokkos/src/seeding/spacepoint_binning.cpp
+++ b/device/kokkos/src/seeding/spacepoint_binning.cpp
@@ -46,6 +46,10 @@ spacepoint_binning::output_type spacepoint_binning::operator()(
     const unsigned int num_threads = 32 * 8;
     const unsigned int num_blocks = (sp_size + num_threads - 1) / num_threads;
 
+    // Hack to avoid warnings thrown by C++20
+    seedfinder_config config = m_config;
+    auto axes = m_axes;
+
     Kokkos::parallel_for(
         "count_grid_capacities", team_policy(num_blocks, Kokkos::AUTO),
         KOKKOS_LAMBDA(const member_type& team_member) {
@@ -55,7 +59,7 @@ spacepoint_binning::output_type spacepoint_binning::operator()(
                     device::count_grid_capacities(
                         team_member.league_rank() * team_member.team_size() +
                             thr,
-                        m_config, m_axes.first, m_axes.second, spacepoints_view,
+                        config, axes.first, axes.second, spacepoints_view,
                         grid_capacities_view);
                 });
         });
@@ -84,7 +88,7 @@ spacepoint_binning::output_type spacepoint_binning::operator()(
                     device::populate_grid(
                         team_member.league_rank() * team_member.team_size() +
                             thr,
-                        m_config, spacepoints_view, grid_view);
+                        config, spacepoints_view, grid_view);
                 });
         });
 

--- a/extern/kokkos/CMakeLists.txt
+++ b/extern/kokkos/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Kokkos as part of the TRACCC project" )
 
 # Declare where to get Kokkos from.
 set( TRACCC_KOKKOS_SOURCE
-   "URL;https://github.com/kokkos/kokkos/archive/refs/tags/3.7.00.tar.gz;URL_MD5;84991eca9f066383abe119a5bc7a11c4"
+   "URL;https://github.com/kokkos/kokkos/archive/refs/tags/4.3.01.tar.gz;URL_MD5;243de871b3dc2cf3990c1c404032df83"
    CACHE STRING "Source for Kokkos, when built as part of this project" )
 mark_as_advanced( TRACCC_KOKKOS_SOURCE )
 FetchContent_Declare( Kokkos ${TRACCC_KOKKOS_SOURCE} )
@@ -26,6 +26,8 @@ FetchContent_Declare( Kokkos ${TRACCC_KOKKOS_SOURCE} )
 # Default options for the Kokkos build.
 set( Kokkos_ENABLE_SERIAL TRUE CACHE BOOL
    "Enable the serial backend of Kokkos" )
+set( BUILD_SHARED_LIBS TRUE CACHE BOOL
+   "Enable building of shared libs in Kokkos" )
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( Kokkos )


### PR DESCRIPTION
The Kokkos code has two problems when it comes to C++20 compatibility. Firstly, the current version simply does not work in C++20 mode; compilation requires Kokkos 4.3.1 or later. There are also some warnings that prevent compilation. This commit fixes these issues by updating to Kokkos 4.3.1 and by adding some hacks to fix the compiler warnings.