### PR TITLE
Update Presets, main branch (2024.10.25.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -26,11 +26,11 @@ jobs:
         platform:
           - name: CPU
             container: ghcr.io/acts-project/ubuntu2404:56
-            options: --preset host-fp32
+            options: --preset host-fp32 -DALGEBRA_PLUGINS_USE_SYSTEM_VC=FALSE
             run_tests: true
           - name: CPU
             container: ghcr.io/acts-project/ubuntu2404:56
-            options: --preset host-fp64
+            options: --preset host-fp64 -DALGEBRA_PLUGINS_USE_SYSTEM_VC=FALSE
             run_tests: false
           - name: CUDA
             container: ghcr.io/acts-project/ubuntu2404_cuda:56

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -26,23 +26,23 @@ jobs:
         platform:
           - name: CPU
             container: ghcr.io/acts-project/ubuntu2404:56
-            cxx_standard: "20"
-            options:
+            options: --preset host-fp32
             run_tests: true
+          - name: CPU
+            container: ghcr.io/acts-project/ubuntu2404:56
+            options: --preset host-fp64
+            run_tests: false
           - name: CUDA
             container: ghcr.io/acts-project/ubuntu2404_cuda:56
-            cxx_standard: "20"
-            options: -DTRACCC_BUILD_CUDA=TRUE -DCMAKE_CUDA_FLAGS="-std=c++20"
+            options: --preset cuda-fp32
             run_tests: false
           - name: SYCL
             container: ghcr.io/acts-project/ubuntu2404_oneapi:56
-            cxx_standard: "20"
-            options: -DTRACCC_BUILD_SYCL=TRUE -DCMAKE_SYCL_FLAGS="-fsycl -fsycl-targets=spir64"
+            options: --preset sycl-fp32 -DCMAKE_SYCL_FLAGS="-fsycl -fsycl-targets=spir64"
             run_tests: true
           - name: KOKKOS
             container: ghcr.io/acts-project/ubuntu2404:56
-            cxx_standard: "20"
-            options: -DTRACCC_BUILD_KOKKOS=TRUE
+            options: -DTRACCC_BUILD_CUDA=FALSE --preset kokkos-fp32
             run_tests: false
         build:
           - Release
@@ -51,34 +51,31 @@ jobs:
           - platform:
               name: CUDA
               container: ghcr.io/acts-project/ubuntu2404_cuda:56
-              cxx_standard: "20"
-              options: -DTRACCC_CUSTOM_SCALARTYPE=double -DDETRAY_CUSTOM_SCALARTYPE=double -DTRACCC_BUILD_CUDA=TRUE -DCMAKE_CUDA_FLAGS="-std=c++20"
+              options: --preset cuda-fp64
               run_tests: false
             build: Release
           - platform:
               name: "SYCL"
               container: ghcr.io/acts-project/ubuntu2404_cuda_oneapi:56
-              cxx_standard: "20"
-              options: -DTRACCC_BUILD_SYCL=TRUE -DTRACCC_BUILD_CUDA=FALSE -DVECMEM_BUILD_CUDA_LIBRARY=FALSE
+              options: --preset sycl-fp32
+              run_tests: false
             build: Release
           - platform:
               name: "SYCL"
               container: ghcr.io/acts-project/ubuntu2404_rocm_oneapi:56
-              cxx_standard: "20"
-              options: -DTRACCC_BUILD_SYCL=TRUE -DVECMEM_BUILD_HIP_LIBRARY=FALSE
+              options: --preset sycl-fp32
+              run_tests: false
             build: Release
           - platform:
               name: ALPAKA
               container: ghcr.io/acts-project/ubuntu2404:56
-              cxx_standard: "20"
-              options: -DTRACCC_BUILD_ALPAKA=TRUE
+              options: -DTRACCC_BUILD_CUDA=FALSE --preset alpaka-fp32
               run_tests: true
             build: Release
           - platform:
               name: ALPAKA
               container: ghcr.io/acts-project/ubuntu2404:56
-              cxx_standard: "20"
-              options: -DTRACCC_BUILD_ALPAKA=TRUE
+              options: -DTRACCC_BUILD_CUDA=FALSE --preset alpaka-fp32
               run_tests: false
             build: Debug
     # Use BASH as the shell from the images.
@@ -92,12 +89,7 @@ jobs:
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
           cmake \
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
-            -DCMAKE_CXX_STANDARD=${{ matrix.platform.cxx_standard }} \
-            -DCMAKE_CUDA_STANDARD=${{ matrix.platform.cxx_standard }} \
-            -DCMAKE_HIP_STANDARD=${{ matrix.platform.cxx_standard }} \
-            -DCMAKE_SYCL_STANDARD=${{ matrix.platform.cxx_standard }} \
             ${{ matrix.platform.options }} \
-            -DTRACCC_FAIL_ON_WARNINGS=TRUE \
             -S ${GITHUB_WORKSPACE} \
             -B build
       - name: Build

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Install dependencies
         run: brew install boost
       - name: Configure
-        run: cmake --preset base -S ${GITHUB_WORKSPACE} -B build
+        run: cmake --preset base-fp32 -S ${GITHUB_WORKSPACE} -B build
       - name: Build
         run: cmake --build build
       - name: Download data files

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -42,7 +42,7 @@ jobs:
             run_tests: true
           - name: KOKKOS
             container: ghcr.io/acts-project/ubuntu2404:56
-            options: -DTRACCC_BUILD_CUDA=FALSE --preset kokkos-fp32
+            options: --preset kokkos-fp32
             run_tests: false
         build:
           - Release
@@ -69,13 +69,13 @@ jobs:
           - platform:
               name: ALPAKA
               container: ghcr.io/acts-project/ubuntu2404:56
-              options: -DTRACCC_BUILD_CUDA=FALSE --preset alpaka-fp32
+              options: --preset alpaka-fp32
               run_tests: true
             build: Release
           - platform:
               name: ALPAKA
               container: ghcr.io/acts-project/ubuntu2404:56
-              options: -DTRACCC_BUILD_CUDA=FALSE --preset alpaka-fp32
+              options: --preset alpaka-fp32
               run_tests: false
             build: Debug
     # Use BASH as the shell from the images.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ build:cuda:
   image: ghcr.io/acts-project/ubuntu2204_cuda:56
   variables:
     TRACCC_BUILD_TYPE: CUDA
-    TRACCC_BUILD_PRESET: cuda
+    TRACCC_BUILD_PRESET: cuda-fp32
 
 # CUDA test job.
 test:cuda:
@@ -73,7 +73,7 @@ build:sycl_intel:
   image: ghcr.io/acts-project/ubuntu2404_oneapi:56
   variables:
     TRACCC_BUILD_TYPE: SYCL
-    TRACCC_BUILD_PRESET: sycl
+    TRACCC_BUILD_PRESET: sycl-fp32
     TRACCC_SYCL_FLAGS: -fsycl -fsycl-targets=spir64
     TRACCC_CMAKE_ARGS: -DTRACCC_BUILD_CUDA=FALSE
 
@@ -93,7 +93,7 @@ build:sycl_nvidia:
   image: ghcr.io/acts-project/ubuntu2204_cuda_oneapi:56
   variables:
     TRACCC_BUILD_TYPE: SYCL
-    TRACCC_BUILD_PRESET: sycl
+    TRACCC_BUILD_PRESET: sycl-fp32
     TRACCC_SYCL_FLAGS: -fsycl -fsycl-targets=nvidia_gpu_sm_75 -Wno-unknown-cuda-version -Wno-deprecated-declarations
     TRACCC_CXX_FLAGS: -Wno-deprecated-declarations
     TRACCC_CMAKE_ARGS: -DTRACCC_BUILD_CUDA=FALSE

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,57 +2,113 @@
    "version" : 3,
    "configurePresets": [
       {
-         "name" : "base",
-         "displayName" : "Base Configuration",
+         "name" : "base-fp32",
+         "displayName" : "Base FP32 Configuration",
          "warnings": {
             "deprecated": true
          },
          "cacheVariables": {
-            "CMAKE_BUILD_TYPE"        : "RelWithDebInfo",
-            "TRACCC_BUILD_TESTING"    : "TRUE",
-            "TRACCC_BUILD_EXAMPLES"   : "TRUE",
-            "TRACCC_FAIL_ON_WARNINGS" : "TRUE",
-            "TRACCC_USE_ROOT"         : "FALSE"
+            "CMAKE_BUILD_TYPE"         : "RelWithDebInfo",
+            "TRACCC_BUILD_TESTING"     : "TRUE",
+            "TRACCC_BUILD_EXAMPLES"    : "TRUE",
+            "TRACCC_BUILD_BENCHMARKS"  : "TRUE",
+            "TRACCC_FAIL_ON_WARNINGS"  : "TRUE",
+            "TRACCC_USE_ROOT"          : "FALSE",
+            "TRACCC_ALGEBRA_PLUGINS"   : "ARRAY",
+            "TRACCC_CUSTOM_SCALARTYPE" : "float",
+            "DETRAY_CUSTOM_SCALARTYPE" : "float"
          }
       },
       {
-         "name" : "cuda",
-         "displayName" : "CUDA Code Development",
-         "inherits": ["base"],
+         "name" : "base-fp64",
+         "displayName" : "Base FP64 Configuration",
+         "warnings": {
+            "deprecated": true
+         },
+         "cacheVariables": {
+            "CMAKE_BUILD_TYPE"         : "RelWithDebInfo",
+            "TRACCC_BUILD_TESTING"     : "TRUE",
+            "TRACCC_BUILD_EXAMPLES"    : "TRUE",
+            "TRACCC_BUILD_BENCHMARKS"  : "TRUE",
+            "TRACCC_FAIL_ON_WARNINGS"  : "TRUE",
+            "TRACCC_USE_ROOT"          : "FALSE",
+            "TRACCC_ALGEBRA_PLUGINS"   : "ARRAY",
+            "TRACCC_CUSTOM_SCALARTYPE" : "double",
+            "DETRAY_CUSTOM_SCALARTYPE" : "double"
+         }
+      },
+      {
+         "name" : "cuda-fp32",
+         "displayName" : "CUDA FP32 Code Development",
+         "inherits": ["base-fp32"],
          "cacheVariables": {
             "TRACCC_BUILD_CUDA" : "TRUE",
             "VECMEM_BUILD_CUDA_LIBRARY" : "TRUE"
          }
       },
       {
-         "name" : "sycl",
-         "displayName" : "SYCL Code Development",
-         "inherits": ["base"],
+         "name" : "cuda-fp64",
+         "displayName" : "CUDA FP64 Code Development",
+         "inherits": ["base-fp64"],
+         "cacheVariables": {
+            "TRACCC_BUILD_CUDA" : "TRUE",
+            "VECMEM_BUILD_CUDA_LIBRARY" : "TRUE"
+         }
+      },
+      {
+         "name" : "sycl-fp32",
+         "displayName" : "SYCL FP32 Code Development",
+         "inherits": ["base-fp32"],
          "cacheVariables": {
             "TRACCC_BUILD_SYCL" : "TRUE",
             "VECMEM_BUILD_SYCL_LIBRARY" : "TRUE"
          }
       },
       {
-         "name" : "alpaka",
-         "displayName" : "Alpaka Code Development",
-         "inherits": ["cuda"],
+         "name" : "sycl-fp64",
+         "displayName" : "SYCL FP64 Code Development",
+         "inherits": ["base-fp64"],
+         "cacheVariables": {
+            "TRACCC_BUILD_SYCL" : "TRUE",
+            "VECMEM_BUILD_SYCL_LIBRARY" : "TRUE"
+         }
+      },
+      {
+         "name" : "alpaka-fp32",
+         "displayName" : "Alpaka FP32 Code Development",
+         "inherits": ["cuda-fp32"],
          "cacheVariables": {
             "TRACCC_BUILD_ALPAKA" : "TRUE"
          }
       },
       {
-         "name" : "kokkos",
-         "displayName" : "Kokkos Code Development",
-         "inherits": ["cuda"],
+         "name" : "alpaka-fp64",
+         "displayName" : "Alpaka FP64 Code Development",
+         "inherits": ["cuda-fp64"],
+         "cacheVariables": {
+            "TRACCC_BUILD_ALPAKA" : "TRUE"
+         }
+      },
+      {
+         "name" : "kokkos-fp32",
+         "displayName" : "Kokkos FP32 Code Development",
+         "inherits": ["cuda-fp32"],
          "cacheVariables": {
             "TRACCC_BUILD_KOKKOS" : "TRUE"
          }
       },
       {
-         "name" : "root",
-         "displayName" : "ROOT Enabled Code Development",
-         "inherits": ["base"],
+         "name" : "kokkos-fp64",
+         "displayName" : "Kokkos FP64 Code Development",
+         "inherits": ["cuda-fp64"],
+         "cacheVariables": {
+            "TRACCC_BUILD_KOKKOS" : "TRUE"
+         }
+      },
+      {
+         "name" : "host-fp32",
+         "displayName": "Host FP32 Code Development",
+         "inherits": ["base-fp32"],
          "cacheVariables": {
             "TRACCC_USE_ROOT" : "TRUE",
             "TRACCC_USE_SYSTEM_TBB" : "TRUE",
@@ -60,25 +116,26 @@
          }
       },
       {
-         "name" : "array",
-         "displayName" : "ARRAY Backended Code Development",
-         "inherits": ["base"],
+         "name" : "host-fp64",
+         "displayName": "Host FP64 Code Development",
+         "inherits": ["base-fp64"],
          "cacheVariables": {
-            "TRACCC_ALGEBRA_PLUGINS" : "ARRAY"
+            "TRACCC_USE_ROOT" : "TRUE",
+            "TRACCC_USE_SYSTEM_TBB" : "TRUE",
+            "ALGEBRA_PLUGINS_USE_SYSTEM_VC" : "TRUE"
          }
       },
       {
-         "name" : "eigen",
-         "displayName" : "EIGEN Backended Code Development",
-         "inherits": ["base"],
-         "cacheVariables": {
-            "TRACCC_ALGEBRA_PLUGINS" : "EIGEN"
-         }
+         "name" : "full-fp32",
+         "displayName": "Full FP32 Code Development",
+         "inherits": ["host-fp32", "cuda-fp32", "sycl-fp32", "alpaka-fp32",
+                      "kokkos-fp32"]
       },
       {
-         "name" : "default",
-         "displayName": "Default Build Configuration",
-         "inherits": ["root", "array"]
+         "name" : "full-fp64",
+         "displayName": "Full FP64 Code Development",
+         "inherits": ["host-fp64", "cuda-fp64", "sycl-fp64", "alpaka-fp64",
+                      "kokkos-fp64"]
       }
    ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -76,7 +76,7 @@
       {
          "name" : "alpaka-fp32",
          "displayName" : "Alpaka FP32 Code Development",
-         "inherits": ["cuda-fp32"],
+         "inherits": ["base-fp32"],
          "cacheVariables": {
             "TRACCC_BUILD_ALPAKA" : "TRUE"
          }
@@ -84,7 +84,7 @@
       {
          "name" : "alpaka-fp64",
          "displayName" : "Alpaka FP64 Code Development",
-         "inherits": ["cuda-fp64"],
+         "inherits": ["base-fp64"],
          "cacheVariables": {
             "TRACCC_BUILD_ALPAKA" : "TRUE"
          }
@@ -92,7 +92,7 @@
       {
          "name" : "kokkos-fp32",
          "displayName" : "Kokkos FP32 Code Development",
-         "inherits": ["cuda-fp32"],
+         "inherits": ["base-fp32"],
          "cacheVariables": {
             "TRACCC_BUILD_KOKKOS" : "TRUE"
          }
@@ -100,7 +100,7 @@
       {
          "name" : "kokkos-fp64",
          "displayName" : "Kokkos FP64 Code Development",
-         "inherits": ["cuda-fp64"],
+         "inherits": ["base-fp64"],
          "cacheVariables": {
             "TRACCC_BUILD_KOKKOS" : "TRUE"
          }

--- a/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
+++ b/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
@@ -129,7 +129,7 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
 
         // Set constrained step size to 1 mm
         sim.get_config().propagation.stepping.step_constraint =
-            1.f * detray::unit<traccc::scalar>::mm;
+            1.f * detray::unit<float>::mm;
 
         sim.run();
 

--- a/tests/common/tests/kalman_fitting_wire_chamber_test.hpp
+++ b/tests/common/tests/kalman_fitting_wire_chamber_test.hpp
@@ -34,7 +34,7 @@ class KalmanFittingWireChamberTests : public KalmanFittingTests {
     static constexpr vector3 B{0, 0, 2 * detray::unit<scalar>::T};
 
     /// Step constraint
-    static const inline scalar step_constraint = 1 * detray::unit<scalar>::mm;
+    static const inline float step_constraint = 1.f * detray::unit<float>::mm;
 
     // Set mask tolerance to a large value not to miss the surface during KF
     static const inline scalar mask_tolerance = 75.f * detray::unit<scalar>::um;

--- a/tests/cpu/test_seeding.cpp
+++ b/tests/cpu/test_seeding.cpp
@@ -39,8 +39,8 @@ TEST(seeding, case1) {
     traccc::seedfilter_config filter_config;
 
     // Adjust parameters
-    finder_config.deltaRMax = 100.f * unit<scalar>::mm;
-    finder_config.maxPtScattering = 0.5f * unit<scalar>::GeV;
+    finder_config.deltaRMax = 100.f * unit<float>::mm;
+    finder_config.maxPtScattering = 0.5f * unit<float>::GeV;
     traccc::seeding_algorithm sa(finder_config, grid_config, filter_config,
                                  host_mr);
 
@@ -81,8 +81,8 @@ TEST(seeding, case2) {
     traccc::seedfilter_config filter_config;
 
     // Adjust parameters
-    finder_config.deltaRMax = 100.f * unit<scalar>::mm;
-    finder_config.maxPtScattering = 0.5f * unit<scalar>::GeV;
+    finder_config.deltaRMax = 100.f * unit<float>::mm;
+    finder_config.maxPtScattering = 0.5f * unit<float>::GeV;
     traccc::seeding_algorithm sa(finder_config, grid_config, filter_config,
                                  host_mr);
 


### PR DESCRIPTION
Re-designed the project's build presets a little.
  - Made explicit FP32 and FP64 presets, to make it a bit easier for users to switch between the two;
  - Ditched the `array` and `eigen` presets, as even I never used those so far;
  - Introduced a pair of `full-fp32` / `full-fp64` presets, which attempt to build everything that the repository has to offer, at the same time.
    * Which I can't actually use in any of my own environments at the moment. 😢 The latest versions of CUDA and oneAPI just do not like to work at the same time. 😦

Technically a lot more combinations could still be added. But I thought this may be the golden middle ground between not having enough variety, and having too much. 🤔

I'm also pondering about reforming our CI setup a little. 🤔 More may very well come to this PR soon...