### PR TITLE
Use traccc scalar type in seeding config

### DIFF
--- a/core/include/traccc/seeding/detail/seeding_config.hpp
+++ b/core/include/traccc/seeding/detail/seeding_config.hpp
@@ -125,7 +125,7 @@ struct seedfinder_config {
                    std::sqrt(radLengthPerSeed) *
                    (1.f + 0.038f * std::log(radLengthPerSeed));
 
-        float maxScatteringAngle = highland / minPt;
+        scalar maxScatteringAngle = highland / minPt;
         maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
 
         pTPerHelixRadius = bFieldInZ;


### PR DESCRIPTION
The maximum scattering angle was being calculated as a floating point values, which was causing errors in the Acts integration. This minor change updates this to use the generic scalar type, which can be synchronised with the Acts scalar type.