### PR TITLE
Wrap the phi of track parameters in the range of [-pi,pi]

### DIFF
--- a/core/include/traccc/edm/track_parameters.hpp
+++ b/core/include/traccc/edm/track_parameters.hpp
@@ -9,6 +9,7 @@
 
 // traccc include
 #include "traccc/definitions/common.hpp"
+#include "traccc/definitions/math.hpp"
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/definitions/track_parametrization.hpp"

--- a/core/include/traccc/edm/track_parameters.hpp
+++ b/core/include/traccc/edm/track_parameters.hpp
@@ -38,7 +38,7 @@ inline void wrap_phi(bound_track_parameters& param) {
 
     traccc::scalar phi = param.phi();
     static constexpr traccc::scalar TWOPI =
-        2. * traccc::constant<traccc::scalar>::pi;
+        2.f * traccc::constant<traccc::scalar>::pi;
     phi = math::fmod(phi, TWOPI);
     if (phi > traccc::constant<traccc::scalar>::pi) {
         phi -= TWOPI;

--- a/core/include/traccc/edm/track_parameters.hpp
+++ b/core/include/traccc/edm/track_parameters.hpp
@@ -31,4 +31,20 @@ using bound_covariance = bound_track_parameters::covariance_type;
 using bound_track_parameters_collection_types =
     collection_types<bound_track_parameters>;
 
+// Wrap the phi of track parameters to [-pi,pi]
+TRACCC_HOST_DEVICE
+inline void wrap_phi(bound_track_parameters& param) {
+
+    traccc::scalar phi = param.phi();
+    static constexpr traccc::scalar TWOPI =
+        2. * traccc::constant<traccc::scalar>::pi;
+    phi = math::fmod(phi, TWOPI);
+    if (phi > traccc::constant<traccc::scalar>::pi) {
+        phi -= TWOPI;
+    } else if (phi < -traccc::constant<traccc::scalar>::pi) {
+        phi += TWOPI;
+    }
+    param.set_phi(phi);
+}
+
 }  // namespace traccc

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
@@ -107,6 +107,8 @@ struct gain_matrix_smoother {
 
         cur_state.smoothed().set_vector(smt_vec);
         cur_state.smoothed().set_covariance(smt_cov);
+        // Wrap the phi in the range of [-pi, pi]
+        wrap_phi(cur_state.smoothed());
 
         matrix_type<D, e_bound_size> H = meas.subs.template projector<D>();
 

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -124,6 +124,8 @@ struct gain_matrix_updater {
         // Set the stepper parameter
         bound_params.set_vector(filtered_vec);
         bound_params.set_covariance(filtered_cov);
+        // Wrap the phi in the range of [-pi, pi]
+        wrap_phi(bound_params);
 
         // Set the track state parameters
         trk_state.filtered().set_vector(filtered_vec);


### PR DESCRIPTION
This is for constraining the values of phi from Kalman updater and smoother to be within [-pi,pi].
If we don't do this, very occasionally, the while loop of[ `wrap_to_pi` of `is_same_angle`](https://github.com/acts-project/traccc/blob/bc55abf73a82625497a63e3a50d8ddb179a227b4/performance/src/performance/details/is_same_angle.cpp#L16) can take very long time.

