### PR TITLE
Increase minimum CMake version to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Mozilla Public License Version 2.0
 
 # Set up the project.
-cmake_minimum_required( VERSION 3.9 )
+cmake_minimum_required( VERSION 3.22 )
 project( traccc VERSION 0.13.0 LANGUAGES CXX )
 
 # Set up the used C++ standard(s).

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Enable CUDA as a language.
 enable_language( CUDA )
 
+# CMake 3.26 is the first to support C++20 in CUDA.
+cmake_minimum_required( VERSION 3.26 )
+
 # Find the CUDA toolkit
 find_package( CUDAToolkit REQUIRED )
 


### PR DESCRIPTION
Earlier versions of CMake were unable to properly configure GCC for C++20 compilation, opting to add the `-std=c++2a` flag instead of the `-std=c++20` flag which broke the build. CMake 3.22 correctly sets the C++20 flag, and as such we are setting this as our new minimum version.