### PR TITLE
Attach algebra-plugins define to core target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,8 +299,6 @@ option( TRACCC_ENABLE_NVTX_PROFILING
 
 # option for algebra plugins (ARRAY EIGEN SMATRIX VC VECMEM)
 set(TRACCC_ALGEBRA_PLUGINS ARRAY CACHE STRING "Algebra plugin to use in the build")
-message(STATUS "Building with plugin type: " ${TRACCC_ALGEBRA_PLUGINS})
-add_definitions(-DALGEBRA_PLUGINS_INCLUDE_${TRACCC_ALGEBRA_PLUGINS})
 
 # Build the traccc code.
 add_subdirectory( core )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -112,3 +112,7 @@ target_link_libraries( traccc_core
 # CUDA or HIP backend with SYCL.
 target_compile_definitions( traccc_core
   PUBLIC $<$<COMPILE_LANGUAGE:SYCL>:EIGEN_NO_CUDA EIGEN_NO_HIP> )
+
+# Set the algebra-plugins plugin to use.
+message(STATUS "Building with plugin type: " ${TRACCC_ALGEBRA_PLUGINS})
+target_compile_definitions(traccc_core PUBLIC ALGEBRA_PLUGINS_INCLUDE_${TRACCC_ALGEBRA_PLUGINS})


### PR DESCRIPTION
Right now, the algebra plugin to be used is selected using a global define in CMake, but this does not carry over when traccc is used as a dependency, e.g. like we do in ACTS. This PR ensures that the define is instead added as a target-specific public definition, which will resolve this issue.