### PR TITLE
Update to VecMem 1.9.0, main branch (2024.09.30.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,13 +84,16 @@ option( TRACCC_USE_SYSTEM_VECMEM
    ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_VECMEM )
    if( TRACCC_USE_SYSTEM_VECMEM )
-      find_package( vecmem 0.7.0 REQUIRED COMPONENTS LANGUAGE )
+      find_package( vecmem 1.8.0 REQUIRED )
    else()
       add_subdirectory( extern/vecmem )
       # Make the "VecMem language code" available for the whole project.
-      include( "${VECMEM_LANGUAGE_DIR}/vecmem-check-language.cmake" )
+      list( PREPEND CMAKE_MODULE_PATH "${VECMEM_LANGUAGE_DIR}" )
    endif()
 endif()
+# Including vecmem-check-language makes sure that the HIP and SYCL languages
+# would be picked up from VecMem.
+include( vecmem-check-language )
 
 # Set up Eigen3.
 option( TRACCC_SETUP_EIGEN3

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.8.0.tar.gz;URL_MD5;afddf52d9568964f25062e1c887246b7"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.9.0.tar.gz;URL_MD5;392f0b7070f74b21bafe515cb39bf97c"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Upgraded the project to using [vecmem-1.9.0](https://github.com/acts-project/vecmem/releases/tag/v1.9.0).

At the same time set the minimum version to `1.8.0`, and changed how vecmem's CMake code would be picked up in this project.

This PR is a required input for #712. Note that I'll set the minimum required version of vecmem to `1.9.0` in that PR. In this one I went with `1.8.0`, as for the current state of this project, that's the actual minimum required. (Once this PR is in. It's a longer story...)