### PR TITLE
Build Profiling, main branch (2024.09.22.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,31 @@ if(${TRACCC_BUILD_HIP} AND ${CMAKE_HIP_STANDARD} LESS 20)
    message(SEND_ERROR "CMAKE_HIP_STANDARD=${CMAKE_HIP_STANDARD}, but traccc requires C++>=20")
 endif()
 
+# Set up build profiling for the project.
+if( CTEST_USE_LAUNCHERS )
+
+   # Find the bash and time executables.
+   find_program( BASH_EXECUTABLE bash REQUIRED )
+   find_program( TIME_EXECUTABLE time REQUIRED )
+
+   # Configure the script that would intercept the build commands and save
+   # profile logs for them.
+   configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/cmake/traccc-ctest.sh.in"
+      "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/traccc-ctest.sh"
+      @ONLY )
+   set( CMAKE_CTEST_COMMAND
+      "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/traccc-ctest.sh" )
+
+   # Remove the performance log during a cleaning step.
+   set_property( DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" APPEND PROPERTY
+      ADDITIONAL_MAKE_CLEAN_FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/traccc_build_performance.log" )
+
+   # Let the user know what happened.
+   message( STATUS
+      "Saving traccc build performance logs using: ${CMAKE_CTEST_COMMAND}" )
+endif()
+
 # Set up VecMem.
 option( TRACCC_SETUP_VECMEM
    "Set up the VecMem target(s) explicitly" TRUE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,18 @@ if( CTEST_USE_LAUNCHERS )
    find_program( BASH_EXECUTABLE bash REQUIRED )
    find_program( TIME_EXECUTABLE time REQUIRED )
 
+   # Decide what flag to use with the time executable to make it print verbose
+   # information.
+   if( "${CMAKE_HOST_SYSTEM_NAME}" MATCHES "Darwin" )
+      set( TIME_VERBOSE_FLAG "-l" )
+   elseif( "${CMAKE_HOST_SYSTEM_NAME}" MATCHES "Linux" )
+      set( TIME_VERBOSE_FLAG "-v" )
+   else()
+      message( WARNING "Build profiling is only supported on Linux and macOS."
+                       "This build will likely fail." )
+      set( TIME_VERBOSE_FLAG "" )
+   endif()
+
    # Configure the script that would intercept the build commands and save
    # profile logs for them.
    configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/cmake/traccc-ctest.sh.in"
@@ -90,6 +102,9 @@ if( CTEST_USE_LAUNCHERS )
       @ONLY )
    set( CMAKE_CTEST_COMMAND
       "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/traccc-ctest.sh" )
+
+   # Clean up.
+   unset( TIME_VERBOSE_FLAG )
 
    # Remove the performance log during a cleaning step.
    set_property( DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" APPEND PROPERTY

--- a/cmake/traccc-ctest.sh.in
+++ b/cmake/traccc-ctest.sh.in
@@ -1,0 +1,17 @@
+#!@BASH_EXECUTABLE@
+#
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Propagate errors.
+set -e
+set -o pipefail
+
+# Run every command through the time command. Recording the time, memory, etc.
+# used by each and every build command.
+@TIME_EXECUTABLE@ --verbose \
+   --output=@CMAKE_CURRENT_BINARY_DIR@/traccc_build_performance.log --append \
+   @CMAKE_CTEST_COMMAND@ $*

--- a/cmake/traccc-ctest.sh.in
+++ b/cmake/traccc-ctest.sh.in
@@ -12,6 +12,6 @@ set -o pipefail
 
 # Run every command through the time command. Recording the time, memory, etc.
 # used by each and every build command.
-command @TIME_EXECUTABLE@ --verbose \
-   --output=@CMAKE_CURRENT_BINARY_DIR@/traccc_build_performance.log --append \
+command @TIME_EXECUTABLE@ @TIME_VERBOSE_FLAG@ \
+   -ao @CMAKE_CURRENT_BINARY_DIR@/traccc_build_performance.log \
    @CMAKE_CTEST_COMMAND@ $*

--- a/cmake/traccc-ctest.sh.in
+++ b/cmake/traccc-ctest.sh.in
@@ -12,6 +12,6 @@ set -o pipefail
 
 # Run every command through the time command. Recording the time, memory, etc.
 # used by each and every build command.
-@TIME_EXECUTABLE@ --verbose \
+command @TIME_EXECUTABLE@ --verbose \
    --output=@CMAKE_CURRENT_BINARY_DIR@/traccc_build_performance.log --append \
    @CMAKE_CTEST_COMMAND@ $*


### PR DESCRIPTION
As we've been discussing between a few of us, the build of the project is getting a bit out of hand by now. :frowning: Building generally takes a long time, and also a surprisingly large amount of memory.

To help with this, first we need to understand exactly which steps of the build take the longest time and the largest amount of memory. To do this, I hijacked the [CTEST_USE_LAUNCHERS](https://cmake.org/cmake/help/latest/module/CTestUseLaunchers.html) feature of [ctest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). Which is the technique we use also in [AtlasCMake](https://gitlab.cern.ch/atlas/atlasexternals/-/tree/main/Build/AtlasCMake?ref_type=heads) for saving "package specific" build logs in ATLAS offline builds.

What happens is that if one specifies `-DCTEST_USE_LAUNCHERS=TRUE` in the CMake configuration command, the newly introduced `traccc-ctest.sh` script gets set up to intercept each and every build command. Including all linking, and any other technical commands. The script then runs the commands through [GNU time](https://www.gnu.org/software/time/), to get detailed statistics about every build command. It saves the the results of this into a file called `traccc_build_performance.log` in the build directory. Which would have entries like:

```
        Command being timed: "/home/krasznaa/software/kitware/cmake-3.30.2/x86_64-ubuntu2204-gcc11-opt/bin/ctest --launch --target-name Vc --build-dir /data/ssd-1tb/projects/traccc/build/_deps/vc-build --output /data/ssd-1tb/projects/traccc/build/_deps/vc-build/trigonometric_SSSE3.cpp -- /home/krasznaa/software/kitware/cmake-3.30.2/x86_64-ubuntu2204-gcc11-opt/bin/cmake -E copy src/trigonometric.cpp /data/ssd-1tb/projects/traccc/build/_deps/vc-build/trigonometric_SSSE3.cpp"
        User time (seconds): 0.00
        System time (seconds): 0.01
        Percent of CPU this job got: 90%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.01
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 9728
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 963
        Voluntary context switches: 6
        Involuntary context switches: 4
        Swaps: 0
        File system inputs: 0
        File system outputs: 48
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

Leading up to some of the really "heavy" commands, like:

```
        Command being timed: "/home/krasznaa/software/kitware/cmake-3.30.2/x86_64-ubuntu2204-gcc11-opt/bin/ctest --launch --target-name traccc_test_cuda --build-dir /data/ssd-1tb/projects/traccc/build/tests/cuda --output CMakeFiles/traccc_test_cuda.dir/test_ckf_combinatorics_telescope.cpp.o --source /data/ssd-1tb/projects/traccc/traccc/tests/cuda/test_ckf_combinatorics_telescope.cpp --language CXX -- /usr/bin/c++ -DACTS_CONCEPTS_SUPPORTED -DALGEBRA_PLUGINS_INCLUDE_ARRAY -DBOOST_ALL_NO_LIB -DCOVFIE_QUIET -DDETRAY_ALGEBRA_ARRAY -DDETRAY_ALGEBRA_EIGEN -DDETRAY_ALGEBRA_VC -DDETRAY_CUSTOM_SCALARTYPE=float -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -DTRACCC_CUSTOM_SCALARTYPE=float -DVECMEM_DEBUG_MSG_LVL=0 -DVECMEM_HAVE_PMR_MEMORY_RESOURCE -DVECMEM_SOURCE_DIR_LENGTH=37 -DVECMEM_SUPPORT_POSIX_ATOMIC_REF -I/data/ssd-1tb/projects/traccc/build/_deps/cccl-src/thrust/thrust/cmake/../.. -I/data/ssd-1tb/projects/traccc/build/_deps/cccl-src/libcudacxx/lib/cmake/libcudacxx/../../../include -I/data/ssd-1tb/projects/traccc/build/_deps/cccl-src/cub/cub/cmake/../.. -I/data/ssd-1tb/projects/traccc/build/_deps/vecmem-build/cuda/CMakeFiles -I/data/ssd-1tb/projects/traccc/build/_deps/vecmem-src/cuda/include -I/data/ssd-1tb/projects/traccc/build/_deps/vecmem-build/core/CMakeFiles -I/data/ssd-1tb/projects/traccc/build/_deps/vecmem-src/core/include -I/data/ssd-1tb/projects/traccc/build/_deps/dfelibs-src -I/data/ssd-1tb/projects/traccc/traccc/core/include -I/data/ssd-1tb/projects/traccc/traccc/plugins/algebra/array/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/frontend/array_cmath/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/common/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/storage/array/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/math/cmath/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/math/common/include -I/data/ssd-1tb/projects/traccc/traccc/plugins/algebra/vecmem/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/frontend/vecmem_cmath/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/storage/vecmem/include -I/data/ssd-1tb/projects/traccc/traccc/plugins/algebra/eigen/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/frontend/eigen_eigen/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/storage/eigen/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/math/eigen/include -I/data/ssd-1tb/projects/traccc/traccc/plugins/algebra/vc/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/frontend/vc_vc/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/storage/vc/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/math/vc/include -I/data/ssd-1tb/projects/traccc/build/_deps/algebraplugins-src/frontend/vc_cmath/include -I/data/ssd-1tb/projects/traccc/traccc/device/common/include -I/data/ssd-1tb/projects/traccc/traccc/device/cuda/include -I/data/ssd-1tb/projects/traccc/traccc/performance/include -I/data/ssd-1tb/projects/traccc/traccc/io/include -I/data/ssd-1tb/projects/traccc/traccc/simulation/include -I/data/ssd-1tb/projects/traccc/traccc/tests/common -isystem /home/krasznaa/software/nvidia/cuda-12.6.1/x86_64/targets/x86_64-linux/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/googletest-src/googletest/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/googletest-src/googletest -isystem /data/ssd-1tb/projects/traccc/build/_deps/detray-src/core/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/detray-build/core/CMakeFiles -isystem /data/ssd-1tb/projects/traccc/build/_deps/detray-src/io/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/nlohmann_json-src/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/covfie-src/lib/core -isystem /data/ssd-1tb/projects/traccc/build/_deps/detray-src/tests/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/detray-src/detectors/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/detray-src/plugins/svgtools/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/actsvg-src/core/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/actsvg-src/meta/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/eigen3-src -isystem /data/ssd-1tb/projects/traccc/build/_deps/detray-src/plugins/algebra/array/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/detray-src/plugins/algebra/eigen/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/vc-src -isystem /data/ssd-1tb/projects/traccc/build/_deps/detray-src/plugins/algebra/vc/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/acts-src/Core/include -isystem /data/ssd-1tb/projects/traccc/build/_deps/acts-build/Core -Wall -Wextra -Wshadow -Wunused-local-typedefs -pedantic -Wold-style-cast -Wfloat-conversion -Werror -O3 -g -std=c++20 -MD -MT tests/cuda/CMakeFiles/traccc_test_cuda.dir/test_ckf_combinatorics_telescope.cpp.o -MF CMakeFiles/traccc_test_cuda.dir/test_ckf_combinatorics_telescope.cpp.o.d -o CMakeFiles/traccc_test_cuda.dir/test_ckf_combinatorics_telescope.cpp.o -c /data/ssd-1tb/projects/traccc/traccc/tests/cuda/test_ckf_combinatorics_telescope.cpp"
        User time (seconds): 51.10
        System time (seconds): 3.26
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:54.37
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 2780640
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 973157
        Voluntary context switches: 11
        Involuntary context switches: 97
        Swaps: 0
        File system inputs: 0
        File system outputs: 478944
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

This PR just writes such a log file, we will still need to write a bit of scripting to extract useful information out of these log files. I imagine that it would be relatively doable to produce let's say a CSV file from this log file with the info we're interested in, and then we could use even something as simple as a spreadsheet application to understand where we need to concentrate our efforts. :thinking: