### PR TITLE
macOS Fixes, main branch (2024.08.14.)

### DIFF
--- a/core/include/traccc/clusterization/clustering_config.hpp
+++ b/core/include/traccc/clusterization/clustering_config.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include <cstddef>
 
 #include "traccc/definitions/qualifiers.hpp"
 

--- a/extern/cccl/CMakeLists.txt
+++ b/extern/cccl/CMakeLists.txt
@@ -44,3 +44,24 @@ set ( CUB_ENABLE_HEADER_TESTING OFF CACHE BOOL "Disable CUB header testing" )
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( CCCL )
+
+# Check if <thrust/pair.h> works out of the box.
+include( CheckCXXSourceCompiles )
+set( CMAKE_REQUIRED_INCLUDES
+   "${CCCL_SOURCE_DIR}/thrust"
+   "${CCCL_SOURCE_DIR}/libcudacxx/include" )
+set( _THRUST_TEST_SOURCE "#include <thrust/pair.h>\nint main() { return 0; }" )
+check_cxx_source_compiles( "${_THRUST_TEST_SOURCE}" TRACCC_THRUST_WORKS )
+# If not, check if the _LIBCUDACXX_STRING_H_HAS_CONST_OVERLOADS flag makes it
+# work.
+if( NOT TRACCC_THRUST_WORKS )
+   set( CMAKE_REQUIRED_DEFINITIONS -D_LIBCUDACXX_STRING_H_HAS_CONST_OVERLOADS )
+   check_cxx_source_compiles( "${_THRUST_TEST_SOURCE}"
+      TRACCC_THRUST_WORKS_WITH_PATCH )
+   if( TRACCC_THRUST_WORKS_WITH_PATCH )
+      target_compile_definitions( _Thrust_Thrust
+         INTERFACE _LIBCUDACXX_STRING_H_HAS_CONST_OVERLOADS )
+   else()
+      message( WARNING "Thrust does not seem to work. The build may fail." )
+   endif()
+endif()


### PR DESCRIPTION
Triggered by @paulgessinger pointing out that the latest version of the code doesn't work on macOS, this is what I had to do to fix that.

As it happens, the `_LIBCUDACXX_STRING_H_HAS_CONST_OVERLOADS` definition makes the code, or at least the part of it that we use, work on macOS. So I added a bit of code that would add `_LIBCUDACXX_STRING_H_HAS_CONST_OVERLOADS` to the `_Thrust_Thrust` target, if it seems that it's needed. I decided to do this only for the case where we build Thrust / CCCL ourselves. Since on macOS we would always do this. (With CUDA not actually supporting macOS.) Plus we can really only vouch for the behaviour of `_LIBCUDACXX_STRING_H_HAS_CONST_OVERLOADS` on the exact version of CCCL that we download ourselves. On any other version all bets are off with how it would work on macOS. :thinking:

The fix in `clustering_config.hpp` is a much more straight forward affair on the other hand. :wink:

@beomki-yeo and @paulgessinger: I'm happy for one of you to set up a macOS CI for the repository. I was not keen on bothering with that myself. (We only need Boost on macOS that may not be available right away on the CI machines.)

Note: It might be worth noting that it's the following code that `_LIBCUDACXX_STRING_H_HAS_CONST_OVERLOADS` affects:

https://github.com/NVIDIA/cccl/blob/v2.5.0/libcudacxx/include/cuda/std/detail/libcxx/include/string.h#L73

Deep, **deep** inside of the CCCL code...