### PR TITLE
ref: Update to detray version 0.75.2

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories( traccc_benchmarks_common
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common )
 target_link_libraries( traccc_benchmarks_common
     PUBLIC benchmark::benchmark benchmark::benchmark_main 
-    traccc::core traccc::io traccc::simulation detray::core detray::utils 
+    traccc::core traccc::io traccc::simulation detray::core detray::test_utils 
     vecmem::core Boost::filesystem)
 
 add_subdirectory(cpu)

--- a/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
+++ b/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
@@ -20,7 +20,6 @@
 #include "detray/core/detector.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/bfield.hpp"
-#include "detray/detectors/build_toy_detector.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes/rectangle2D.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
@@ -29,7 +28,8 @@
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/propagator.hpp"
 #include "detray/propagator/rk_stepper.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/benchmarks/cpu/CMakeLists.txt
+++ b/benchmarks/cpu/CMakeLists.txt
@@ -12,7 +12,7 @@ traccc_add_executable(benchmark_cpu
     "toy_detector_cpu.cpp"
     LINK_LIBRARIES benchmark::benchmark benchmark::benchmark_main 
     traccc::core traccc_benchmarks_common 
-    detray::core detray::utils vecmem::core)
+    detray::core detray::detectors vecmem::core)
 
 if(OpenMP_CXX_FOUND)
     target_link_libraries(traccc_benchmark_cpu PRIVATE OpenMP::OpenMP_CXX)

--- a/benchmarks/cuda/CMakeLists.txt
+++ b/benchmarks/cuda/CMakeLists.txt
@@ -7,6 +7,6 @@
 traccc_add_executable( benchmark_cuda
    "toy_detector_cuda.cpp"
    LINK_LIBRARIES benchmark::benchmark 
-   vecmem::core vecmem::cuda
+   vecmem::core vecmem::cuda detray::detectors
    traccc::core traccc::device_common 
    traccc::cuda traccc_benchmarks_common )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -105,7 +105,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp"
   "src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cpp" )
 target_link_libraries( traccc_core
-  PUBLIC Eigen3::Eigen vecmem::core detray::core detray::utils traccc::Thrust
+  PUBLIC Eigen3::Eigen vecmem::core detray::core detray::detectors traccc::Thrust
          traccc::algebra )
 
 # Prevent Eigen from getting confused when building code for a

--- a/device/alpaka/CMakeLists.txt
+++ b/device/alpaka/CMakeLists.txt
@@ -8,7 +8,7 @@
 include( traccc-alpaka-functions )
 include( traccc-compiler-options-cpp )
 
-set(PUBLIC_LIBRARIES traccc::core traccc::device_common detray::core detray::utils vecmem::core covfie::core)
+set(PUBLIC_LIBRARIES traccc::core traccc::device_common vecmem::core covfie::core)
 set(PRIVATE_LIBRARIES alpaka::alpaka traccc::Thrust)
 
 if(alpaka_ACC_GPU_CUDA_ENABLE)

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -91,7 +91,7 @@ endif()
 target_compile_options( traccc_cuda
   PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr> )
 target_link_libraries( traccc_cuda
-  PUBLIC traccc::core detray::core detray::utils vecmem::core covfie::core
+  PUBLIC traccc::core detray::core vecmem::core covfie::core
   PRIVATE CUDA::cudart traccc::Thrust traccc::device_common vecmem::cuda )
 
 # For CUDA 11 turn on separable compilation. This is necessary for using

--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -44,5 +44,5 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
   "src/sanity/ordered_on.hpp"
 )
 target_link_libraries( traccc_sycl
-  PUBLIC traccc::core detray::core detray::utils vecmem::core covfie::core
+  PUBLIC traccc::core detray::core vecmem::core covfie::core
   PRIVATE traccc::device_common vecmem::sycl )

