### PR TITLE
Enhance the track matching condition

### DIFF
--- a/performance/include/traccc/efficiency/finding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/finding_performance_writer.hpp
@@ -55,6 +55,7 @@ class finding_performance_writer {
         scalar z_min = -500.f * traccc::unit<scalar>::mm;
         scalar z_max = 500.f * traccc::unit<scalar>::mm;
         scalar r_max = 200.f * traccc::unit<scalar>::mm;
+        scalar matching_ratio = 0.5f;
     };
 
     /// Construct from configuration and log level.

--- a/performance/include/traccc/efficiency/seeding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/seeding_performance_writer.hpp
@@ -54,6 +54,7 @@ class seeding_performance_writer {
         scalar z_min = -500.f * traccc::unit<scalar>::mm;
         scalar z_max = 500.f * traccc::unit<scalar>::mm;
         scalar r_max = 200.f * traccc::unit<scalar>::mm;
+        scalar matching_ratio = 0.5f;
     };
 
     /// Construct from configuration and log level.

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -173,7 +173,8 @@ void finding_performance_writer::write_common(
         // Consider it being matched if hit counts is larger than the half
         // of the number of measurements
         assert(measurements.size() > 0u);
-        if (particle_hit_counts.at(0).hit_counts > measurements.size() / 2) {
+        if (particle_hit_counts.at(0).hit_counts / measurements.size() >
+            matching_ratio) {
             const auto pid = particle_hit_counts.at(0).ptc.particle_id;
             match_counter[pid]++;
         } else {

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -170,14 +170,15 @@ void finding_performance_writer::write_common(
         std::vector<particle_hit_count> particle_hit_counts =
             identify_contributing_particles(measurements, evt_map.meas_ptc_map);
 
-        if (particle_hit_counts.size() == 1) {
-            auto pid = particle_hit_counts.at(0).ptc.particle_id;
+        // Consider it being matched if hit counts is larger than the half
+        // of the number of measurements
+        assert(measurements.size() > 0u);
+        if (particle_hit_counts.at(0).hit_counts >= measurements.size() / 2) {
+            const auto pid = particle_hit_counts.at(0).ptc.particle_id;
             match_counter[pid]++;
-        }
-
-        if (particle_hit_counts.size() > 1) {
+        } else {
             for (particle_hit_count const& phc : particle_hit_counts) {
-                auto pid = phc.ptc.particle_id;
+                const auto pid = phc.ptc.particle_id;
                 fake_counter[pid]++;
             }
         }

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -174,7 +174,7 @@ void finding_performance_writer::write_common(
         // of the number of measurements
         assert(measurements.size() > 0u);
         if (particle_hit_counts.at(0).hit_counts / measurements.size() >
-            matching_ratio) {
+            m_cfg.matching_ratio) {
             const auto pid = particle_hit_counts.at(0).ptc.particle_id;
             match_counter[pid]++;
         } else {

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -173,7 +173,7 @@ void finding_performance_writer::write_common(
         // Consider it being matched if hit counts is larger than the half
         // of the number of measurements
         assert(measurements.size() > 0u);
-        if (particle_hit_counts.at(0).hit_counts >= measurements.size() / 2) {
+        if (particle_hit_counts.at(0).hit_counts > measurements.size() / 2) {
             const auto pid = particle_hit_counts.at(0).ptc.particle_id;
             match_counter[pid]++;
         } else {

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -76,7 +76,7 @@ void seeding_performance_writer::write(
         std::vector<particle_hit_count> particle_hit_counts =
             identify_contributing_particles(measurements, evt_map.meas_ptc_map);
 
-        if (particle_hit_counts.size() > measurements.size() / 2) {
+        if (particle_hit_counts.at(0).hit_counts > measurements.size() / 2) {
             auto pid = particle_hit_counts.at(0).ptc.particle_id;
             match_counter[pid]++;
         }

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -76,7 +76,8 @@ void seeding_performance_writer::write(
         std::vector<particle_hit_count> particle_hit_counts =
             identify_contributing_particles(measurements, evt_map.meas_ptc_map);
 
-        if (particle_hit_counts.at(0).hit_counts > measurements.size() / 2) {
+        if (particle_hit_counts.at(0).hit_counts / measurements.size() >
+            matching_ratio) {
             auto pid = particle_hit_counts.at(0).ptc.particle_id;
             match_counter[pid]++;
         }

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -70,12 +70,13 @@ void seeding_performance_writer::write(
     seed_collection_types::const_device seeds(seeds_view);
     for (const seed& sd : seeds) {
 
+        const auto measurements = sd.get_measurements(spacepoints_view);
+
         // Check which particle matches this seed.
         std::vector<particle_hit_count> particle_hit_counts =
-            identify_contributing_particles(
-                sd.get_measurements(spacepoints_view), evt_map.meas_ptc_map);
+            identify_contributing_particles(measurements, evt_map.meas_ptc_map);
 
-        if (particle_hit_counts.size() == 1) {
+        if (particle_hit_counts.size() > measurements.size() / 2) {
             auto pid = particle_hit_counts.at(0).ptc.particle_id;
             match_counter[pid]++;
         }

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -77,7 +77,7 @@ void seeding_performance_writer::write(
             identify_contributing_particles(measurements, evt_map.meas_ptc_map);
 
         if (particle_hit_counts.at(0).hit_counts / measurements.size() >
-            matching_ratio) {
+            m_cfg.matching_ratio) {
             auto pid = particle_hit_counts.at(0).ptc.particle_id;
             match_counter[pid]++;
         }


### PR DESCRIPTION
Currently, a track is considered to be unmatched if its measurements are from multiple particles.
However, the ACTS defines that the track is matched if the number of measurements of major particle is larger than the half of the number of measurements. This increases the actual tracking efficieny of `seq_example` slightly

Related code in ACTS:
https://github.com/acts-project/acts/blob/69e0b6b181a14daab9b99e1ae6b576914a060afb/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TrackTruthMatcher.cpp#L97
