### PR TITLE
Add an option for align vector for telescope plane placement

### DIFF
--- a/examples/options/include/traccc/options/telescope_detector.hpp
+++ b/examples/options/include/traccc/options/telescope_detector.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/options/details/interface.hpp"
+#include "traccc/options/details/value_array.hpp"
 
 namespace traccc::opts {
 
@@ -31,6 +32,8 @@ class telescope_detector : public interface {
     float smearing = 50.f;
     /// Half length of plane [mm]
     float half_length = 1000000.f;
+    /// Vector for plane alingment
+    opts::value_array<float, 3> align_vector{0.f, 0.f, 1.f};
 
     /// @}
 

--- a/examples/options/src/telescope_detector.cpp
+++ b/examples/options/src/telescope_detector.cpp
@@ -38,6 +38,11 @@ telescope_detector::telescope_detector()
     m_desc.add_options()("half-length-mm",
                          po::value(&half_length)->default_value(half_length),
                          "Half length of plane [mm]");
+    m_desc.add_options()("align-vector",
+                         po::value(&align_vector)
+                             ->value_name("X:Y:Z")
+                             ->default_value(align_vector),
+                         "Vector for plane placement");
 }
 
 void telescope_detector::read(const po::variables_map&) {
@@ -59,7 +64,8 @@ std::ostream& telescope_detector::print_impl(std::ostream& out) const {
         << "  Smearing        : " << smearing / detray::unit<float>::um
         << " [um]\n"
         << "  Half length     : " << half_length / detray::unit<float>::mm
-        << " [mm]";
+        << " [mm]"
+        << "  Align axis      : " << align_vector << " \n";
     return out;
 }
 

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -53,9 +53,13 @@ int simulate(const traccc::opts::generation& generation_opts,
      * Build a telescope geometry
      *****************************/
 
+    const auto align_vec = telescope_opts.align_vector;
+    vector3 align_axis{align_vec[0u], align_vec[1u], align_vec[2u]};
+    align_axis = vector::normalize(align_axis);
+
     // Plane alignment direction (aligned to z-axis)
     detray::detail::ray<traccc::default_algebra> traj{
-        {0, 0, 0}, 0, {0, 0, 1}, -1};
+        {0, 0, 0}, 0, align_axis, -1};
     // Position of planes (in mm unit)
     std::vector<scalar> plane_positions;
 


### PR DESCRIPTION
This is to enable to create telescope detector in different axes, e.g. x-axis. Creating only in z-axis may not be desirable as it is numerically instable