--- a/examples/run/cpu/CMakeLists.txt
+++ b/examples/run/cpu/CMakeLists.txt
@@ -6,18 +6,18 @@
 
 traccc_add_executable( seeding_example "seeding_example.cpp"
    LINK_LIBRARIES vecmem::core traccc::core traccc::io
-   traccc::performance traccc::options detray::utils detray::io)
+   traccc::performance traccc::options detray::detectors detray::io)
 
 traccc_add_executable( seq_example "seq_example.cpp"
    LINK_LIBRARIES vecmem::core traccc::core traccc::io
-   traccc::performance traccc::options detray::utils detray::io)
+   traccc::performance traccc::options detray::detectors detray::io)
 
 traccc_add_executable( truth_finding_example "truth_finding_example.cpp"
-   LINK_LIBRARIES vecmem::core detray::utils traccc::core traccc::io
+   LINK_LIBRARIES vecmem::core detray::detectors traccc::core traccc::io
    traccc::performance traccc::options)
 
 traccc_add_executable( truth_fitting_example "truth_fitting_example.cpp"
-   LINK_LIBRARIES vecmem::core detray::io detray::utils traccc::core
+   LINK_LIBRARIES vecmem::core detray::io detray::detectors traccc::core
    traccc::io traccc::performance traccc::options)
 
 traccc_add_executable( ccl_example "ccl_example.cpp"
@@ -33,14 +33,14 @@ add_library( traccc_examples_cpu STATIC
    "full_chain_algorithm.hpp"
    "full_chain_algorithm.cpp" )
 target_link_libraries( traccc_examples_cpu
-   PUBLIC vecmem::core detray::core detray::utils traccc::core )
+   PUBLIC vecmem::core detray::core detray::detectors traccc::core )
 
 traccc_add_executable( throughput_st "throughput_st.cpp"
-   LINK_LIBRARIES vecmem::core detray::utils detray::io
+   LINK_LIBRARIES vecmem::core detray::detectors detray::io
                   traccc::core traccc::io traccc::performance
                   traccc::options traccc_examples_cpu )
 
 traccc_add_executable( throughput_mt "throughput_mt.cpp"
-   LINK_LIBRARIES TBB::tbb vecmem::core detray::utils detray::io
+   LINK_LIBRARIES TBB::tbb vecmem::core detray::detectors detray::io
                   traccc::core traccc::io traccc::performance
                   traccc::options traccc_examples_cpu )

