### PR TITLE
Issue warnings for non-Release builds

### DIFF
--- a/examples/run/CMakeLists.txt
+++ b/examples/run/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Project include(s).
 include( traccc-compiler-options-cpp )
 
+# Inform the code that it is being built in Release mode.
+if (${CMAKE_BUILD_TYPE} STREQUAL "Release")
+   add_definitions(-DTRACCC_BUILD_TYPE_IS_RELEASE)
+endif()
+
 # Add all the subdirectories that can be built.
 add_subdirectory(cpu)
 

--- a/examples/run/common/optimization_warning.hpp
+++ b/examples/run/common/optimization_warning.hpp
@@ -1,0 +1,27 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <iostream>
+
+#if !defined(TRACCC_BUILD_TYPE_IS_RELEASE) || !defined(NDEBUG) || \
+    defined(_DEBUG)
+#define TRACCC_OPTIMIZATION_WARNING()                                         \
+    do {                                                                      \
+        std::cout                                                             \
+            << "WARNING: traccc was built without Release mode, without the " \
+               "`NDEBUG` flag, or (on MSVC) with the `_DEBUG` flag. "         \
+               "Performance is guaranteed to be much lower and compute "      \
+               "performance results should be considered unreliable!"         \
+            << std::endl;                                                     \
+    } while (false)
+#else
+#define TRACCC_OPTIMIZATION_WARNING() \
+    do {                              \
+    } while (false)
+#endif

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -18,6 +18,9 @@
 #include "traccc/options/track_propagation.hpp"
 #include "traccc/options/track_seeding.hpp"
 
+// Local include(s)
+#include "optimization_warning.hpp"
+
 // I/O include(s).
 #include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_detector.hpp"
@@ -67,6 +70,8 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
          finding_opts, propagation_opts, throughput_opts, threading_opts},
         argc,
         argv};
+
+    TRACCC_OPTIMIZATION_WARNING();
 
     // Set up the timing info holder.
     performance::timing_info times;
@@ -226,6 +231,7 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
     // Print some results.
     std::cout << "Reconstructed track parameters: " << rec_track_params.load()
               << std::endl;
+    TRACCC_OPTIMIZATION_WARNING();
     std::cout << "Time totals:" << std::endl;
     std::cout << times << std::endl;
     std::cout << "Throughput:" << std::endl;
@@ -235,6 +241,7 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
               << performance::throughput{throughput_opts.processed_events,
                                          times, "Event processing"}
               << std::endl;
+    TRACCC_OPTIMIZATION_WARNING();
 
     // Print results to log file
     if (throughput_opts.log_file != "\0") {

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -17,6 +17,9 @@
 #include "traccc/options/track_propagation.hpp"
 #include "traccc/options/track_seeding.hpp"
 
+// Local include(s)
+#include "optimization_warning.hpp"
+
 // I/O include(s).
 #include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_detector.hpp"
@@ -57,6 +60,8 @@ int throughput_st(std::string_view description, int argc, char* argv[],
          finding_opts, propagation_opts, throughput_opts},
         argc,
         argv};
+
+    TRACCC_OPTIMIZATION_WARNING();
 
     // Set up the timing info holder.
     performance::timing_info times;
@@ -168,6 +173,7 @@ int throughput_st(std::string_view description, int argc, char* argv[],
     // Print some results.
     std::cout << "Reconstructed track parameters: " << rec_track_params
               << std::endl;
+    TRACCC_OPTIMIZATION_WARNING();
     std::cout << "Time totals:" << std::endl;
     std::cout << times << std::endl;
     std::cout << "Throughput:" << std::endl;
@@ -177,6 +183,7 @@ int throughput_st(std::string_view description, int argc, char* argv[],
               << performance::throughput{throughput_opts.processed_events,
                                          times, "Event processing"}
               << std::endl;
+    TRACCC_OPTIMIZATION_WARNING();
 
     // Return gracefully.
     return 0;


### PR DESCRIPTION
A common pitfall when using traccc seems to be that people build it in non-Release mode and then get poor performance. This commit adds a bunch of warning prints to make sure that the code will inform you if you try to run it in non-Release mode.