### PR TITLE
Update to detray version v0.74.2

### DIFF
--- a/benchmarks/cuda/toy_detector_cuda.cpp
+++ b/benchmarks/cuda/toy_detector_cuda.cpp
@@ -150,23 +150,14 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
                 tp_cuda(spacepoints_cuda_buffer, seeds_cuda_buffer, B);
             stream.synchronize();
 
-            // Navigation buffer
-            auto navigation_buffer = detray::create_candidates_buffer(
-                det,
-                device_finding.get_config().navigation_buffer_size_scaler *
-                    copy.get_size(seeds_cuda_buffer),
-                mr.main, mr.host);
-
             // Run CKF track finding
-            track_candidates_cuda_buffer =
-                device_finding(det_view, field, navigation_buffer,
-                               measurements_cuda_buffer, params_cuda_buffer);
+            track_candidates_cuda_buffer = device_finding(
+                det_view, field, measurements_cuda_buffer, params_cuda_buffer);
             stream.synchronize();
 
             // Run track fitting
             track_states_cuda_buffer =
-                device_fitting(det_view, field, navigation_buffer,
-                               track_candidates_cuda_buffer);
+                device_fitting(det_view, field, track_candidates_cuda_buffer);
             stream.synchronize();
 
             // Create a temporary buffer that will receive the device memory.

--- a/core/include/traccc/finding/finding_algorithm.ipp
+++ b/core/include/traccc/finding/finding_algorithm.ipp
@@ -131,7 +131,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
              * Material interaction
              *************************/
 
-            // Get intersection at surface
+            // Get surface corresponding to bound params
             const detray::tracking_surface sf{det, in_param.surface_link()};
 
             const cxt_t ctx{};
@@ -180,14 +180,12 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
                     break;
                 }
 
-                bound_track_parameters bound_param(in_param.surface_link(),
-                                                   in_param.vector(),
-                                                   in_param.covariance());
                 const auto& meas = measurements[item_id];
 
                 track_state<algebra_type> trk_state(meas);
 
-                // Run the Kalman update
+                // Run the Kalman update on a copy of the track parameters
+                bound_track_parameters bound_param(in_param);
                 sf.template visit_mask<gain_matrix_updater<algebra_type>>(
                     trk_state, bound_param);
 
@@ -218,10 +216,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
                                        orig_param_id,
                                        skip_counter + 1});
 
-                bound_track_parameters bound_param(in_param.surface_link(),
-                                                   in_param.vector(),
-                                                   in_param.covariance());
-                updated_params.push_back(bound_param);
+                updated_params.push_back(in_param);
                 n_branches++;
             }
         }
@@ -272,7 +267,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 
             // Propagate to the next surface
             propagator.propagate_sync(propagation,
-                                      std::tie(s0, s1, s2, s3, s4));
+                                      detray::tie(s0, s1, s2, s3, s4));
 
             // If a surface found, add the parameter for the next
             // step

--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -54,11 +54,6 @@ struct finding_config {
      ****************************/
     /// The number of measurements to be iterated per thread
     unsigned int n_measurements_per_thread = 8;
-
-    /// Max number of candidates per seed used for navigation buffer creation
-    /// @NOTE: This is supposed to be larger than (at least equal to)
-    /// max_num_branches_per_seed
-    unsigned int navigation_buffer_size_scaler = 20;
 };
 
 }  // namespace traccc

