### PR TITLE
Fix register overload in CUDA spacepoint formation

### DIFF
--- a/device/cuda/src/seeding/spacepoint_formation_algorithm.cu
+++ b/device/cuda/src/seeding/spacepoint_formation_algorithm.cu
@@ -18,11 +18,11 @@ namespace traccc::cuda {
 namespace kernels {
 
 template <typename detector_t>
-__global__ void form_spacepoints(
-    typename detector_t::view_type det_view,
-    measurement_collection_types::const_view measurements_view,
-    const unsigned int measurement_count,
-    spacepoint_collection_types::view spacepoints_view) {
+__global__ void __launch_bounds__(1024, 1)
+    form_spacepoints(typename detector_t::view_type det_view,
+                     measurement_collection_types::const_view measurements_view,
+                     const unsigned int measurement_count,
+                     spacepoint_collection_types::view spacepoints_view) {
 
     device::form_spacepoints<detector_t>(threadIdx.x + blockIdx.x * blockDim.x,
                                          det_view, measurements_view,


### PR DESCRIPTION
PR #719 refactored the spacepoint formation to use the detray detector. While this was and remains a good idea, the introduction of the detray detector massively increases the register use of the kernel, to the point that I was seeing "too many resources requested for launch" errors. This commit modifies the kernel to specify appropriate launch bounds, allowing the compiler to better tune the register usage and resolve the bug.