### PR TITLE
Fix integer comparison bugs in device CKF

### DIFF
--- a/device/common/include/traccc/finding/device/impl/add_links_for_holes.ipp
+++ b/device/common/include/traccc/finding/device/impl/add_links_for_holes.ipp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <utility>
+
 namespace traccc::device {
 
 TRACCC_DEVICE inline void add_links_for_holes(
@@ -45,8 +47,10 @@ TRACCC_DEVICE inline void add_links_for_holes(
     vecmem::device_vector<candidate_link> links(links_view);
 
     // Last step ID
-    const unsigned int previous_step =
-        (step == 0) ? std::numeric_limits<unsigned int>::max() : step - 1;
+    const candidate_link::link_index_type::first_type previous_step =
+        (step == 0) ? std::numeric_limits<
+                          candidate_link::link_index_type::first_type>::max()
+                    : step - 1;
 
     if (n_candidates[globalIndex] == 0u) {
 
@@ -72,10 +76,12 @@ TRACCC_DEVICE inline void add_links_for_holes(
                        : prev_links[prev_param_to_link[globalIndex]].n_skipped);
 
         // Add a dummy link
-        links.at(l_pos) = {{previous_step, globalIndex},
-                           std::numeric_limits<unsigned int>::max(),
-                           orig_param_id,
-                           skip_counter + 1};
+        links.at(l_pos) = {
+            {previous_step, globalIndex},
+            std::numeric_limits<std::decay_t<decltype(
+                std::declval<candidate_link>().meas_idx)>>::max(),
+            orig_param_id,
+            skip_counter + 1};
 
         out_params.at(l_pos) = in_params.at(globalIndex);
     }

--- a/device/common/include/traccc/finding/device/impl/build_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/build_tracks.ipp
@@ -54,7 +54,6 @@ TRACCC_DEVICE inline void build_tracks(
     // Count the number of skipped steps
     unsigned int n_skipped{0u};
     while (true) {
-
         if (L.meas_idx > n_meas) {
             n_skipped++;
         }
@@ -83,11 +82,10 @@ TRACCC_DEVICE inline void build_tracks(
          it++) {
         i++;
 
-        while (L.meas_idx > n_meas) {
-            if (L.previous.first < 0) {
-                break;
-            }
-
+        while (L.meas_idx > n_meas &&
+               L.previous.first !=
+                   std::numeric_limits<
+                       candidate_link::link_index_type::first_type>::max()) {
             const auto link_pos =
                 param_to_link[L.previous.first][L.previous.second];
 

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -66,8 +66,10 @@ TRACCC_DEVICE inline void find_tracks(
     vecmem::device_vector<const unsigned int> ref_meas_idx(ref_meas_idx_view);
 
     // Last step ID
-    const int previous_step =
-        (step == 0) ? std::numeric_limits<int>::max() : step - 1;
+    const candidate_link::link_index_type::first_type previous_step =
+        (step == 0) ? std::numeric_limits<
+                          candidate_link::link_index_type::first_type>::max()
+                    : step - 1;
 
     const unsigned int n_measurements_sum = n_measurements_prefix_sum.back();
     const unsigned int stride = globalIndex * cfg.n_measurements_per_thread;


### PR DESCRIPTION
This commit fixes a few bugs in the device CKF to do with the integral representation of the previous step number. Firstly, the previous step of step 0 (e.g. some sort of sentinel value) was being inconsistently defined as either the maximum value of a signed int or an unsigned int, and this was stored in an integer, leading to unexpected behaviour. Furthermore, the track building kernel was not correctly checking for the sentinel value, but rather looking for values smaller than 0.