--- a/core/include/traccc/utils/seed_generator.hpp
+++ b/core/include/traccc/utils/seed_generator.hpp
@@ -56,7 +56,7 @@ struct seed_generator {
         const detray::tracking_surface sf{m_detector, surface_link};
 
         const cxt_t ctx{};
-        auto bound_vec = sf.free_to_bound_vector(ctx, free_param.vector());
+        auto bound_vec = sf.free_to_bound_vector(ctx, free_param);
 
         auto bound_cov =
             matrix_operator().template zero<e_bound_size, e_bound_size>();
@@ -78,10 +78,8 @@ struct seed_generator {
 
         for (std::size_t i = 0; i < e_bound_size; i++) {
 
-            matrix_operator().element(bound_param.vector(), i, 0) =
-                std::normal_distribution<scalar>(
-                    matrix_operator().element(bound_param.vector(), i, 0),
-                    m_stddevs[i])(generator);
+            bound_param[i] = std::normal_distribution<scalar>(
+                bound_param[i], m_stddevs[i])(generator);
 
             matrix_operator().element(bound_param.covariance(), i, i) =
                 m_stddevs[i] * m_stddevs[i];

--- a/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
+++ b/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
@@ -38,7 +38,7 @@ TRACCC_DEVICE inline void apply_interaction(
 
     auto& bound_param = params.at(globalIndex);
 
-    // Get intersection at surface
+    // Get surface corresponding to bound params
     const detray::tracking_surface sf{det, bound_param.surface_link()};
     const typename detector_t::geometry_context ctx{};
 

--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -25,7 +25,6 @@ namespace traccc::device {
 /// @param[in] globalIndex        The index of the current thread
 /// @param[in] cfg                Track finding config object
 /// @param[in] det_data           Detector view object
-/// @param[in] nav_candidates_buffer Navgation buffer
 /// @param[in] in_params_view     Input parameters
 /// @param[in] links_view         Link container for the current step
 /// @param[in] step               Step index
@@ -41,8 +40,6 @@ TRACCC_DEVICE inline void propagate_to_next_surface(
     std::size_t globalIndex, const config_t cfg,
     typename propagator_t::detector_type::view_type det_data,
     bfield_t field_data,
-    vecmem::data::jagged_vector_view<typename propagator_t::intersection_type>
-        nav_candidates_buffer,
     bound_track_parameters_collection_types::const_view in_params_view,
     vecmem::data::vector_view<const candidate_link> links_view,
     const unsigned int step, const unsigned int& n_in_params,

--- a/device/common/include/traccc/fitting/device/fit.hpp
+++ b/device/common/include/traccc/fitting/device/fit.hpp
@@ -21,17 +21,15 @@ namespace traccc::device {
 ///
 /// @param[in] globalIndex   The index of the current thread
 /// @param[in] det_data      Detector view object
-/// @param[in] nav_candidates_buffer Buffer for navigation candidate objects
 /// @param[in] track_candidates_view The input track candidates
 /// @param[out] track_states_view The output of fitted track states
 ///
-template <typename fitter_t, typename detector_view_t>
+template <typename fitter_t>
 TRACCC_HOST_DEVICE inline void fit(
-    std::size_t globalIndex, detector_view_t det_data,
+    std::size_t globalIndex,
+    typename fitter_t::detector_type::view_type det_data,
     const typename fitter_t::bfield_type field_data,
     const typename fitter_t::config_type cfg,
-    vecmem::data::jagged_vector_view<typename fitter_t::intersection_type>
-        nav_candidates_buffer,
     track_candidate_container_types::const_view track_candidates_view,
     track_state_container_types::view track_states_view);
 

--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,20 +9,16 @@
 
 namespace traccc::device {
 
-template <typename fitter_t, typename detector_view_t>
+template <typename fitter_t>
 TRACCC_HOST_DEVICE inline void fit(
-    std::size_t globalIndex, detector_view_t det_data,
+    std::size_t globalIndex,
+    typename fitter_t::detector_type::view_type det_data,
     const typename fitter_t::bfield_type field_data,
     const typename fitter_t::config_type cfg,
-    vecmem::data::jagged_vector_view<typename fitter_t::intersection_type>
-        nav_candidates_buffer,
     track_candidate_container_types::const_view track_candidates_view,
     track_state_container_types::view track_states_view) {
 
     typename fitter_t::detector_type det(det_data);
-
-    vecmem::jagged_device_vector<typename fitter_t::intersection_type>
-        nav_candidates(nav_candidates_buffer);
 
     track_candidate_container_types::const_device track_candidates(
         track_candidates_view);
@@ -52,7 +48,7 @@ TRACCC_HOST_DEVICE inline void fit(
     typename fitter_t::state fitter_state(track_states_per_track);
 
     // Run fitting
-    fitter.fit(seed_param, fitter_state, nav_candidates.at(globalIndex));
+    fitter.fit(seed_param, fitter_state);
 
     // Get the final fitting information
     track_states[globalIndex].header = fitter_state.m_fit_res;

--- a/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
@@ -41,8 +41,6 @@ class finding_algorithm
     : public algorithm<track_candidate_container_types::buffer(
           const typename navigator_t::detector_type::view_type&,
           const typename stepper_t::magnetic_field_type&,
-          const vecmem::data::jagged_vector_view<
-              typename navigator_t::intersection_type>&,
           const typename measurement_collection_types::view&,
           const bound_track_parameters_collection_types::buffer&)> {
 
@@ -63,7 +61,7 @@ class finding_algorithm
 
     /// Actor chain for propagate to the next surface and its propagator type
     using actor_type =
-        detray::actor_chain<std::tuple, detray::pathlimit_aborter,
+        detray::actor_chain<detray::dtuple, detray::pathlimit_aborter,
                             detray::parameter_transporter<algebra_type>,
                             interaction_register<interactor>, interactor,
                             ckf_aborter>;
@@ -90,13 +88,10 @@ class finding_algorithm
     /// Run the algorithm
     ///
     /// @param det_view  Detector view object
-    /// @param navigation_buffer  Buffer for navigation candidates
     /// @param seeds     Input seeds
     track_candidate_container_types::buffer operator()(
         const typename detector_type::view_type& det_view,
         const bfield_type& field_view,
-        const vecmem::data::jagged_vector_view<
-            typename navigator_t::intersection_type>& navigation_buffer,
         const typename measurement_collection_types::view& measurements,
         const bound_track_parameters_collection_types::buffer& seeds)
         const override;

--- a/device/cuda/include/traccc/cuda/fitting/fitting_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/fitting/fitting_algorithm.hpp
@@ -30,8 +30,6 @@ class fitting_algorithm
     : public algorithm<track_state_container_types::buffer(
           const typename fitter_t::detector_type::view_type&,
           const typename fitter_t::bfield_type&,
-          const vecmem::data::jagged_vector_view<
-              typename fitter_t::intersection_type>&,
           const typename track_candidate_container_types::const_view&)> {
 
     public:
@@ -52,8 +50,6 @@ class fitting_algorithm
     track_state_container_types::buffer operator()(
         const typename fitter_t::detector_type::view_type& det_view,
         const typename fitter_t::bfield_type& field_view,
-        const vecmem::data::jagged_vector_view<
-            typename fitter_t::intersection_type>& navigation_buffer,
         const typename track_candidate_container_types::const_view&
             track_candidates_view) const override;
 

--- a/device/sycl/include/traccc/sycl/fitting/fitting_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/fitting/fitting_algorithm.hpp
@@ -31,8 +31,6 @@ class fitting_algorithm
     : public algorithm<track_state_container_types::buffer(
           const typename fitter_t::detector_type::view_type&,
           const typename fitter_t::bfield_type&,
-          const vecmem::data::jagged_vector_view<
-              typename fitter_t::intersection_type>&,
           const typename track_candidate_container_types::const_view&)> {
 
     public:
@@ -51,8 +49,6 @@ class fitting_algorithm
     track_state_container_types::buffer operator()(
         const typename fitter_t::detector_type::view_type& det_view,
         const typename fitter_t::bfield_type& field_view,
-        const vecmem::data::jagged_vector_view<
-            typename fitter_t::intersection_type>& navigation_buffer,
         const typename track_candidate_container_types::const_view&
             track_candidates_view) const override;
 

--- a/device/sycl/src/fitting/fitting_algorithm.sycl
+++ b/device/sycl/src/fitting/fitting_algorithm.sycl
@@ -47,8 +47,6 @@ template <typename fitter_t>
 track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
     const typename fitter_t::detector_type::view_type& det_view,
     const typename fitter_t::bfield_type& field_view,
-    const vecmem::data::jagged_vector_view<
-        typename fitter_t::intersection_type>& navigation_buffer,
     const typename track_candidate_container_types::const_view&
         track_candidates_view) const {
 
@@ -68,7 +66,6 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
 
     m_copy->setup(track_states_buffer.headers);
     m_copy->setup(track_states_buffer.items);
-    m_copy->setup(navigation_buffer);
 
     track_state_container_types::view track_states_view(track_states_buffer);
 
@@ -85,13 +82,11 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
         .submit([&](::sycl::handler& h) {
             h.parallel_for<kernels::fit>(
                 trackParamsNdRange,
-                [det_view, field_view, config = m_cfg, navigation_buffer,
-                 track_candidates_view,
+                [det_view, field_view, config = m_cfg, track_candidates_view,
                  track_states_view](::sycl::nd_item<1> item) {
-                    device::fit<fitter_t>(item.get_global_linear_id(), det_view,
-                                          field_view, config, navigation_buffer,
-                                          track_candidates_view,
-                                          track_states_view);
+                    device::fit<fitter_t>(
+                        item.get_global_linear_id(), det_view, field_view,
+                        config, track_candidates_view, track_states_view);
                 });
         })
         .wait_and_throw();

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -155,22 +155,13 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     // If we have a Detray detector, run the track finding and fitting.
     if (m_detector != nullptr) {
 
-        // Create the buffer needed by track finding and fitting.
-        auto navigation_buffer = detray::create_candidates_buffer(
-            *m_detector,
-            m_finding_config.navigation_buffer_size_scaler *
-                m_copy.get_size(track_params),
-            *m_cached_device_mr, &m_host_mr);
-
         // Run the track finding (asynchronously).
-        const finding_algorithm::output_type track_candidates =
-            m_finding(m_device_detector_view, m_field, navigation_buffer,
-                      measurements, track_params);
+        const finding_algorithm::output_type track_candidates = m_finding(
+            m_device_detector_view, m_field, measurements, track_params);
 
         // Run the track fitting (asynchronously).
         const fitting_algorithm::output_type track_states =
-            m_fitting(m_device_detector_view, m_field, navigation_buffer,
-                      track_candidates);
+            m_fitting(m_device_detector_view, m_field, track_candidates);
 
         // Copy a limited amount of result data back to the host.
         output_type result{&m_host_mr};

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -312,13 +312,6 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                             {0.f, 0.f, seeding_opts.seedfinder.bFieldInZ});
             }  // stop measuring track params cpu timer
 
-            // Navigation buffer
-            auto navigation_buffer = detray::create_candidates_buffer(
-                host_det,
-                device_finding.get_config().navigation_buffer_size_scaler *
-                    copy.get_size(seeds_cuda_buffer),
-                mr.main, mr.host);
-
             /*------------------------
                Track Finding with CKF
               ------------------------*/
@@ -326,9 +319,9 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             {
                 traccc::performance::timer t("Track finding with CKF (cuda)",
                                              elapsedTimes);
-                track_candidates_cuda_buffer = device_finding(
-                    det_view, field, navigation_buffer,
-                    measurements_cuda_buffer, params_cuda_buffer);
+                track_candidates_cuda_buffer =
+                    device_finding(det_view, field, measurements_cuda_buffer,
+                                   params_cuda_buffer);
             }
 
             if (accelerator_opts.compare_with_cpu) {
@@ -346,9 +339,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                 traccc::performance::timer t("Track fitting with KF (cuda)",
                                              elapsedTimes);
 
-                track_states_cuda_buffer =
-                    device_fitting(det_view, field, navigation_buffer,
-                                   track_candidates_cuda_buffer);
+                track_states_cuda_buffer = device_fitting(
+                    det_view, field, track_candidates_cuda_buffer);
             }
 
             if (accelerator_opts.compare_with_cpu) {

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -345,18 +345,12 @@ int seq_run(const traccc::opts::detector& detector_opts,
             // Perform track finding and fitting only when using a Detray
             // geometry.
             if (detector_opts.use_detray_detector) {
-                // CUDA
-                auto navigation_buffer = detray::create_candidates_buffer(
-                    host_detector,
-                    finding_cfg.navigation_buffer_size_scaler *
-                        copy.get_size(seeds_cuda_buffer),
-                    mr.main, mr.host);
                 {
                     traccc::performance::timer timer{"Track finding (cuda)",
                                                      elapsedTimes};
                     track_candidates_buffer = finding_alg_cuda(
-                        device_detector_view, field, navigation_buffer,
-                        measurements_cuda_buffer, params_cuda_buffer);
+                        device_detector_view, field, measurements_cuda_buffer,
+                        params_cuda_buffer);
                 }
                 // CPU
                 if (accelerator_opts.compare_with_cpu) {
@@ -370,8 +364,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
                     traccc::performance::timer timer{"Track fitting (cuda)",
                                                      elapsedTimes};
                     track_states_buffer = fitting_alg_cuda(
-                        device_detector_view, field, navigation_buffer,
-                        track_candidates_buffer);
+                        device_detector_view, field, track_candidates_buffer);
                 }
                 // CPU
                 if (accelerator_opts.compare_with_cpu) {

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -224,20 +224,12 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
         async_copy.setup(track_candidates_cuda_buffer.headers);
         async_copy.setup(track_candidates_cuda_buffer.items);
 
-        // Navigation buffer
-        auto navigation_buffer = detray::create_candidates_buffer(
-            host_det,
-            device_finding.get_config().navigation_buffer_size_scaler *
-                seeds.size(),
-            mr.main, mr.host);
-
         {
             traccc::performance::timer t("Track finding  (cuda)", elapsedTimes);
 
             // Run finding
-            track_candidates_cuda_buffer =
-                device_finding(det_view, field, navigation_buffer,
-                               measurements_cuda_buffer, seeds_buffer);
+            track_candidates_cuda_buffer = device_finding(
+                det_view, field, measurements_cuda_buffer, seeds_buffer);
         }
 
         traccc::track_candidate_container_types::host track_candidates_cuda =
@@ -252,8 +244,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
             // Run fitting
             track_states_cuda_buffer =
-                device_fitting(det_view, field, navigation_buffer,
-                               track_candidates_cuda_buffer);
+                device_fitting(det_view, field, track_candidates_cuda_buffer);
         }
         traccc::track_state_container_types::host track_states_cuda =
             track_state_d2h(track_states_cuda_buffer);

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -185,10 +185,6 @@ int main(int argc, char* argv[]) {
             truth_track_candidates_cuda_buffer =
                 track_candidate_h2d(traccc::get_data(truth_track_candidates));
 
-        // Navigation buffer
-        auto navigation_buffer = detray::create_candidates_buffer(
-            host_det, truth_track_candidates.size(), mr.main, mr.host);
-
         // Instantiate cuda containers/collections
         traccc::track_state_container_types::buffer track_states_cuda_buffer{
             {{}, *(mr.host)}, {{}, *(mr.host), mr.host}};
@@ -197,9 +193,8 @@ int main(int argc, char* argv[]) {
             traccc::performance::timer t("Track fitting  (cuda)", elapsedTimes);
 
             // Run fitting
-            track_states_cuda_buffer =
-                device_fitting(det_view, field, navigation_buffer,
-                               truth_track_candidates_cuda_buffer);
+            track_states_cuda_buffer = device_fitting(
+                det_view, field, truth_track_candidates_cuda_buffer);
         }
 
         traccc::track_state_container_types::host track_states_cuda =

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.73.0.tar.gz;URL_MD5;ada6e82aff6b1082dea8fc95ba0f3b9c"
+"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.74.2.tar.gz;URL_MD5;5ce179984fcf73368ca792f789a84ed5"
    CACHE STRING "Source for Detray, when built as part of this project" )
 
 mark_as_advanced( TRACCC_DETRAY_SOURCE )

--- a/performance/include/traccc/resolution/fitting_performance_writer.hpp
+++ b/performance/include/traccc/resolution/fitting_performance_writer.hpp
@@ -78,21 +78,17 @@ class fitting_performance_writer {
         const detray::tracking_surface sf{det, meas.surface_link};
         using cxt_t = typename detector_t::geometry_context;
         const cxt_t ctx{};
-        const auto truth_local =
-            sf.global_to_local(ctx, global_pos, vector::normalize(global_mom));
+        const auto truth_bound =
+            sf.global_to_bound(ctx, global_pos, vector::normalize(global_mom));
 
         // Return value
-        bound_track_parameters truth_param;
-        auto& truth_vec = truth_param.vector();
-        getter::element(truth_vec, e_bound_loc0, 0) = truth_local[0];
-        getter::element(truth_vec, e_bound_loc1, 0) = truth_local[1];
-        getter::element(truth_vec, e_bound_phi, 0) = getter::phi(global_mom);
-        getter::element(truth_vec, e_bound_theta, 0) =
-            getter::theta(global_mom);
+        bound_track_parameters truth_param{};
+        truth_param.set_bound_local(truth_bound);
+        truth_param.set_phi(getter::phi(global_mom));
+        truth_param.set_theta(getter::theta(global_mom));
         // @todo: Assign a proper value to time
-        getter::element(truth_vec, e_bound_time, 0) = 0.;
-        getter::element(truth_vec, e_bound_qoverp, 0) =
-            ptc.charge / getter::norm(global_mom);
+        truth_param.set_time(0.f);
+        truth_param.set_qop(ptc.charge / getter::norm(global_mom));
 
         // For the moment, only fill with the first measurements
         if (fit_res.ndf > 0 && !trk_state.is_hole) {

--- a/performance/src/resolution/res_plot_tool.cpp
+++ b/performance/src/resolution/res_plot_tool.cpp
@@ -113,8 +113,7 @@ void res_plot_tool::fill(res_plot_cache& cache,
         scalar pull = 0.f;
 
         if (idx < e_bound_size) {
-            residual = getter::element(fit_param.vector(), idx, 0) -
-                       getter::element(truth_param.vector(), idx, 0);
+            residual = fit_param[idx] - truth_param[idx];
             pull = residual /
                    std::sqrt(getter::element(fit_param.covariance(), idx, idx));
         } else if (par_name == "qopT") {

--- a/simulation/include/traccc/simulation/simulator.hpp
+++ b/simulation/include/traccc/simulation/simulator.hpp
@@ -88,8 +88,8 @@ struct simulator {
             m_scatterer.set_seed(event_id);
             writer_state.set_seed(event_id);
 
-            auto actor_states =
-                std::tie(m_transporter, m_scatterer, m_resetter, writer_state);
+            auto actor_states = detray::tie(m_transporter, m_scatterer,
+                                            m_resetter, writer_state);
 
             for (auto track : *m_track_generator.get()) {
 

--- a/tests/cpu/test_simulation.cpp
+++ b/tests/cpu/test_simulation.cpp
@@ -43,10 +43,8 @@ TEST(traccc_simulation, simulation) {
     const detray::mask<detray::rectangle2D> re{
         0u, 10.f * detray::unit<scalar>::mm, 10.f * detray::unit<scalar>::mm};
 
-    detray::bound_track_parameters<traccc::default_algebra> bound_params;
-    auto& bound_vec = bound_params.vector();
-    getter::element(bound_vec, traccc::e_bound_loc0, 0u) = 1.f;
-    getter::element(bound_vec, traccc::e_bound_loc1, 0u) = 2.f;
+    detray::bound_track_parameters<traccc::default_algebra> bound_params{};
+    bound_params.set_bound_local({1.f, 2.f});
 
     measurement_smearer<traccc::default_algebra> smearer(0.f, 0.f);
 

--- a/tests/cuda/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cuda/test_ckf_combinatorics_telescope.cpp
@@ -142,14 +142,11 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
         rk_stepper_type, device_navigator_type>::config_type cfg_no_limit;
     cfg_no_limit.ptc_hypothesis = ptc;
     cfg_no_limit.max_num_branches_per_seed = 100000;
-    cfg_no_limit.navigation_buffer_size_scaler =
-        cfg_no_limit.max_num_branches_per_seed;
 
     typename traccc::cuda::finding_algorithm<
         rk_stepper_type, device_navigator_type>::config_type cfg_limit;
     cfg_limit.ptc_hypothesis = ptc;
     cfg_limit.max_num_branches_per_seed = 500;
-    cfg_limit.navigation_buffer_size_scaler = 5000;
 
     // Finding algorithm object
     traccc::cuda::finding_algorithm<rk_stepper_type, device_navigator_type>
@@ -205,28 +202,13 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
         copy.setup(track_candidates_limit_cuda_buffer.headers);
         copy.setup(track_candidates_limit_cuda_buffer.items);
 
-        // Navigation buffer
-        auto navigation_buffer = detray::create_candidates_buffer(
-            host_det,
-            device_finding.get_config().navigation_buffer_size_scaler *
-                seeds.size(),
-            mr.main, mr.host);
-
-        auto navigation_limit_buffer = detray::create_candidates_buffer(
-            host_det,
-            device_finding_limit.get_config().navigation_buffer_size_scaler *
-                seeds.size(),
-            mr.main, mr.host);
-
         // Run device finding
         track_candidates_cuda_buffer =
-            device_finding(det_view, field, navigation_buffer,
-                           measurements_buffer, seeds_buffer);
+            device_finding(det_view, field, measurements_buffer, seeds_buffer);
 
         // Run device finding (Limit)
-        track_candidates_limit_cuda_buffer =
-            device_finding_limit(det_view, field, navigation_limit_buffer,
-                                 measurements_buffer, seeds_buffer);
+        track_candidates_limit_cuda_buffer = device_finding_limit(
+            det_view, field, measurements_buffer, seeds_buffer);
 
         traccc::track_candidate_container_types::host track_candidates_cuda =
             track_candidate_d2h(track_candidates_cuda_buffer);

--- a/tests/cuda/test_ckf_toy_detector.cpp
+++ b/tests/cuda/test_ckf_toy_detector.cpp
@@ -142,7 +142,6 @@ TEST_P(CkfToyDetectorTests, Run) {
         rk_stepper_type, device_navigator_type>::config_type cfg;
     cfg.ptc_hypothesis = ptc;
     cfg.max_num_branches_per_seed = 500;
-    cfg.navigation_buffer_size_scaler = 100;
 
     cfg.propagation.navigation.search_window = search_window;
 
@@ -196,21 +195,13 @@ TEST_P(CkfToyDetectorTests, Run) {
         copy.setup(track_candidates_cuda_buffer.headers);
         copy.setup(track_candidates_cuda_buffer.items);
 
-        // Navigation buffer
-        auto navigation_buffer = detray::create_candidates_buffer(
-            host_det,
-            device_finding.get_config().navigation_buffer_size_scaler *
-                seeds.size(),
-            mr.main, mr.host);
-
         // Run host finding
         auto track_candidates =
             host_finding(host_det, field, measurements_per_event, seeds);
 
         // Run device finding
         track_candidates_cuda_buffer =
-            device_finding(det_view, field, navigation_buffer,
-                           measurements_buffer, seeds_buffer);
+            device_finding(det_view, field, measurements_buffer, seeds_buffer);
 
         traccc::track_candidate_container_types::host track_candidates_cuda =
             track_candidate_d2h(track_candidates_cuda_buffer);

--- a/tests/cuda/test_kalman_fitter_telescope.cpp
+++ b/tests/cuda/test_kalman_fitter_telescope.cpp
@@ -166,18 +166,14 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
         // n_trakcs = 100
         ASSERT_EQ(track_candidates.size(), n_truth_tracks);
 
-        // Navigation buffer
-        auto navigation_buffer = detray::create_candidates_buffer(
-            host_det, track_candidates.size(), mr.main, mr.host);
-
         // track candidates buffer
         const traccc::track_candidate_container_types::buffer
             track_candidates_cuda_buffer =
                 track_candidate_h2d(traccc::get_data(track_candidates));
 
         // Run fitting
-        track_states_cuda_buffer = device_fitting(
-            det_view, field, navigation_buffer, track_candidates_cuda_buffer);
+        track_states_cuda_buffer =
+            device_fitting(det_view, field, track_candidates_cuda_buffer);
 
         traccc::track_state_container_types::host track_states_cuda =
             track_state_d2h(track_states_cuda_buffer);

--- a/tests/sycl/test_kalman_fitter_telescope.sycl
+++ b/tests/sycl/test_kalman_fitter_telescope.sycl
@@ -182,18 +182,14 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
         // n_trakcs = 100
         ASSERT_EQ(track_candidates.size(), n_truth_tracks);
 
-        // Navigation buffer
-        auto navigation_buffer = detray::create_candidates_buffer(
-            host_det, track_candidates.size(), mr.main, mr.host);
-
         // track candidates buffer
         const traccc::track_candidate_container_types::buffer
             track_candidates_sycl_buffer =
                 track_candidate_h2d(traccc::get_data(track_candidates));
 
         // Run fitting
-        track_states_sycl_buffer = device_fitting(
-            det_view, field, navigation_buffer, track_candidates_sycl_buffer);
+        track_states_sycl_buffer =
+            device_fitting(det_view, field, track_candidates_sycl_buffer);
 
         traccc::track_state_container_types::host track_states_sycl =
             track_state_d2h(track_states_sycl_buffer);


### PR DESCRIPTION
Update to detray v0.74.2
Main changes:
- Remove distinction between free vector and free track parameters and refactor track param class interface a bit
- Move the transform index onto the barcode
- fixed window navigation (will remove the navigation buffer, as the navigator can now deal with a static fixed size memory)
