### PR TITLE
Add CPU and CUDA benchmark for toy detector reconstruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ option( TRACCC_BUILD_ALPAKA "Build the Alpaka sources included in traccc"
    FALSE )
 option( TRACCC_BUILD_IO "Build the IO module (needed by examples, performance, testing)" TRUE )
 option( TRACCC_BUILD_TESTING "Build the (unit) tests of traccc" TRUE )
+option( TRACCC_BUILD_BENCHMARKS "Build the benchmarks of traccc" TRUE )
 option( TRACCC_BUILD_EXAMPLES "Build the examples of traccc" TRUE )
 
 # Flags controlling what traccc should use.
@@ -291,6 +292,20 @@ if( TRACCC_SETUP_GOOGLETEST )
    endif()
 endif()
 
+# Set up Google Benchmark
+option( TRACCC_SETUP_BENCHMARKS
+   "Set up the Google Benchmark target(s) explicitly" TRUE )
+option( TRACCC_USE_SYSTEM_BENCHMARKS
+   "Pick up an existing installation of Google Benchmark from the build environment"
+   ${TRACCC_USE_SYSTEM_LIBS} )
+if( TRACCC_SETUP_BENCHMARKS )
+   if( TRACCC_USE_SYSTEM_BENCHMARKS )
+      find_package( benchmark REQUIRED )
+   else()
+      add_subdirectory( extern/benchmark )
+   endif()
+endif()
+
 option( TRACCC_ENABLE_NVTX_PROFILING
         "Use instrument functions to enable fine grained profiling" FALSE )
 
@@ -339,6 +354,16 @@ if( BUILD_TESTING AND TRACCC_BUILD_TESTING )
       message(FATAL_ERROR "traccc::io is disabled, but it is required to build the tests.")
    endif()
    add_subdirectory( tests )
+endif()
+
+# Set up the benchmark(s).
+if( TRACCC_BUILD_BENCHMARKS )
+   # Find Boost.
+   find_package( Boost REQUIRED COMPONENTS filesystem)
+   if ( NOT TRACCC_BUILD_IO )
+      message(FATAL_ERROR "traccc::io is disabled, but it is required to build the tests.")
+   endif()
+   add_subdirectory( benchmarks )
 endif()
 
 if(TRACCC_BUILD_FUTHARK)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,23 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Project include(s).
+include( traccc-compiler-options-cpp )
+
+# Set up a common library, shared by all of the tests.
+add_library( traccc_benchmarks_common STATIC
+    "common/benchmarks/toy_detector_benchmark.hpp" )
+target_include_directories( traccc_benchmarks_common
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common )
+target_link_libraries( traccc_benchmarks_common
+    PUBLIC benchmark::benchmark benchmark::benchmark_main 
+    traccc::core traccc::io traccc::simulation detray::core detray::utils 
+    vecmem::core Boost::filesystem)
+
+add_subdirectory(cpu)
+if( TRACCC_BUILD_CUDA )
+    add_subdirectory(cuda)
+endif()

