### PR TITLE
Simplify ODD Strip Module Handling, main branch (2024.08.20.)

### DIFF
--- a/core/include/traccc/clusterization/impl/measurement_creation.ipp
+++ b/core/include/traccc/clusterization/impl/measurement_creation.ipp
@@ -111,7 +111,6 @@ TRACCC_HOST_DEVICE inline void fill_measurement(
     if (mod.pixel.dimension == 1) {
         m.meas_dim = 1;
         m.local[1] = 0.f;
-        m.variance[1] = mod.pixel.variance_y;
     }
 }
 

--- a/core/include/traccc/geometry/pixel_data.hpp
+++ b/core/include/traccc/geometry/pixel_data.hpp
@@ -24,7 +24,6 @@ struct pixel_data {
     scalar pitch_x = 1.f;
     scalar pitch_y = 1.f;
     char dimension = 2;
-    scalar variance_y = 0.f;
 
     TRACCC_HOST_DEVICE
     vector2 get_pitch() const { return {pitch_x, pitch_y}; };

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -142,7 +142,6 @@ inline void aggregate_cluster(
     if (this_module.pixel.dimension == 1) {
         out.meas_dim = 1;
         out.local[1] = 0.f;
-        out.variance[1] = this_module.pixel.variance_y;
     } else {
         out.meas_dim = 2;
     }

--- a/io/include/traccc/io/digitization_config.hpp
+++ b/io/include/traccc/io/digitization_config.hpp
@@ -17,7 +17,6 @@ namespace traccc {
 struct module_digitization_config {
     Acts::BinUtility segmentation;
     char dimensions = 2;
-    float variance_y = 0.f;
 };
 
 /// Type describing the digitization configuration for the whole detector

--- a/io/src/csv/read_cells.cpp
+++ b/io/src/csv/read_cells.cpp
@@ -83,7 +83,6 @@ traccc::cell_module get_module(const std::uint64_t geometry_id,
             result.pixel.pitch_y = binning_data[1].step;
         }
         result.pixel.dimension = geo_it->dimensions;
-        result.pixel.variance_y = geo_it->variance_y;
     }
 
     return result;


### PR DESCRIPTION
Removed the `traccc::pixel_data::variance_y` variable. As discussed in https://github.com/acts-project/traccc/pull/627#discussion_r1649794653, there was no reason to keep this variable in memory. The values coming from the digitization files were the same as what we get with the formula implemented in the measurement creation code.

At the same time made the code for detecting 1D modules a lot more robust. Now the decision is made based on the number of "bins" in a module's segmentation.

I tested on our multi-muon ODD simulations that these changes don't affect the output of `traccc_seq_example`. (While also testing that for instance setting all modules to be 2D would have a visible effect.)

I wanted to put this in before making the same simplification in #627 as well. :thinking: