### PR TITLE
Improve the seeding and finding performance

### DIFF
--- a/core/include/traccc/seeding/detail/seeding_config.hpp
+++ b/core/include/traccc/seeding/detail/seeding_config.hpp
@@ -19,12 +19,8 @@ struct seedfinder_config {
     seedfinder_config() { setup(); }
 
     // limiting location of measurements
-    // Beomki's note: this value introduces redundant bins
-    // without any spacepoints
-    // m_config.zMin = -2800.;
-    // m_config.zMax = 2800.;
-    float zMin = -1186.f * unit<float>::mm;
-    float zMax = 1186.f * unit<float>::mm;
+    float zMin = -2000.f * unit<float>::mm;
+    float zMax = 2000.f * unit<float>::mm;
     float rMax = 200.f * unit<float>::mm;
     // WARNING: if rMin is smaller than impactMax, the bin size will be 2*pi,
     // which will make seeding very slow!
@@ -42,12 +38,12 @@ struct seedfinder_config {
     // lower cutoff for seeds in MeV
     float minPt = 500.f * unit<float>::MeV;
     // cot of maximum theta angle
-    // equivalent to 2.7 eta (pseudorapidity)
-    float cotThetaMax = 7.40627f;
+    // equivalent to 4 eta (pseudorapidity)
+    float cotThetaMax = 27.2845f;
     // minimum distance in mm in r between two measurements within one seed
-    float deltaRMin = 1 * unit<float>::mm;
+    float deltaRMin = 20 * unit<float>::mm;
     // maximum distance in mm in r between two measurements within one seed
-    float deltaRMax = 60 * unit<float>::mm;
+    float deltaRMax = 280 * unit<float>::mm;
 
     // FIXME: this is not used yet
     //        float upperPtResolutionPerSeed = 20* Acts::GeV;
@@ -61,12 +57,12 @@ struct seedfinder_config {
     // impact parameter in mm
     float impactMax = 10. * unit<float>::mm;
     // how many sigmas of scattering angle should be considered?
-    float sigmaScattering = 1.0;
+    float sigmaScattering = 3.0;
     // Upper pt limit for scattering calculation
     float maxPtScattering = 10 * unit<float>::GeV;
 
     // for how many seeds can one SpacePoint be the middle SpacePoint?
-    int maxSeedsPerSpM = 20;
+    int maxSeedsPerSpM = 10;
 
     float bFieldInZ = 1.99724f * unit<float>::T;
     // location of beam in x,y plane.

--- a/performance/include/traccc/efficiency/finding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/finding_performance_writer.hpp
@@ -51,7 +51,7 @@ class finding_performance_writer {
             {"Num", plot_helpers::binning("N", 30, -0.5f, 29.5f)}};
 
         /// Cut values
-        scalar pT_cut = 0.1f * traccc::unit<scalar>::GeV;
+        scalar pT_cut = 1.f * traccc::unit<scalar>::GeV;
         scalar z_min = -500.f * traccc::unit<scalar>::mm;
         scalar z_max = 500.f * traccc::unit<scalar>::mm;
         scalar r_max = 200.f * traccc::unit<scalar>::mm;

--- a/performance/include/traccc/efficiency/finding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/finding_performance_writer.hpp
@@ -51,7 +51,7 @@ class finding_performance_writer {
             {"Num", plot_helpers::binning("N", 30, -0.5f, 29.5f)}};
 
         /// Cut values
-        scalar pT_cut = 1.f * traccc::unit<scalar>::GeV;
+        scalar pT_cut = 0.5f * traccc::unit<scalar>::GeV;
         scalar z_min = -500.f * traccc::unit<scalar>::mm;
         scalar z_max = 500.f * traccc::unit<scalar>::mm;
         scalar r_max = 200.f * traccc::unit<scalar>::mm;

--- a/performance/include/traccc/efficiency/finding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/finding_performance_writer.hpp
@@ -52,6 +52,9 @@ class finding_performance_writer {
 
         /// Cut values
         scalar pT_cut = 0.1f * traccc::unit<scalar>::GeV;
+        scalar z_min = -500.f * traccc::unit<scalar>::mm;
+        scalar z_max = 500.f * traccc::unit<scalar>::mm;
+        scalar r_max = 200.f * traccc::unit<scalar>::mm;
     };
 
     /// Construct from configuration and log level.

--- a/performance/include/traccc/efficiency/seeding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/seeding_performance_writer.hpp
@@ -50,7 +50,7 @@ class seeding_performance_writer {
             {"Num", plot_helpers::binning("N", 30, -0.5f, 29.5f)}};
 
         /// Cut values
-        scalar pT_cut = 1.f * traccc::unit<scalar>::GeV;
+        scalar pT_cut = 0.5f * traccc::unit<scalar>::GeV;
         scalar z_min = -500.f * traccc::unit<scalar>::mm;
         scalar z_max = 500.f * traccc::unit<scalar>::mm;
         scalar r_max = 200.f * traccc::unit<scalar>::mm;

--- a/performance/include/traccc/efficiency/seeding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/seeding_performance_writer.hpp
@@ -51,6 +51,9 @@ class seeding_performance_writer {
 
         /// Cut values
         scalar pT_cut = 1.f * traccc::unit<scalar>::GeV;
+        scalar z_min = -500.f * traccc::unit<scalar>::mm;
+        scalar z_max = 500.f * traccc::unit<scalar>::mm;
+        scalar r_max = 200.f * traccc::unit<scalar>::mm;
     };
 
     /// Construct from configuration and log level.

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -187,7 +187,9 @@ void finding_performance_writer::write_common(
     for (auto const& [pid, ptc] : evt_map.ptc_map) {
 
         // Count only charged particles which satisfy pT_cut
-        if (ptc.charge == 0 || getter::perp(ptc.momentum) < m_cfg.pT_cut) {
+        if (ptc.charge == 0 || getter::perp(ptc.momentum) < m_cfg.pT_cut ||
+            ptc.vertex[2] < m_cfg.z_min || ptc.vertex[2] > m_cfg.z_max ||
+            getter::perp(ptc.vertex) > m_cfg.r_max) {
             continue;
         }
 

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -84,7 +84,9 @@ void seeding_performance_writer::write(
     for (auto const& [pid, ptc] : evt_map.ptc_map) {
 
         // Count only charged particles which satisfiy pT_cut
-        if (ptc.charge == 0 || getter::perp(ptc.momentum) < m_cfg.pT_cut) {
+        if (ptc.charge == 0 || getter::perp(ptc.momentum) < m_cfg.pT_cut ||
+            ptc.vertex[2] < m_cfg.z_min || ptc.vertex[2] > m_cfg.z_max ||
+            getter::perp(ptc.vertex) > m_cfg.r_max) {
             continue;
         }
 
@@ -128,7 +130,9 @@ void seeding_performance_writer::write(
     for (auto const& [pid, ptc] : evt_map.ptc_map) {
 
         // Count only charged particles which satisfiy pT_cut
-        if (ptc.charge == 0 || getter::perp(ptc.momentum) < m_cfg.pT_cut) {
+        if (ptc.charge == 0 || getter::perp(ptc.momentum) < m_cfg.pT_cut ||
+            ptc.vertex[2] < m_cfg.z_min || ptc.vertex[2] > m_cfg.z_max ||
+            getter::perp(ptc.vertex) > m_cfg.r_max) {
             continue;
         }
 

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -78,6 +78,13 @@ TEST_P(CompareWithActsSeedingTests, Run) {
 
     // Seeding Config
     traccc::seedfinder_config traccc_config;
+    traccc_config.zMin = -1186.f * traccc::unit<float>::mm;
+    traccc_config.zMax = 1186.f * traccc::unit<float>::mm;
+    traccc_config.cotThetaMax = 7.40627f;
+    traccc_config.deltaRMin = 1.f * traccc::unit<float>::mm;
+    traccc_config.deltaRMax = 60.f * traccc::unit<float>::mm;
+    traccc_config.sigmaScattering = 1.0f;
+
     traccc::spacepoint_grid_config grid_config(traccc_config);
 
     // Declare algorithms


### PR DESCRIPTION
The efficiency drop is from bad seeding config (which was optimized for tml detector) and loose particle selection in performance writers. I also synchronized the truth cut for seeding and finding performance writer

After fixing them, good efficiency is obtained for single muon ODD events

```
./bin/traccc_seq_example --digitization-file=geometries/odd/odd-digi-geometric-config.json --detector-file=geometries/odd_full/odd-detray_geometry_detray.json --grid-file=geometries/odd_full/odd-detray_surface_grids_detray.json --material-file=geometries/odd_full/odd-detray_material_detray.json --use-detray-detector --use-acts-geom-source --input-directory=odd/geant4_10muon_100GeV/ --input-events=100 --check-performance
```

![image](https://github.com/user-attachments/assets/579a7a5b-c060-4485-aef3-8ae916e89955)
