### PR TITLE
Update detray version to v0.73.0

### DIFF
--- a/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
+++ b/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
@@ -124,8 +124,8 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
 
         auto sim = traccc::simulator<detector_type, b_field_t, generator_type,
                                      writer_type>(
-            n_events, det, field, std::move(generator),
-            std::move(smearer_writer_cfg), full_path);
+            detray::muon<traccc::scalar>(), n_events, det, field,
+            std::move(generator), std::move(smearer_writer_cfg), full_path);
 
         // Set constrained step size to 1 mm
         sim.get_config().propagation.stepping.step_constraint =

--- a/core/include/traccc/edm/track_parameters.hpp
+++ b/core/include/traccc/edm/track_parameters.hpp
@@ -24,7 +24,6 @@ using free_track_parameters =
 using bound_track_parameters =
     detray::bound_track_parameters<traccc::default_algebra>;
 using free_vector = free_track_parameters::vector_type;
-using free_covariance = free_track_parameters::covariance_type;
 using bound_vector = bound_track_parameters::vector_type;
 using bound_covariance = bound_track_parameters::covariance_type;
 

--- a/core/include/traccc/finding/finding_algorithm.ipp
+++ b/core/include/traccc/finding/finding_algorithm.ipp
@@ -8,6 +8,7 @@
 // Project include(s).
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/sanity/contiguous_on.hpp"
+#include "traccc/utils/particle.hpp"
 #include "traccc/utils/projections.hpp"
 
 // detray include(s).
@@ -138,7 +139,10 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
             // Apply interactor
             typename interactor_type::state interactor_state;
             interactor_type{}.update(
-                ctx, in_param, interactor_state,
+                ctx,
+                detail::correct_particle_hypothesis(m_cfg.ptc_hypothesis,
+                                                    in_param),
+                in_param, interactor_state,
                 static_cast<int>(detray::navigation::direction::e_forward), sf);
 
             // Get barcode and measurements range on surface
@@ -247,6 +251,9 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
             const auto& param = updated_params[link_id];
             // Create propagator state
             typename propagator_type::state propagation(param, field, det);
+            propagation.set_particle(detail::correct_particle_hypothesis(
+                m_cfg.ptc_hypothesis, param));
+
             propagation._stepping
                 .template set_constraint<detray::step::constraint::e_accuracy>(
                     m_cfg.propagation.stepping.step_constraint);

--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -7,7 +7,11 @@
 
 #pragma once
 
+// traccc include(s).
+#include "traccc/definitions/primitives.hpp"
+
 // detray include(s).
+#include "detray/definitions/pdg_particle.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/propagator/propagation_config.hpp"
 