--- a/examples/run/cuda/CMakeLists.txt
+++ b/examples/run/cuda/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package( CUDAToolkit REQUIRED )
 traccc_add_executable( seq_example_cuda "seq_example_cuda.cpp"
    LINK_LIBRARIES vecmem::core vecmem::cuda traccc::io traccc::performance
                   traccc::core traccc::device_common traccc::cuda
-                  traccc::options detray::utils detray::io )
+                  traccc::options detray::detectors detray::io )
 traccc_add_executable( seeding_example_cuda "seeding_example_cuda.cpp"
    LINK_LIBRARIES vecmem::core vecmem::cuda traccc::io traccc::performance
                   traccc::core traccc::device_common traccc::cuda
@@ -33,17 +33,17 @@ add_library( traccc_examples_cuda STATIC
    "full_chain_algorithm.hpp"
    "full_chain_algorithm.cpp" )
 target_link_libraries( traccc_examples_cuda
-   PUBLIC CUDA::cudart vecmem::core vecmem::cuda detray::core detray::utils
+   PUBLIC CUDA::cudart vecmem::core vecmem::cuda detray::core detray::detectors
           traccc::core traccc::device_common traccc::cuda )
 
 traccc_add_executable( throughput_st_cuda "throughput_st.cpp"
-   LINK_LIBRARIES vecmem::core vecmem::cuda detray::utils detray::io
+   LINK_LIBRARIES vecmem::core vecmem::cuda detray::detectors detray::io
                   traccc::io traccc::performance
                   traccc::core traccc::device_common traccc::cuda
                   traccc::options traccc_examples_cuda )
 
 traccc_add_executable( throughput_mt_cuda "throughput_mt.cpp"
-   LINK_LIBRARIES TBB::tbb vecmem::core vecmem::cuda detray::utils detray::io
+   LINK_LIBRARIES TBB::tbb vecmem::core vecmem::cuda detray::detectors detray::io
                   traccc::io traccc::performance
                   traccc::core traccc::device_common traccc::cuda
                   traccc::options traccc_examples_cuda )

--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -35,17 +35,17 @@ add_library( traccc_examples_sycl OBJECT
    "full_chain_algorithm.hpp"
    "full_chain_algorithm.sycl" )
 target_link_libraries( traccc_examples_sycl
-   PUBLIC vecmem::core vecmem::sycl detray::core detray::utils
+   PUBLIC vecmem::core vecmem::sycl detray::core detray::detectors
           traccc::core traccc::device_common traccc::sycl )
 
 traccc_add_executable( throughput_st_sycl "throughput_st.cpp"
-   LINK_LIBRARIES vecmem::core vecmem::sycl detray::utils detray::io
+   LINK_LIBRARIES vecmem::core vecmem::sycl detray::detectors detray::io
                   traccc::io traccc::performance
                   traccc::core traccc::device_common traccc::sycl
                   traccc::options traccc_examples_sycl )
 
 traccc_add_executable( throughput_mt_sycl "throughput_mt.cpp"
-   LINK_LIBRARIES TBB::tbb vecmem::core vecmem::sycl detray::utils detray::io
+   LINK_LIBRARIES TBB::tbb vecmem::core vecmem::sycl detray::detectors detray::io
                   traccc::io traccc::performance
                   traccc::core traccc::device_common traccc::sycl
                   traccc::options traccc_examples_sycl )

--- a/examples/simulation/CMakeLists.txt
+++ b/examples/simulation/CMakeLists.txt
@@ -7,21 +7,21 @@
 # Simulation with the default metadata and json inputs
 traccc_add_executable(simulate "simulate.cpp"
     LINK_LIBRARIES vecmem::core traccc::io traccc::core
-    traccc::options traccc::simulation detray::core detray::utils covfie::core 
-    Boost::filesystem)    
+    traccc::options traccc::simulation detray::core detray::test_utils covfie::core 
+    Boost::filesystem)
 
 # Simulation with the detectors pre-built in detray
 traccc_add_executable(simulate_telescope "simulate_telescope.cpp"
     LINK_LIBRARIES vecmem::core traccc::io traccc::core
-    traccc::options traccc::simulation detray::core detray::utils covfie::core 
+    traccc::options traccc::simulation detray::core detray::test_utils covfie::core 
     Boost::filesystem)
 
 traccc_add_executable(simulate_toy_detector "simulate_toy_detector.cpp"
     LINK_LIBRARIES vecmem::core traccc::io traccc::core
-    traccc::options traccc::simulation detray::core detray::utils covfie::core
+    traccc::options traccc::simulation detray::core detray::test_utils covfie::core
     Boost::filesystem)
 
 traccc_add_executable(simulate_wire_chamber "simulate_wire_chamber.cpp"
     LINK_LIBRARIES vecmem::core traccc::io traccc::core
-    traccc::options traccc::simulation detray::core detray::utils covfie::core 
+    traccc::options traccc::simulation detray::core detray::test_utils covfie::core 
     Boost::filesystem)

--- a/examples/simulation/simulate.cpp
+++ b/examples/simulation/simulate.cpp
@@ -26,7 +26,7 @@
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/propagator.hpp"
 #include "detray/propagator/rk_stepper.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -20,13 +20,13 @@
 
 // detray include(s).
 #include "detray/detectors/bfield.hpp"
-#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes/rectangle2D.hpp"
 #include "detray/io/frontend/detector_writer.hpp"
 #include "detray/materials/material.hpp"
 #include "detray/navigation/detail/ray.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/detectors/build_telescope_detector.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/examples/simulation/simulate_toy_detector.cpp
+++ b/examples/simulation/simulate_toy_detector.cpp
@@ -19,9 +19,9 @@
 
 // detray include(s).
 #include "detray/detectors/bfield.hpp"
