### PR TITLE
ref: benchmark toy detector config

### DIFF
--- a/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
+++ b/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
@@ -53,7 +53,7 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
     traccc::seedfinder_config seeding_cfg;
     traccc::seedfilter_config filter_cfg;
     traccc::spacepoint_grid_config grid_cfg{seeding_cfg};
-    traccc::finding_config finding_cfg = get_trk_finding_config();
+    traccc::finding_config finding_cfg;
     traccc::fitting_config fitting_cfg;
 
     static constexpr std::array<float, 2> phi_range{
@@ -80,6 +80,10 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
         std::cout << "Please be patient. It may take some time to generate "
                      "the simulation data."
                   << std::endl;
+
+        // Apply correct propagation config
+        apply_propagation_config(finding_cfg.propagation);
+        apply_propagation_config(fitting_cfg.propagation);
 
         // Use deterministic random number generator for testing
         using uniform_gen_t = detray::detail::random_numbers<
@@ -126,11 +130,11 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
             detray::muon<traccc::scalar>(), n_events, det, field,
             std::move(generator), std::move(smearer_writer_cfg), full_path);
 
+        // Same propagation configuration for sim and reco
+        apply_propagation_config(sim.get_config().propagation);
         // Set constrained step size to 1 mm
         sim.get_config().propagation.stepping.step_constraint =
             1.f * detray::unit<float>::mm;
-        // Otherwise same propagation configuration for sim and reco
-        sim.get_config().propagation = finding_cfg.propagation;
 
         sim.run();
 
@@ -156,16 +160,13 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
         return toy_cfg;
     }
 
-    traccc::finding_config get_trk_finding_config() const {
-
-        traccc::finding_config finding_cfg{};
-
+    void apply_propagation_config(detray::propagation::config& cfg) const {
         // Configure the propagation for the toy detector
-        finding_cfg.propagation.navigation.search_window = {3, 3};
-        finding_cfg.propagation.navigation.overstep_tolerance =
-            -300.f * detray::unit<traccc::scalar>::um;
-
-        return finding_cfg;
+        cfg.navigation.search_window = {3, 3};
+        cfg.navigation.overstep_tolerance = -300.f * detray::unit<float>::um;
+        cfg.navigation.min_mask_tolerance = 1e-5f * detray::unit<float>::mm;
+        cfg.navigation.max_mask_tolerance = 3.f * detray::unit<float>::mm;
+        cfg.navigation.mask_tolerance_scalor = 0.05f;
     }
 
     void SetUp(::benchmark::State& /*state*/) {

--- a/benchmarks/cpu/toy_detector_cpu.cpp
+++ b/benchmarks/cpu/toy_detector_cpu.cpp
@@ -62,7 +62,7 @@ BENCHMARK_F(ToyDetectorBenchmark, CPU)(benchmark::State& state) {
     for (auto _ : state) {
 
 // Iterate over events
-#pragma omp parallel for
+#pragma omp parallel for schedule(dynamic)
         for (unsigned int i_evt = 0; i_evt < n_events; i_evt++) {
 
             auto& spacepoints_per_event = spacepoints[i_evt];

--- a/benchmarks/cuda/toy_detector_cuda.cpp
+++ b/benchmarks/cuda/toy_detector_cuda.cpp
@@ -32,7 +32,6 @@
 // VecMem include(s).
 #include <vecmem/memory/cuda/device_memory_resource.hpp>
 #include <vecmem/memory/cuda/host_memory_resource.hpp>
-#include <vecmem/memory/cuda/managed_memory_resource.hpp>
 #include <vecmem/memory/host_memory_resource.hpp>
 #include <vecmem/utils/cuda/async_copy.hpp>
 #include <vecmem/utils/cuda/copy.hpp>
@@ -56,7 +55,6 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
     vecmem::cuda::host_memory_resource cuda_host_mr;
     vecmem::cuda::device_memory_resource device_mr;
     traccc::memory_resource mr{device_mr, &cuda_host_mr};
-    vecmem::cuda::managed_memory_resource mng_mr;
 
     // Copy and stream
     vecmem::copy host_copy;
@@ -65,9 +63,9 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
     vecmem::cuda::async_copy async_copy{stream.cudaStream()};
 
     // Read back detector file
-    host_detector_type det{mng_mr};
+    host_detector_type det{cuda_host_mr};
     traccc::io::read_detector(
-        det, mng_mr, sim_dir + "toy_detector_geometry.json",
+        det, cuda_host_mr, sim_dir + "toy_detector_geometry.json",
         sim_dir + "toy_detector_homogeneous_material.json",
         sim_dir + "toy_detector_surface_grids.json");
 
@@ -84,8 +82,10 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
     traccc::cuda::fitting_algorithm<device_fitter_type> device_fitting(
         fitting_cfg, mr, async_copy, stream);
 
+    // Copy detector to device
+    auto det_buffer = detray::get_buffer(det, device_mr, copy);
     // Detector view object
-    auto det_view = detray::get_data(det);
+    auto det_view = detray::get_data(det_buffer);
 
     // D2H copy object
     traccc::device::container_d2h_copy_alg<traccc::track_state_container_types>
@@ -147,7 +147,7 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
                     det_view, field, track_candidates_cuda_buffer);
 
             // Create a temporary buffer that will receive the device memory.
-            auto size = track_states_cuda_buffer.headers.size();
+            /*auto size = track_states_cuda_buffer.headers.size();
             std::vector<std::size_t> capacities(size, 0);
             std::transform(track_states_cuda_buffer.items.host_ptr(),
                            track_states_cuda_buffer.items.host_ptr() + size,
@@ -156,7 +156,7 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
 
             // Copy the track states back to the host.
             traccc::track_state_container_types::host track_states_host =
-                track_state_d2h(track_states_cuda_buffer);
+                track_state_d2h(track_states_cuda_buffer);*/
         }
     }
 


### PR DESCRIPTION
Allow the toy detector grids to find all neighboring surfaces, this should increase the number of tracks that can be found and fitted. Furthermore, I restricted the simulation to an eta region, where the tracks should hit a decent number of sensitive surface. Apart from that, the detector is now copied to device instead of using managed memory.

Edit: I also remove the copy of the track states back to host containers and allowed openMP to use dynamic scheduling for better load balancing