### PR TITLE
ref: Update to detray version 0.79.0 and algebra-plugins version 0.25.0

### DIFF
--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Algebra Plugins as part of the TRACCC project" )
 
 # Declare where to get Algebra Plugins from.
 set( TRACCC_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.24.0.tar.gz;URL_MD5;e9b4c531c61d9988aae6cab95f257948"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.25.0.tar.gz;URL_MD5;8201744f8b2a8ff7fbcf21bd1b4549b9"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 
 mark_as_advanced( TRACCC_ALGEBRA_PLUGINS_SOURCE )

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.78.0.tar.gz;URL_MD5;9ab5782683f14041e2ec528b5f2d4cb0"
+"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.79.0.tar.gz;URL_MD5;b2eb38b7a58c55f41aa5e295c21e1aeb"
    CACHE STRING "Source for Detray, when built as part of this project" )
 
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
@@ -43,12 +43,14 @@ set( DETRAY_BUILD_INTEGRATIONTESTS FALSE CACHE BOOL
    "Turn off the build of the Detray integration tests" )
 set( DETRAY_BUILD_BENCHMARKS FALSE CACHE BOOL
    "Turn off the build of the Detray benchmarks" )
+set( DETRAY_BUILD_CLI_TOOLS FALSE CACHE BOOL
+   "Turn off the build of the Detray CLI tools" )
 set( DETRAY_BUILD_TUTORIALS FALSE CACHE BOOL
    "Turn off the build of the Detray tutorials" )
 set( DETRAY_EIGEN_PLUGIN TRUE CACHE BOOL
    "Turn on the build of the Detray Eigen code" )
-set( DETRAY_VC_PLUGIN TRUE CACHE BOOL
-   "Turn on the build of the Detray Vc code" )
+set( DETRAY_VC_AOS_PLUGIN TRUE CACHE BOOL
+   "Turn on the build of the Detray Vc AoS code" )
 
 # Needed for 'performance', 'simulation', 'examples', 'tests' and 'benchmarks'
 if( TRACCC_BUILD_IO OR TRACCC_BUILD_EXAMPLES OR (BUILD_TESTING AND TRACCC_BUILD_TESTING) OR TRACCC_BUILD_BENCHMARKS )
@@ -58,6 +60,8 @@ else()
    set( DETRAY_BUILD_TEST_UTILS FALSE CACHE BOOL
       "Turn off the build of the Detray tests utilities" )
 endif()
+set( DETRAY_BUILD_VALIDATION_TOOLS FALSE CACHE BOOL
+   "Turn off the build of the Detray validation tools" )
 
 set( DETRAY_SETUP_VECMEM FALSE CACHE BOOL
    "Do not set up VecMem as part of Detray" )

--- a/plugins/algebra/CMakeLists.txt
+++ b/plugins/algebra/CMakeLists.txt
@@ -31,8 +31,8 @@ if( ALGEBRA_PLUGINS_INCLUDE_SMATRIX )
   target_link_libraries( traccc_algebra INTERFACE traccc::smatrix )
 endif()
 
-# Make use of algebra::vc_vc, if it is available.
+# Make use of algebra::vc_aos, if it is available.
 if( ALGEBRA_PLUGINS_INCLUDE_VC )
   add_subdirectory( vc )
-  target_link_libraries( traccc_algebra INTERFACE traccc::vc )
+  target_link_libraries( traccc_algebra INTERFACE traccc::vc_aos )
 endif()

--- a/plugins/algebra/vc/CMakeLists.txt
+++ b/plugins/algebra/vc/CMakeLists.txt
@@ -1,13 +1,13 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
-# Set up the "build" of the traccc::vc library.
-traccc_add_library( traccc_vc vc TYPE INTERFACE
+# Set up the "build" of the traccc::vc_aos library.
+traccc_add_library( traccc_vc_aos vc_aos TYPE INTERFACE
   "include/traccc/plugins/algebra/vc_definitions.hpp" )
-target_link_libraries( traccc_vc
-  INTERFACE algebra::vc_vc detray::algebra_vc vecmem::core )
-target_compile_definitions( traccc_vc
+target_link_libraries( traccc_vc_aos
+  INTERFACE algebra::vc_cmath detray::algebra_vc_aos vecmem::core )
+target_compile_definitions( traccc_vc_aos
   INTERFACE TRACCC_CUSTOM_SCALARTYPE=${TRACCC_CUSTOM_SCALARTYPE} )


### PR DESCRIPTION
Mostly addressing maintainability issues in detray:
 
- Rename vc to vc_aos
- Remove enable_if 
- Use ranges algorithms
- Refactor type traits into concepts
- Split dependency between benchmarks and svgtools and make validation utils lib