-#include "detray/detectors/build_toy_detector.hpp"
 #include "detray/io/frontend/detector_writer.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/examples/simulation/simulate_wire_chamber.cpp
+++ b/examples/simulation/simulate_wire_chamber.cpp
@@ -19,9 +19,9 @@
 
 // detray include(s).
 #include "detray/detectors/bfield.hpp"
-#include "detray/detectors/create_wire_chamber.hpp"
 #include "detray/io/frontend/detector_writer.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/detectors/create_wire_chamber.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.74.2.tar.gz;URL_MD5;5ce179984fcf73368ca792f789a84ed5"
+"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.75.2.tar.gz;URL_MD5;47b359f9817785f8a235830c921070d6"
    CACHE STRING "Source for Detray, when built as part of this project" )
 
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
@@ -37,14 +37,27 @@ FetchContent_Declare( Detray ${TRACCC_DETRAY_SOURCE_FULL} )
 set( DETRAY_CUSTOM_SCALARTYPE "float" CACHE STRING
    "Scalar type to use in the Detray code" )
 
-set( DETRAY_BUILD_TESTING FALSE CACHE BOOL
+set( DETRAY_BUILD_UNITTESTS FALSE CACHE BOOL
    "Turn off the build of the Detray unit tests" )
+set( DETRAY_BUILD_INTEGRATIONTESTS FALSE CACHE BOOL
+   "Turn off the build of the Detray integration tests" )
+set( DETRAY_BUILD_BENCHMARKS FALSE CACHE BOOL
+   "Turn off the build of the Detray benchmarks" )
 set( DETRAY_BUILD_TUTORIALS FALSE CACHE BOOL
    "Turn off the build of the Detray tutorials" )
 set( DETRAY_EIGEN_PLUGIN TRUE CACHE BOOL
    "Turn on the build of the Detray Eigen code" )
 set( DETRAY_VC_PLUGIN TRUE CACHE BOOL
    "Turn on the build of the Detray Vc code" )
+
+# Needed for 'performance', 'simulation', 'examples', 'tests' and 'benchmarks'
+if( TRACCC_BUILD_IO OR TRACCC_BUILD_EXAMPLES OR (BUILD_TESTING AND TRACCC_BUILD_TESTING) OR TRACCC_BUILD_BENCHMARKS )
+   set( DETRAY_BUILD_TEST_UTILS TRUE CACHE BOOL
+      "Turn on the build of the Detray tests utilities if needed" )
+else()
+   set( DETRAY_BUILD_TEST_UTILS FALSE CACHE BOOL
+      "Turn off the build of the Detray tests utilities" )
+endif()
 
 set( DETRAY_SETUP_VECMEM FALSE CACHE BOOL
    "Do not set up VecMem as part of Detray" )

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -64,7 +64,7 @@ traccc_add_library( traccc_performance performance TYPE SHARED
    "include/traccc/performance/throughput.hpp"
    "src/performance/throughput.cpp" )
 target_link_libraries( traccc_performance
-   PUBLIC traccc::core traccc::io covfie::core )
+   PUBLIC traccc::core traccc::io covfie::core detray::test_utils )
 
 # Use ROOT in traccc::performance, if requested.
 if( TRACCC_USE_ROOT )

--- a/performance/src/resolution/res_plot_tool.cpp
+++ b/performance/src/resolution/res_plot_tool.cpp
@@ -9,7 +9,7 @@
 #include "res_plot_tool.hpp"
 
 // Detray include(s).
-#include "detray/utils/statistics.hpp"
+#include "detray/test/utils/statistics.hpp"
 
 // ROOT include(s).
 #ifdef TRACCC_HAVE_ROOT

--- a/simulation/CMakeLists.txt
+++ b/simulation/CMakeLists.txt
@@ -12,4 +12,4 @@ traccc_add_library( traccc_simulation simulation TYPE INTERFACE
   "include/traccc/simulation/smearing_writer.hpp" )
 target_link_libraries( traccc_simulation
   INTERFACE traccc::core traccc::io detray::core detray::io
-            detray::utils dfelibs::dfelibs )
+            detray::test_utils dfelibs::dfelibs )

