### PR TITLE
build: Only apply `-Wfloat-conversion` if traccc is top-level

### DIFF
--- a/cmake/traccc-compiler-options-cpp.cmake
+++ b/cmake/traccc-compiler-options-cpp.cmake
@@ -22,7 +22,7 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wextra" )
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wshadow" )
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wunused-local-typedefs" )
-   traccc_add_flag( CMAKE_CXX_FLAGS "-Wpedantic" )
+   traccc_add_flag( CMAKE_CXX_FLAGS "-pedantic" )
    if(PROJECT_IS_TOP_LEVEL)
      traccc_add_flag( CMAKE_CXX_FLAGS "-Wfloat-conversion" )
    endif()

--- a/cmake/traccc-compiler-options-cpp.cmake
+++ b/cmake/traccc-compiler-options-cpp.cmake
@@ -22,8 +22,10 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wextra" )
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wshadow" )
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wunused-local-typedefs" )
-   traccc_add_flag( CMAKE_CXX_FLAGS "-pedantic" )
-   traccc_add_flag( CMAKE_CXX_FLAGS "-Wfloat-conversion" )
+   traccc_add_flag( CMAKE_CXX_FLAGS "-Wpedantic" )
+   if(PROJECT_IS_TOP_LEVEL)
+     traccc_add_flag( CMAKE_CXX_FLAGS "-Wfloat-conversion" )
+   endif()
 
    # Fail on warnings, if asked for that behaviour.
    if( TRACCC_FAIL_ON_WARNINGS )


### PR DESCRIPTION
Also changes `-pedantic` to `-Wpedantic` which I think was a typo (they're different options)