### PR TITLE
Disable Default CUDA Build, main branch (2024.08.13.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,17 +44,8 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
 include( traccc-functions )
 
-# Check if CUDA is available.
-include( CheckLanguage )
-check_language( CUDA )
-set( TRACCC_BUILD_CUDA_DEFAULT FALSE )
-if( CMAKE_CUDA_COMPILER )
-   set( TRACCC_BUILD_CUDA_DEFAULT TRUE )
-endif()
-
 # Flags controlling which parts of traccc to build.
-option( TRACCC_BUILD_CUDA "Build the CUDA sources included in traccc"
-   ${TRACCC_BUILD_CUDA_DEFAULT} )
+option( TRACCC_BUILD_CUDA "Build the CUDA sources included in traccc" FALSE )
 option( TRACCC_BUILD_HIP "Build the HIP sources included in traccc" FALSE)
 option( TRACCC_BUILD_SYCL "Build the SYCL sources included in traccc" FALSE )
 option( TRACCC_BUILD_FUTHARK "Build the Futhark sources included in traccc"
@@ -71,9 +62,6 @@ option( TRACCC_BUILD_EXAMPLES "Build the examples of traccc" TRUE )
 # Flags controlling what traccc should use.
 option( TRACCC_USE_SYSTEM_LIBS "Use system libraries be default" FALSE )
 option( TRACCC_USE_ROOT "Use ROOT in the build (if needed)" TRUE )
-
-# Clean up.
-unset( TRACCC_BUILD_CUDA_DEFAULT )
 
 # Check CUDA and SYCL C++ standards
 if(${TRACCC_BUILD_CUDA} AND ${CMAKE_CUDA_STANDARD} LESS 20)


### PR DESCRIPTION
This is a bit of a subjective proposal, so I'm interested in the feedback...

To make my life just a little easier, I'd like to stop the project from automatically enabling the build of its CUDA code when it thinks that it found a functional CUDA version. And so be consistent with how the SYCL, Alpaka, etc. sources need to be "turned on" for the build.

My reason is a bit complicated. It stems from the issue described under: https://discourse.cmake.org/t/checklanguage-does-not-take-the-c-standard-into-account When I set up the latest version of oneAPI with the latest version of CUDA, right now I both have to explicitly turn on the build of the SYCL code (for the NVIDIA backend, that's why I also have CUDA set up), and turn off the build of the CUDA code. Unfortunately the `sycl` preset in `CMakePresets.json` doesn't do this at the moment. So I can't use VSCode for SYCL code development with the latest oneAPI version at the moment, without modifying the CMake code a little.

Instead of doing that, I thought that this specific update could be acceptable by everyone. This way I could easily use the `sycl` preset (with VSCode) with the latest oneAPI version, and the `cuda` preset in a different environment in which I do not set up oneAPI at all.

But this does mean that if one of you didn't use any presets, and didn't set `TRACCC_BUILD_CUDA` so far when doing CUDA developments, you'd need to have a little longer configuration command from now on. :thinking: