### PR TITLE
Access track parameters in a sorted order for KF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,20 @@ if( TRACCC_SETUP_TBB )
    endif()
 endif()
 
+# Set up DPL if SYCL is built.
+option( TRACCC_SETUP_DPL
+   "Set up the DPL target(s) explicitly" ${TRACCC_BUILD_SYCL} )
+option( TRACCC_USE_SYSTEM_DPL
+   "Pick up an existing installation of DPL from the build environment"
+   ${TRACCC_USE_SYSTEM_LIBS} )
+if( TRACCC_SETUP_DPL )
+   if( TRACCC_USE_SYSTEM_DPL )
+      find_package( DPL REQUIRED )
+   else()
+      add_subdirectory( extern/dpl )
+   endif()
+endif()
+
 # Set up Kokkos.
 option( TRACCC_SETUP_KOKKOS
    "Set up the Kokkos library" ${TRACCC_BUILD_KOKKOS} )

--- a/device/common/CMakeLists.txt
+++ b/device/common/CMakeLists.txt
@@ -79,6 +79,8 @@ traccc_add_library( traccc_device_common device_common TYPE SHARED
    # Track fitting funtions(s).
    "include/traccc/fitting/device/fit.hpp"
    "include/traccc/fitting/device/impl/fit.ipp"
+   "include/traccc/fitting/device/fill_sort_keys.hpp"
+   "include/traccc/fitting/device/impl/fill_sort_keys.ipp"
    )
 target_link_libraries( traccc_device_common
    PUBLIC traccc::Thrust traccc::core vecmem::core )

--- a/device/common/include/traccc/edm/device/sort_key.hpp
+++ b/device/common/include/traccc/edm/device/sort_key.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/definitions/primitives.hpp"
+#include "traccc/edm/track_candidate.hpp"
 #include "traccc/edm/track_parameters.hpp"
 
 namespace traccc::device {
@@ -18,7 +19,7 @@ using sort_key = traccc::scalar;
 TRACCC_HOST_DEVICE
 inline sort_key get_sort_key(const bound_track_parameters& params) {
     // key = |theta - pi/2|
-    return math::abs(params.theta() - constant<traccc::scalar>::pi_2);
+    return math::fabs(params.theta() - constant<traccc::scalar>::pi_2);
 }
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/fitting/device/fill_sort_keys.hpp
+++ b/device/common/include/traccc/fitting/device/fill_sort_keys.hpp
@@ -1,0 +1,35 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/edm/device/sort_key.hpp"
+#include "traccc/edm/track_candidate.hpp"
+
+// System include(s).
+#include <cstddef>
+
+namespace traccc::device {
+
+/// Function used to fill key container
+///
+/// @param[in] globalIndex   The index of the current thread
+/// @param[in] track_candidates_view The input track candidates
+/// @param[out] keys_view    The key values
+/// @param[out] ids_view     The param ids
+///
+TRACCC_HOST_DEVICE inline void fill_sort_keys(
+    std::size_t globalIndex,
+    const track_candidate_container_types::const_view& track_candidates_view,
+    vecmem::data::vector_view<device::sort_key> keys_view,
+    vecmem::data::vector_view<unsigned int> ids_view);
+
+}  // namespace traccc::device
+
+// Include the implementation.
+#include "traccc/fitting/device/impl/fill_sort_keys.ipp"

--- a/device/common/include/traccc/fitting/device/fit.hpp
+++ b/device/common/include/traccc/fitting/device/fit.hpp
@@ -31,6 +31,7 @@ TRACCC_HOST_DEVICE inline void fit(
     const typename fitter_t::bfield_type field_data,
     const typename fitter_t::config_type cfg,
     track_candidate_container_types::const_view track_candidates_view,
+    const vecmem::data::vector_view<const unsigned int>& param_ids_view,
     track_state_container_types::view track_states_view);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/fitting/device/impl/fill_sort_keys.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fill_sort_keys.ipp
@@ -1,0 +1,37 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::device {
+
+TRACCC_HOST_DEVICE inline void fill_sort_keys(
+    std::size_t globalIndex,
+    const track_candidate_container_types::const_view& track_candidates_view,
+    vecmem::data::vector_view<device::sort_key> keys_view,
+    vecmem::data::vector_view<unsigned int> ids_view) {
+
+    track_candidate_container_types::const_device track_candidates(
+        track_candidates_view);
+
+    // Keys
+    vecmem::device_vector<device::sort_key> keys_device(keys_view);
+
+    // Param id
+    vecmem::device_vector<unsigned int> ids_device(ids_view);
+
+    if (globalIndex >= keys_device.size()) {
+        return;
+    }
+
+    // Key = The number of measurements
+    keys_device.at(globalIndex) = static_cast<traccc::scalar>(
+        track_candidates.at(globalIndex).items.size());
+    ids_device.at(globalIndex) = globalIndex;
+}
+
+}  // namespace traccc::device

--- a/device/cuda/src/fitting/fitting_algorithm.cu
+++ b/device/cuda/src/fitting/fitting_algorithm.cu
@@ -9,6 +9,7 @@
 #include "../utils/cuda_error_handling.hpp"
 #include "../utils/utils.hpp"
 #include "traccc/cuda/fitting/fitting_algorithm.hpp"
+#include "traccc/fitting/device/fill_sort_keys.hpp"
 #include "traccc/fitting/device/fit.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 
@@ -17,6 +18,9 @@
 #include "detray/detectors/bfield.hpp"
 #include "detray/propagator/rk_stepper.hpp"
 
+// Thrust include(s).
+#include <thrust/sort.h>
+
 // System include(s).
 #include <vector>
 
@@ -24,17 +28,27 @@ namespace traccc::cuda {
 
 namespace kernels {
 
+__global__ void fill_sort_keys(
+    track_candidate_container_types::const_view track_candidates_view,
+    vecmem::data::vector_view<device::sort_key> keys_view,
+    vecmem::data::vector_view<unsigned int> ids_view) {
+
+    device::fill_sort_keys(threadIdx.x + blockIdx.x * blockDim.x,
+                           track_candidates_view, keys_view, ids_view);
+}
+
 template <typename fitter_t, typename detector_view_t>
 __global__ void fit(
     detector_view_t det_data, const typename fitter_t::bfield_type field_data,
     const typename fitter_t::config_type cfg,
     track_candidate_container_types::const_view track_candidates_view,
+    vecmem::data::vector_view<const unsigned int> param_ids_view,
     track_state_container_types::view track_states_view) {
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
 
     device::fit<fitter_t>(gid, det_data, field_data, cfg, track_candidates_view,
-                          track_states_view);
+                          param_ids_view, track_states_view);
 }
 
 }  // namespace kernels
@@ -82,10 +96,27 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
         const unsigned int nThreads = m_warp_size * 2;
         const unsigned int nBlocks = (n_tracks + nThreads - 1) / nThreads;
 
+        vecmem::data::vector_buffer<device::sort_key> keys_buffer(n_tracks,
+                                                                  m_mr.main);
+        vecmem::data::vector_buffer<unsigned int> param_ids_buffer(n_tracks,
+                                                                   m_mr.main);
+
+        // Get key and value for sorting
+        kernels::fill_sort_keys<<<nBlocks, nThreads, 0, stream>>>(
+            track_candidates_view, keys_buffer, param_ids_buffer);
+        TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+
+        // Sort the key to get the sorted parameter ids
+        vecmem::device_vector<device::sort_key> keys_device(keys_buffer);
+        vecmem::device_vector<unsigned int> param_ids_device(param_ids_buffer);
+
+        thrust::sort_by_key(thrust::cuda::par.on(stream), keys_device.begin(),
+                            keys_device.end(), param_ids_device.begin());
+
         // Run the track fitting
         kernels::fit<fitter_t><<<nBlocks, nThreads, 0, stream>>>(
             det_view, field_view, m_cfg, track_candidates_view,
-            track_states_buffer);
+            param_ids_buffer, track_states_buffer);
         TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
     }
 

