### PR TITLE
Fix fitting performance writer by changing the measurement comparator

### DIFF
--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -62,11 +62,16 @@ TRACCC_HOST_DEVICE inline bool operator<(const measurement& lhs,
 
     if (lhs.surface_link != rhs.surface_link) {
         return lhs.surface_link < rhs.surface_link;
-    } else if (math::fabs(lhs.local[0] - rhs.local[0]) > float_epsilon) {
-        return (lhs.local[0] < rhs.local[0]);
-    } else {
-        return (lhs.local[1] < rhs.local[1]);
+    } else if (lhs.local[0] != rhs.local[0]) {
+        return lhs.local[0] < rhs.local[0];
+    } else if (lhs.local[1] != rhs.local[1]) {
+        return lhs.local[1] < rhs.local[1];
+    } else if (lhs.variance[0] != rhs.variance[0]) {
+        return lhs.variance[0] < rhs.variance[0];
+    } else if (lhs.variance[1] != rhs.variance[1]) {
+        return lhs.variance[1] < rhs.variance[1];
     }
+    return false;
 }
 
 /// Equality operator for measurements

--- a/performance/include/traccc/resolution/fitting_performance_writer.hpp
+++ b/performance/include/traccc/resolution/fitting_performance_writer.hpp
@@ -76,13 +76,13 @@ class fitting_performance_writer {
         // Find the contributing particle
         // @todo: Use identify_contributing_particles function
         std::map<particle, std::size_t> contributing_particles =
-            meas_to_ptc_map[meas];
+            meas_to_ptc_map.at(meas);
 
         const particle ptc = contributing_particles.begin()->first;
 
         // Find the truth global position and momentum
-        const auto global_pos = meas_to_param_map[meas].first;
-        const auto global_mom = meas_to_param_map[meas].second;
+        const auto global_pos = meas_to_param_map.at(meas).first;
+        const auto global_mom = meas_to_param_map.at(meas).second;
 
         const detray::tracking_surface sf{det, meas.surface_link};
         using cxt_t = typename detector_t::geometry_context;

--- a/tests/sycl/test_clusterization.sycl
+++ b/tests/sycl/test_clusterization.sycl
@@ -9,6 +9,7 @@
 #include "tests/cca_test.hpp"
 #include "traccc/definitions/common.hpp"
 #include "traccc/geometry/silicon_detector_description.hpp"
+#include "traccc/performance/collection_comparator.hpp"
 #include "traccc/sycl/clusterization/clusterization_algorithm.hpp"
 
 // VecMem include(s).
@@ -77,15 +78,25 @@ TEST(SYCLClustering, SingleModule) {
 
     // Check the results
     EXPECT_EQ(copy.get_size(measurements_buffer), 2u);
-    std::set<measurement> test;
-    test.insert(measurements[0]);
-    test.insert(measurements[1]);
 
-    std::set<measurement> ref;
-    ref.insert(
+    measurement_collection_types::host references;
+    references.push_back(
         {{2.5f, 2.5f}, {0.75f, 0.0833333f}, detray::geometry::barcode{0u}});
-    ref.insert(
+    references.push_back(
         {{6.5f, 5.5f}, {0.483333f, 0.483333f}, detray::geometry::barcode{0u}});
 
-    EXPECT_EQ(test, ref);
+    for (const auto& test : measurements) {
+        // 0.01 % uncertainty
+        auto iso = traccc::details::is_same_object<measurement>(test, 0.0001f);
+        bool matched = false;
+
+        for (const auto& ref : references) {
+            if (iso(ref)) {
+                matched = true;
+                break;
+            }
+        }
+
+        ASSERT_TRUE(matched);
+    }
 }


### PR DESCRIPTION
The measurement comparison operator with `float_epsilon` is causing a bug in `event_data`.  When the difference between the new measurement and one in the map is bigger than `float_epsilon`, the measurement is not added to the map.
(You can find the simple code that reproduces this behavior: https://godbolt.org/z/3hP9P5Eo9)

I fixed the issue by removing the `float_epsilon`. Also put `at` instead of `[]` wherever possible to make sure that there is the measurement in the map