### PR TITLE
Add the workflow for continuous benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,17 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  detray_benchmark_job:
+    runs-on: ubuntu-latest
+    steps:
+      - run: >
+          curl -X POST --fail
+          -F token=${{ secrets.TRACCC_BENCHMARK_TRIGGER_TOKEN }}
+          -F ref=master
+          --form variables[MERGE_TIME]="$(date '+%Y-%m-%d_%H:%M:%S')"
+          --form variables[SOURCE_SHA]="${{ github.sha }}"
+          https://gitlab.cern.ch/api/v4/projects/190887/trigger/pipeline 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,16 @@ Attaching file performance_track_finding.root as _file0...
 root [1] finding_trackeff_vs_eta->Draw()
 ```
 
+## Continuous benchmark
+
+Monitoring the event throughput of track reconstruction with the toy geometry
+
+- Number of events: 100
+- Number of tracks per event: 5000
+- Algorithms used: seeding, track finding and track fitting
+
+<img src="https://gitlab.cern.ch/acts/traccc-benchmark/-/raw/master/plots/toy_data.png?ref_type=heads" width="500" height="500" /> 
+
 ## Troubleshooting
 
 The following are potentially useful instructions for troubleshooting various


### PR DESCRIPTION
Follow-up PR after #674. (Thanks to @paulgessinger for advices)

This will run the benchmark code for every merged PR through [traccc-benchmark](https://gitlab.cern.ch/acts/traccc-benchmark) and show the event throughput plots at README