--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -45,4 +45,4 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
 )
 target_link_libraries( traccc_sycl
   PUBLIC traccc::core detray::core vecmem::core covfie::core
-  PRIVATE traccc::device_common vecmem::sycl )
+  PRIVATE traccc::device_common vecmem::sycl oneDPL )

--- a/device/sycl/src/fitting/fitting_algorithm.sycl
+++ b/device/sycl/src/fitting/fitting_algorithm.sycl
@@ -7,6 +7,7 @@
 
 // Project include(s).
 #include "../utils/get_queue.hpp"
+#include "traccc/fitting/device/fill_sort_keys.hpp"
 #include "traccc/fitting/device/fit.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 #include "traccc/sycl/fitting/fitting_algorithm.hpp"
@@ -18,6 +19,10 @@
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/rk_stepper.hpp"
 
+// DPL include(s).
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+
 // System include(s).
 #include <vector>
 
@@ -27,6 +32,9 @@ namespace kernels {
 /// Class identifying the kernel running @c
 /// traccc::device::fit
 class fit;
+/// Class identifying the kernel running @c
+/// traccc::device::fill_sort_keys
+class fill_sort_keys;
 }  // namespace kernels
 
 template <typename fitter_t>
@@ -74,19 +82,47 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
     // (=32)
     unsigned int localSize = 64;
 
+    vecmem::data::vector_buffer<device::sort_key> keys_buffer(n_tracks,
+                                                              m_mr.main);
+    vecmem::data::vector_buffer<unsigned int> param_ids_buffer(n_tracks,
+                                                               m_mr.main);
+    vecmem::data::vector_view<device::sort_key> keys_view(keys_buffer);
+    vecmem::data::vector_view<unsigned int> param_ids_view(param_ids_buffer);
+
+    // Sort the key to get the sorted parameter ids
+    vecmem::device_vector<device::sort_key> keys_device(keys_buffer);
+    vecmem::device_vector<unsigned int> param_ids_device(param_ids_buffer);
+
     // 1 dim ND Range for the kernel
     auto trackParamsNdRange =
         traccc::sycl::calculate1DimNdRange(n_tracks, localSize);
 
     details::get_queue(m_queue)
         .submit([&](::sycl::handler& h) {
+            h.parallel_for<kernels::fill_sort_keys>(
+                trackParamsNdRange, [track_candidates_view, keys_view,
+                                     param_ids_view](::sycl::nd_item<1> item) {
+                    device::fill_sort_keys(item.get_global_linear_id(),
+                                           track_candidates_view, keys_view,
+                                           param_ids_view);
+                });
+        })
+        .wait_and_throw();
+
+    oneapi::dpl::sort_by_key(oneapi::dpl::execution::dpcpp_default,
+                             keys_device.begin(), keys_device.end(),
+                             param_ids_device.begin());
+
+    details::get_queue(m_queue)
+        .submit([&](::sycl::handler& h) {
             h.parallel_for<kernels::fit>(
                 trackParamsNdRange,
                 [det_view, field_view, config = m_cfg, track_candidates_view,
-                 track_states_view](::sycl::nd_item<1> item) {
-                    device::fit<fitter_t>(
-                        item.get_global_linear_id(), det_view, field_view,
-                        config, track_candidates_view, track_states_view);
+                 param_ids_view, track_states_view](::sycl::nd_item<1> item) {
+                    device::fit<fitter_t>(item.get_global_linear_id(), det_view,
+                                          field_view, config,
+                                          track_candidates_view, param_ids_view,
+                                          track_states_view);
                 });
         })
         .wait_and_throw();

