### PR TITLE
Enable `-Wconversion`

### DIFF
--- a/benchmarks/cpu/toy_detector_cpu.cpp
+++ b/benchmarks/cpu/toy_detector_cpu.cpp
@@ -70,7 +70,7 @@ BENCHMARK_F(ToyDetectorBenchmark, CPU)(benchmark::State& state) {
 
 // Iterate over events
 #pragma omp parallel for
-        for (int i_evt = 0; i_evt < n_events; i_evt++) {
+        for (unsigned int i_evt = 0; i_evt < n_events; i_evt++) {
 
             auto& spacepoints_per_event = spacepoints[i_evt];
             auto& measurements_per_event = measurements[i_evt];

--- a/benchmarks/cuda/toy_detector_cuda.cpp
+++ b/benchmarks/cuda/toy_detector_cuda.cpp
@@ -96,12 +96,9 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
 
         for (int i = -10; i < n_events; i++) {
 
-            int i_evt = i;
-
             // First 10 events are for cold run
-            if (i < 0) {
-                i_evt = 0;
-            }
+            unsigned int i_evt = static_cast<unsigned int>(std::max(i, 0));
+
             // Measure the time after the cold run
             if (i == 0) {
                 state.ResumeTiming();
@@ -112,13 +109,15 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
 
             // Copy the spacepoint and module data to the device.
             traccc::spacepoint_collection_types::buffer spacepoints_cuda_buffer(
-                spacepoints_per_event.size(), mr.main);
+                static_cast<unsigned int>(spacepoints_per_event.size()),
+                mr.main);
             async_copy(vecmem::get_data(spacepoints_per_event),
                        spacepoints_cuda_buffer);
 
             traccc::measurement_collection_types::buffer
-                measurements_cuda_buffer(measurements_per_event.size(),
-                                         mr.main);
+                measurements_cuda_buffer(
+                    static_cast<unsigned int>(measurements_per_event.size()),
+                    mr.main);
             async_copy(vecmem::get_data(measurements_per_event),
                        measurements_cuda_buffer);
 

--- a/cmake/traccc-compiler-options-cpp.cmake
+++ b/cmake/traccc-compiler-options-cpp.cmake
@@ -25,7 +25,7 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    traccc_add_flag( CMAKE_CXX_FLAGS "-pedantic" )
    traccc_add_flag( CMAKE_CXX_FLAGS "-Wold-style-cast" )
    if(PROJECT_IS_TOP_LEVEL)
-     traccc_add_flag( CMAKE_CXX_FLAGS "-Wfloat-conversion" )
+     traccc_add_flag( CMAKE_CXX_FLAGS "-Wconversion" )
    endif()
 
    # Fail on warnings, if asked for that behaviour.

--- a/core/include/traccc/clusterization/impl/sparse_ccl.ipp
+++ b/core/include/traccc/clusterization/impl/sparse_ccl.ipp
@@ -28,7 +28,7 @@ TRACCC_HOST_DEVICE inline unsigned int make_union(
     vecmem::device_vector<unsigned int>& labels, unsigned int e1,
     unsigned int e2) {
 
-    int e;
+    unsigned int e;
     if (e1 < e2) {
         e = e1;
         assert(e2 < labels.size());

--- a/core/include/traccc/edm/seed.hpp
+++ b/core/include/traccc/edm/seed.hpp
@@ -30,8 +30,9 @@ struct seed {
         const spacepoint_collection_types::const_view& spacepoints_view) const {
         const spacepoint_collection_types::const_device spacepoints(
             spacepoints_view);
-        return {spacepoints.at(spB_link).meas, spacepoints.at(spM_link).meas,
-                spacepoints.at(spT_link).meas};
+        return {spacepoints.at(static_cast<unsigned int>(spB_link)).meas,
+                spacepoints.at(static_cast<unsigned int>(spM_link)).meas,
+                spacepoints.at(static_cast<unsigned int>(spT_link)).meas};
     }
 
     TRACCC_HOST_DEVICE
@@ -39,8 +40,9 @@ struct seed {
         const spacepoint_collection_types::const_view& spacepoints_view) const {
         const spacepoint_collection_types::const_device spacepoints(
             spacepoints_view);
-        return {spacepoints.at(spB_link), spacepoints.at(spM_link),
-                spacepoints.at(spT_link)};
+        return {spacepoints.at(static_cast<unsigned int>(spB_link)),
+                spacepoints.at(static_cast<unsigned int>(spM_link)),
+                spacepoints.at(static_cast<unsigned int>(spT_link))};
     }
 };
 

--- a/core/include/traccc/finding/candidate_link.hpp
+++ b/core/include/traccc/finding/candidate_link.hpp
@@ -20,7 +20,7 @@ namespace traccc {
 struct candidate_link {
 
     // Type of index
-    using link_index_type = thrust::pair<int, unsigned int>;
+    using link_index_type = thrust::pair<unsigned int, unsigned int>;
 
     // Index of link from the previous step
     link_index_type previous;

--- a/core/include/traccc/finding/finding_algorithm.ipp
+++ b/core/include/traccc/finding/finding_algorithm.ipp
@@ -28,6 +28,8 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
     const measurement_collection_types::host& measurements,
     const bound_track_parameters_collection_types::host& seeds) const {
 
+    assert(m_cfg.min_track_candidates_per_track > 1);
+
     /*****************************************************************
      * Measurement Operations
      *****************************************************************/
@@ -42,7 +44,8 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 
     auto end = std::unique_copy(measurements.begin(), measurements.end(),
                                 uniques.begin(), measurement_equal_comp());
-    const unsigned int n_modules = end - uniques.begin();
+    const unsigned int n_modules =
+        static_cast<unsigned int>(end - uniques.begin());
 
     // Get upper bounds of unique elements
     std::vector<unsigned int> upper_bounds;
@@ -50,7 +53,8 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
     for (unsigned int i = 0; i < n_modules; i++) {
         auto up = std::upper_bound(measurements.begin(), measurements.end(),
                                    uniques[i], measurement_sort_comp());
-        upper_bounds.push_back(std::distance(measurements.begin(), up));
+        upper_bounds.push_back(
+            static_cast<unsigned int>(std::distance(measurements.begin(), up)));
     }
     const auto n_meas = measurements.size();
 
@@ -88,8 +92,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 
     std::vector<bound_track_parameters> out_params;
 
-    for (int step = 0;
-         step < static_cast<int>(m_cfg.max_track_candidates_per_track);
+    for (unsigned int step = 0; step < m_cfg.max_track_candidates_per_track;
          step++) {
 
         // Iterate over input parameters
@@ -104,8 +107,8 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
         out_params.reserve(n_in_params);
 
         // Previous step ID
-        const int previous_step =
-            (step == 0) ? std::numeric_limits<int>::max() : step - 1;
+        const unsigned int previous_step =
+            (step == 0) ? std::numeric_limits<unsigned int>::max() : step - 1;
 
         std::fill(n_trks_per_seed.begin(), n_trks_per_seed.end(), 0);
 
@@ -158,13 +161,14 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 
             if (lo2 == barcodes.begin()) {
                 range.first = 0u;
-                range.second = upper_bounds[bcd_id];
+                range.second = upper_bounds[static_cast<std::size_t>(bcd_id)];
             } else if (lo2 == barcodes.end()) {
                 range.first = 0u;
                 range.second = 0u;
             } else {
-                range.first = upper_bounds[bcd_id - 1];
-                range.second = upper_bounds[bcd_id];
+                range.first =
+                    upper_bounds[static_cast<std::size_t>(bcd_id - 1)];
+                range.second = upper_bounds[static_cast<std::size_t>(bcd_id)];
             }
 
             unsigned int n_branches = 0;
@@ -223,7 +227,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
          * Propagate to the next surface
          *********************************/
 
-        const unsigned int n_links = links[step].size();
+        const std::size_t n_links = links[step].size();
         for (unsigned int link_id = 0; link_id < n_links; link_id++) {
 
             const unsigned int seed_idx = links[step][link_id].seed_idx;
@@ -276,7 +280,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
             // Unless the track found a surface, it is considered a
             // tip
             else if (!s4.success &&
-                     step >= static_cast<int>(
+                     step >= static_cast<unsigned int>(
                                  m_cfg.min_track_candidates_per_track) -
                                  1) {
                 tips.push_back({step, link_id});
@@ -285,7 +289,8 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
             // If no more CKF step is expected, current candidate is
             // kept as a tip
             if (s4.success &&
-                step == static_cast<int>(m_cfg.max_track_candidates_per_track) -
+                step == static_cast<unsigned int>(
+                            m_cfg.max_track_candidates_per_track) -
                             1) {
                 tips.push_back({step, link_id});
             }
@@ -319,7 +324,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
                 break;
             }
 
-            const unsigned int link_pos =
+            const unsigned long link_pos =
                 param_to_link[L.previous.first][L.previous.second];
             L = links[L.previous.first][link_pos];
         }

--- a/core/include/traccc/geometry/silicon_detector_description.hpp
+++ b/core/include/traccc/geometry/silicon_detector_description.hpp
@@ -222,6 +222,6 @@ using silicon_detector_description = vecmem::edm::container<
     vecmem::edm::type::vector<geometry_id>, vecmem::edm::type::vector<scalar>,
     vecmem::edm::type::vector<scalar>, vecmem::edm::type::vector<scalar>,
     vecmem::edm::type::vector<scalar>, vecmem::edm::type::vector<scalar>,
-    vecmem::edm::type::vector<char> >;
+    vecmem::edm::type::vector<unsigned char> >;
 
 }  // namespace traccc

--- a/core/include/traccc/sanity/contiguous_on.hpp
+++ b/core/include/traccc/sanity/contiguous_on.hpp
@@ -54,9 +54,11 @@ is_contiguous_on(P&& projection, const CONTAINER& in) {
     // Compress adjacent elements
     for (std::size_t i = 0; i < n; ++i) {
         if (i == 0) {
-            iout[iout_size++] = projection(in.at(i));
+            iout[iout_size++] =
+                projection(in.at(static_cast<CONTAINER::size_type>(i)));
         } else {
-            projection_t v = projection(in.at(i));
+            projection_t v =
+                projection(in.at(static_cast<CONTAINER::size_type>(i)));
 
             if (v != iout[iout_size - 1]) {
                 iout[iout_size++] = v;

--- a/core/include/traccc/seeding/detail/seeding_config.hpp
+++ b/core/include/traccc/seeding/detail/seeding_config.hpp
@@ -62,7 +62,7 @@ struct seedfinder_config {
     float maxPtScattering = 10 * unit<float>::GeV;
 
     // for how many seeds can one SpacePoint be the middle SpacePoint?
-    int maxSeedsPerSpM = 10;
+    unsigned int maxSeedsPerSpM = 10;
 
     float bFieldInZ = 1.99724f * unit<float>::T;
     // location of beam in x,y plane.

--- a/core/include/traccc/seeding/spacepoint_binning_helper.hpp
+++ b/core/include/traccc/seeding/spacepoint_binning_helper.hpp
@@ -68,8 +68,9 @@ inline std::pair<detray::axis2::circular<>, detray::axis2::regular<>> get_axes(
         // seed making step. So each individual bin should cover
         // 1/config.phiBinDeflectionCoverage of the maximum expected azimutal
         // deflection
-        scalar deltaPhi = (outerAngle - innerAngle + deltaAngleWithMaxD0) /
-                          grid_config.phiBinDeflectionCoverage;
+        scalar deltaPhi =
+            (outerAngle - innerAngle + deltaAngleWithMaxD0) /
+            static_cast<scalar>(grid_config.phiBinDeflectionCoverage);
 
         // sanity check: if the delta phi is equal to or less than zero, we'll
         // be creating an infinite or a negative number of bins, which would be
@@ -82,7 +83,8 @@ inline std::pair<detray::axis2::circular<>, detray::axis2::regular<>> get_axes(
 
         // divide 2pi by angle delta to get number of phi-bins
         // size is always 2pi even for regions of interest
-        phiBins = std::llround(2 * M_PI / deltaPhi + 0.5);
+        phiBins = static_cast<detray::dindex>(
+            std::llround(2 * M_PI / deltaPhi + 0.5));
         // need to scale the number of phi bins accordingly to the number of
         // consecutive phi bins in the seed making step.
         // Each individual bin should be approximately a fraction (depending on
@@ -99,8 +101,9 @@ inline std::pair<detray::axis2::circular<>, detray::axis2::regular<>> get_axes(
 
     scalar zBinSize = grid_config.cotThetaMax * grid_config.deltaRMax;
     detray::dindex zBins = std::max(
-        1, static_cast<int>(
-               std::floor((grid_config.zMax - grid_config.zMin) / zBinSize)));
+        static_cast<detray::dindex>(1),
+        static_cast<detray::dindex>(
+            std::floor((grid_config.zMax - grid_config.zMin) / zBinSize)));
 
     detray::axis2::regular m_z_axis{zBins, grid_config.zMin, grid_config.zMax,
                                     mr};

--- a/core/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cpp
+++ b/core/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cpp
@@ -484,8 +484,8 @@ void greedy_ambiguity_resolution_algorithm::resolve(state_t& state) const {
     auto track_comperator = [&state](std::size_t a, std::size_t b) {
         /// Helper to calculate the relative amount of shared measurements.
         auto relative_shared_measurements = [&state](std::size_t i) {
-            return 1.0 * state.shared_measurements_per_track[i] /
-                   state.measurements_per_track[i].size();
+            return static_cast<double>(state.shared_measurements_per_track[i]) /
+                   static_cast<double>(state.measurements_per_track[i].size());
         };
 
         if (relative_shared_measurements(a) !=

--- a/core/src/clusterization/measurement_creation_algorithm.cpp
+++ b/core/src/clusterization/measurement_creation_algorithm.cpp
@@ -36,7 +36,7 @@ measurement_creation_algorithm::operator()(
     measurement_collection_types::device measurements{vecmem::get_data(result)};
 
     // Process the clusters one-by-one.
-    for (std::size_t i = 0; i < clusters.size(); ++i) {
+    for (decltype(clusters)::size_type i = 0; i < clusters.size(); ++i) {
 
         // Get the cluster.
         const auto cluster = clusters[i];

--- a/core/src/clusterization/sparse_ccl_algorithm.cpp
+++ b/core/src/clusterization/sparse_ccl_algorithm.cpp
@@ -45,7 +45,7 @@ sparse_ccl_algorithm::output_type sparse_ccl_algorithm::operator()(
     clusters.resize(num_clusters);
 
     // Add cells to their clusters.
-    for (std::size_t cell_idx = 0; cell_idx < cluster_indices.size();
+    for (unsigned int cell_idx = 0; cell_idx < cluster_indices.size();
          ++cell_idx) {
         clusters.cell_indices()[cluster_indices[cell_idx]].push_back(cell_idx);
     }

--- a/core/src/seeding/seed_filtering.cpp
+++ b/core/src/seeding/seed_filtering.cpp
@@ -91,7 +91,7 @@ void seed_filtering::operator()(
         seeds_per_spM = std::move(new_seeds);
     }
 
-    unsigned int maxSeeds = seeds_per_spM.size();
+    decltype(seeds_per_spM)::size_type maxSeeds = seeds_per_spM.size();
 
     if (maxSeeds > m_filter_config.maxSeedsPerSpM) {
         maxSeeds = m_filter_config.maxSeedsPerSpM + 1;
@@ -103,7 +103,7 @@ void seed_filtering::operator()(
     // ordering by weight by filterSeeds_2SpFixed means these are the lowest
     // weight seeds
 
-    for (; it < itBegin + maxSeeds; ++it) {
+    for (; it < itBegin + static_cast<long>(maxSeeds); ++it) {
         seeds.push_back(*it);
     }
 }

--- a/core/src/seeding/spacepoint_binning.cpp
+++ b/core/src/seeding/spacepoint_binning.cpp
@@ -8,6 +8,8 @@
 // Library include(s).
 #include "traccc/seeding/spacepoint_binning.hpp"
 
+#include <detray/definitions/detail/indexing.hpp>
+
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/seeding/spacepoint_binning_helper.hpp"
 
@@ -37,7 +39,8 @@ spacepoint_binning::output_type spacepoint_binning::operator()(
             detray::detail::invalid_value<size_t>()) {
             const std::size_t bin_index =
                 phi_axis.bin(isp.phi()) + phi_axis.bins() * z_axis.bin(isp.z());
-            g2.bin(bin_index).push_back(std::move(isp));
+            g2.bin(static_cast<detray::dindex>(bin_index))
+                .push_back(std::move(isp));
         }
     }
     return g2;

--- a/core/src/seeding/track_params_estimation.cpp
+++ b/core/src/seeding/track_params_estimation.cpp
@@ -21,10 +21,10 @@ track_params_estimation::output_type track_params_estimation::operator()(
     const seed_collection_types::host& seeds, const vector3& bfield,
     const std::array<traccc::scalar, traccc::e_bound_size>& stddev) const {
 
-    const unsigned int num_seeds = seeds.size();
+    const seed_collection_types::host::size_type num_seeds = seeds.size();
     output_type result(num_seeds, &m_mr.get());
 
-    for (unsigned int i = 0; i < num_seeds; ++i) {
+    for (seed_collection_types::host::size_type i = 0; i < num_seeds; ++i) {
         bound_track_parameters track_params;
         track_params.set_vector(
             seed_to_bound_vector(spacepoints, seeds[i], bfield));

--- a/device/common/include/traccc/device/impl/fill_prefix_sum.ipp
+++ b/device/common/include/traccc/device/impl/fill_prefix_sum.ipp
@@ -23,8 +23,10 @@ inline void fill_prefix_sum(
     }
 
     const prefix_sum_size_t previous =
-        (globalIndex == 0) ? 0 : sizes[globalIndex - 1];
-    const prefix_sum_size_t current = sizes[globalIndex];
+        (globalIndex == 0) ? 0
+                           : sizes[static_cast<unsigned int>(globalIndex - 1)];
+    const prefix_sum_size_t current =
+        sizes[static_cast<unsigned int>(globalIndex)];
     for (prefix_sum_size_t i = 0; i < current - previous; ++i) {
         result.at(previous + i) = {globalIndex, i};
     }

--- a/device/common/src/make_prefix_sum_buffer.cpp
+++ b/device/common/src/make_prefix_sum_buffer.cpp
@@ -32,7 +32,7 @@ prefix_sum_buffer_t make_prefix_sum_buffer(
     if (mr.host != nullptr) {
         // Create buffer and view objects
         vecmem::data::vector_buffer<prefix_sum_size_t> sizes_sum_buff(
-            sizes_sum.size(), mr.main);
+            static_cast<unsigned int>(sizes_sum.size()), mr.main);
         copy.setup(sizes_sum_buff);
         (copy)(vecmem::get_data(sizes_sum), sizes_sum_buff)->wait();
         vecmem::data::vector_view<prefix_sum_size_t> sizes_sum_view(

--- a/examples/io/create_binaries.cpp
+++ b/examples/io/create_binaries.cpp
@@ -37,7 +37,7 @@ int create_binaries(const traccc::opts::detector& detector_opts,
                                            : traccc::data_format::csv));
 
     // Loop over events
-    for (unsigned int event = input_opts.skip;
+    for (std::size_t event = input_opts.skip;
          event < input_opts.events + input_opts.skip; ++event) {
 
         // Read the cells from the relevant event file

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -33,7 +33,19 @@
 #include <vecmem/memory/binary_page_memory_resource.hpp>
 
 // TBB include(s).
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
 #include <tbb/global_control.h>
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GNU diagnostic push
+#pragma GNU diagnostic ignored "-Wold-style-cast"
+#include <tbb/global_control.h>
+#pragma GNU diagnostic pop
+#else
+#include <tbb/global_control.h>
+#endif
 #include <tbb/task_arena.h>
 #include <tbb/task_group.h>
 
@@ -157,7 +169,7 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
     }
 
     // Seed the random number generator.
-    std::srand(std::time(0));
+    std::srand(static_cast<unsigned int>(std::time(0)));
 
     // Dummy count uses output of tp algorithm to ensure the compiler
     // optimisations don't skip any step
@@ -173,15 +185,16 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
         for (std::size_t i = 0; i < throughput_opts.cold_run_events; ++i) {
 
             // Choose which event to process.
-            const std::size_t event = std::rand() % input_opts.events;
+            const std::size_t event =
+                static_cast<std::size_t>(std::rand()) % input_opts.events;
 
             // Launch the processing of the event.
             arena.execute([&, event]() {
                 group.run([&, event]() {
-                    rec_track_params.fetch_add(
-                        algs.at(tbb::this_task_arena::current_thread_index())(
-                                input[event])
-                            .size());
+                    rec_track_params.fetch_add(algs.at(static_cast<std::size_t>(
+                        tbb::this_task_arena::current_thread_index()))(
+                                                       input[event])
+                                                   .size());
                 });
             });
         }
@@ -201,15 +214,16 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
         for (std::size_t i = 0; i < throughput_opts.processed_events; ++i) {
 
             // Choose which event to process.
-            const std::size_t event = std::rand() % input_opts.events;
+            const std::size_t event =
+                static_cast<std::size_t>(std::rand()) % input_opts.events;
 
             // Launch the processing of the event.
             arena.execute([&, event]() {
                 group.run([&, event]() {
-                    rec_track_params.fetch_add(
-                        algs.at(tbb::this_task_arena::current_thread_index())(
-                                input[event])
-                            .size());
+                    rec_track_params.fetch_add(algs.at(static_cast<std::size_t>(
+                        tbb::this_task_arena::current_thread_index()))(
+                                                       input[event])
+                                                   .size());
                 });
             });
         }

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -120,7 +120,7 @@ int throughput_st(std::string_view description, int argc, char* argv[],
         (detector_opts.use_detray_detector ? &detector : nullptr));
 
     // Seed the random number generator.
-    std::srand(std::time(0));
+    std::srand(static_cast<unsigned int>(std::time(0)));
 
     // Dummy count uses output of tp algorithm to ensure the compiler
     // optimisations don't skip any step
@@ -136,7 +136,8 @@ int throughput_st(std::string_view description, int argc, char* argv[],
         for (std::size_t i = 0; i < throughput_opts.cold_run_events; ++i) {
 
             // Choose which event to process.
-            const std::size_t event = std::rand() % input_opts.events;
+            const std::size_t event =
+                static_cast<std::size_t>(std::rand()) % input_opts.events;
 
             // Process one event.
             rec_track_params += (*alg)(input[event]).size();
@@ -154,7 +155,8 @@ int throughput_st(std::string_view description, int argc, char* argv[],
         for (std::size_t i = 0; i < throughput_opts.processed_events; ++i) {
 
             // Choose which event to process.
-            const std::size_t event = std::rand() % input_opts.events;
+            const std::size_t event =
+                static_cast<std::size_t>(std::rand()) % input_opts.events;
 
             // Process one event.
             rec_track_params += (*alg)(input[event]).size();

--- a/examples/run/cpu/ccl_example.cpp
+++ b/examples/run/cpu/ccl_example.cpp
@@ -23,8 +23,9 @@
 namespace {
 double delta_ms(std::chrono::high_resolution_clock::time_point s,
                 std::chrono::high_resolution_clock::time_point e) {
-    return std::chrono::duration_cast<std::chrono::microseconds>(e - s)
-               .count() /
+    return static_cast<double>(
+               std::chrono::duration_cast<std::chrono::microseconds>(e - s)
+                   .count()) /
            1000.0;
 }
 }  // namespace

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -155,7 +155,7 @@ int seq_run(const traccc::opts::input_data& input_opts,
     traccc::performance::timing_info elapsedTimes;
 
     // Loop over events
-    for (unsigned int event = input_opts.skip;
+    for (std::size_t event = input_opts.skip;
          event < input_opts.events + input_opts.skip; ++event) {
 
         traccc::edm::silicon_cell_collection::host cells_per_event{host_mr};

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -124,7 +124,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
                                                               stddevs);
 
     // Iterate over events
-    for (unsigned int event = input_opts.skip;
+    for (std::size_t event = input_opts.skip;
          event < input_opts.events + input_opts.skip; ++event) {
 
         // Truth Track Candidates
@@ -137,8 +137,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
         // Prepare truth seeds
         traccc::bound_track_parameters_collection_types::host seeds(&host_mr);
-        const unsigned int n_tracks = truth_track_candidates.size();
-        for (unsigned int i_trk = 0; i_trk < n_tracks; i_trk++) {
+        const std::size_t n_tracks = truth_track_candidates.size();
+        for (std::size_t i_trk = 0; i_trk < n_tracks; i_trk++) {
             seeds.push_back(truth_track_candidates.at(i_trk).header);
         }
 
@@ -163,13 +163,13 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
         std::cout << "Number of fitted tracks: " << track_states.size()
                   << std::endl;
 
-        const unsigned int n_fitted_tracks = track_states.size();
+        const std::size_t n_fitted_tracks = track_states.size();
 
         if (performance_opts.run) {
             find_performance_writer.write(traccc::get_data(track_candidates),
                                           evt_data);
 
-            for (unsigned int i = 0; i < n_fitted_tracks; i++) {
+            for (std::size_t i = 0; i < n_fitted_tracks; i++) {
                 const auto& trk_states_per_track = track_states.at(i).items;
 
                 const auto& fit_res = track_states[i].header;

--- a/examples/run/cpu/truth_fitting_example.cpp
+++ b/examples/run/cpu/truth_fitting_example.cpp
@@ -123,7 +123,7 @@ int main(int argc, char* argv[]) {
     traccc::seed_generator<host_detector_type> sg(host_det, stddevs);
 
     // Iterate over events
-    for (unsigned int event = input_opts.skip;
+    for (auto event = input_opts.skip;
          event < input_opts.events + input_opts.skip; ++event) {
 
         // Truth Track Candidates
@@ -141,7 +141,8 @@ int main(int argc, char* argv[]) {
         std::cout << "Number of fitted tracks: " << track_states.size()
                   << std::endl;
 
-        const unsigned int n_fitted_tracks = track_states.size();
+        const decltype(track_states)::size_type n_fitted_tracks =
+            track_states.size();
 
         if (performance_opts.run) {
 

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -145,8 +145,8 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     const edm::silicon_cell_collection::host& cells) const {
 
     // Create device copy of input collections
-    edm::silicon_cell_collection::buffer cells_buffer(cells.size(),
-                                                      *m_cached_device_mr);
+    edm::silicon_cell_collection::buffer cells_buffer(
+        static_cast<unsigned int>(cells.size()), *m_cached_device_mr);
     m_copy(vecmem::get_data(cells), cells_buffer)->ignore();
 
     // Run the clusterization (asynchronously).

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -244,13 +244,15 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
             // Copy the spacepoint and module data to the device.
             traccc::spacepoint_collection_types::buffer spacepoints_cuda_buffer(
-                spacepoints_per_event.size(), mr.main);
+                static_cast<unsigned int>(spacepoints_per_event.size()),
+                mr.main);
             async_copy(vecmem::get_data(spacepoints_per_event),
                        spacepoints_cuda_buffer);
 
             traccc::measurement_collection_types::buffer
-                measurements_cuda_buffer(measurements_per_event.size(),
-                                         mr.main);
+                measurements_cuda_buffer(
+                    static_cast<unsigned int>(measurements_per_event.size()),
+                    mr.main);
             async_copy(vecmem::get_data(measurements_per_event),
                        measurements_cuda_buffer);
 
@@ -384,7 +386,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                 }
             }
             std::cout << "Track candidate matching Rate: "
-                      << float(n_matches) / track_candidates.size()
+                      << float(n_matches) /
+                             static_cast<float>(track_candidates.size())
                       << std::endl;
         }
 

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -194,7 +194,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
     traccc::performance::timing_info elapsedTimes;
 
     // Loop over events
-    for (unsigned int event = input_opts.skip;
+    for (std::size_t event = input_opts.skip;
          event < input_opts.events + input_opts.skip; ++event) {
 
         // Instantiate host containers/collections
@@ -236,7 +236,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
 
             // Create device copy of input collections
             traccc::edm::silicon_cell_collection::buffer cells_buffer(
-                cells_per_event.size(), mr.main);
+                static_cast<unsigned int>(cells_per_event.size()), mr.main);
             copy(vecmem::get_data(cells_per_event), cells_buffer);
 
             // CUDA
@@ -419,9 +419,10 @@ int seq_run(const traccc::opts::detector& detector_opts,
             }
 
             std::cout << "  Track candidates (item) matching rate: "
-                      << 100. * float(n_matches) /
-                             std::max(track_candidates.size(),
-                                      track_candidates_cuda.size())
+                      << 100. * static_cast<double>(n_matches) /
+                             static_cast<double>(
+                                 std::max(track_candidates.size(),
+                                          track_candidates_cuda.size()))
                       << "%" << std::endl;
 
             // Compare tracks fitted on the host and on the device.

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -171,7 +171,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
                                                               stddevs);
 
     // Iterate over events
-    for (unsigned int event = input_opts.skip;
+    for (std::size_t event = input_opts.skip;
          event < input_opts.events + input_opts.skip; ++event) {
 
         // Truth Track Candidates
@@ -184,8 +184,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
         // Prepare truth seeds
         traccc::bound_track_parameters_collection_types::host seeds(mr.host);
-        const unsigned int n_tracks = truth_track_candidates.size();
-        for (unsigned int i_trk = 0; i_trk < n_tracks; i_trk++) {
+        const std::size_t n_tracks = truth_track_candidates.size();
+        for (std::size_t i_trk = 0; i_trk < n_tracks; i_trk++) {
             seeds.push_back(truth_track_candidates.at(i_trk).header);
         }
 
@@ -204,7 +204,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
             input_opts.format);
 
         traccc::measurement_collection_types::buffer measurements_cuda_buffer(
-            measurements_per_event.size(), mr.main);
+            static_cast<unsigned int>(measurements_per_event.size()), mr.main);
         async_copy(vecmem::get_data(measurements_per_event),
                    measurements_cuda_buffer);
 
@@ -283,7 +283,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
                 }
             }
             std::cout << "Track candidate matching Rate: "
-                      << float(n_matches) / track_candidates.size()
+                      << float(n_matches) /
+                             static_cast<float>(track_candidates.size())
                       << std::endl;
 
             // Compare the track parameters made on the host and on the device.

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -170,7 +170,7 @@ int main(int argc, char* argv[]) {
     traccc::performance::timing_info elapsedTimes;
 
     // Iterate over events
-    for (unsigned int event = input_opts.skip;
+    for (std::size_t event = input_opts.skip;
          event < input_opts.events + input_opts.skip; ++event) {
 
         // Truth Track Candidates

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -60,7 +60,8 @@ int simulate(const traccc::opts::generation& generation_opts,
     std::vector<scalar> plane_positions;
 
     for (unsigned int i = 0; i < telescope_opts.n_planes; i++) {
-        plane_positions.push_back(i * telescope_opts.spacing);
+        plane_positions.push_back(static_cast<float>(i) *
+                                  telescope_opts.spacing);
     }
 
     // B field value and its type

--- a/extern/dfelibs/CMakeLists.txt
+++ b/extern/dfelibs/CMakeLists.txt
@@ -33,3 +33,8 @@ set( dfelibs_ENABLE_INSTALL TRUE CACHE BOOL
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( dfelibs )
+
+get_target_property( _incDirs dfelibs INTERFACE_INCLUDE_DIRECTORIES )
+target_include_directories( dfelibs
+   SYSTEM INTERFACE ${_incDirs} )
+unset( _incDirs )

--- a/io/include/traccc/io/digitization_config.hpp
+++ b/io/include/traccc/io/digitization_config.hpp
@@ -16,7 +16,7 @@ namespace traccc {
 /// Type describing the digitization configuration of a detector module
 struct module_digitization_config {
     Acts::BinUtility segmentation;
-    char dimensions = 2;
+    unsigned char dimensions = 2;
 };
 
 /// Type describing the digitization configuration for the whole detector

--- a/io/src/csv/read_particles.cpp
+++ b/io/src/csv/read_particles.cpp
@@ -103,8 +103,10 @@ void read_particles(particle_container_types::host& particles,
             std::distance(temp_particles.begin(), particle_it);
 
         // Add the measurement to the particle's collection.
-        particle_measurements[particle_index].push_back(
-            temp_measurements.at(hit_to_measurement_it->second));
+        particle_measurements[static_cast<decltype(
+                                  particle_measurements)::size_type>(
+                                  particle_index)]
+            .push_back(temp_measurements.at(hit_to_measurement_it->second));
 
         // Increment the hit ID.
         ++hit_id;

--- a/io/src/obj/write_seeds.cpp
+++ b/io/src/obj/write_seeds.cpp
@@ -33,9 +33,10 @@ void write_seeds(std::string_view filename,
     std::map<std::size_t, std::size_t> spacepoint_indices;
 
     // Helper lambda to write a spacepoint to the output file.
-    auto write_spacepoint = [&file, &spacepoints, &spacepoint_indices](
-                                std::size_t memory_index,
-                                std::size_t file_index) -> bool {
+    auto write_spacepoint =
+        [&file, &spacepoints, &spacepoint_indices](
+            spacepoint_collection_types::const_device::size_type memory_index,
+            std::size_t file_index) -> bool {
         // Check whether this spacepoint has already been written.
         if (spacepoint_indices.find(memory_index) != spacepoint_indices.end()) {
             return false;
@@ -54,13 +55,25 @@ void write_seeds(std::string_view filename,
     std::size_t file_index = 1;
     file << "# Spacepoints from which the seeds are built\n";
     for (const seed& s : seeds) {
-        if (write_spacepoint(s.spB_link, file_index)) {
+        if (write_spacepoint(
+                static_cast<
+                    spacepoint_collection_types::const_device::size_type>(
+                    s.spB_link),
+                file_index)) {
             file_index++;
         }
-        if (write_spacepoint(s.spM_link, file_index)) {
+        if (write_spacepoint(
+                static_cast<
+                    spacepoint_collection_types::const_device::size_type>(
+                    s.spM_link),
+                file_index)) {
             file_index++;
         }
-        if (write_spacepoint(s.spT_link, file_index)) {
+        if (write_spacepoint(
+                static_cast<
+                    spacepoint_collection_types::const_device::size_type>(
+                    s.spT_link),
+                file_index)) {
             file_index++;
         }
     }

--- a/io/src/read_binary.hpp
+++ b/io/src/read_binary.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // VecMem include(s).
+#include <ios>
 #include <vecmem/edm/host.hpp>
 #include <vecmem/memory/memory_resource.hpp>
 
@@ -46,7 +47,8 @@ container_t read_binary_container(std::string_view filename,
     // Read the sizes of the item vector.
     std::vector<std::size_t> items_size(headers_size);
     in_file.read(reinterpret_cast<char*>(items_size.data()),
-                 headers_size * sizeof(typename std::size_t));
+                 static_cast<std::streamsize>(headers_size *
+                                              sizeof(typename std::size_t)));
 
     // Create the result container, and set it to the correct (outer) size right
     // away.
@@ -92,7 +94,8 @@ void read_binary_collection(collection_t& result, std::string_view filename) {
 
     // Read the items into memory.
     in_file.read(reinterpret_cast<char*>(result.data()),
-                 size * sizeof(typename collection_t::value_type));
+                 static_cast<std::streamsize>(
+                     size * sizeof(typename collection_t::value_type)));
 }
 
 /// Implementation detail for @c traccc::io::details::read_binary_soa
@@ -124,7 +127,8 @@ void read_binary_soa_variable(std::vector<TYPE, ALLOC>& result,
     result.resize(size);
 
     // Read the items into memory.
-    in_file.read(reinterpret_cast<char*>(result.data()), size * sizeof(TYPE));
+    in_file.read(reinterpret_cast<char*>(result.data()),
+                 static_cast<std::streamsize>(size * sizeof(TYPE)));
 }
 
 /// Implementation detail for @c traccc::io::details::read_binary_soa
@@ -144,7 +148,8 @@ void read_binary_soa_variable(
     // Read the sizes of the "inner" vectors.
     std::vector<std::size_t> inner_sizes(outer_size);
     in_file.read(reinterpret_cast<char*>(inner_sizes.data()),
-                 outer_size * sizeof(typename std::size_t));
+                 static_cast<std::streamsize>(outer_size *
+                                              sizeof(typename std::size_t)));
 
     // Resize the outer vector.
     result.resize(outer_size);

--- a/io/src/write_binary.hpp
+++ b/io/src/write_binary.hpp
@@ -84,7 +84,8 @@ void write_binary_collection(std::string_view filename,
 
     // Write the items.
     out_file.write(reinterpret_cast<const char*>(collection.data()),
-                   size * sizeof(typename collection_t::value_type));
+                   static_cast<std::streamsize>(
+                       size * sizeof(typename collection_t::value_type)));
 }
 
 /// Implementation detail for @c traccc::io::details::write_binary_soa
@@ -114,7 +115,7 @@ void write_binary_soa_variable(const vecmem::device_vector<TYPE>& var,
 
     // Write the contents of the vector.
     out_file.write(reinterpret_cast<const char*>(var.data()),
-                   size * sizeof(TYPE));
+                   static_cast<std::streamsize>(size * sizeof(TYPE)));
 }
 
 /// Implementation detail for @c traccc::io::details::write_binary_soa

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -150,9 +150,9 @@ void finding_performance_writer::write_common(
     std::map<particle_id, std::size_t> fake_counter;
 
     // Iterate over the tracks.
-    const unsigned int n_tracks = tracks.size();
+    const std::size_t n_tracks = tracks.size();
 
-    for (unsigned int i = 0; i < n_tracks; i++) {
+    for (std::size_t i = 0; i < n_tracks; i++) {
 
         const std::vector<measurement>& measurements = tracks[i];
 
@@ -180,7 +180,8 @@ void finding_performance_writer::write_common(
         // Consider it being matched if hit counts is larger than the half
         // of the number of measurements
         assert(measurements.size() > 0u);
-        if (particle_hit_counts.at(0).hit_counts / measurements.size() >
+        if (static_cast<double>(particle_hit_counts.at(0).hit_counts) /
+                static_cast<double>(measurements.size()) >
             m_cfg.matching_ratio) {
             const auto pid = particle_hit_counts.at(0).ptc.particle_id;
             match_counter[pid]++;

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -86,7 +86,8 @@ void seeding_performance_writer::write(
         // Consider it being matched if hit counts is larger than the half
         // of the number of measurements
         assert(measurements.size() > 0u);
-        if (particle_hit_counts.at(0).hit_counts / measurements.size() >
+        if (static_cast<double>(particle_hit_counts.at(0).hit_counts) /
+                static_cast<double>(measurements.size()) >
             m_cfg.matching_ratio) {
             auto pid = particle_hit_counts.at(0).ptc.particle_id;
             match_counter[pid]++;

--- a/performance/src/performance/details/is_same_object.cpp
+++ b/performance/src/performance/details/is_same_object.cpp
@@ -119,8 +119,10 @@ is_same_object<track_candidate_collection_types::host>::is_same_object(
 bool is_same_object<track_candidate_collection_types::host>::operator()(
     const track_candidate_collection_types::host& obj) const {
 
-    const unsigned int n_cands = m_ref.get().size();
-    for (unsigned int i = 0; i < n_cands; i++) {
+    const track_candidate_collection_types::host::size_type n_cands =
+        m_ref.get().size();
+    for (track_candidate_collection_types::host::size_type i = 0; i < n_cands;
+         i++) {
 
         const bool is_same = m_ref.get()[i] == obj[i];
 

--- a/tests/common/tests/kalman_fitting_test.cpp
+++ b/tests/common/tests/kalman_fitting_test.cpp
@@ -85,7 +85,7 @@ void KalmanFittingTests::ndf_tests(
     const fitting_result<traccc::default_algebra>& fit_res,
     const track_state_collection_types::host& track_states_per_track) {
 
-    scalar dim_sum = 0;
+    unsigned int dim_sum = 0;
     std::size_t n_effective_states = 0;
 
     for (const auto& state : track_states_per_track) {

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -322,8 +322,12 @@ TEST_P(CompareWithActsSeedingTests, Run) {
     // Ensure that ACTS and traccc give the same result
     // @TODO Uncomment the line below once acts-project/acts#2132 is merged
     // EXPECT_EQ(seeds.size(), seedVector.size());
-    EXPECT_NEAR(seeds.size(), seedVector.size(), seeds.size() * 0.0023);
-    EXPECT_GT(float(n_seed_match) / seeds.size(), 0.9977);
+    EXPECT_NEAR(static_cast<double>(seeds.size()),
+                static_cast<double>(seedVector.size()),
+                static_cast<double>(seeds.size()) * 0.0023);
+    EXPECT_GT(
+        static_cast<double>(n_seed_match) / static_cast<double>(seeds.size()),
+        0.9977);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
@@ -192,8 +192,8 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
      * Success rate test
      ********************/
 
-    float success_rate =
-        static_cast<float>(n_success) / (n_truth_tracks * n_events);
+    float success_rate = static_cast<float>(n_success) /
+                         static_cast<float>(n_truth_tracks * n_events);
 
     ASSERT_FLOAT_EQ(success_rate, 1.00f);
 }

--- a/tests/cpu/test_kalman_fitter_telescope.cpp
+++ b/tests/cpu/test_kalman_fitter_telescope.cpp
@@ -167,8 +167,8 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
      * Success rate test
      ********************/
 
-    float success_rate =
-        static_cast<float>(n_success) / (n_truth_tracks * n_events);
+    float success_rate = static_cast<float>(n_success) /
+                         static_cast<float>(n_truth_tracks * n_events);
 
     ASSERT_FLOAT_EQ(success_rate, 1.00f);
 }

--- a/tests/cpu/test_kalman_fitter_wire_chamber.cpp
+++ b/tests/cpu/test_kalman_fitter_wire_chamber.cpp
@@ -173,8 +173,8 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
      * Success rate test
      ********************/
 
-    scalar success_rate =
-        static_cast<scalar>(n_success) / (n_truth_tracks * n_events);
+    scalar success_rate = static_cast<scalar>(n_success) /
+                          static_cast<scalar>(n_truth_tracks * n_events);
 
     ASSERT_GE(success_rate, 0.99f);
     ASSERT_LE(success_rate, 1.00f);

--- a/tests/cuda/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cuda/test_ckf_combinatorics_telescope.cpp
@@ -183,7 +183,7 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
         traccc::io::read_measurements(measurements_per_event, i_evt, path);
 
         traccc::measurement_collection_types::buffer measurements_buffer(
-            measurements_per_event.size(), mr.main);
+            static_cast<unsigned int>(measurements_per_event.size()), mr.main);
         copy(vecmem::get_data(measurements_per_event), measurements_buffer);
 
         // Instantiate output cuda containers/collections

--- a/tests/cuda/test_ckf_toy_detector.cpp
+++ b/tests/cuda/test_ckf_toy_detector.cpp
@@ -180,7 +180,7 @@ TEST_P(CkfToyDetectorTests, Run) {
         traccc::io::read_measurements(measurements_per_event, i_evt, path);
 
         traccc::measurement_collection_types::buffer measurements_buffer(
-            measurements_per_event.size(), mr.main);
+            static_cast<unsigned int>(measurements_per_event.size()), mr.main);
         copy(vecmem::get_data(measurements_per_event), measurements_buffer);
 
         // Instantiate output cuda containers/collections
@@ -202,7 +202,9 @@ TEST_P(CkfToyDetectorTests, Run) {
             track_candidate_d2h(track_candidates_cuda_buffer);
 
         // Simple check
-        ASSERT_NEAR(track_candidates.size(), track_candidates_cuda.size(), 1u);
+        ASSERT_TRUE(
+            std::llabs(static_cast<long>(track_candidates.size()) -
+                       static_cast<long>(track_candidates_cuda.size())) <= 1u);
         ASSERT_GE(track_candidates.size(), n_truth_tracks);
 
         // Make sure that the outputs from cpu and cuda CKF are equivalent
@@ -221,7 +223,8 @@ TEST_P(CkfToyDetectorTests, Run) {
 
         float matching_rate =
             float(n_matches) /
-            std::max(track_candidates.size(), track_candidates_cuda.size());
+            static_cast<float>(std::max(track_candidates.size(),
+                                        track_candidates_cuda.size()));
         EXPECT_GE(matching_rate, 0.999f);
     }
 }

--- a/tests/cuda/test_kalman_fitter_telescope.cpp
+++ b/tests/cuda/test_kalman_fitter_telescope.cpp
@@ -207,8 +207,8 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
      * Success rate test
      ********************/
 
-    float success_rate =
-        static_cast<float>(n_success) / (n_truth_tracks * n_events);
+    float success_rate = static_cast<float>(n_success) /
+                         static_cast<float>(n_truth_tracks * n_events);
 
     ASSERT_FLOAT_EQ(success_rate, 1.00f);
 }


### PR DESCRIPTION
This commit replaces the existing `Wfloat-conversion` flag with the more strict `-Wconverion` and fixes related errors. These were mostly harmless integer conversions, but certainly also some nasty improper floating point-to-integer conversions which may constitute bugs.