### PR TITLE
Fix full chain algorithm deallocation order

### DIFF
--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -81,12 +81,7 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
       m_filter_config(parent.m_filter_config) {
 }
 
-full_chain_algorithm::~full_chain_algorithm() {
-
-    // We need to ensure that the caching memory resource would be deleted
-    // before the device memory resource that it is based on.
-    m_cached_device_mr.reset();
-}
+full_chain_algorithm::~full_chain_algorithm() = default;
 
 full_chain_algorithm::output_type full_chain_algorithm::operator()(
     const cell_collection_types::host& cells,

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -126,12 +126,7 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
     }
 }
 
-full_chain_algorithm::~full_chain_algorithm() {
-
-    // We need to ensure that the caching memory resource would be deleted
-    // before the device memory resource that it is based on.
-    m_cached_device_mr.reset();
-}
+full_chain_algorithm::~full_chain_algorithm() = default;
 
 full_chain_algorithm::output_type full_chain_algorithm::operator()(
     const cell_collection_types::host& cells,

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -103,8 +103,6 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
 
 full_chain_algorithm::~full_chain_algorithm() {
     // Need to ensure that objects would be deleted in the correct order.
-    m_cached_device_mr.reset();
-    m_device_mr.reset();
     delete m_data;
 }
 


### PR DESCRIPTION
Since #595 was merged, some of the throughput examples started to fail. After some investigation, it turned out that this was not actually a mistake in #595, but rather a long-standing bug in the full chain algorithms.

The situation was such that the full chain algorithms had custom destructors which destroyed the caching memory resources, which are pointers that need to be destroyed before the underlying memory resource they use. This creates a problem, namely that the cached memory resource is destroyed before _any other_ members of the class, including any long-standing memory allocations. When those allocations are then destroyed, the memory resource no longer exists and the program segfaults.

Thankfully, the fix for this was very easy as the aforementioned destructors are not necessary at all, as the C++ standard guarantees that members are destroyed in reverse initialization order, and since our full chain algorithms always (correctly) specify the caching memory resource _after_ the base memory resource, the default destructors are more than sufficient.

In order to fix the segmentation fault, this commit simply removes the offending destructors.