--- a/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
+++ b/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
@@ -1,0 +1,186 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Traccc include(s).
+#include "traccc/definitions/common.hpp"
+#include "traccc/finding/finding_algorithm.hpp"
+#include "traccc/fitting/fitting_algorithm.hpp"
+#include "traccc/io/utils.hpp"
+#include "traccc/seeding/seeding_algorithm.hpp"
+#include "traccc/seeding/track_params_estimation.hpp"
+#include "traccc/simulation/measurement_smearer.hpp"
+#include "traccc/simulation/simulator.hpp"
+#include "traccc/simulation/smearing_writer.hpp"
+
+// Detray include(s).
+#include "detray/core/detector.hpp"
+#include "detray/definitions/units.hpp"
+#include "detray/detectors/bfield.hpp"
+#include "detray/detectors/build_toy_detector.hpp"
+#include "detray/geometry/mask.hpp"
+#include "detray/geometry/shapes/rectangle2D.hpp"
+#include "detray/io/frontend/detector_reader.hpp"
+#include "detray/io/frontend/detector_writer.hpp"
+#include "detray/navigation/detail/ray.hpp"
+#include "detray/navigation/navigator.hpp"
+#include "detray/propagator/propagator.hpp"
+#include "detray/propagator/rk_stepper.hpp"
+#include "detray/simulation/event_generator/track_generators.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// Boost include(s).
+#include <boost/filesystem.hpp>
+
+// Google Benchmark include(s).
+#include <benchmark/benchmark.h>
+
+class ToyDetectorBenchmark : public benchmark::Fixture {
+    public:
+    static const int n_events = 100u;
+    static const int n_tracks = 5000u;
+
+    std::vector<traccc::spacepoint_collection_types::host> spacepoints;
+    std::vector<traccc::measurement_collection_types::host> measurements;
+
+    // Configs
+    traccc::seedfinder_config seeding_cfg;
+    traccc::seedfilter_config filter_cfg;
+    traccc::spacepoint_grid_config grid_cfg{seeding_cfg};
+    traccc::finding_config<float> finding_cfg;
+    traccc::fitting_config fitting_cfg;
+
+    static constexpr std::array<float, 2> phi_range{
+        -traccc::constant<float>::pi, traccc::constant<float>::pi};
+    static constexpr std::array<float, 2> theta_range{
+        0.f, traccc::constant<float>::pi};
+    static constexpr std::array<float, 2> mom_range{
+        10.f * traccc::unit<float>::GeV, 100.f * traccc::unit<float>::GeV};
+
+    static inline const std::string sim_dir = "toy_detector_benchmark/";
+
+    // Detector type
+    using detector_type = detray::detector<detray::toy_metadata>;
+
+    // B field value and its type
+    // @TODO: Set B field as argument
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t>;
+
+    static constexpr traccc::vector3 B{0, 0,
+                                       2 * detray::unit<traccc::scalar>::T};
+
+    ToyDetectorBenchmark() {
+
+        std::cout << "Please be patient. It may take some time to generate "
+                     "the simulation data."
+                  << std::endl;
+
+        // VecMem memory resource(s)
+        vecmem::host_memory_resource host_mr;
+
+        // Use deterministic random number generator for testing
+        using uniform_gen_t = detray::detail::random_numbers<
+            traccc::scalar, std::uniform_real_distribution<traccc::scalar>>;
+
+        // Build the detector
+        auto [det, name_map] =
+            detray::build_toy_detector(host_mr, get_toy_config());
+
+        // B field
+        auto field = detray::bfield::create_const_field(B);
+
+        // Origin of particles
+        using generator_type =
+            detray::random_track_generator<traccc::free_track_parameters,
+                                           uniform_gen_t>;
+        generator_type::configuration gen_cfg{};
+        gen_cfg.n_tracks(n_tracks);
+        gen_cfg.phi_range(phi_range);
+        gen_cfg.theta_range(theta_range);
+        gen_cfg.mom_range(mom_range);
+        generator_type generator(gen_cfg);
+
+        // Smearing value for measurements
+        traccc::measurement_smearer<traccc::default_algebra> meas_smearer(
+            50 * detray::unit<traccc::scalar>::um,
+            50 * detray::unit<traccc::scalar>::um);
+
+        // Type declarations
+        using writer_type = traccc::smearing_writer<
+            traccc::measurement_smearer<traccc::default_algebra>>;
+
+        // Writer config
+        typename writer_type::config smearer_writer_cfg{meas_smearer};
+
+        // Run simulator
+        const std::string full_path = traccc::io::data_directory() + sim_dir;
+
+        boost::filesystem::create_directories(full_path);
+
+        auto sim = traccc::simulator<detector_type, b_field_t, generator_type,
+                                     writer_type>(
+            n_events, det, field, std::move(generator),
+            std::move(smearer_writer_cfg), full_path);
+
+        // Set constrained step size to 1 mm
+        sim.get_config().propagation.stepping.step_constraint =
+            1.f * detray::unit<traccc::scalar>::mm;
+
+        sim.run();
+
+        // Write detector file
+        auto writer_cfg = detray::io::detector_writer_config{}
+                              .format(detray::io::format::json)
+                              .replace_files(true)
+                              .write_grids(true)
+                              .write_material(true)
+                              .path(sim_dir);
+        detray::io::write_detector(det, name_map, writer_cfg);
+    }
+
+    detray::toy_det_config get_toy_config() const {
+
+        // Create the toy geometry
+        detray::toy_det_config toy_cfg{};
+        toy_cfg.n_brl_layers(4u).n_edc_layers(7u).do_check(false);
+
+        // @TODO: Increase the material budget again
+        toy_cfg.module_mat_thickness(0.11f * detray::unit<traccc::scalar>::mm);
+
+        return toy_cfg;
+    }
+
+    void SetUp(::benchmark::State& /*state*/) {
+
+        // VecMem memory resource(s)
+        vecmem::host_memory_resource host_mr;
+
+        // Build the detector
+        auto [det, name_map] =
+            detray::build_toy_detector(host_mr, get_toy_config());
+
+        // Read geometry
+        traccc::geometry surface_transforms =
+            traccc::io::alt_read_geometry(det);
+
+        // Read events
+        for (std::size_t i_evt = 0; i_evt < n_events; i_evt++) {
+
+            // Read the hits from the relevant event file
+            traccc::io::spacepoint_reader_output readOut(&host_mr);
+            traccc::io::read_spacepoints(readOut, i_evt, sim_dir,
+                                         surface_transforms);
+            spacepoints.push_back(readOut.spacepoints);
+
+            // Read measurements
+            traccc::io::measurement_reader_output meas_read_out(&host_mr);
+            traccc::io::read_measurements(meas_read_out, i_evt, sim_dir);
+            measurements.push_back(meas_read_out.measurements);
+        }
+    }
+};

