### PR TITLE
Move shared CCL variables into single struct

### DIFF
--- a/device/alpaka/src/clusterization/clusterization_algorithm.cpp
+++ b/device/alpaka/src/clusterization/clusterization_algorithm.cpp
@@ -38,11 +38,8 @@ struct CCLKernel {
 
         traccc::alpaka::thread_id1 thread_id(acc);
 
-        auto& partition_start =
-            ::alpaka::declareSharedVar<std::size_t, __COUNTER__>(acc);
-        auto& partition_end =
-            ::alpaka::declareSharedVar<std::size_t, __COUNTER__>(acc);
-        auto& outi = ::alpaka::declareSharedVar<std::size_t, __COUNTER__>(acc);
+        auto& shared = ::alpaka::declareSharedVar<
+            device::details::ccl_kernel_static_smem_parcel, __COUNTER__>(acc);
 
         device::details::index_t* const shared_v =
             ::alpaka::getDynSharedMem<device::details::index_t>(acc);
@@ -56,9 +53,8 @@ struct CCLKernel {
 
         alpaka::barrier<TAcc> barry_r(&acc);
 
-        device::ccl_kernel(cfg, thread_id, cells_view, modules_view,
-                           partition_start, partition_end, outi, f_view,
-                           gf_view, f_backup_view, gf_backup_view,
+        device::ccl_kernel(cfg, thread_id, cells_view, modules_view, shared,
+                           f_view, gf_view, f_backup_view, gf_backup_view,
                            adjc_backup_view, adjv_backup_view, backup_mutex,
                            barry_r, measurements_view, cell_links);
     }

--- a/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
+++ b/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
@@ -26,6 +26,13 @@
 #include <cstddef>
 
 namespace traccc::device {
+namespace details {
+struct ccl_kernel_static_smem_parcel {
+    std::size_t partition_start;
+    std::size_t partition_end;
+    uint32_t outi;
+};
+}  // namespace details
 
 /// Function which reads raw detector cells and turns them into measurements.
 ///
@@ -59,7 +66,7 @@ TRACCC_DEVICE inline void ccl_kernel(
     const clustering_config cfg, const thread_id_t& thread_id,
     const cell_collection_types::const_view cells_view,
     const cell_module_collection_types::const_view modules_view,
-    std::size_t& partition_start, std::size_t& partition_end, std::size_t& outi,
+    details::ccl_kernel_static_smem_parcel& smem,
     vecmem::data::vector_view<details::index_t> f_view,
     vecmem::data::vector_view<details::index_t> gf_view,
     vecmem::data::vector_view<details::index_t> f_backup_view,

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -42,8 +42,7 @@ __global__ void ccl_kernel(
     vecmem::data::vector_view<device::details::index_t> adjv_backup_view,
     unsigned int* backup_mutex_ptr) {
 
-    __shared__ std::size_t partition_start, partition_end;
-    __shared__ std::size_t outi;
+    __shared__ device::details::ccl_kernel_static_smem_parcel shared;
     extern __shared__ device::details::index_t shared_v[];
     vecmem::device_atomic_ref<unsigned int> backup_mutex(*backup_mutex_ptr);
 
@@ -58,9 +57,8 @@ __global__ void ccl_kernel(
     traccc::cuda::barrier barry_r;
     const cuda::thread_id1 thread_id;
 
-    device::ccl_kernel(cfg, thread_id, cells_view, modules_view,
-                       partition_start, partition_end, outi, f_view, gf_view,
-                       f_backup_view, gf_backup_view, adjc_backup_view,
+    device::ccl_kernel(cfg, thread_id, cells_view, modules_view, shared, f_view,
+                       gf_view, f_backup_view, gf_backup_view, adjc_backup_view,
                        adjv_backup_view, backup_mutex, barry_r,
                        measurements_view, cell_links);
 }

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -117,14 +117,16 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     details::get_queue(m_queue)
         .submit([&](::sycl::handler& h) {
             // Allocate shared memory for the kernel.
-            vecmem::sycl::local_accessor<std::size_t> shared_uint(3, h);
+            vecmem::sycl::local_accessor<
+                device::details::ccl_kernel_static_smem_parcel>
+                shared(1, h);
             vecmem::sycl::local_accessor<device::details::index_t> shared_idx(
                 2 * m_config.max_partition_size(), h);
 
             // Launch the kernel.
             h.parallel_for<kernels::ccl_kernel>(
                 cclKernelRange,
-                [shared_uint, shared_idx, cells_view, modules_view,
+                [shared, shared_idx, cells_view, modules_view,
                  measurements_view, cell_links_view,
                  f_backup_view = vecmem::get_data(m_f_backup),
                  gf_backup_view = vecmem::get_data(m_gf_backup),
@@ -139,9 +141,6 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
                     vecmem::data::vector_view<device::details::index_t> gf_view{
                         static_cast<vector_size_t>(cfg.max_partition_size()),
                         &shared_idx[cfg.max_partition_size()]};
-                    std::size_t& partition_start = shared_uint[0];
-                    std::size_t& partition_end = shared_uint[1];
-                    std::size_t& outi = shared_uint[2];
 
                     // Mutex for scratch space
                     vecmem::device_atomic_ref<unsigned int> backup_mutex(
@@ -152,12 +151,11 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
                     const sycl::thread_id1 thread_id(item);
 
                     // Run the algorithm for this thread.
-                    device::ccl_kernel(cfg, thread_id, cells_view, modules_view,
-                                       partition_start, partition_end, outi,
-                                       f_view, gf_view, f_backup_view,
-                                       gf_backup_view, adjc_backup_view,
-                                       adjv_backup_view, backup_mutex, barry_r,
-                                       measurements_view, cell_links_view);
+                    device::ccl_kernel(
+                        cfg, thread_id, cells_view, modules_view, shared[0],
+                        f_view, gf_view, f_backup_view, gf_backup_view,
+                        adjc_backup_view, adjv_backup_view, backup_mutex,
+                        barry_r, measurements_view, cell_links_view);
                 });
         })
         .wait_and_throw();


### PR DESCRIPTION
The current CCL kernels have so many parameters that it's a real pain in the rear to maintain them and to make changes to them. This commit reduces the number of parameters a little bit by taking all statically-known shared memory data and unifying it into a single struct which can be passed around more easily.