### PR TITLE
Not using detector description for partial chain examples

### DIFF
--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -120,14 +120,6 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
      * Build a geometry
      *****************************/
 
-    // Construct the detector description object.
-    traccc::silicon_detector_description::host host_det_descr{host_mr};
-    traccc::io::read_detector_description(
-        host_det_descr, detector_opts.detector_file,
-        detector_opts.digitization_file,
-        (detector_opts.use_detray_detector ? traccc::data_format::json
-                                           : traccc::data_format::csv));
-
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host host_det{mng_mr};
     assert(detector_opts.use_detray_detector == true);
@@ -181,14 +173,14 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                 traccc::performance::timer t("Hit reading  (cpu)",
                                              elapsedTimes);
                 // Read the hits from the relevant event file
-                traccc::io::read_spacepoints(
-                    spacepoints_per_event, event, input_opts.directory,
-                    &host_det_descr, input_opts.format);
+                traccc::io::read_spacepoints(spacepoints_per_event, event,
+                                             input_opts.directory, nullptr,
+                                             input_opts.format);
 
                 // Read measurements
-                traccc::io::read_measurements(
-                    measurements_per_event, event, input_opts.directory,
-                    &host_det_descr, input_opts.format);
+                traccc::io::read_measurements(measurements_per_event, event,
+                                              input_opts.directory, nullptr,
+                                              input_opts.format);
             }  // stop measuring hit reading timer
 
             /*----------------------------

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -109,13 +109,6 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     const traccc::vector3 B{0, 0, 2 * detray::unit<traccc::scalar>::T};
     auto field = detray::bfield::create_const_field(B);
 
-    // Construct the detector description object.
-    traccc::silicon_detector_description::host det_descr{host_mr};
-    traccc::io::read_detector_description(
-        det_descr, detector_opts.detector_file, detector_opts.digitization_file,
-        (detector_opts.use_detray_detector ? traccc::data_format::json
-                                           : traccc::data_format::csv));
-
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host detector{host_mr};
     assert(detector_opts.use_detray_detector == true);
@@ -157,7 +150,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         traccc::spacepoint_collection_types::host spacepoints_per_event{
             &host_mr};
         traccc::io::read_spacepoints(spacepoints_per_event, event,
-                                     input_opts.directory, &det_descr,
+                                     input_opts.directory, nullptr,
                                      input_opts.format);
         n_spacepoints += spacepoints_per_event.size();
 
@@ -183,7 +176,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         traccc::measurement_collection_types::host measurements_per_event{
             &host_mr};
         traccc::io::read_measurements(measurements_per_event, event,
-                                      input_opts.directory, &det_descr,
+                                      input_opts.directory, nullptr,
                                       input_opts.format);
         n_measurements += measurements_per_event.size();
 

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -81,13 +81,6 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
     const traccc::vector3 B{0, 0, 2 * detray::unit<traccc::scalar>::T};
     auto field = detray::bfield::create_const_field(B);
 
-    // Construct the detector description object.
-    traccc::silicon_detector_description::host det_descr{host_mr};
-    traccc::io::read_detector_description(
-        det_descr, detector_opts.detector_file, detector_opts.digitization_file,
-        (detector_opts.use_detray_detector ? traccc::data_format::json
-                                           : traccc::data_format::csv));
-
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host detector{host_mr};
     assert(detector_opts.use_detray_detector == true);
@@ -152,7 +145,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
         traccc::measurement_collection_types::host measurements_per_event{
             &host_mr};
         traccc::io::read_measurements(measurements_per_event, event,
-                                      input_opts.directory, &det_descr,
+                                      input_opts.directory, nullptr,
                                       input_opts.format);
 
         // Run finding

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -128,14 +128,6 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     const traccc::vector3 B{0, 0, 2 * detray::unit<traccc::scalar>::T};
     auto field = detray::bfield::create_const_field(B);
 
-    // Construct the detector description object.
-    traccc::silicon_detector_description::host host_det_descr{host_mr};
-    traccc::io::read_detector_description(
-        host_det_descr, detector_opts.detector_file,
-        detector_opts.digitization_file,
-        (detector_opts.use_detray_detector ? traccc::data_format::json
-                                           : traccc::data_format::csv));
-
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host host_det{mng_mr};
     assert(detector_opts.use_detray_detector == true);
@@ -233,14 +225,14 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                 traccc::performance::timer t("Hit reading  (cpu)",
                                              elapsedTimes);
                 // Read the hits from the relevant event file
-                traccc::io::read_spacepoints(
-                    spacepoints_per_event, event, input_opts.directory,
-                    &host_det_descr, input_opts.format);
+                traccc::io::read_spacepoints(spacepoints_per_event, event,
+                                             input_opts.directory, nullptr,
+                                             input_opts.format);
 
                 // Read measurements
-                traccc::io::read_measurements(
-                    measurements_per_event, event, input_opts.directory,
-                    &host_det_descr, input_opts.format);
+                traccc::io::read_measurements(measurements_per_event, event,
+                                              input_opts.directory, nullptr,
+                                              input_opts.format);
             }  // stop measuring hit reading timer
 
             /*----------------------------

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -106,13 +106,6 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
     const traccc::vector3 B{0, 0, 2 * detray::unit<traccc::scalar>::T};
     auto field = detray::bfield::create_const_field(B);
 
-    // Construct the detector description object.
-    traccc::silicon_detector_description::host det_descr{mng_mr};
-    traccc::io::read_detector_description(
-        det_descr, detector_opts.detector_file, detector_opts.digitization_file,
-        (detector_opts.use_detray_detector ? traccc::data_format::json
-                                           : traccc::data_format::csv));
-
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host detector{mng_mr};
     assert(detector_opts.use_detray_detector == true);
@@ -205,7 +198,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
         traccc::measurement_collection_types::host measurements_per_event{
             mr.host};
         traccc::io::read_measurements(measurements_per_event, event,
-                                      input_opts.directory, &det_descr,
+                                      input_opts.directory, nullptr,
                                       input_opts.format);
 
         traccc::measurement_collection_types::buffer measurements_cuda_buffer(

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -26,7 +26,6 @@
 
 // options
 #include "traccc/options/accelerator.hpp"
-#include "traccc/options/detector.hpp"
 #include "traccc/options/input_data.hpp"
 #include "traccc/options/performance.hpp"
 #include "traccc/options/program_options.hpp"
@@ -53,7 +52,6 @@
 
 int seq_run(const traccc::opts::track_seeding& seeding_opts,
             const traccc::opts::input_data& input_opts,
-            const traccc::opts::detector& detector_opts,
             const traccc::opts::performance& performance_opts,
             const traccc::opts::accelerator& accelerator_opts) {
 
@@ -81,14 +79,6 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     /*****************************
      * Build a geometry
      *****************************/