--- a/simulation/include/traccc/simulation/simulator.hpp
+++ b/simulation/include/traccc/simulation/simulator.hpp
@@ -20,7 +20,7 @@
 #include "detray/propagator/actors/parameter_transporter.hpp"
 #include "detray/propagator/propagator.hpp"
 #include "detray/propagator/rk_stepper.hpp"
-#include "detray/simulation/random_scatterer.hpp"
+#include "detray/test/utils/simulation/random_scatterer.hpp"
 
 // System include(s).
 #include <limits>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories( traccc_tests_common
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common )
 target_link_libraries( traccc_tests_common
     PUBLIC dfelibs::dfelibs GTest::gtest ActsCore vecmem::core
-           detray::core detray::utils detray::io covfie::core traccc::core traccc::io )
+           detray::core detray::detectors detray::io detray::test_utils  covfie::core traccc::core traccc::io )
 
 # Use ROOT in traccc_tests_common, if requested.
 if( TRACCC_USE_ROOT )

--- a/tests/common/tests/kalman_fitting_telescope_test.hpp
+++ b/tests/common/tests/kalman_fitting_telescope_test.hpp
@@ -11,11 +11,11 @@
 #include "kalman_fitting_test.hpp"
 
 // Detray include(s).
-#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes/rectangle2D.hpp"
 #include "detray/io/frontend/detector_writer.hpp"
 #include "detray/navigation/detail/ray.hpp"
+#include "detray/test/utils/detectors/build_telescope_detector.hpp"
 
 namespace traccc {
 

--- a/tests/common/tests/kalman_fitting_test.hpp
+++ b/tests/common/tests/kalman_fitting_test.hpp
@@ -19,7 +19,7 @@
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/propagator.hpp"
 #include "detray/propagator/rk_stepper.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // GTest include(s).
 #include <gtest/gtest.h>

--- a/tests/common/tests/kalman_fitting_toy_detector_test.hpp
+++ b/tests/common/tests/kalman_fitting_toy_detector_test.hpp
@@ -12,8 +12,8 @@
 
 // Detray include(s).
 #include "detray/detectors/bfield.hpp"
-#include "detray/detectors/build_toy_detector.hpp"
 #include "detray/io/frontend/detector_writer.hpp"
+#include "detray/test/utils/detectors/build_toy_detector.hpp"
 
 // System include(s)
 #include <array>

--- a/tests/common/tests/kalman_fitting_wire_chamber_test.hpp
+++ b/tests/common/tests/kalman_fitting_wire_chamber_test.hpp
@@ -12,8 +12,8 @@
 
 // Detray include(s).
 #include "detray/detectors/bfield.hpp"
-#include "detray/detectors/create_wire_chamber.hpp"
 #include "detray/io/frontend/detector_writer.hpp"
+#include "detray/test/utils/detectors/create_wire_chamber.hpp"
 
 // System include(s)
 #include <array>

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -24,4 +24,4 @@ traccc_add_test(cpu
     "test_sanity_contiguous_on.cpp"
     LINK_LIBRARIES GTest::gtest_main vecmem::core 
     traccc_tests_common traccc::core traccc::io traccc::performance 
-    traccc::simulation detray::core detray::utils covfie::core )
+    traccc::simulation detray::core detray::detectors detray::io detray::test_utils covfie::core )

--- a/tests/cpu/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cpu/test_ckf_combinatorics_telescope.cpp
@@ -21,7 +21,7 @@
 // detray include(s).
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/propagator/propagator.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
@@ -21,7 +21,7 @@
 // detray include(s).
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/propagator/propagator.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/tests/cpu/test_kalman_fitter_telescope.cpp
+++ b/tests/cpu/test_kalman_fitter_telescope.cpp
@@ -19,7 +19,7 @@
 
 // detray include(s).
 #include "detray/io/frontend/detector_reader.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/tests/cpu/test_kalman_fitter_wire_chamber.cpp
