### PR TITLE
Add benchmark formatting to CI

### DIFF
--- a/.github/check_format.sh
+++ b/.github/check_format.sh
@@ -7,7 +7,7 @@
 
 set -e # abort on error
 
-INCLUDE_DIRS=("core device examples io tests performance plugins simulation")
+INCLUDE_DIRS=("core device examples io tests performance plugins simulation benchmarks")
 
 if [ $# -ne 1 ]; then
     echo "wrong number of arguments"

--- a/benchmarks/cuda/toy_detector_cuda.cpp
+++ b/benchmarks/cuda/toy_detector_cuda.cpp
@@ -195,5 +195,5 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
     }
 
     state.counters["event_throughput_Hz"] = benchmark::Counter(
-        static_cast<double>(n_events), benchmark::Counter::kIsRate);    
+        static_cast<double>(n_events), benchmark::Counter::kIsRate);
 }


### PR DESCRIPTION
The formatting CI currently doesn't check the (relatively new) benchmark directory. This commit ensures that benchmarks are correctly formatted.