### PR TITLE
Use surface link for module projection

### DIFF
--- a/core/include/traccc/clusterization/impl/measurement_creation.ipp
+++ b/core/include/traccc/clusterization/impl/measurement_creation.ipp
@@ -129,7 +129,6 @@ TRACCC_HOST_DEVICE inline void fill_measurement(
     const auto module_dd = det_descr.at(module_idx);
 
     // Fill the measurement object.
-    m.module_link = module_idx;
     m.surface_link = module_dd.geometry_id();
     // normalize the cell position
     m.local = mean;

--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -45,7 +45,6 @@ struct measurement {
 
     /// Link to Module vector index
     using link_type = unsigned int;
-    link_type module_link = 0;
 
     /// Cluster link
     std::size_t cluster_link = std::numeric_limits<std::size_t>::max();

--- a/core/include/traccc/utils/projections.hpp
+++ b/core/include/traccc/utils/projections.hpp
@@ -24,7 +24,7 @@ struct [[maybe_unused]] cell_module_projection{
 
 struct [[maybe_unused]] measurement_module_projection{
     TRACCC_HOST_DEVICE auto operator()(const traccc::measurement& m)
-        const {return m.module_link;
+        const {return m.surface_link;
 }
 }
 ;

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -136,7 +136,6 @@ inline void aggregate_cluster(
     out.local = mean + offset;
     out.variance = var;
     out.surface_link = module_descr.geometry_id();
-    out.module_link = module_idx;
     // Set a unique identifier for the measurement.
     out.measurement_id = link;
     // Set the dimensionality of the measurement.

--- a/io/include/traccc/io/mapper.hpp
+++ b/io/include/traccc/io/mapper.hpp
@@ -42,10 +42,9 @@ using measurement_particle_map =
 particle_map generate_particle_map(std::size_t event,
                                    const std::string& particle_dir);
 
-hit_particle_map generate_hit_particle_map(
-    std::size_t event, const std::string& hits_dir,
-    const std::string& particle_dir,
-    const geoId_link_map& link_map = geoId_link_map());
+hit_particle_map generate_hit_particle_map(std::size_t event,
+                                           const std::string& hits_dir,
+                                           const std::string& particle_dir);
 
 hit_map generate_hit_map(std::size_t event, const std::string& hits_dir);
 

--- a/io/src/csv/read_measurements.cpp
+++ b/io/src/csv/read_measurements.cpp
@@ -36,15 +36,6 @@ void read_measurements(measurement_collection_types::host& measurements,
     csv::measurement iomeas;
     while (reader.read(iomeas)) {
 
-        // Find the module index for the measurement.
-        unsigned int link = 0u;
-        if (dd != nullptr) {
-            auto it = m.find(iomeas.geometry_id);
-            if (it != m.end()) {
-                link = it->second;
-            }
-        }
-
         // Construct the measurement object.
         traccc::measurement meas;
         std::array<typename transform3::size_type, 2u> indices{0u, 0u};
@@ -75,7 +66,6 @@ void read_measurements(measurement_collection_types::host& measurements,
 
         meas.subs.set_indices(indices);
         meas.surface_link = detray::geometry::barcode{iomeas.geometry_id};
-        meas.module_link = link;
         // Keeps measurement_id for ambiguity resolution
         meas.measurement_id = iomeas.measurement_id;
 

--- a/io/src/mapper.cpp
+++ b/io/src/mapper.cpp
@@ -61,8 +61,7 @@ particle_map generate_particle_map(std::size_t event,
 
 hit_particle_map generate_hit_particle_map(std::size_t event,
                                            const std::string& hits_dir,
-                                           const std::string& particle_dir,
-                                           const geoId_link_map& link_map) {
+                                           const std::string& particle_dir) {
     hit_particle_map result;
 
     auto pmap = generate_particle_map(event, particle_dir);
@@ -81,14 +80,6 @@ hit_particle_map generate_hit_particle_map(std::size_t event,
 
         spacepoint sp;
         sp.global = {iohit.tx, iohit.ty, iohit.tz};
-
-        unsigned int link = 0;
-        auto it = link_map.find(iohit.geometry_id);
-        if (it != link_map.end()) {
-            link = (*it).second;
-        }
-
-        sp.meas.module_link = link;
 
         particle ptc = pmap[iohit.particle_id];
 
@@ -198,8 +189,7 @@ particle_cell_map generate_particle_cell_map(std::size_t event,
 
     particle_cell_map result;
 
-    auto h_p_map =
-        generate_hit_particle_map(event, hits_dir, particle_dir, link_map);
+    auto h_p_map = generate_hit_particle_map(event, hits_dir, particle_dir);
 
     auto h_c_map =
         generate_hit_cell_map(event, cells_dir, hits_dir, resource, link_map);
@@ -324,8 +314,7 @@ measurement_particle_map generate_measurement_particle_map(
         link_map[dd.geometry_id()[i].value()] = i;
     }
 
-    auto h_p_map =
-        generate_hit_particle_map(event, hits_dir, particle_dir, link_map);
+    auto h_p_map = generate_hit_particle_map(event, hits_dir, particle_dir);
 
     for (const auto& hit : spacepoints) {
         const auto& meas = hit.meas;

--- a/performance/src/performance/details/is_same_object.cpp
+++ b/performance/src/performance/details/is_same_object.cpp
@@ -24,8 +24,7 @@ bool is_same_object<measurement>::operator()(const measurement& obj) const {
     return (is_same_scalar(obj.local[0], m_ref.get().local[0], m_unc) &&
             is_same_scalar(obj.local[1], m_ref.get().local[1], m_unc) &&
             is_same_scalar(obj.variance[0], m_ref.get().variance[0], m_unc) &&
-            is_same_scalar(obj.variance[1], m_ref.get().variance[1], m_unc) &&
-            obj.module_link == m_ref.get().module_link);
+            is_same_scalar(obj.variance[1], m_ref.get().variance[1], m_unc));
 }
 
 /// @}

--- a/tests/alpaka/test_cca.cpp
+++ b/tests/alpaka/test_cca.cpp
@@ -70,8 +70,8 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
         copy(measurements_buffer, measurements)->wait();
 
         for (std::size_t i = 0; i < measurements.size(); i++) {
-            result[dd.acts_geometry_id().at(measurements.at(i).module_link)]
-                .push_back(measurements.at(i));
+            result[measurements.at(i).surface_link.value()].push_back(
+                measurements.at(i));
         }
 
         return result;

--- a/tests/common/tests/cca_test.hpp
+++ b/tests/common/tests/cca_test.hpp
@@ -147,6 +147,7 @@ class ConnectedComponentAnalysisTests
         traccc::silicon_detector_description::host dd{mr};
         dd.resize(NMODULES);
         for (std::size_t i = 0; i < NMODULES; ++i) {
+            dd.geometry_id()[i] = detray::geometry::barcode{i};
             dd.acts_geometry_id()[i] = i;
             dd.reference_x()[i] = -0.5f;
             dd.reference_y()[i] = -0.5f;

--- a/tests/cpu/test_cca.cpp
+++ b/tests/cpu/test_cca.cpp
@@ -37,8 +37,8 @@ cca_function_t f = [](const traccc::edm::silicon_cell_collection::host& cells,
         vecmem::get_data(dd);
     auto measurements = ca(cells_data, dd_data);
     for (std::size_t i = 0; i < measurements.size(); i++) {
-        result[dd.acts_geometry_id().at(measurements.at(i).module_link)]
-            .push_back(measurements.at(i));
+        result[measurements.at(i).surface_link.value()].push_back(
+            measurements.at(i));
     }
 
     return result;

--- a/tests/cuda/test_cca.cpp
+++ b/tests/cuda/test_cca.cpp
@@ -57,8 +57,8 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
         copy(measurements_buffer, measurements)->wait();
 
         for (std::size_t i = 0; i < measurements.size(); i++) {
-            result[dd.acts_geometry_id().at(measurements.at(i).module_link)]
-                .push_back(measurements.at(i));
+            result[measurements.at(i).surface_link.value()].push_back(
+                measurements.at(i));
         }
 
         return result;

--- a/tests/sycl/test_cca.sycl
+++ b/tests/sycl/test_cca.sycl
@@ -58,8 +58,8 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
         copy(measurements_buffer, measurements)->wait();
 
         for (std::size_t i = 0; i < measurements.size(); i++) {
-            result[dd.acts_geometry_id().at(measurements.at(i).module_link)]
-                .push_back(measurements.at(i));
+            result[measurements.at(i).surface_link.value()].push_back(
+                measurements.at(i));
         }
 
         return result;


### PR DESCRIPTION
I think module links do not have to be used after clusterization. This also helps the currect refactoring of #692 