+++ b/tests/cpu/test_kalman_fitter_wire_chamber.cpp
@@ -21,7 +21,7 @@
 
 // detray include(s).
 #include "detray/io/frontend/detector_reader.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/tests/cpu/test_simulation.cpp
+++ b/tests/cpu/test_simulation.cpp
@@ -15,15 +15,15 @@
 
 // Detray include(s).
 #include "detray/detectors/bfield.hpp"
-#include "detray/detectors/build_telescope_detector.hpp"
-#include "detray/detectors/build_toy_detector.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes/line.hpp"
 #include "detray/geometry/shapes/rectangle2D.hpp"
 #include "detray/geometry/tracking_surface.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/detectors/build_telescope_detector.hpp"
+#include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/statistics.hpp"
 #include "detray/tracks/bound_track_parameters.hpp"
-#include "detray/utils/statistics.hpp"
 
 // GTest include(s).
 #include <gtest/gtest.h>

--- a/tests/cpu/test_spacepoint_formation.cpp
+++ b/tests/cpu/test_spacepoint_formation.cpp
@@ -11,9 +11,9 @@
 #include "traccc/seeding/experimental/spacepoint_formation.hpp"
 
 // Detray include(s).
-#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/geometry/shapes/rectangle2D.hpp"
 #include "detray/navigation/detail/ray.hpp"
+#include "detray/test/utils/detectors/build_telescope_detector.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -53,7 +53,7 @@ traccc_add_test(
     vecmem::cuda
     detray::core
     detray::io
-    detray::utils
+    detray::test_utils
     traccc::core
     traccc::device_common
     traccc::cuda

--- a/tests/cuda/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cuda/test_ckf_combinatorics_telescope.cpp
@@ -22,7 +22,7 @@
 // detray include(s).
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/propagator/propagator.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/cuda/device_memory_resource.hpp>

--- a/tests/cuda/test_ckf_toy_detector.cpp
+++ b/tests/cuda/test_ckf_toy_detector.cpp
@@ -24,7 +24,7 @@
 // detray include(s).
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/propagator/propagator.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/cuda/device_memory_resource.hpp>

--- a/tests/cuda/test_kalman_fitter_telescope.cpp
+++ b/tests/cuda/test_kalman_fitter_telescope.cpp
@@ -25,7 +25,7 @@
 // detray include(s).
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/propagator/propagator.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/cuda/device_memory_resource.hpp>

--- a/tests/cuda/test_spacepoint_formation.cpp
+++ b/tests/cuda/test_spacepoint_formation.cpp
@@ -11,8 +11,8 @@
 #include "traccc/edm/spacepoint.hpp"
 
 // Detray include(s).
-#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/navigation/detail/ray.hpp"
+#include "detray/test/utils/detectors/build_telescope_detector.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/cuda/device_memory_resource.hpp>

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -29,7 +29,7 @@ traccc_add_test(
     vecmem::sycl
     detray::core
     detray::io
-    detray::utils
+    detray::test_utils
     traccc::core
     traccc::device_common
     traccc::sycl

--- a/tests/sycl/test_kalman_fitter_telescope.sycl
+++ b/tests/sycl/test_kalman_fitter_telescope.sycl
@@ -28,7 +28,7 @@
 // detray include(s).
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/propagator/propagator.hpp"
-#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/tests/sycl/test_spacepoint_formation.sycl
+++ b/tests/sycl/test_spacepoint_formation.sycl
@@ -11,10 +11,10 @@
 #include "traccc/sycl/seeding/experimental/spacepoint_formation.hpp"
 
 // Detray include(s).
-#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes/rectangle2D.hpp"
 #include "detray/navigation/detail/ray.hpp"
+#include "detray/test/utils/detectors/build_telescope_detector.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>


### PR DESCRIPTION
This integrates a new library ```detray::test_utils``` that contains headers that are useful for testing. The bfield creation and detector types have been moved to ```detray::detectors```. Both was previously packaged in ```detray::utils```