--- a/extern/dpl/CMakeLists.txt
+++ b/extern/dpl/CMakeLists.txt
@@ -1,0 +1,37 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.14 )
+include( FetchContent )
+
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
+# Tell the user what's happening.
+message( STATUS "Building oneDPL as part of the TRACCC project" )
+
+# Declare where to get DPL from.
+set( TRACCC_DPL_SOURCE
+   "URL;https://github.com/oneapi-src/oneDPL/archive/refs/tags/oneDPL-2022.6.0-rc1.tar.gz;URL_MD5;f52a2ed5c9e4cdb3c65c2465b50abecf"
+   CACHE STRING "Source for DPL, when built as part of this project" )
+mark_as_advanced( TRACCC_DPL_SOURCE )
+FetchContent_Declare( DPL ${TRACCC_DPL_SOURCE} )
+
+# Set the default oneDPL threading backend.
+set( ONEDPL_BACKEND "dpcpp" CACHE STRING "oneDPL threading backend" )
+
+# Get it into the current directory.
+FetchContent_MakeAvailable( DPL )
+
+# Treat the oneDPL headers as "system headers", to avoid getting warnings from
+# them.
+get_target_property( _incDirs oneDPL INTERFACE_INCLUDE_DIRECTORIES )
+target_include_directories( oneDPL
+   SYSTEM INTERFACE ${_incDirs} )
+unset( _incDirs )

