### PR TITLE
Add missing files to CMakeLists.txt

### DIFF
--- a/device/common/CMakeLists.txt
+++ b/device/common/CMakeLists.txt
@@ -33,6 +33,8 @@ traccc_add_library( traccc_device_common device_common TYPE SHARED
    "include/traccc/clusterization/device/impl/reduce_problem_cell.ipp"
    "include/traccc/clusterization/device/aggregate_cluster.hpp"
    "include/traccc/clusterization/device/impl/aggregate_cluster.ipp"
+   "include/traccc/clusterization/device/ccl_kernel_definitions.hpp"
+   "include/traccc/clusterization/device/ccl_kernel.hpp"
    # Spacepoint binning function(s).
    "include/traccc/seeding/device/count_grid_capacities.hpp"
    "include/traccc/seeding/device/impl/count_grid_capacities.ipp"


### PR DESCRIPTION
Neza has reported that `fatal error: traccc/clusterization/device/ccl_kernel_definitions.hpp: No such file or directory` appears in the client build.

I think it is because the corresponding files are missing in the `CMakeLists.txt` (not 100% sure though)