### PR TITLE
Fix the starting positoin of telescope build in simulation

### DIFF
--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -60,7 +60,7 @@ int simulate(const traccc::opts::generation& generation_opts,
     std::vector<scalar> plane_positions;
 
     for (unsigned int i = 0; i < telescope_opts.n_planes; i++) {
-        plane_positions.push_back((i + 1) * telescope_opts.spacing);
+        plane_positions.push_back(i * telescope_opts.spacing);
     }
 
     // B field value and its type


### PR DESCRIPTION
The first plane should be placed on the origin by default - otherwise the track (generated by default options) will be out of the geometry