--- a/benchmarks/cpu/CMakeLists.txt
+++ b/benchmarks/cpu/CMakeLists.txt
@@ -1,0 +1,19 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Look for openMP, which is used for the CPU benchmark
+find_package(OpenMP)
+
+# Build the benchmark executable.
+traccc_add_executable(benchmark_cpu
+    "toy_detector_cpu.cpp"
+    LINK_LIBRARIES benchmark::benchmark benchmark::benchmark_main 
+    traccc::core traccc_benchmarks_common 
+    detray::core detray::utils vecmem::core)
+
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(traccc_benchmark_cpu PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/benchmarks/cpu/toy_detector_cpu.cpp
+++ b/benchmarks/cpu/toy_detector_cpu.cpp
@@ -1,0 +1,95 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Traccc algorithm include(s).
+#include "traccc/finding/finding_algorithm.hpp"
+#include "traccc/fitting/fitting_algorithm.hpp"
+#include "traccc/seeding/seeding_algorithm.hpp"
+#include "traccc/seeding/track_params_estimation.hpp"
+
+// Traccc IO include(s).
+#include "traccc/io/event_map2.hpp"
+#include "traccc/io/read_geometry.hpp"
+#include "traccc/io/read_measurements.hpp"
+#include "traccc/io/read_spacepoints.hpp"
+
+// Local include(s).
+#include "benchmarks/toy_detector_benchmark.hpp"
+
+// Detray include(s).
+#include "detray/core/detector.hpp"
+#include "detray/detectors/bfield.hpp"
+#include "detray/io/frontend/detector_reader.hpp"
+#include "detray/navigation/navigator.hpp"
+#include "detray/propagator/propagator.hpp"
+#include "detray/propagator/rk_stepper.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// Google benchmark include(s).
+#include <benchmark/benchmark.h>
+
+BENCHMARK_F(ToyDetectorBenchmark, CPU)(benchmark::State& state) {
+
+    // Type declarations
+    using rk_stepper_type =
+        detray::rk_stepper<b_field_t::view_t,
+                           typename detector_type::algebra_type,
+                           detray::constrained_step<>>;
+    using host_detector_type = detray::detector<detray::default_metadata>;
+    using host_navigator_type = detray::navigator<const host_detector_type>;
+    using host_fitter_type =
+        traccc::kalman_fitter<rk_stepper_type, host_navigator_type>;
+
+    // VecMem memory resource(s)
+    vecmem::host_memory_resource host_mr;
+
+    // Read back detector file
+    const std::string path = sim_dir;
+    detray::io::detector_reader_config reader_cfg{};
+    reader_cfg.add_file(path + "toy_detector_geometry.json")
+        .add_file(path + "toy_detector_homogeneous_material.json")
+        .add_file(path + "toy_detector_surface_grids.json");
+
+    auto [det, names] =
+        detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
+
+    // B field
+    auto field = detray::bfield::create_const_field(B);
+
+    // Algorithms
+    traccc::seeding_algorithm sa(seeding_cfg, grid_cfg, filter_cfg, host_mr);
+    traccc::track_params_estimation tp(host_mr);
+    traccc::finding_algorithm<rk_stepper_type, host_navigator_type>
+        host_finding(finding_cfg);
+    traccc::fitting_algorithm<host_fitter_type> host_fitting(fitting_cfg);
+
+    for (auto _ : state) {
+
+// Iterate over events
+#pragma omp parallel for
+        for (int i_evt = 0; i_evt < n_events; i_evt++) {
+
+            auto& spacepoints_per_event = spacepoints[i_evt];
+            auto& measurements_per_event = measurements[i_evt];
+
+            // Seeding
+            auto seeds = sa(spacepoints_per_event);
+
+            // Track param estimation
+            auto params = tp(spacepoints_per_event, seeds, B);
+
+            // Track finding with CKF
+            auto track_candidates =
+                host_finding(det, field, measurements_per_event, params);
+
+            // Track fitting with KF
+            auto track_states = host_fitting(det, field, track_candidates);
+        }
+    }
+}

--- a/benchmarks/cuda/CMakeLists.txt
+++ b/benchmarks/cuda/CMakeLists.txt
@@ -1,0 +1,12 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+traccc_add_executable( benchmark_cuda
+   "toy_detector_cuda.cpp"
+   LINK_LIBRARIES benchmark::benchmark 
+   vecmem::core vecmem::cuda
+   traccc::core traccc::device_common 
+   traccc::cuda traccc_benchmarks_common )

--- a/benchmarks/cuda/toy_detector_cuda.cpp
+++ b/benchmarks/cuda/toy_detector_cuda.cpp
@@ -1,0 +1,196 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/cuda/finding/finding_algorithm.hpp"
+#include "traccc/cuda/fitting/fitting_algorithm.hpp"
+#include "traccc/cuda/seeding/seeding_algorithm.hpp"
+#include "traccc/cuda/seeding/track_params_estimation.hpp"
+#include "traccc/device/container_d2h_copy_alg.hpp"
+#include "traccc/io/event_map2.hpp"
+#include "traccc/io/read_geometry.hpp"
+#include "traccc/io/read_measurements.hpp"
+#include "traccc/io/read_spacepoints.hpp"
+
+// Local include(s).
+#include "benchmarks/toy_detector_benchmark.hpp"
+
+// Detray include(s).
+#include "detray/core/detector.hpp"
+#include "detray/detectors/bfield.hpp"
+#include "detray/io/frontend/detector_reader.hpp"
+#include "detray/navigation/navigator.hpp"
+#include "detray/propagator/propagator.hpp"
+#include "detray/propagator/rk_stepper.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/memory/cuda/host_memory_resource.hpp>
+#include <vecmem/memory/cuda/managed_memory_resource.hpp>
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/utils/cuda/async_copy.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+
+// Google benchmark include(s).
+#include <benchmark/benchmark.h>
+
+BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
+
+    // Type declarations
+    using rk_stepper_type =
+        detray::rk_stepper<b_field_t::view_t,
+                           typename detector_type::algebra_type,
+                           detray::constrained_step<>>;
+    using host_detector_type = detray::detector<detray::default_metadata>;
+    using device_detector_type =
+        detray::detector<detray::default_metadata,
+                         detray::device_container_types>;
+    using device_navigator_type = detray::navigator<const device_detector_type>;
+    using device_fitter_type =
+        traccc::kalman_fitter<rk_stepper_type, device_navigator_type>;
+
+    // Memory resources used by the application.
+    vecmem::host_memory_resource host_mr;
+    vecmem::cuda::host_memory_resource cuda_host_mr;
+    vecmem::cuda::device_memory_resource device_mr;
+    traccc::memory_resource mr{device_mr, &cuda_host_mr};
+    vecmem::cuda::managed_memory_resource mng_mr;
+
+    // Copy and stream
+    vecmem::copy host_copy;
+    vecmem::cuda::copy copy;
+    traccc::cuda::stream stream;
+    vecmem::cuda::async_copy async_copy{stream.cudaStream()};
+
+    // Read back detector file
+    const std::string path = sim_dir;
+    detray::io::detector_reader_config reader_cfg{};
+    reader_cfg.add_file(path + "toy_detector_geometry.json")
+        .add_file(path + "toy_detector_homogeneous_material.json")
+        .add_file(path + "toy_detector_surface_grids.json");
+
+    auto [det, names] =
+        detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
+
+    // B field
+    auto field = detray::bfield::create_const_field(B);
+
+    // Algorithms
+    traccc::cuda::seeding_algorithm sa_cuda(seeding_cfg, grid_cfg, filter_cfg,
+                                            mr, async_copy, stream);
+    traccc::cuda::track_params_estimation tp_cuda(mr, async_copy, stream);
+    traccc::cuda::finding_algorithm<rk_stepper_type, device_navigator_type>
+        device_finding(finding_cfg, mr, async_copy, stream);
+    traccc::cuda::fitting_algorithm<device_fitter_type> device_fitting(
+        fitting_cfg, mr, async_copy, stream);
+
+    // Detector view object
+    auto det_view = detray::get_data(det);
+
+    // D2H copy object
+    traccc::device::container_d2h_copy_alg<traccc::track_state_container_types>
+        track_state_d2h{mr, copy};
+
+    for (auto _ : state) {
+
+        state.PauseTiming();
+
+        for (int i = -10; i < n_events; i++) {
+
+            int i_evt = i;
+
+            // First 10 events are for cold run
+            if (i < 0) {
+                i_evt = 0;
+            }
+            // Measure the time after the cold run
+            if (i == 0) {
+                state.ResumeTiming();
+            }
+
+            auto& spacepoints_per_event = spacepoints[i_evt];
+            auto& measurements_per_event = measurements[i_evt];
+
+            // Initialize the containers
+            traccc::seed_collection_types::buffer seeds_cuda_buffer(0,
+                                                                    *(mr.host));
+            traccc::bound_track_parameters_collection_types::buffer
+                params_cuda_buffer(0, *mr.host);
+
+            traccc::track_candidate_container_types::buffer
+                track_candidates_cuda_buffer{{{}, *(mr.host)},
+                                             {{}, *(mr.host), mr.host}};
+
+            traccc::track_state_container_types::buffer
+                track_states_cuda_buffer{{{}, *(mr.host)},
+                                         {{}, *(mr.host), mr.host}};
+
+            // Copy the spacepoint and module data to the device.
+            traccc::spacepoint_collection_types::buffer spacepoints_cuda_buffer(
+                spacepoints_per_event.size(), mr.main);
+            async_copy(vecmem::get_data(spacepoints_per_event),
+                       spacepoints_cuda_buffer);
+
+            traccc::measurement_collection_types::buffer
+                measurements_cuda_buffer(measurements_per_event.size(),
+                                         mr.main);
+            async_copy(vecmem::get_data(measurements_per_event),
+                       measurements_cuda_buffer);
+
+            // Run seeding
+            seeds_cuda_buffer = sa_cuda(spacepoints_cuda_buffer);
+            stream.synchronize();
+
+            // Run track parameter estimation
+            params_cuda_buffer =
+                tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer, B);
+            stream.synchronize();
+
+            // Navigation buffer
+            auto navigation_buffer = detray::create_candidates_buffer(
+                det,
+                device_finding.get_config().navigation_buffer_size_scaler *
+                    copy.get_size(seeds_cuda_buffer),
+                mr.main, mr.host);
+
+            // Run CKF track finding
+            track_candidates_cuda_buffer =
+                device_finding(det_view, field, navigation_buffer,
+                               measurements_cuda_buffer, params_cuda_buffer);
+            stream.synchronize();
+
+            // Run track fitting
+            track_states_cuda_buffer =
+                device_fitting(det_view, field, navigation_buffer,
+                               track_candidates_cuda_buffer);
+            stream.synchronize();
+
+            // Create a temporary buffer that will receive the device memory.
+            auto size = track_states_cuda_buffer.headers.size();
+            std::vector<std::size_t> capacities(size, 0);
+            std::transform(track_states_cuda_buffer.items.host_ptr(),
+                           track_states_cuda_buffer.items.host_ptr() + size,
+                           capacities.begin(),
+                           [](const auto& view) { return view.capacity(); });
+
+            traccc::track_state_container_types::buffer
+                track_states_host_buffer{{size, *(mr.host)},
+                                         {capacities, *(mr.host), mr.host}};
+            host_copy.setup(track_states_host_buffer.headers);
+            host_copy.setup(track_states_host_buffer.items);
+
+            // Copy the device container into this temporary host buffer.
+            vecmem::copy::event_type header_event =
+                copy(track_states_cuda_buffer.headers,
+                     track_states_host_buffer.headers,
+                     vecmem::copy::type::device_to_host);
+            vecmem::copy::event_type item_event = copy(
+                track_states_cuda_buffer.items, track_states_host_buffer.items,
+                vecmem::copy::type::device_to_host);
+        }
+    }
+}

--- a/core/include/traccc/definitions/common.hpp
+++ b/core/include/traccc/definitions/common.hpp
@@ -18,6 +18,9 @@ namespace traccc {
 template <typename scalar_t>
 using unit = detray::unit<scalar_t>;
 
+template <typename scalar_t>
+using constant = detray::constant<scalar_t>;
+
 // epsilon for float variables
 constexpr scalar float_epsilon = 1e-5f;
 

--- a/extern/benchmark/CMakeLists.txt
+++ b/extern/benchmark/CMakeLists.txt
@@ -1,0 +1,44 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+cmake_minimum_required(VERSION 3.11)
+include(FetchContent)
+
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
+# Tell the user what's happening.
+message(STATUS "Building Google Benchmark as part of the TRACCC project")
+
+# Declare where to get Google Benchmark from.
+set(TRACCC_BENCHMARK_SOURCE
+   "URL;https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz;URL_MD5;7b93dd03670665684f1b2e9b70ad17fe"
+   CACHE STRING "Source for Google Benchmark, when built as part of this project")
+mark_as_advanced(TRACCC_BENCHMARK_SOURCE)
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(TRACCC_BENCHMARK_SOURCE_FULL "${TRACCC_BENCHMARK_SOURCE};SYSTEM")
+else()
+   set(TRACCC_BENCHMARK_SOURCE_FULL "${TRACCC_BENCHMARK_SOURCE}")
+endif()
+mark_as_advanced( TRACCC_BENCHMARK_SOURCE_FULL )
+
+FetchContent_Declare(Benchmark ${TRACCC_BENCHMARK_SOURCE_FULL})
+
+# Options used in the build of Google Benchmark.
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Turn off the tests in Google Benchmark")
+set(BENCHMARK_ENABLE_WERROR OFF CACHE BOOL "Turn off the -Werror for Release build")
+
+# Get it into the current directory.
+FetchContent_MakeAvailable(Benchmark)
+
+# Set up an alias for the Google Benchmark target with the same name that it
+# has when we find it pre-installed.
+add_library(benchmark::benchmark ALIAS benchmark)

--- a/extern/benchmark/README.md
+++ b/extern/benchmark/README.md
@@ -1,0 +1,10 @@
+# Google Benchmark Build Instructions
+
+This subdirectory holds instructions for building
+[benchmark](https://github.com/google/benchmark) as part of this project.
+This is meant to come in handy for building the project's benchmarks in
+environments which do not provide Google Branchmark themselves.
+
+Note that since Google Benchmark is only needed for the tests of this project,
+which are not installed together with the project, Google Benchmark is not
+installed together with the project either.


### PR DESCRIPTION
This is for benchmarking the general speed of the track reconstruction in the toy geometry. (There will be a follow-up PR for monitoring)

Because the geometry and simulation data is not very forward compatible, the simulation is also done in the benchmark suite before the reconstruction. Of course, the simulation time is not included in the timing measurement.

Unfortunately, the simulation does not support the digitization, the performance of clusterization is not included in this benchmark.

Following is the output of CPU (+OpenMP) and CUDA benchmark with the single precision on my laptop:

### CPU
```
[beomki@device-11 traccc_build]$ ./bin/traccc_benchmark_cpu 
2024-08-14T10:31:38+02:00
Running ./bin/traccc_benchmark_cpu
Run on (12 X 4367.4 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 3.16, 3.19, 2.06
WARNING: No entries in volume finder

Detector check: OK
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
ToyDetectorBenchmark/CPU 1.4495e+10 ns   1.3887e+10 ns            1
```

### CUDA
```
[beomki@device-11 traccc_build]$ ./bin/traccc_benchmark_cuda
2024-08-14T10:33:49+02:00
Running ./bin/traccc_benchmark_cuda
Run on (12 X 4344.84 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 2.94, 3.16, 2.20
WARNING: No entries in volume finder

Detector check: OK
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
ToyDetectorBenchmark/CUDA 4734637722 ns   4719869245 ns            1
```