-
-    // Construct the detector description object.
-    traccc::silicon_detector_description::host host_det_descr{host_mr};
-    traccc::io::read_detector_description(
-        host_det_descr, detector_opts.detector_file,
-        detector_opts.digitization_file,
-        (detector_opts.use_detray_detector ? traccc::data_format::json
-                                           : traccc::data_format::csv));
 
     // Seeding algorithm
     traccc::seeding_algorithm sa(seeding_opts.seedfinder,
@@ -134,9 +124,9 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                 traccc::performance::timer t("Hit reading  (cpu)",
                                              elapsedTimes);
                 // Read the hits from the relevant event file
-                traccc::io::read_spacepoints(
-                    spacepoints_per_event, event, input_opts.directory,
-                    &host_det_descr, input_opts.format);
+                traccc::io::read_spacepoints(spacepoints_per_event, event,
+                                             input_opts.directory, nullptr,
+                                             input_opts.format);
 
             }  // stop measuring hit reading timer
 
@@ -258,19 +248,17 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 int main(int argc, char* argv[]) {
 
     // Program options.
-    traccc::opts::detector detector_opts;
     traccc::opts::input_data input_opts;
     traccc::opts::track_seeding seeding_opts;
     traccc::opts::performance performance_opts;
     traccc::opts::accelerator accelerator_opts;
     traccc::opts::program_options program_opts{
         "Full Tracking Chain Using SYCL (without clusterization)",
-        {detector_opts, input_opts, seeding_opts, performance_opts,
-         accelerator_opts},
+        {input_opts, seeding_opts, performance_opts, accelerator_opts},
         argc,
         argv};
 
     // Run the application.
-    return seq_run(seeding_opts, input_opts, detector_opts, performance_opts,
+    return seq_run(seeding_opts, input_opts, performance_opts,
                    accelerator_opts);
 }


### PR DESCRIPTION
Currently, the examples of partial chains make an error when the geometry json and digitizatoin config json are pointing to different geometry.

Problem is some geometries (e.g. ITk) that we are using do not have digitization config yet so it will always clash with the default one from TML detector. 

This PR disables reading the digitization config file, which is not used in the algorithm anyway.