### PR TITLE
Silence Vc Warning(s), main branch (2024.09.21.)

### DIFF
--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -47,5 +47,13 @@ set( ALGEBRA_PLUGINS_SETUP_GOOGLETEST FALSE CACHE BOOL
 set( ALGEBRA_PLUGINS_SETUP_BENCHMARK FALSE CACHE BOOL
    "Do not set up GoogleTest in Algebra Plugins" )
 
+# Disable a pesky warning coming from the Vc build.
+include( CheckCXXCompilerFlag )
+check_cxx_compiler_flag( "-Wno-deprecated-enum-enum-conversion"
+   TRACCC_HAS_NO_DEPRECATED_ENUM_ENUM_CONVERSION )
+if( TRACCC_HAS_NO_DEPRECATED_ENUM_ENUM_CONVERSION )
+   traccc_add_flag( CMAKE_CXX_FLAGS "-Wno-deprecated-enum-enum-conversion" )
+endif()
+
 # Get it into the current directory.
 FetchContent_MakeAvailable( AlgebraPlugins )


### PR DESCRIPTION
The [Vc](https://github.com/VcDevel/Vc) source code generates warnings with GCC and Clang when using C++20. Warnings like:

```
[143/492] Building CXX object _deps/vc-build/CMakeFiles/Vc.dir/trigonometric_AVX2+FMA+BMI2.cpp.o
In file included from /data/ssd-1tb/projects/traccc/build-sycl/_deps/vc-build/trigonometric_AVX2+FMA+BMI2.cpp:31:
In file included from /data/ssd-1tb/projects/traccc/build-sycl/_deps/vc-src/Vc/vector.h:32:
In file included from /data/ssd-1tb/projects/traccc/build-sycl/_deps/vc-src/Vc/scalar/vector.h:39:
In file included from /data/ssd-1tb/projects/traccc/build-sycl/_deps/vc-src/Vc/scalar/types.h:28:
In file included from /data/ssd-1tb/projects/traccc/build-sycl/_deps/vc-src/Vc/scalar/../common/types.h:37:
/data/ssd-1tb/projects/traccc/build-sycl/_deps/vc-src/Vc/scalar/../common/../global.h:609:5: warning: arithmetic between different enumeration types ('Vc_1::Implementation' and 'Vc_1::ExtraInstructions') is deprecated [-Wdeprecated-enum-enum-conversion]
  585 |     + Vc::PopcntInstructions
      |     ^ ~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

This takes care of silencing those warnings.

Note that the warnings are not coming from compiling this project's code, but rather from compiling the source files of Vc itself. In the same manner, the flag is only added to that build. The rest of the project doesn't receive this flag.