### PR TITLE
TBB Re-Configuration Fix, main branch (2024.10.30.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,20 @@ if( TRACCC_SETUP_EIGEN3 )
    endif()
 endif()
 
+# Set up TBB.
+option( TRACCC_SETUP_TBB
+   "Set up the TBB target(s) explicitly" TRUE )
+option( TRACCC_USE_SYSTEM_TBB
+   "Pick up an existing installation of TBB from the build environment"
+   ${TRACCC_USE_SYSTEM_LIBS} )
+if( TRACCC_SETUP_TBB )
+   if( TRACCC_USE_SYSTEM_TBB )
+      find_package( TBB REQUIRED )
+   else()
+      add_subdirectory( extern/tbb )
+   endif()
+endif()
+
 # Set up CCCL.
 option( TRACCC_SETUP_THRUST
    "Set up the Thrust target(s) explicitly" TRUE )
@@ -187,20 +201,6 @@ if( TRACCC_SETUP_ROCTHRUST )
    # Dress up the rocthrust target a little.
    target_compile_definitions( rocthrust INTERFACE
       THRUST_IGNORE_CUB_VERSION_CHECK )
-endif()
-
-# Set up TBB.
-option( TRACCC_SETUP_TBB
-   "Set up the TBB target(s) explicitly" TRUE )
-option( TRACCC_USE_SYSTEM_TBB
-   "Pick up an existing installation of TBB from the build environment"
-   ${TRACCC_USE_SYSTEM_LIBS} )
-if( TRACCC_SETUP_TBB )
-   if( TRACCC_USE_SYSTEM_TBB )
-      find_package( TBB REQUIRED )
-   else()
-      add_subdirectory( extern/tbb )
-   endif()
 endif()
 
 # Set up DPL if SYCL is built.

--- a/extern/tbb/CMakeLists.txt
+++ b/extern/tbb/CMakeLists.txt
@@ -1,11 +1,11 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # CMake include(s).
-cmake_minimum_required( VERSION 3.14 )
+cmake_minimum_required( VERSION 3.24 )
 include( FetchContent )
 
 # Silence FetchContent warnings with CMake >=3.24.
@@ -18,10 +18,10 @@ message( STATUS "Building TBB as part of the TRACCC project" )
 
 # Declare where to get TBB from.
 set( TRACCC_TBB_SOURCE
-   "URL;https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.7.0.tar.gz;URL_MD5;68e617448f71df02d8688c84d53778f6"
+   "URL;https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.13.0.tar.gz;URL_MD5;f287cd007240a838286ff13e7deaee12"
    CACHE STRING "Source for TBB, when built as part of this project" )
 mark_as_advanced( TRACCC_TBB_SOURCE )
-FetchContent_Declare( TBB ${TRACCC_TBB_SOURCE} )
+FetchContent_Declare( TBB ${TRACCC_TBB_SOURCE} OVERRIDE_FIND_PACKAGE )
 
 # Options used in the build of TBB.
 set( TBB_TEST FALSE CACHE BOOL "Turn off the TBB tests" )


### PR DESCRIPTION
As discussed with @stephenswat earlier today, @paulgessinger's update in #682 revealed a deeper issue with our build.

What happened was that [oneDPL](https://github.com/oneapi-src/oneDPL) would call `find_package(TBB)` to access TBB, when using the `"dpcpp"` backend. (The one we actually use.)

https://github.com/oneapi-src/oneDPL/blob/main/CMakeLists.txt#L163

This would:
  - Look for an external TBB, and also finding it as part of either oneAPI or the general setup that we would have for ROOT;
  - Set up the `TBB_DIR` cache variable, pointing at the external TBB version that was found.

This would work ~fine on the first CMake configuration. Even though at this point oneDPL would link against a different version of TBB than the one building together with the project. 😦 But on a re-configuration, we would now bump into:

https://github.com/oneapi-src/oneTBB/blob/v2021.7.0/CMakeLists.txt#L210

I.e. on this re-configuration we would completely abandon our own TBB version, and rather pick up the external version that was previously found by oneDPL.

To fix this, I had to do two things:
  - Upgrade to a newer version of TBB. One in which defining `TBB_DIR` by itself would not make it abandon setting up its own version of TBB. (In https://github.com/oneapi-src/oneTBB/blob/v2021.13.0/CMakeLists.txt#L236 the previous `OR` was changed to an `AND`.)
  - Make use of a new feature in [FetchContent_Declare](https://cmake.org/cmake/help/latest/module/FetchContent.html#command:fetchcontent_declare) that makes any subsequent calls to `find_package(TBB)` be practically a no-op. This way ensuring that oneDPL would actually use the TBB version that we are building ourselves.

Yepp, some non-trivial CMake-ing going on here... 😛

P.S. I moved the setup of TBB before (Roc)Thrust, because those can also conditionally use TBB themselves. Even if in our current build they don't.