--- a/extern/dpl/README.txt
+++ b/extern/dpl/README.txt
@@ -1,0 +1,4 @@
+# Build Recipe for oneDPL
+
+This directory holds a build recipe for building
+[DPL](https://github.com/oneapi-src/oneDPL) for this project.

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -15,6 +15,7 @@ traccc_add_test(
     # TODO: Reactivate this once #655 is fixed.
     # test_kalman_fitter_telescope.sycl
     test_clusterization.sycl
+    test_dpl.sycl
     test_spacepoint_formation.sycl
     test_barrier.sycl
     test_mutex.sycl
@@ -37,4 +38,5 @@ traccc_add_test(
     traccc::io
     traccc::simulation
     traccc_tests_common
+    oneDPL
 )

--- a/tests/sycl/test_dpl.sycl
+++ b/tests/sycl/test_dpl.sycl
@@ -1,0 +1,124 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// DPL include(s).
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_buffer.hpp>
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/memory/sycl/device_memory_resource.hpp>
+#include <vecmem/utils/sycl/copy.hpp>
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+namespace {
+
+// Simple asynchronous handler function
+auto handle_async_error = [](::sycl::exception_list elist) {
+    for (auto& e : elist) {
+        try {
+            std::rethrow_exception(e);
+        } catch (::sycl::exception& e) {
+            std::cout << "ASYNC EXCEPTION!!\n";
+            std::cout << e.what() << "\n";
+        }
+    }
+};
+
+}  // namespace
+
+TEST(dpl, sort) {
+
+    ::sycl::queue q(handle_async_error);
+    vecmem::sycl::copy copy{&q};
+    vecmem::host_memory_resource host_resource;
+    vecmem::sycl::device_memory_resource device_resource{&q};
+
+    vecmem::vector<unsigned int> host_vector{{3, 2, 1, 8, 4}, &host_resource};
+
+    auto host_buffer = vecmem::get_data(host_vector);
+    auto device_buffer = copy.to(vecmem::get_data(host_vector), device_resource,
+                                 vecmem::copy::type::host_to_device);
+
+    vecmem::device_vector<unsigned int> device_vector(device_buffer);
+
+    oneapi::dpl::sort(oneapi::dpl::execution::dpcpp_default,
+                      device_vector.begin(), device_vector.end());
+
+    copy(device_buffer, host_buffer, vecmem::copy::type::device_to_host);
+
+    ASSERT_EQ(host_vector[0], 1);
+    ASSERT_EQ(host_vector[1], 2);
+    ASSERT_EQ(host_vector[2], 3);
+    ASSERT_EQ(host_vector[3], 4);
+    ASSERT_EQ(host_vector[4], 8);
+}
+
+TEST(dpl, scan) {
+
+    ::sycl::queue q(handle_async_error);
+    vecmem::sycl::copy copy{&q};
+    vecmem::host_memory_resource host_resource;
+    vecmem::sycl::device_memory_resource device_resource{&q};
+
+    vecmem::vector<unsigned int> host_vector{{3, 2, 1, 8, 4}, &host_resource};
+
+    auto host_buffer = vecmem::get_data(host_vector);
+    auto device_buffer = copy.to(vecmem::get_data(host_vector), device_resource,
+                                 vecmem::copy::type::host_to_device);
+
+    vecmem::device_vector<unsigned int> device_vector(device_buffer);
+
+    oneapi::dpl::inclusive_scan(oneapi::dpl::execution::dpcpp_default,
+                                device_vector.begin(), device_vector.end(),
+                                device_vector.begin());
+
+    copy(device_buffer, host_buffer, vecmem::copy::type::device_to_host);
+
+    ASSERT_EQ(host_vector[0], 3);
+    ASSERT_EQ(host_vector[1], 5);
+    ASSERT_EQ(host_vector[2], 6);
+    ASSERT_EQ(host_vector[3], 14);
+    ASSERT_EQ(host_vector[4], 18);
+}
+
+TEST(dpl, fill) {
+
+    ::sycl::queue q(handle_async_error);
+    vecmem::sycl::copy copy{&q};
+    vecmem::host_memory_resource host_resource;
+    vecmem::sycl::device_memory_resource device_resource{&q};
+
+    vecmem::vector<unsigned int> host_vector{{1, 1, 1, 1, 1, 1, 1},
+                                             &host_resource};
+
+    auto host_buffer = vecmem::get_data(host_vector);
+    auto device_buffer = copy.to(vecmem::get_data(host_vector), device_resource,
+                                 vecmem::copy::type::host_to_device);
+
+    vecmem::device_vector<unsigned int> device_vector(device_buffer);
+
+    oneapi::dpl::fill(oneapi::dpl::execution::dpcpp_default,
+                      device_vector.begin(), device_vector.end(), 112);
+
+    copy(device_buffer, host_buffer, vecmem::copy::type::device_to_host);
+
+    ASSERT_EQ(host_vector[0], 112);
+    ASSERT_EQ(host_vector[1], 112);
+    ASSERT_EQ(host_vector[2], 112);
+    ASSERT_EQ(host_vector[3], 112);
+    ASSERT_EQ(host_vector[4], 112);
+    ASSERT_EQ(host_vector[5], 112);
+    ASSERT_EQ(host_vector[6], 112);
+}


### PR DESCRIPTION
Based on #706 

### UPDATE

Now the KF also uses the sorting method, but with a different standard: the number of measurements ($$n$$) of the track. 

The problem of using $$\theta$$ method is that the branching still can be an issue if the some of tracks in the warp end too early unexpectedly (or continue with too many measurements). We can prevent them by sorting the tracks w.r.t to the number of measurements.

One can still argue that the different step size between the planes can be problematic, and I think that is a valid point :thinking: 
It is not easy to know which one between $$\theta$$ or $$n$$ is better until one check the results. At least the ODD data says that sorting with $$n$$ is beneficial.

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
  | Sort CKF and KF (PR) | Sort CKF | No sort (main)
-- | -- | -- | --
mt cuda [Hz] | 19.01 | 17.85 | 15.0808

Of course we can try to improve this further by experimenting different values or combining them

-------------------------------------------------------------------------


The main purpose of the PR is sorting the track parameters with based on $$\theta$$, to reduce the branching divergence. (Similar to the binning method that Markus mentioned in the parallelization meeting) 

As it turned out that sorting the track parameters themselves is quite expensive, I decided to make a small vector holding $$\theta$$ and vector indices, which is sorted instead. In the kernel, the track parameters are accessed by the indices of this small vector.

Following is the benchmark result with `traccc_throughput_mt_cuda` ODD data and `traccc_benchmark_cuda` with toy geometry

Command for **mt_cuda**: 
`./bin/traccc_throughput_mt_cuda --detector-file=geometries/odd/odd-detray_geometry_detray.json --digitization-file=geometries/odd/odd-digi-geometric-config.json --grid-file=geometries/odd/odd-detray_surface_grids_detray.json --use-detray-detector --input-directory=../../../../../../../bld6/data/traccc/geant4_ttbar_mu100/ --cpu-threads 2`

Command for **cuda toy benchmark**:
`./bin/traccc_benchmark_cuda`

Device: NVIDIA RTX A6000

![image](https://github.com/user-attachments/assets/e878344e-c2a2-4c49-ada9-04658a58c7e8)
