### PR TITLE
Add theta range input

### DIFF
--- a/examples/options/CMakeLists.txt
+++ b/examples/options/CMakeLists.txt
@@ -49,6 +49,5 @@ target_link_libraries( traccc_options
    PUBLIC
       Boost::program_options
       traccc::io
-   PRIVATE
       traccc::performance
 )

--- a/examples/options/include/traccc/options/generation.hpp
+++ b/examples/options/include/traccc/options/generation.hpp
@@ -11,6 +11,7 @@
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/options/details/interface.hpp"
 #include "traccc/options/details/value_array.hpp"
+#include "traccc/utils/ranges.hpp"
 
 // detray include(s).
 #include "detray/definitions/pdg_particle.hpp"
@@ -42,6 +43,9 @@ class generation : public interface {
     opts::value_array<float, 2> phi_range{-180.f, 180.f};
     /// Range of eta
     opts::value_array<float, 2> eta_range{-2.f, 2.f};
+    /// Range of theta [rad] (corresponding to eta range of [-2,2])
+    opts::value_array<float, 2> theta_range{eta_to_theta_range(eta_range)};
+
     /// PDG number for particle type (Default: muon)
     int pdg_number = 13;
 
@@ -50,8 +54,6 @@ class generation : public interface {
     /// @name Derived options
     /// @{
 
-    /// Range of theta [rad]
-    opts::value_array<float, 2> theta_range{0.f, 0.f};
     /// Particle type
     detray::pdg_particle<traccc::scalar> ptc_type =
         detray::muon<traccc::scalar>();

--- a/performance/include/traccc/utils/ranges.hpp
+++ b/performance/include/traccc/utils/ranges.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/definitions/math.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 
 // System include(s).
@@ -19,8 +20,17 @@ template <typename range_t>
 TRACCC_HOST_DEVICE inline range_t eta_to_theta_range(const range_t& eta_range) {
     // @NOTE: eta_range[0] is converted to theta_range[1] and eta_range[1]
     // to theta_range[0] because theta(minEta) > theta(maxEta)
-    return {2 * std::atan(std::exp(-eta_range[1])),
-            2 * std::atan(std::exp(-eta_range[0]))};
+    return {2.f * math::atan(std::exp(-eta_range[1])),
+            2.f * math::atan(std::exp(-eta_range[0]))};
+}
+
+template <typename range_t>
+TRACCC_HOST_DEVICE inline range_t theta_to_eta_range(
+    const range_t& theta_range) {
+    // @NOTE: theta_range[0] is converted to eta_range[1] and theta_range[1]
+    // to eta_range[0]
+    return {-math::log(math::tan(theta_range[1] * 0.5f)),
+            -math::log(math::tan(theta_range[0] * 0.5f))};
 }
 
 }  // namespace traccc

--- a/tests/cpu/test_ranges.cpp
+++ b/tests/cpu/test_ranges.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,4 +29,17 @@ TEST(ranges, eta_to_theta) {
                 0.1f * detray::unit<scalar>::degree);
     ASSERT_NEAR(theta_range[1], 170.f * detray::unit<scalar>::degree,
                 0.1f * detray::unit<scalar>::degree);
+}
+
+// Test theta_to_eta_range function
+TEST(ranges, theta_to_eta) {
+
+    std::array<scalar, 2> theta_range{45.f * detray::unit<scalar>::degree,
+                                      175.f * detray::unit<scalar>::degree};
+    const auto eta_range = theta_to_eta_range(theta_range);
+
+    // Comparing with the values provided by
+    // https://www.star.bnl.gov/~dmitry/calc2.html
+    ASSERT_NEAR(eta_range[0], -3.131f, 1e-3f);
+    ASSERT_NEAR(eta_range[1], 0.881f, 1e-3f);
 }


### PR DESCRIPTION
This PR allows to set a theta range input instead of eta when `use-theta-range-input` is ON. 

Currently this is the best I could come up with but I wonder if we can block the set of `theta-range` when `use-theta-range-input` is OFF.