### PR TITLE
Remove artifact upload from format CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,8 +14,3 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check
         run: .github/check_format.sh .
-      - uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: changed
-          path: changed


### PR DESCRIPTION
The format CI has broken due to a deprecation of the artifact uploading action. As far as I know, nobody is really using the uploaded artifact, so I have opted to fix the CI by simply removing this part of the job.