@@ -40,6 +44,10 @@ struct finding_config {
 
     /// Propagation configuration
     detray::propagation::config propagation{};
+
+    /// Particle hypothesis
+    detray::pdg_particle<traccc::scalar> ptc_hypothesis =
+        detray::muon<traccc::scalar>();
 
     /****************************
      *  GPU-specfic parameters

--- a/core/include/traccc/fitting/fitting_config.hpp
+++ b/core/include/traccc/fitting/fitting_config.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // detray include(s).
+#include "detray/definitions/pdg_particle.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/propagator/propagation_config.hpp"
 
@@ -20,6 +21,10 @@ struct fitting_config {
 
     /// Propagation configuration
     detray::propagation::config propagation{};
+
+    /// Particle hypothesis
+    detray::pdg_particle<traccc::scalar> ptc_hypothesis =
+        detray::muon<traccc::scalar>();
 };
 
 }  // namespace traccc

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -17,6 +17,7 @@
 #include "traccc/fitting/kalman_filter/kalman_actor.hpp"
 #include "traccc/fitting/kalman_filter/kalman_step_aborter.hpp"
 #include "traccc/fitting/kalman_filter/statistics_updater.hpp"
+#include "traccc/utils/particle.hpp"
 
 // detray include(s).
 #include "detray/propagator/actor_chain.hpp"
@@ -171,6 +172,8 @@ class kalman_fitter {
         // Create propagator state
         typename propagator_type::state propagation(
             seed_params, m_field, m_detector, std::move(nav_candidates));
+        propagation.set_particle(detail::correct_particle_hypothesis(
+            m_cfg.ptc_hypothesis, seed_params));
 
         // @TODO: Should be removed once detray is fixed to set the
         // volume in the constructor

--- a/core/include/traccc/utils/particle.hpp
+++ b/core/include/traccc/utils/particle.hpp
@@ -1,0 +1,102 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// traccc include(s).
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/track_parameters.hpp"
+
+// detray include(s).
+#include "detray/definitions/pdg_particle.hpp"
+
+// System include(s).
+#include <stdexcept>
+
+namespace traccc {
+
+namespace detail {
+
+template <typename scalar_t>
+TRACCC_HOST_DEVICE inline detray::pdg_particle<scalar_t>
+particle_from_pdg_number(const int pdg_num) {
+
+    switch (pdg_num) {
+        case 11:
+            return detray::electron<scalar_t>();
+        case -11:
+            return detray::positron<scalar_t>();
+        case 13:
+            return detray::muon<scalar_t>();
+        case -13:
+            return detray::antimuon<scalar_t>();
+        case 211:
+            return detray::pion_plus<scalar_t>();
+        case -211:
+            return detray::pion_minus<scalar_t>();
+    }
+
+    return detray::muon<scalar_t>();
+}
+
+// Apply the charge operator to return the antimatter
+template <typename scalar_t>
+TRACCC_HOST_DEVICE inline detray::pdg_particle<scalar_t> charge_conjugation(
+    const detray::pdg_particle<scalar_t>& ptc) {
+
+    const auto pdg_num = ptc.pdg_num();
+
+    switch (pdg_num) {
+        case 11:
+            return detray::positron<scalar_t>();
+        case -11:
+            return detray::electron<scalar_t>();
+        case 13:
+            return detray::antimuon<scalar_t>();
+        case -13:
+            return detray::muon<scalar_t>();
+        case 211:
+            return detray::pion_minus<scalar_t>();
+        case -211:
+            return detray::pion_plus<scalar_t>();
+    }
+
+    return detray::muon<scalar_t>();
+}
+
+// Return the consistent particle type based on the particle hypothesis and the
+// charge of the track parameters
+template <typename scalar_t>
+TRACCC_HOST_DEVICE inline detray::pdg_particle<scalar_t>
+correct_particle_hypothesis(
+    const detray::pdg_particle<scalar_t>& ptc_hypothesis,
+    const bound_track_parameters& params) {
+
+    if (ptc_hypothesis.charge() * params.qop() > 0.f) {
+        return ptc_hypothesis;
+    } else {
+        return charge_conjugation(ptc_hypothesis);
+    }
+}
+
+template <typename scalar_t>
+TRACCC_HOST_DEVICE inline detray::pdg_particle<scalar_t>
+correct_particle_hypothesis(
+    const detray::pdg_particle<scalar_t>& ptc_hypothesis,
+    const free_track_parameters& params) {
+
+    if (ptc_hypothesis.charge() * params.qop() > 0.f) {
+        return ptc_hypothesis;
+    } else {
+        return charge_conjugation(ptc_hypothesis);
+    }
+}
+
+}  // namespace detail
+
+}  // namespace traccc

--- a/core/include/traccc/utils/seed_generator.hpp
+++ b/core/include/traccc/utils/seed_generator.hpp
@@ -49,7 +49,8 @@ struct seed_generator {
     /// @param stddevs standard deviations for track parameter smearing
     bound_track_parameters operator()(
         const detray::geometry::barcode surface_link,
-        const free_track_parameters& free_param) {
+        const free_track_parameters& free_param,
+        const detray::pdg_particle<scalar>& ptc_type) {
 
         // Get bound parameter
         const detray::tracking_surface sf{m_detector, surface_link};
@@ -66,11 +67,13 @@ struct seed_generator {
         using interactor_type =
             detray::pointwise_material_interactor<algebra_type>;
 
+        assert(ptc_type.charge() * bound_param.qop() > 0.f);
+
         // Apply interactor
         typename interactor_type::state interactor_state;
         interactor_state.do_multiple_scattering = false;
         interactor_type{}.update(
-            ctx, bound_param, interactor_state,
+            ctx, ptc_type, bound_param, interactor_state,
             static_cast<int>(detray::navigation::direction::e_backward), sf);
 
         for (std::size_t i = 0; i < e_bound_size; i++) {

--- a/device/common/include/traccc/finding/device/apply_interaction.hpp
+++ b/device/common/include/traccc/finding/device/apply_interaction.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
+#include "traccc/finding/finding_config.hpp"
 
 namespace traccc::device {
 
@@ -16,14 +17,15 @@ namespace traccc::device {
 /// track parameters
 ///
 /// @param[in] globalIndex     The index of the current thread
+/// @param[in] cfg             Track finding config object
 /// @param[in] det_data        Detector view object
 /// @param[in] n_params        The number of parameters (or tracks)
 /// @param[out] params_view    Collection of output bound track_parameters
 ///
 template <typename detector_t>
 TRACCC_DEVICE inline void apply_interaction(
-    std::size_t globalIndex, typename detector_t::view_type det_data,
-    const int n_params,
+    std::size_t globalIndex, const finding_config& cfg,
+    typename detector_t::view_type det_data, const int n_params,
     bound_track_parameters_collection_types::view params_view);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
+++ b/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/definitions/math.hpp"
+#include "traccc/utils/particle.hpp"
 
 // Detray include(s).
 #include "detray/geometry/tracking_surface.hpp"
@@ -17,8 +18,8 @@ namespace traccc::device {
 
 template <typename detector_t>
 TRACCC_DEVICE inline void apply_interaction(
-    std::size_t globalIndex, typename detector_t::view_type det_data,
-    const int n_params,
+    std::size_t globalIndex, const finding_config& cfg,
+    typename detector_t::view_type det_data, const int n_params,
     bound_track_parameters_collection_types::view params_view) {
 
     // Type definitions
@@ -44,7 +45,9 @@ TRACCC_DEVICE inline void apply_interaction(
     // Apply interactor
     typename interactor_type::state interactor_state;
     interactor_type{}.update(
-        ctx, bound_param, interactor_state,
+        ctx,
+        detail::correct_particle_hypothesis(cfg.ptc_hypothesis, bound_param),
+        bound_param, interactor_state,
         static_cast<int>(detray::navigation::direction::e_forward), sf);
 }
 

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -86,6 +86,8 @@ TRACCC_DEVICE inline void propagate_to_next_surface(
     // Create propagator state
     typename propagator_t::state propagation(
         in_par, field_data, det, std::move(nav_candidates.at(globalIndex)));
+    propagation.set_particle(
+        detail::correct_particle_hypothesis(cfg.ptc_hypothesis, in_par));
     propagation._stepping
         .template set_constraint<detray::step::constraint::e_accuracy>(
             cfg.propagation.stepping.step_constraint);

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -65,12 +65,14 @@ __global__ void make_barcode_sequence(
 /// CUDA kernel for running @c traccc::device::apply_interaction
 template <typename detector_t>
 __global__ void apply_interaction(
-    typename detector_t::view_type det_data, const int n_params,
+    typename detector_t::view_type det_data, const finding_config cfg,
+    const int n_params,
     bound_track_parameters_collection_types::view params_view) {
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
 
-    device::apply_interaction<detector_t>(gid, det_data, n_params, params_view);
+    device::apply_interaction<detector_t>(gid, cfg, det_data, n_params,
+                                          params_view);
 }
 
 /// CUDA kernel for running @c traccc::device::count_measurements
@@ -351,7 +353,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
         nThreads = m_warp_size * 2;
         nBlocks = (n_in_params + nThreads - 1) / nThreads;
         kernels::apply_interaction<detector_type>
-            <<<nBlocks, nThreads, 0, stream>>>(det_view, n_in_params,
+            <<<nBlocks, nThreads, 0, stream>>>(det_view, m_cfg, n_in_params,
                                                in_params_buffer);
         TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 

--- a/examples/options/include/traccc/options/generation.hpp
+++ b/examples/options/include/traccc/options/generation.hpp
@@ -8,8 +8,12 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/definitions/primitives.hpp"
 #include "traccc/options/details/interface.hpp"
 #include "traccc/options/details/value_array.hpp"
+
+// detray include(s).
+#include "detray/definitions/pdg_particle.hpp"
 
 // System include(s).
 #include <cstddef>
@@ -38,8 +42,8 @@ class generation : public interface {
     opts::value_array<float, 2> phi_range{-180.f, 180.f};
     /// Range of eta
     opts::value_array<float, 2> eta_range{-2.f, 2.f};
-    /// Charge of particles
-    float charge{-1.f};
+    /// PDG number for particle type (Default: muon)
+    int pdg_number = 13;
 
     /// @}
 
@@ -48,6 +52,9 @@ class generation : public interface {
 
     /// Range of theta [rad]
     opts::value_array<float, 2> theta_range{0.f, 0.f};
+    /// Particle type
+    detray::pdg_particle<traccc::scalar> ptc_type =
+        detray::muon<traccc::scalar>();
 
     /// @}
 

--- a/examples/options/include/traccc/options/track_finding.hpp
+++ b/examples/options/include/traccc/options/track_finding.hpp
@@ -52,6 +52,8 @@ class track_finding : public interface, public config_provider<finding_config> {
     unsigned int nmax_per_seed = 10;
     /// Maximum allowed number of skipped steps per candidate
     unsigned int max_num_skipping_per_cand = 3;
+    /// PDG number for particle hypothesis (Default: muon)
+    int pdg_number = 13;
     /// @}
 
     /// Print the specific options of this class

--- a/examples/options/src/generation.cpp
+++ b/examples/options/src/generation.cpp
@@ -8,6 +8,7 @@
 // Project include(s).
 #include "traccc/options/generation.hpp"
 
+#include "traccc/utils/particle.hpp"
 #include "traccc/utils/ranges.hpp"
 
 // Detray include(s).
@@ -48,8 +49,9 @@ generation::generation() : interface("Particle Generation Options") {
         "gen-eta",
         po::value(&eta_range)->value_name("MIN:MAX")->default_value(eta_range),
         "Range of eta");
-    m_desc.add_options()("charge", po::value(&charge)->default_value(charge),
-                         "Charge of particles");
+    m_desc.add_options()("particle-type",
+                         po::value<int>(&pdg_number)->default_value(pdg_number),
+                         "PDG number for the particle type");
 }
 
 void generation::read(const po::variables_map&) {
@@ -59,6 +61,7 @@ void generation::read(const po::variables_map&) {
     mom_range *= detray::unit<float>::GeV;
     phi_range *= detray::unit<float>::degree;
     theta_range = eta_to_theta_range(eta_range);
+    ptc_type = detail::particle_from_pdg_number<traccc::scalar>(pdg_number);
 }
 
 std::ostream& generation::print_impl(std::ostream& out) const {
@@ -76,7 +79,7 @@ std::ostream& generation::print_impl(std::ostream& out) const {
         << "  Eta range                      : " << eta_range << "\n"
         << "  Theta range                    : "
         << theta_range / detray::unit<float>::degree << " deg\n"
-        << "  Charge                         : " << charge;
+        << "  PDG Number                     : " << pdg_number;
     return out;
 }
 

--- a/examples/options/src/track_finding.cpp
+++ b/examples/options/src/track_finding.cpp
@@ -8,6 +8,8 @@
 // Project include(s).
 #include "traccc/options/track_finding.hpp"
 
+#include "traccc/utils/particle.hpp"
+
 // System include(s).
 #include <iostream>
 
@@ -56,6 +58,14 @@ track_finding::track_finding() : interface("Track Finding Options") {
         po::value<unsigned int>(&max_num_skipping_per_cand)
             ->default_value(max_num_skipping_per_cand),
         "Maximum allowed number of skipped steps per candidate");
+    m_desc.add_options()(
+        "max-num-skipping-per-cand",
+        po::value<unsigned int>(&max_num_skipping_per_cand)
+            ->default_value(max_num_skipping_per_cand),
+        "Maximum allowed number of skipped steps per candidate");
+    m_desc.add_options()("particle-hypothesis",
+                         po::value<int>(&pdg_number)->default_value(pdg_number),
+                         "PDG number for the particle hypothesis");
 }
 
 track_finding::operator finding_config() const {
@@ -69,6 +79,8 @@ track_finding::operator finding_config() const {
     out.chi2_max = chi2_max;
     out.max_num_branches_per_seed = nmax_per_seed;
     out.max_num_skipping_per_cand = max_num_skipping_per_cand;
+    out.ptc_hypothesis =
+        detail::particle_from_pdg_number<traccc::scalar>(pdg_number);
     return out;
 }
 
@@ -86,7 +98,8 @@ std::ostream& track_finding::print_impl(std::ostream& out) const {
         << "  Maximum Chi2             : " << chi2_max << "\n"
         << "  Maximum branches per step: " << nmax_per_seed << "\n"
         << "  Maximum number of skipped steps per candidates: "
-        << max_num_skipping_per_cand;
+        << max_num_skipping_per_cand << "\n"
+        << "  PDG Number: " << pdg_number;
     return out;
 }
 

--- a/examples/simulation/simulate.cpp
+++ b/examples/simulation/simulate.cpp
@@ -99,7 +99,6 @@ int main(int argc, char* argv[]) {
     gen_cfg.phi_range(generation_opts.phi_range);
     gen_cfg.theta_range(generation_opts.theta_range);
     gen_cfg.mom_range(generation_opts.mom_range);
-    gen_cfg.charge(generation_opts.charge);
     generator_type generator(gen_cfg);
 
     // Smearing value for measurements
@@ -119,8 +118,8 @@ int main(int argc, char* argv[]) {
 
     auto sim = traccc::simulator<host_detector_type, b_field_t, generator_type,
                                  writer_type>(
-        generation_opts.events, host_det, field, std::move(generator),
-        std::move(smearer_writer_cfg), full_path);
+        generation_opts.ptc_type, generation_opts.events, host_det, field,
+        std::move(generator), std::move(smearer_writer_cfg), full_path);
 
     sim.get_config().propagation = propagation_opts;
 

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -109,7 +109,7 @@ int simulate(const traccc::opts::generation& generation_opts,
     gen_cfg.phi_range(generation_opts.phi_range);
     gen_cfg.theta_range(generation_opts.theta_range);
     gen_cfg.mom_range(generation_opts.mom_range);
-    gen_cfg.charge(generation_opts.charge);
+    gen_cfg.charge(generation_opts.ptc_type.charge());
     generator_type generator(gen_cfg);
 
     // Smearing value for measurements
@@ -131,8 +131,8 @@ int simulate(const traccc::opts::generation& generation_opts,
 
     auto sim = traccc::simulator<detector_type, b_field_t, generator_type,
                                  writer_type>(
-        generation_opts.events, det, field, std::move(generator),
-        std::move(smearer_writer_cfg), full_path);
+        generation_opts.ptc_type, generation_opts.events, det, field,
+        std::move(generator), std::move(smearer_writer_cfg), full_path);
     sim.get_config().propagation = propagation_opts;
 
     sim.run();

--- a/examples/simulation/simulate_toy_detector.cpp
+++ b/examples/simulation/simulate_toy_detector.cpp
@@ -82,7 +82,6 @@ int simulate(const traccc::opts::generation& generation_opts,
     gen_cfg.phi_range(generation_opts.phi_range);
     gen_cfg.theta_range(generation_opts.theta_range);
     gen_cfg.mom_range(generation_opts.mom_range);
-    gen_cfg.charge(generation_opts.charge);
     generator_type generator(gen_cfg);
 
     // Smearing value for measurements
@@ -103,8 +102,8 @@ int simulate(const traccc::opts::generation& generation_opts,
 
     auto sim = traccc::simulator<detector_type, b_field_t, generator_type,
                                  writer_type>(
-        generation_opts.events, det, field, std::move(generator),
-        std::move(smearer_writer_cfg), full_path);
+        generation_opts.ptc_type, generation_opts.events, det, field,
+        std::move(generator), std::move(smearer_writer_cfg), full_path);
     sim.get_config().propagation = propagation_opts;
 
     sim.run();

--- a/examples/simulation/simulate_wire_chamber.cpp
+++ b/examples/simulation/simulate_wire_chamber.cpp
@@ -83,7 +83,7 @@ int simulate(const traccc::opts::generation& generation_opts,
     gen_cfg.phi_range(generation_opts.phi_range);
     gen_cfg.theta_range(generation_opts.theta_range);
     gen_cfg.mom_range(generation_opts.mom_range);
-    gen_cfg.charge(generation_opts.charge);
+    gen_cfg.charge(generation_opts.ptc_type.charge());
     generator_type generator(gen_cfg);
 
     // Smearing value for measurements
@@ -104,8 +104,8 @@ int simulate(const traccc::opts::generation& generation_opts,
 
     auto sim = traccc::simulator<detector_type, b_field_t, generator_type,
                                  writer_type>(
-        generation_opts.events, det, field, std::move(generator),
-        std::move(smearer_writer_cfg), full_path);
+        generation_opts.ptc_type, generation_opts.events, det, field,
+        std::move(generator), std::move(smearer_writer_cfg), full_path);
     sim.get_config().propagation = propagation_opts;
 
     sim.run();

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.72.1.tar.gz;URL_MD5;342ab0bfba45c5764c8eef3842897c16"
+"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.73.0.tar.gz;URL_MD5;ada6e82aff6b1082dea8fc95ba0f3b9c"
    CACHE STRING "Source for Detray, when built as part of this project" )
 
 mark_as_advanced( TRACCC_DETRAY_SOURCE )

--- a/io/include/traccc/io/event_map2.hpp
+++ b/io/include/traccc/io/event_map2.hpp
@@ -12,6 +12,7 @@
 #include "traccc/edm/particle.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/edm/track_candidate.hpp"
+#include "traccc/utils/particle.hpp"
 
 namespace traccc {
 
@@ -34,7 +35,9 @@ struct event_map2 {
             const free_track_parameters free_param(xp.first, 0.f, xp.second,
                                                    ptc.charge);
 
-            auto seed_params = sg(measurements[0].surface_link, free_param);
+            auto seed_params =
+                sg(measurements[0].surface_link, free_param,
+                   detail::particle_from_pdg_number<scalar>(ptc.particle_type));
 
             // Candidate objects
             vecmem::vector<track_candidate> candidates;

--- a/simulation/include/traccc/simulation/smearing_writer.hpp
+++ b/simulation/include/traccc/simulation/smearing_writer.hpp
@@ -16,6 +16,7 @@
 #include "traccc/simulation/measurement_smearer.hpp"
 
 // Detray core include(s).
+#include "detray/definitions/pdg_particle.hpp"
 #include "detray/geometry/tracking_surface.hpp"
 #include "detray/propagator/base_actor.hpp"
 #include "detray/tracks/bound_track_parameters.hpp"
@@ -68,12 +69,14 @@ struct smearing_writer : detray::actor {
         void set_seed(const uint_fast64_t sd) { m_meas_smearer.set_seed(sd); }
 
         void write_particle(
-            const detray::free_track_parameters<algebra_type>& track) {
+            const detray::free_track_parameters<algebra_type>& track,
+            const detray::pdg_particle<scalar_type>& ptc_type) {
             io::csv::particle particle;
             const auto pos = track.pos();
-            const auto mom = track.mom();
+            const auto mom = track.mom(ptc_type.charge());
 
             particle.particle_id = particle_id;
+            particle.particle_type = ptc_type.pdg_num();
             particle.vx = static_cast<float>(pos[0]);
             particle.vy = static_cast<float>(pos[1]);
             particle.vz = static_cast<float>(pos[2]);
@@ -81,7 +84,7 @@ struct smearing_writer : detray::actor {
             particle.px = static_cast<float>(mom[0]);
             particle.py = static_cast<float>(mom[1]);
             particle.pz = static_cast<float>(mom[2]);
-            particle.q = static_cast<float>(track.charge());
+            particle.q = static_cast<float>(ptc_type.charge());
 
             m_particle_writer.append(particle);
         }
@@ -116,7 +119,7 @@ struct smearing_writer : detray::actor {
 
             const auto track = stepping();
             const auto pos = track.pos();
-            const auto mom = track.mom();
+            const auto mom = track.mom(stepping._ptc.charge());
 
             const auto sf = navigation.get_surface();
 

--- a/tests/common/tests/kalman_fitting_test.hpp
+++ b/tests/common/tests/kalman_fitting_test.hpp
@@ -14,6 +14,7 @@
 // detray include(s).
 #include "detray/core/detector.hpp"
 #include "detray/core/detector_metadata.hpp"
+#include "detray/definitions/pdg_particle.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/propagator.hpp"
@@ -39,14 +40,16 @@ namespace traccc {
 /// (4) momentum range
 /// (5) eta range
 /// (6) phi range
-/// (7) charge
+/// (7) particle type
 /// (8) number of tracks per event
 /// (9) number of events
+/// (10) random charge
 class KalmanFittingTests
     : public ::testing::TestWithParam<std::tuple<
           std::string, std::array<scalar, 3u>, std::array<scalar, 3u>,
           std::array<scalar, 2u>, std::array<scalar, 2u>,
-          std::array<scalar, 2u>, scalar, unsigned int, unsigned int>> {
+          std::array<scalar, 2u>, detray::pdg_particle<scalar>, unsigned int,
+          unsigned int, bool>> {
 
     public:
     /// Type declarations

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,10 +1,13 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # Declare the core library test(s).
-traccc_add_test(core "test_algorithm.cpp" "test_module_map.cpp"
+traccc_add_test(core 
+   "test_algorithm.cpp" 
+   "test_module_map.cpp" 
+   "particle.cpp"
    LINK_LIBRARIES GTest::gtest_main traccc_tests_common
    traccc::core traccc::io)

--- a/tests/core/particle.cpp
+++ b/tests/core/particle.cpp
@@ -1,0 +1,48 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/utils/particle.hpp"
+
+#include "traccc/definitions/common.hpp"
+#include "traccc/edm/track_parameters.hpp"
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+TEST(particle, particle_with_pdg_num) {
+    const auto muon = traccc::detail::particle_from_pdg_number<float>(13);
+
+    EXPECT_FLOAT_EQ(muon.mass(), 105.6583755f * traccc::unit<float>::MeV);
+    EXPECT_FLOAT_EQ(muon.charge(), -1.f);
+
+    const auto positron = traccc::detail::particle_from_pdg_number<float>(-11);
+
+    EXPECT_FLOAT_EQ(positron.mass(), traccc::constant<float>::m_e);
+    EXPECT_FLOAT_EQ(positron.charge(), 1.f);
+}
+
+TEST(particle, charge_conjugation) {
+
+    const auto positron =
+        traccc::detail::charge_conjugation(detray::electron<float>());
+    EXPECT_FLOAT_EQ(positron.mass(), traccc::constant<float>::m_e);
+    EXPECT_FLOAT_EQ(positron.charge(), 1.f);
+}
+
+TEST(particle, correct_particle_hypothesis) {
+
+    traccc::free_track_parameters free_trk({1.f, 1.f, 1.f}, 0.f,
+                                           {2.f, 3.f, 4.f}, 1.f);
+
+    const auto positron = traccc::detail::correct_particle_hypothesis(
+        detray::electron<float>(), free_trk);
+
+    EXPECT_FLOAT_EQ(positron.mass(), traccc::constant<float>::m_e);
+    EXPECT_FLOAT_EQ(positron.charge(), 1.f);
+}

--- a/tests/cpu/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cpu/test_ckf_combinatorics_telescope.cpp
@@ -45,9 +45,9 @@ TEST_P(CpuCkfCombinatoricsTelescopeTests, Run) {
     const std::array<scalar, 2u> eta_range = std::get<4>(GetParam());
     const std::array<scalar, 2u> theta_range = eta_to_theta_range(eta_range);
     const std::array<scalar, 2u> phi_range = std::get<5>(GetParam());
-    const scalar charge = std::get<6>(GetParam());
     const unsigned int n_truth_tracks = std::get<7>(GetParam());
     const unsigned int n_events = std::get<8>(GetParam());
+    const bool random_charge = std::get<9>(GetParam());
 
     /*****************************
      * Build a telescope geometry
@@ -82,7 +82,7 @@ TEST_P(CpuCkfCombinatoricsTelescopeTests, Run) {
     gen_cfg.phi_range(phi_range[0], phi_range[1]);
     gen_cfg.theta_range(theta_range[0], theta_range[1]);
     gen_cfg.mom_range(mom_range[0], mom_range[1]);
-    gen_cfg.charge(charge);
+    gen_cfg.randomize_charge(random_charge);
     generator_type generator(gen_cfg);
 
     // Smearing value for measurements
@@ -99,8 +99,8 @@ TEST_P(CpuCkfCombinatoricsTelescopeTests, Run) {
     std::filesystem::create_directories(full_path);
     auto sim = traccc::simulator<host_detector_type, b_field_t, generator_type,
                                  writer_type>(
-        n_events, host_det, field, std::move(generator),
-        std::move(smearer_writer_cfg), full_path);
+        std::get<6>(GetParam()), n_events, host_det, field,
+        std::move(generator), std::move(smearer_writer_cfg), full_path);
     sim.run();
 
     /*****************************
@@ -170,17 +170,21 @@ TEST_P(CpuCkfCombinatoricsTelescopeTests, Run) {
 // Testing two identical tracks
 INSTANTIATE_TEST_SUITE_P(
     CpuCkfCombinatoricsTelescopeValidation0, CpuCkfCombinatoricsTelescopeTests,
-    ::testing::Values(std::make_tuple(
-        "telescope_combinatorics_twin", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 2u>{100.f, 100.f}, std::array<scalar, 2u>{0.f, 0.f},
-        std::array<scalar, 2u>{0.f, 0.f}, -1.f, 2, 1)));
+    ::testing::Values(std::make_tuple("telescope_combinatorics_twin",
+                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
+                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
+                                      std::array<scalar, 2u>{100.f, 100.f},
+                                      std::array<scalar, 2u>{0.f, 0.f},
+                                      std::array<scalar, 2u>{0.f, 0.f},
+                                      detray::muon<scalar>(), 2, 1, false)));
 
 // Testing three identical tracks
 INSTANTIATE_TEST_SUITE_P(
     CpuCkfCombinatoricsTelescopeValidation1, CpuCkfCombinatoricsTelescopeTests,
-    ::testing::Values(std::make_tuple(
-        "telescope_combinatorics_trio", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 2u>{100.f, 100.f}, std::array<scalar, 2u>{0.f, 0.f},
-        std::array<scalar, 2u>{0.f, 0.f}, -1.f, 3, 1)));
+    ::testing::Values(std::make_tuple("telescope_combinatorics_trio",
+                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
+                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
+                                      std::array<scalar, 2u>{100.f, 100.f},
+                                      std::array<scalar, 2u>{0.f, 0.f},
+                                      std::array<scalar, 2u>{0.f, 0.f},
+                                      detray::muon<scalar>(), 3, 1, false)));

--- a/tests/cpu/test_kalman_fitter_telescope.cpp
+++ b/tests/cpu/test_kalman_fitter_telescope.cpp
@@ -43,9 +43,10 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     const std::array<scalar, 2u> eta_range = std::get<4>(GetParam());
     const std::array<scalar, 2u> theta_range = eta_to_theta_range(eta_range);
     const std::array<scalar, 2u> phi_range = std::get<5>(GetParam());
-    const scalar charge = std::get<6>(GetParam());
+    const detray::pdg_particle<scalar> ptc = std::get<6>(GetParam());
     const unsigned int n_truth_tracks = std::get<7>(GetParam());
     const unsigned int n_events = std::get<8>(GetParam());
+    const bool random_charge = std::get<9>(GetParam());
 
     // Performance writer
     traccc::fitting_performance_writer::config fit_writer_cfg;
@@ -84,7 +85,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     gen_cfg.phi_range(phi_range[0], phi_range[1]);
     gen_cfg.theta_range(theta_range[0], theta_range[1]);
     gen_cfg.mom_range(mom_range[0], mom_range[1]);
-    gen_cfg.charge(charge);
+    gen_cfg.randomize_charge(random_charge);
     generator_type generator(gen_cfg);
 
     // Smearing value for measurements
@@ -101,7 +102,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     std::filesystem::create_directories(full_path);
     auto sim = traccc::simulator<host_detector_type, b_field_t, generator_type,
                                  writer_type>(
-        n_events, host_det, field, std::move(generator),
+        ptc, n_events, host_det, field, std::move(generator),
         std::move(smearer_writer_cfg), full_path);
     sim.run();
 
@@ -114,6 +115,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
 
     // Fitting algorithm object
     typename traccc::fitting_algorithm<host_fitter_type>::config_type fit_cfg;
+    fit_cfg.ptc_hypothesis = ptc;
     fitting_algorithm<host_fitter_type> fitting(fit_cfg);
 
     // Iterate over events
@@ -177,7 +179,7 @@ INSTANTIATE_TEST_SUITE_P(
         "telescope_1_GeV_0_phi_muon", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
         std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f},
-        -1.f, 100, 100)));
+        detray::muon<scalar>(), 100, 100, false)));
 
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation1, KalmanFittingTelescopeTests,
@@ -185,7 +187,8 @@ INSTANTIATE_TEST_SUITE_P(
         "telescope_10_GeV_0_phi_muon", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{10.f, 10.f}, std::array<scalar, 2u>{0.f, 0.f},
-        std::array<scalar, 2u>{0.f, 0.f}, -1.f, 100, 100)));
+        std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 100, 100,
+        false)));
 
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation2, KalmanFittingTelescopeTests,
@@ -193,14 +196,23 @@ INSTANTIATE_TEST_SUITE_P(
         "telescope_100_GeV_0_phi_muon", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{100.f, 100.f}, std::array<scalar, 2u>{0.f, 0.f},
-        std::array<scalar, 2u>{0.f, 0.f}, -1.f, 100, 100)));
+        std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 100, 100,
+        false)));
 
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation3, KalmanFittingTelescopeTests,
-    ::testing::Values(std::make_tuple("telescope_1_GeV_0_phi_anti_muon",
-                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
-                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
-                                      std::array<scalar, 2u>{1.f, 1.f},
-                                      std::array<scalar, 2u>{0.f, 0.f},
-                                      std::array<scalar, 2u>{0.f, 0.f}, 1.f,
-                                      100, 100)));
+    ::testing::Values(std::make_tuple(
+        "telescope_1_GeV_0_phi_anti_muon",
+        std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
+        std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f},
+        detray::antimuon<scalar>(), 100, 100, false)));
+
+INSTANTIATE_TEST_SUITE_P(
+    KalmanFitTelescopeValidation4, KalmanFittingTelescopeTests,
+    ::testing::Values(std::make_tuple(
+        "telescope_1_GeV_0_random_charge",
+        std::array<scalar, 3u>{0.f, 0.f, 0.f},
+        std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
+        std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f},
+        detray::antimuon<scalar>(), 100, 100, true)));

--- a/tests/cpu/test_simulation.cpp
+++ b/tests/cpu/test_simulation.cpp
@@ -112,7 +112,8 @@ GTEST_TEST(traccc_simulation, toy_detector_simulation) {
     typename writer_type::config writer_cfg{smearer};
 
     auto sim = simulator<detector_type, b_field_t, generator_type, writer_type>(
-        n_events, detector, field, std::move(generator), std::move(writer_cfg));
+        detray::muon<scalar>(), n_events, detector, field, std::move(generator),
+        std::move(writer_cfg));
 
     // Lift step size constraints
     sim.get_config().propagation.stepping.step_constraint =
@@ -264,8 +265,8 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
     typename writer_type::config writer_cfg{smearer};
 
     auto sim = simulator<detector_type, b_field_t, generator_type, writer_type>(
-        n_events, detector, field, std::move(generator), std::move(writer_cfg),
-        directory);
+        detray::muon<scalar>(), n_events, detector, field, std::move(generator),
+        std::move(writer_cfg), directory);
 
     // Lift step size constraints
     sim.get_config().propagation.stepping.step_constraint =

--- a/tests/cpu/test_track_params_estimation.cpp
+++ b/tests/cpu/test_track_params_estimation.cpp
@@ -22,20 +22,24 @@
 
 using namespace traccc;
 
-TEST(track_params_estimation, helix) {
+namespace {
 
-    // Memory resource used by the EDM.
-    vecmem::host_memory_resource host_mr;
+// Memory resource used by the EDM.
+vecmem::host_memory_resource host_mr;
+
+}  // namespace
+
+TEST(track_params_estimation, helix_negative_charge) {
 
     // Set B field
     const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
                     2. * unit<scalar>::T};
 
     // Track property
+    const scalar q{-1.f * unit<scalar>::e};
     const point3 pos{0.f, 0.f, 0.f};
     const scalar time{0.f};
     const vector3 mom{1.f * unit<scalar>::GeV, 0.f, 1.f * unit<scalar>::GeV};
-    const scalar q{-1.f * unit<scalar>::e};
 
     // Make a helix
     detray::detail::helix<traccc::default_algebra> hlx(
@@ -58,5 +62,43 @@ TEST(track_params_estimation, helix) {
     // Make sure that the reconstructed momentum is equal to the original
     // momentum
     ASSERT_EQ(bound_params.size(), 1u);
-    ASSERT_NEAR(bound_params[0].p(), getter::norm(mom), 2.f * 1e-4);
+    ASSERT_NEAR(bound_params[0].p(q), getter::norm(mom), 2.f * 1e-4);
+    ASSERT_TRUE(bound_params[0].qop() < 0.f);
+}
+
+TEST(track_params_estimation, helix_positive_charge) {
+
+    // Set B field
+    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
+                    2. * unit<scalar>::T};
+
+    // Track property
+    const scalar q{1.f * unit<scalar>::e};
+    const point3 pos{0.f, 0.f, 0.f};
+    const scalar time{0.f};
+    const vector3 mom{1.f * unit<scalar>::GeV, 0.f, 1.f * unit<scalar>::GeV};
+
+    // Make a helix
+    detray::detail::helix<traccc::default_algebra> hlx(
+        pos, time, vector::normalize(mom), q / getter::norm(mom), &B);
+
+    // Make three spacepoints with the helix
+    spacepoint_collection_types::host spacepoints;
+    spacepoints.push_back({hlx(50 * unit<scalar>::mm), {}});
+    spacepoints.push_back({hlx(100 * unit<scalar>::mm), {}});
+    spacepoints.push_back({hlx(150 * unit<scalar>::mm), {}});
+
+    // Make a seed from the three spacepoints
+    seed_collection_types::host seeds;
+    seeds.push_back({0u, 1u, 2u, 0.f, 0.f});
+
+    // Run track parameter estimation
+    traccc::track_params_estimation tp(host_mr);
+    auto bound_params = tp(spacepoints, seeds, B);
+
+    // Make sure that the reconstructed momentum is equal to the original
+    // momentum
+    ASSERT_EQ(bound_params.size(), 1u);
+    ASSERT_NEAR(bound_params[0].p(q), getter::norm(mom), 2.f * 1e-4);
+    ASSERT_TRUE(bound_params[0].qop() > 0.f);
 }

--- a/tests/sycl/test_kalman_fitter_telescope.sycl
+++ b/tests/sycl/test_kalman_fitter_telescope.sycl
@@ -69,9 +69,10 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     const std::array<scalar, 2u> eta_range = std::get<4>(GetParam());
     const std::array<scalar, 2u> theta_range = eta_to_theta_range(eta_range);
     const std::array<scalar, 2u> phi_range = std::get<5>(GetParam());
-    const scalar charge = std::get<6>(GetParam());
+    const detray::pdg_particle<scalar> ptc = std::get<6>(GetParam());
     const unsigned int n_truth_tracks = std::get<7>(GetParam());
     const unsigned int n_events = std::get<8>(GetParam());
+    const bool random_charge = std::get<9>(GetParam());
 
     // Performance writer
     traccc::fitting_performance_writer::config fit_writer_cfg;
@@ -121,7 +122,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     gen_cfg.phi_range(phi_range[0], phi_range[1]);
     gen_cfg.theta_range(theta_range[0], theta_range[1]);
     gen_cfg.mom_range(mom_range[0], mom_range[1]);
-    gen_cfg.charge(charge);
+    gen_cfg.randomize_charge(random_charge);
     generator_type generator(gen_cfg);
 
     // Smearing value for measurements
@@ -138,8 +139,8 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     std::filesystem::create_directories(full_path);
     auto sim = traccc::simulator<host_detector_type, b_field_t, generator_type,
                                  writer_type>(
-        n_events, host_det, field, std::move(generator),
-        std::move(smearer_writer_cfg), full_path);
+        std::get<6>(GetParam()), n_events, host_det, field,
+        std::move(generator), std::move(smearer_writer_cfg), full_path);
     sim.run();
 
     /***************
@@ -161,6 +162,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     // Fitting algorithm object
     typename traccc::sycl::fitting_algorithm<device_fitter_type>::config_type
         fit_cfg;
+    fit_cfg.ptc_hypothesis = ptc;
     traccc::sycl::fitting_algorithm<device_fitter_type> device_fitting(fit_cfg,
                                                                        mr, &q);
 
@@ -225,22 +227,25 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
 
 INSTANTIATE_TEST_SUITE_P(
     SYCLKalmanFitTelescopeValidation, KalmanFittingTelescopeTests,
-    ::testing::Values(
-        std::make_tuple("sycl_telescope_1_GeV_0_phi",
-                        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-                        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-                        std::array<scalar, 2u>{1.f, 1.f},
-                        std::array<scalar, 2u>{0.f, 0.f},
-                        std::array<scalar, 2u>{0.f, 0.f}, -1.f, 100, 100),
-        std::make_tuple("sycl_telescope_10_GeV_0_phi",
-                        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-                        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-                        std::array<scalar, 2u>{10.f, 10.f},
-                        std::array<scalar, 2u>{0.f, 0.f},
-                        std::array<scalar, 2u>{0.f, 0.f}, -1.f, 100, 100),
-        std::make_tuple("sycl_telescope_100_GeV_0_phi",
-                        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-                        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-                        std::array<scalar, 2u>{100.f, 100.f},
-                        std::array<scalar, 2u>{0.f, 0.f},
-                        std::array<scalar, 2u>{0.f, 0.f}, -1.f, 100, 100)));
+    ::testing::Values(std::make_tuple("sycl_telescope_1_GeV_0_phi",
+                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
+                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
+                                      std::array<scalar, 2u>{1.f, 1.f},
+                                      std::array<scalar, 2u>{0.f, 0.f},
+                                      std::array<scalar, 2u>{0.f, 0.f},
+                                      detray::muon<scalar>(), 100, 100, false),
+                      std::make_tuple("sycl_telescope_10_GeV_0_phi",
+                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
+                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
+                                      std::array<scalar, 2u>{10.f, 10.f},
+                                      std::array<scalar, 2u>{0.f, 0.f},
+                                      std::array<scalar, 2u>{0.f, 0.f},
+                                      detray::muon<scalar>(), 100, 100, false),
+                      std::make_tuple("sycl_telescope_100_GeV_0_phi",
+                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
+                                      std::array<scalar, 3u>{0.f, 0.f, 0.f},
+                                      std::array<scalar, 2u>{100.f, 100.f},
+                                      std::array<scalar, 2u>{0.f, 0.f},
+                                      std::array<scalar, 2u>{0.f, 0.f},
+                                      detray::muon<scalar>(), 100, 100,
+                                      false)));


### PR DESCRIPTION
As of detray v0.73.0, we need to handle the particle hypothesis appropriately. 
Free covariance matrix is also removed as it turned out to be unnecessary.


It is not relevant with the detray version update, but the PR make the test for the track parameter estimation cover the positive charge as well.