### PR TITLE
Externals Update, main branch (2024.08.14.)

### DIFF
--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,7 +18,7 @@ message( STATUS "Building GoogleTest as part of the TRACCC project" )
 
 # Declare where to get GoogleTest from.
 set( TRACCC_GOOGLETEST_SOURCE
-   "URL;https://github.com/google/googletest/archive/release-1.11.0.tar.gz;URL_MD5;e8a8df240b6938bb6384155d4c37d937"
+   "URL;https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz;URL_MD5;7e11f6cfcf6498324ac82d567dcb891e"
    CACHE STRING "Source for GoogleTest, when built as part of this project" )
 mark_as_advanced( TRACCC_GOOGLETEST_SOURCE )
 FetchContent_Declare( GoogleTest ${TRACCC_GOOGLETEST_SOURCE} )

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.6.0.tar.gz;URL_MD5;1af26e9d27e4b24e68028d041869e95f"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.7.0.tar.gz;URL_MD5;4544ec9b3686fdae558b613d9ea12233"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )

--- a/tests/common/tests/cca_test.hpp
+++ b/tests/common/tests/cca_test.hpp
@@ -30,6 +30,10 @@
 
 // System include(s).
 #include <functional>
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <string>
 
 using cca_function_t = std::function<
     std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>>(


### PR DESCRIPTION
This is mainly to update to the latest VecMem version, to help with a build issue discovered in #627. (Because of that, it's relatively urgent.)

But while I was at it, I also updated to the latest version of GoogleTest. Which then also necessitated adding an `<iomanip>` include, which was missing so far from one of the tests.