### PR TITLE
VecMem 1.8.0 Update, main branch (2024.09.21.)

### DIFF
--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.7.0.tar.gz;URL_MD5;4544ec9b3686fdae558b613d9ea12233"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.8.0.tar.gz;URL_MD5;afddf52d9568964f25062e1c887246b7"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Updated to [VecMem 1.8.0](https://github.com/acts-project/vecmem/releases/tag/v1.8.0).

Apart from the "robustness updates", it will be needed for the SoA cell EDM update coming in a PR very soon. :wink: