### PR TITLE
macOS Fixes, main branch (2024.10.26.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  builds:
+  containers:
     name: ${{ matrix.platform.name }}-${{ matrix.build }}
     runs-on: ubuntu-latest
     container: ${{ matrix.platform.container }}
@@ -117,3 +117,19 @@ jobs:
         if: "matrix.platform.name == 'CUDA' && matrix.build == 'Debug'"
         continue-on-error: true
         run: ${GITHUB_WORKSPACE}/.github/find_f64_ptx.py --source ${GITHUB_WORKSPACE} --build build $(find build -name "*.ptx")
+
+  macos:
+    runs-on: macos-14
+    name: macOS-Release
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: brew install boost
+      - name: Configure
+        run: cmake --preset base -S ${GITHUB_WORKSPACE} -B build
+      - name: Build
+        run: cmake --build build
+      - name: Download data files
+        run: ${GITHUB_WORKSPACE}/data/traccc_data_get_files.sh
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -8,13 +8,13 @@
 include( traccc-compiler-options-cpp )
 
 # Set up a common library, shared by all of the tests.
-add_library( traccc_benchmarks_common STATIC
+add_library( traccc_benchmarks_common INTERFACE
     "common/benchmarks/toy_detector_benchmark.hpp" )
 target_include_directories( traccc_benchmarks_common
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common )
+    INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/common )
 target_link_libraries( traccc_benchmarks_common
-    PUBLIC benchmark::benchmark benchmark::benchmark_main 
-    traccc::core traccc::io traccc::simulation detray::core detray::test_utils 
+    INTERFACE benchmark::benchmark benchmark::benchmark_main
+    traccc::core traccc::io traccc::simulation detray::core detray::test_utils
     vecmem::core Boost::filesystem)
 
 add_subdirectory(cpu)

--- a/core/include/traccc/utils/seed_generator.hpp
+++ b/core/include/traccc/utils/seed_generator.hpp
@@ -41,7 +41,7 @@ struct seed_generator {
                    const std::array<scalar, e_bound_size>& stddevs,
                    const std::size_t sd = 0)
         : m_detector(det), m_stddevs(stddevs) {
-        generator.seed(sd);
+        m_generator.seed(static_cast<std::mt19937::result_type>(sd));
     }
 
     /// Seed generator operation
@@ -80,7 +80,7 @@ struct seed_generator {
         for (std::size_t i = 0; i < e_bound_size; i++) {
 
             bound_param[i] = std::normal_distribution<scalar>(
-                bound_param[i], m_stddevs[i])(generator);
+                bound_param[i], m_stddevs[i])(m_generator);
 
             matrix_operator().element(bound_param.covariance(), i, i) =
                 m_stddevs[i] * m_stddevs[i];
@@ -91,8 +91,8 @@ struct seed_generator {
 
     private:
     // Random generator
-    std::random_device rd{};
-    std::mt19937 generator{rd()};
+    std::random_device m_rd{};
+    std::mt19937 m_generator{m_rd()};
 
     // Detector object
     const detector_t& m_detector;

--- a/performance/include/traccc/resolution/fitting_performance_writer.hpp
+++ b/performance/include/traccc/resolution/fitting_performance_writer.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -75,7 +75,7 @@ class fitting_performance_writer {
 
         // Find the contributing particle
         // @todo: Use identify_contributing_particles function
-        std::map<particle, uint64_t> contributing_particles =
+        std::map<particle, std::size_t> contributing_particles =
             meas_to_ptc_map[meas];
 
         const particle ptc = contributing_particles.begin()->first;

--- a/performance/src/performance/details/is_same_angle.cpp
+++ b/performance/src/performance/details/is_same_angle.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,7 @@
 
 // System include(s).
 #include <cmath>
+#include <numbers>
 
 namespace {
 


### PR DESCRIPTION
Triggered by the report from @CrossR and Fabrice, these are things that I needed to fix to make the project (without any GPU support of course...) build on macOS 15.0.1 with Xcode 16.0.

The biggest one being that `traccc_benchmarks_common` was set up very incorrectly so far. Yet, the archival application (`ar`) on Linux did not complain about this for some reason. Apparently on Linux it's okay to create a static library with absolutely no content. But on macOS it clearly isn't. 🤔

The rest are some conversion issues and a missing include.