### PR TITLE
exp: propagation-centric host ckf

### DIFF
--- a/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
+++ b/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
@@ -60,8 +60,7 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
 
     static constexpr std::array<float, 2> phi_range{
         -traccc::constant<float>::pi, traccc::constant<float>::pi};
-    static constexpr std::array<float, 2> theta_range{
-        0.f, traccc::constant<float>::pi};
+    static constexpr std::array<float, 2> eta_range{-4, 4};
     static constexpr std::array<float, 2> mom_range{
         10.f * traccc::unit<float>::GeV, 100.f * traccc::unit<float>::GeV};
 
@@ -83,6 +82,10 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
                      "the simulation data."
                   << std::endl;
 
+        // Apply correct propagation config
+        apply_propagation_config(finding_cfg);
+        apply_propagation_config(fitting_cfg);
+
         // Use deterministic random number generator for testing
         using uniform_gen_t = detray::detail::random_numbers<
             traccc::scalar, std::uniform_real_distribution<traccc::scalar>>;
@@ -101,7 +104,7 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
         generator_type::configuration gen_cfg{};
         gen_cfg.n_tracks(n_tracks);
         gen_cfg.phi_range(phi_range);
-        gen_cfg.theta_range(theta_range);
+        gen_cfg.eta_range(eta_range);
         gen_cfg.mom_range(mom_range);
         generator_type generator(gen_cfg);
 
@@ -127,6 +130,8 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
             detray::muon<traccc::scalar>(), n_events, det, field,
             std::move(generator), std::move(smearer_writer_cfg), full_path);
 
+        // Same propagation configuration for sim and reco
+        apply_propagation_config(sim.get_config());
         // Set constrained step size to 1 mm
         sim.get_config().propagation.stepping.step_constraint =
             1.f * detray::unit<float>::mm;
@@ -153,6 +158,20 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
         toy_cfg.module_mat_thickness(0.11f * detray::unit<traccc::scalar>::mm);
 
         return toy_cfg;
+    }
+
+    template <typename config_t>
+    void apply_propagation_config(config_t& cfg) const {
+
+        // Configure the propagation for the toy detector
+        cfg.propagation.navigation.search_window = {3, 3};
+        cfg.propagation.navigation.overstep_tolerance =
+            -300.f * detray::unit<float>::um;
+        cfg.propagation.navigation.min_mask_tolerance =
+            1e-5f * detray::unit<float>::mm;
+        cfg.propagation.navigation.max_mask_tolerance =
+            3.f * detray::unit<float>::mm;
+        cfg.propagation.navigation.mask_tolerance_scalor = 0.05f;
     }
 
     void SetUp(::benchmark::State& /*state*/) {

--- a/benchmarks/cpu/toy_detector_cpu.cpp
+++ b/benchmarks/cpu/toy_detector_cpu.cpp
@@ -30,6 +30,7 @@
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/propagator.hpp"
 #include "detray/propagator/rk_stepper.hpp"
+#include "detray/test/utils/inspectors.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -42,8 +43,7 @@ BENCHMARK_F(ToyDetectorBenchmark, CPU)(benchmark::State& state) {
     // Type declarations
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t,
-                           typename detector_type::algebra_type,
-                           detray::constrained_step<>>;
+                           typename detector_type::algebra_type>;
     using host_detector_type = traccc::default_detector::host;
     using host_navigator_type = detray::navigator<const host_detector_type>;
     using host_fitter_type =

--- a/benchmarks/cuda/toy_detector_cuda.cpp
+++ b/benchmarks/cuda/toy_detector_cuda.cpp
@@ -44,8 +44,7 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
     // Type declarations
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t,
-                           typename detector_type::algebra_type,
-                           detray::constrained_step<>>;
+                           typename detector_type::algebra_type>;
     using host_detector_type = traccc::default_detector::host;
     using device_detector_type = traccc::default_detector::device;
     using device_navigator_type = detray::navigator<const device_detector_type>;

--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -93,6 +93,20 @@ struct measurement_sort_comp {
     }
 };
 
+struct measurement_bcd_comp {
+    TRACCC_HOST_DEVICE
+    bool operator()(const detray::geometry::barcode bcd,
+                    const measurement& rhs) {
+        return bcd < rhs.surface_link;
+    }
+
+    TRACCC_HOST_DEVICE
+    bool operator()(const measurement& lhs,
+                    const detray::geometry::barcode bcd) {
+        return lhs.surface_link < bcd;
+    }
+};
+
 struct measurement_equal_comp {
     TRACCC_HOST_DEVICE
     bool operator()(const measurement& lhs, const measurement& rhs) {

--- a/core/include/traccc/edm/track_candidate.hpp
+++ b/core/include/traccc/edm/track_candidate.hpp
@@ -8,11 +8,9 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/edm/container.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/edm/track_parameters.hpp"
-
-// Detray include(s).
-#include "detray/geometry/barcode.hpp"
 
 namespace traccc {
 

--- a/core/include/traccc/finding/actors/ckf_aborter.hpp
+++ b/core/include/traccc/finding/actors/ckf_aborter.hpp
@@ -34,8 +34,8 @@ struct ckf_aborter : detray::actor {
     DETRAY_HOST_DEVICE void operator()(state &abrt_state,
                                        propagator_state_t &prop_state) const {
 
-        auto &navigation = prop_state._navigation;
-        auto &stepping = prop_state._stepping;
+        auto &navigation = prop_state.navigation();
+        auto &stepping = prop_state.stepping();
 
         abrt_state.count++;
 

--- a/core/include/traccc/finding/actors/interaction_register.hpp
+++ b/core/include/traccc/finding/actors/interaction_register.hpp
@@ -26,7 +26,7 @@ struct interaction_register : detray::actor {
     DETRAY_HOST_DEVICE void operator()(state &s,
                                        propagator_state_t &prop_state) const {
 
-        auto &navigation = prop_state._navigation;
+        auto &navigation = prop_state.navigation();
 
         // Do not apply material interaction on the sensitive surface - it is
         // applied outside the propagator

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -171,10 +171,11 @@ class kalman_fitter {
 
         // @TODO: Should be removed once detray is fixed to set the
         // volume in the constructor
-        propagation._navigation.set_volume(seed_params.surface_link().volume());
+        propagation.navigation().set_volume(
+            seed_params.surface_link().volume());
 
         // Set overstep tolerance, stepper constraint and mask tolerance
-        propagation._stepping
+        propagation.stepping()
             .template set_constraint<detray::step::constraint::e_accuracy>(
                 m_cfg.propagation.stepping.step_constraint);
 

--- a/core/include/traccc/fitting/kalman_filter/kalman_step_aborter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_step_aborter.hpp
@@ -46,7 +46,7 @@ struct kalman_step_aborter : public detray::actor {
                                        propagator_state_t& prop_state) const {
 
         // Convenience reference to the navigation state.
-        auto& navigation = prop_state._navigation;
+        auto& navigation = prop_state.navigation();
 
         // Reset the step count if the track is on a sensitive surface.
         if (navigation.is_on_sensitive()) {

--- a/core/include/traccc/utils/seed_generator.hpp
+++ b/core/include/traccc/utils/seed_generator.hpp
@@ -64,18 +64,21 @@ struct seed_generator {
 
         bound_track_parameters bound_param{surface_link, bound_vec, bound_cov};
 
-        // Type definitions
-        using interactor_type =
-            detray::pointwise_material_interactor<algebra_type>;
-
         assert(ptc_type.charge() * bound_param.qop() > 0.f);
 
         // Apply interactor
-        typename interactor_type::state interactor_state;
-        interactor_state.do_multiple_scattering = false;
-        interactor_type{}.update(
-            ctx, ptc_type, bound_param, interactor_state,
-            static_cast<int>(detray::navigation::direction::e_backward), sf);
+        if (sf.has_material()) {
+            // Type definitions
+            using interactor_type =
+                detray::pointwise_material_interactor<algebra_type>;
+
+            typename interactor_type::state interactor_state;
+            interactor_state.do_multiple_scattering = false;
+            interactor_type{}.update(
+                ctx, ptc_type, bound_param, interactor_state,
+                static_cast<int>(detray::navigation::direction::e_backward),
+                sf);
+        }
 
         for (std::size_t i = 0; i < e_bound_size; i++) {
 

--- a/core/src/finding/ckf_algorithm_defdet_cfield.cpp
+++ b/core/src/finding/ckf_algorithm_defdet_cfield.cpp
@@ -6,7 +6,7 @@
  */
 
 // Local include(s).
-#include "find_tracks.hpp"
+#include "find_tracks_alt.hpp"
 #include "traccc/finding/ckf_algorithm.hpp"
 
 // Detray include(s).

--- a/core/src/finding/ckf_algorithm_teldet_cfield.cpp
+++ b/core/src/finding/ckf_algorithm_teldet_cfield.cpp
@@ -6,7 +6,7 @@
  */
 
 // Local include(s).
-#include "find_tracks.hpp"
+#include "find_tracks_alt.hpp"
 #include "traccc/finding/ckf_algorithm.hpp"
 
 // Detray include(s).

--- a/core/src/finding/find_tracks.hpp
+++ b/core/src/finding/find_tracks.hpp
@@ -111,10 +111,9 @@ track_candidate_container_types::host find_tracks(
     const measurement_collection_types::const_device::size_type n_meas =
         measurements.size();
 
-    // Get the number of measurements of each module
-    std::vector<unsigned int> sizes(n_modules);
-    std::adjacent_difference(upper_bounds.begin(), upper_bounds.end(),
-                             sizes.begin());
+    // Get index ranges in the measurement container per detector surface
+    std::vector<unsigned int> meas_ranges;
+    meas_ranges.reserve(det.surfaces().size());
 
     // Create barcode sequence
     std::vector<detray::geometry::barcode> barcodes(n_modules);
@@ -184,7 +183,7 @@ track_candidate_container_types::host find_tracks(
              * Material interaction
              *************************/
 
-            // Get surface corresponding to bound params
+            // Get surface corresponding to bound track params
             const detray::tracking_surface sf{det, in_param.surface_link()};
 
             const typename navigator_t::detector_type::geometry_context ctx{};
@@ -226,6 +225,7 @@ track_candidate_container_types::host find_tracks(
             /*****************************************************************
              * Find tracks (CKF)
              *****************************************************************/
+            unsigned int n_branches = 0;
 
             // Iterate over the measurements
             for (unsigned int item_id = range.first; item_id < range.second;

--- a/core/src/finding/find_tracks.hpp
+++ b/core/src/finding/find_tracks.hpp
@@ -301,7 +301,7 @@ track_candidate_container_types::host find_tracks(
             propagation.set_particle(detail::correct_particle_hypothesis(
                 config.ptc_hypothesis, param));
 
-            propagation._stepping
+            propagation.stepping()
                 .template set_constraint<detray::step::constraint::e_accuracy>(
                     config.propagation.stepping.step_constraint);
 
@@ -315,7 +315,7 @@ track_candidate_container_types::host find_tracks(
 
             // @TODO: Should be removed once detray is fixed to set the
             // volume in the constructor
-            propagation._navigation.set_volume(param.surface_link().volume());
+            propagation.navigation().set_volume(param.surface_link().volume());
 
             // Propagate to the next surface
             propagator.propagate_sync(propagation,
@@ -324,7 +324,7 @@ track_candidate_container_types::host find_tracks(
             // If a surface found, add the parameter for the next
             // step
             if (s4.success) {
-                out_params.push_back(propagation._stepping.bound_params());
+                out_params.push_back(propagation.stepping().bound_params());
                 param_to_link[step].push_back(link_id);
             }
             // Unless the track found a surface, it is considered a

--- a/core/src/finding/find_tracks.hpp
+++ b/core/src/finding/find_tracks.hpp
@@ -111,9 +111,10 @@ track_candidate_container_types::host find_tracks(
     const measurement_collection_types::const_device::size_type n_meas =
         measurements.size();
 
-    // Get index ranges in the measurement container per detector surface
-    std::vector<unsigned int> meas_ranges;
-    meas_ranges.reserve(det.surfaces().size());
+    // Get the number of measurements of each module
+    std::vector<unsigned int> sizes(n_modules);
+    std::adjacent_difference(upper_bounds.begin(), upper_bounds.end(),
+                             sizes.begin());
 
     // Create barcode sequence
     std::vector<detray::geometry::barcode> barcodes(n_modules);
@@ -183,7 +184,7 @@ track_candidate_container_types::host find_tracks(
              * Material interaction
              *************************/
 
-            // Get surface corresponding to bound track params
+            // Get surface corresponding to bound params
             const detray::tracking_surface sf{det, in_param.surface_link()};
 
             const typename navigator_t::detector_type::geometry_context ctx{};
@@ -225,7 +226,6 @@ track_candidate_container_types::host find_tracks(
             /*****************************************************************
              * Find tracks (CKF)
              *****************************************************************/
-            unsigned int n_branches = 0;
 
             // Iterate over the measurements
             for (unsigned int item_id = range.first; item_id < range.second;

--- a/core/src/finding/find_tracks_alt.hpp
+++ b/core/src/finding/find_tracks_alt.hpp
@@ -1,0 +1,424 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/track_candidate.hpp"
+#include "traccc/edm/track_state.hpp"
+#include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/finding_config.hpp"
+#include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
+#include "traccc/sanity/contiguous_on.hpp"
+#include "traccc/utils/particle.hpp"
+#include "traccc/utils/projections.hpp"
+
+// Detray include(s).
+//#include <detray/definitions/detail/algorithms.hpp>
+#include <detray/propagator/actor_chain.hpp>
+#include <detray/propagator/actors/aborters.hpp>
+#include <detray/propagator/actors/parameter_resetter.hpp>
+#include <detray/propagator/actors/parameter_transporter.hpp>
+#include <detray/propagator/actors/pointwise_material_interactor.hpp>
+#include <detray/propagator/propagator.hpp>
+
+// System include
+#include <algorithm>
+
+namespace traccc::details {
+
+template <typename stepper_t, typename navigator_t>
+track_candidate_container_types::host find_tracks(
+    const typename navigator_t::detector_type& det,
+    const typename stepper_t::magnetic_field_type& field,
+    const measurement_collection_types::const_view& measurements_view,
+    const bound_track_parameters_collection_types::const_view& seeds_view,
+    const finding_config& config) {
+
+    /*****************************************************************
+     * Types used by the track finding
+     *****************************************************************/
+
+    /// Algebra types
+    using algebra_t = typename navigator_t::detector_type::algebra_type;
+
+    /// Actor types
+    using aborter = detray::pathlimit_aborter;
+    using transporter = detray::parameter_transporter<algebra_t>;
+    using interactor = detray::pointwise_material_interactor<algebra_t>;
+    using resetter = detray::parameter_resetter<algebra_t>;
+
+    using actor_type = detray::actor_chain<detray::tuple, aborter, transporter,
+                                           interactor, resetter>;
+
+    using propagator_type =
+        detray::propagator<stepper_t, navigator_t, actor_type>;
+
+    /// Helper structs
+    /// @{
+    /// Navigation state and current bound track params for a track candidate
+    struct navigation_stream {
+        typename navigator_t::state navigation;
+        bound_track_parameters track_params;
+    };
+
+    /// Trace the measurements and number of holes per track
+    struct trace_state {
+        // Track index that this candidate was branched off from
+        unsigned int parent_idx{std::numeric_limits<unsigned int>::max()};
+        // Index of measurement in original track where this cand. branched off
+        unsigned int branch_meas_idx{0u};
+        // Number of surfaces reached without compatible measurement
+        unsigned int n_skipped{0u};
+        // Number of total measurements assigned to a track candidate
+        unsigned int n_meas{0u};
+        // Indices of measurements after initial branching
+        vecmem::vector<unsigned int> meas_indices{};
+    };
+
+    /// Package measurements with the corresponding filtered track parameters
+    struct candidate {
+        bound_track_parameters filtered_params;
+        unsigned int meas_idx;
+        float chi2;
+
+        /// @param rhs is the right hand side candidate for comparison
+        constexpr bool operator<(const candidate& rhs) const {
+            return (chi2 < rhs.chi2);
+        }
+
+        /// @param rhs is the left hand side candidate for comparison
+        constexpr bool operator>(const candidate& rhs) const {
+            return (chi2 > rhs.chi2);
+        }
+    };
+    /// @}
+
+    /*****************************************************************
+     * Measurement Operations
+     *****************************************************************/
+
+    // Create the measurement container.
+    measurement_collection_types::const_device measurements{measurements_view};
+
+    // Check contiguity of the measurements
+    assert(
+        host::is_contiguous_on(measurement_module_projection(), measurements));
+
+    // Get index ranges in the measurement container per detector surface
+    std::vector<unsigned int> meas_ranges;
+    meas_ranges.reserve(det.surfaces().size());
+
+    for (const auto& sf_desc : det.surfaces()) {
+        // Measurements can only be found on sensitive surfaces
+        if (!sf_desc.is_sensitive()) {
+            // Lower range index is the upper index of the previous range
+            // This is guaranteed by the measurement sorting step
+            const auto sf_idx{sf_desc.index()};
+            const unsigned int lo{sf_idx == 0u ? 0u : meas_ranges[sf_idx - 1u]};
+
+            // Hand the upper index of the previous range through to assign
+            // the lower index of the next valid range correctly
+            meas_ranges.push_back(lo);
+            continue;
+        }
+
+        auto up = std::upper_bound(measurements.begin(), measurements.end(),
+                                      sf_desc.barcode(), measurement_bcd_comp());
+        meas_ranges.push_back(
+            static_cast<unsigned int>(std::distance(measurements.begin(), up)));
+    }
+
+    /*****************************************************************
+     * CKF Preparations
+     *****************************************************************/
+
+    // Create the input seeds container.
+    bound_track_parameters_collection_types::const_device seeds{seeds_view};
+
+    const std::size_t n_seeds{seeds.size()};
+    const unsigned int n_max_nav_streams{
+        math::min(config.max_num_branches_per_seed, 20000u)};
+    const unsigned int n_max_branches_per_surface{
+        math::min(config.max_num_branches_per_surface, 10u)};
+
+    // Measurement trace per track
+    std::vector<trace_state> traces;
+    traces.resize(n_seeds * n_max_nav_streams);
+
+    // Compatible measurements and filtered track params on a given surface
+    std::vector<candidate> candidates{};
+    candidates.reserve(n_max_branches_per_surface);
+
+    // Create detray propagator
+    propagator_type propagator(config.propagation);
+
+    // Navigation streams: One inner vector per seed, which contains
+    // the branched navigation streams for the respective seed
+    std::vector<std::vector<navigation_stream>> nav_streams_per_seed;
+    nav_streams_per_seed.reserve(n_seeds);
+
+    // Create initial navigation stream for each seed
+    for (const auto& seed : seeds) {
+        auto& nav_streams = nav_streams_per_seed.emplace_back();
+        nav_streams.reserve(n_max_nav_streams);
+
+        auto& nav_stream =
+            nav_streams.emplace_back(typename navigator_t::state(det), seed);
+        nav_stream.navigation.set_volume(seed.surface_link().volume());
+
+        // Construct propagation state around the navigation stream
+        typename propagator_type::non_owning_state propagation(
+            nav_stream.track_params, field, nav_stream.navigation);
+        propagation.set_particle(detail::correct_particle_hypothesis(
+            config.ptc_hypothesis, nav_stream.track_params));
+
+        // Create actor states
+        typename aborter::state s0{config.propagation.stepping.path_limit};
+        typename transporter::state s1;
+        typename interactor::state s2;
+        typename resetter::state s3;
+
+        auto actor_states = detray::tie(s0, s1, s2, s3);
+
+        propagator.init(propagation, actor_states);
+
+        // Make sure the CKF can start on a sensitive surface
+        if (propagation._heartbeat &&
+            !nav_stream.navigation.is_on_sensitive()) {
+            propagator.propagate_to_next(propagation, actor_states);
+        }
+        // Either exited detector by portal right away or are on first
+        // sensitive surface
+        assert(nav_stream.navigation.is_complete() ||
+               nav_stream.navigation.is_on_sensitive());
+    }
+
+    // Step through the sensitive surfaces along the tracks
+    const auto n_steps{static_cast<int>(config.max_track_candidates_per_track)};
+    for (int step = 0; step < n_steps; step++) {
+std::cout << "Step " << step << std::endl;
+        // Step through all track candidates (branches) for a given seed
+        for (unsigned int seed_idx = 0u; seed_idx < n_seeds; seed_idx++) {
+std::cout << "Seed " << seed_idx << std::endl;
+
+            auto& nav_streams = nav_streams_per_seed[seed_idx];
+            const auto n_traces{static_cast<unsigned int>(nav_streams.size())};
+            assert(n_traces >= 1u);
+            for (unsigned int br_idx = 0u; br_idx < n_traces; ++br_idx) {
+                // The navigation stream for this trace
+                auto& nav_stream = nav_streams[br_idx];
+                const auto& navigation = nav_stream.navigation;
+
+                // Propagation is no longer alive (trace finished or hit error)
+                if (!navigation.is_alive()) {
+                    continue;
+                }
+                assert(navigation.is_on_sensitive());
+
+                // Get current detector surface (sensitive)
+                const auto sf = navigation.get_surface();
+
+                /***************************************************************
+                 * Find compatible measurements
+                 **************************************************************/
+
+                // Iterate over the measurements for this surface
+                const auto sf_idx{sf.index()};
+                const unsigned int lo{sf_idx == 0u ? 0u
+                                                   : meas_ranges[sf_idx - 1]};
+                const unsigned int up{meas_ranges[sf_idx]};
+
+                for (unsigned int meas_id = lo; meas_id < up; meas_id++) {
+
+                    track_state<algebra_t> trk_state(measurements[meas_id]);
+
+                    // Run the Kalman update on a copy of the track parameters
+                    const bool res = sf.template visit_mask<
+                        gain_matrix_updater<algebra_t>>(
+                        trk_state, nav_stream.track_params);
+                    std::cout << "Measurement chi2: " << trk_state.filtered_chi2() << std::endl;
+                    // Found a good measurement?
+                    if (const auto chi2 = trk_state.filtered_chi2();
+                        res && chi2 < config.chi2_max) {
+                        candidates.emplace_back(trk_state.filtered(), meas_id,
+                                                chi2);
+                    }
+                }
+
+                /***************************************************************
+                 * Update current navigation stream and branch
+                 **************************************************************/
+
+                const unsigned int trc_idx{seed_idx * n_max_nav_streams +
+                                             br_idx};
+                auto& parent = traces[trc_idx];
+
+                // Count hole in case no measurements were found
+                if (candidates.empty()) {
+                    parent.n_skipped++;
+
+                    // If number of skips is larger than the maximal value,
+                    // consider the track to be finished
+                    if (parent.n_skipped >
+                        config.max_num_skipping_per_cand) {
+                        nav_stream.navigation.abort();
+                        assert(!navigation.is_alive());
+                    }
+                } else {
+                    // Consider only the best candidates
+                    std::sort(candidates.begin(), candidates.end());
+
+                    // Update the track parameters in the current navigation
+                    nav_stream.track_params = candidates[0u].filtered_params;
+                    parent.meas_indices.push_back(candidates[0u].meas_idx);
+                    parent.n_meas++;
+                    nav_stream.navigation.set_high_trust();
+
+                    // Number of potential new branches
+                    unsigned int n_branches{math::min(
+                        static_cast<unsigned int>(candidates.size()) - 1u,
+                        n_max_branches_per_surface)};
+
+                    // Number of allowed new branches for this seed
+                    auto allowed_branches{static_cast<int>(n_max_nav_streams) -
+                                          static_cast<int>(nav_streams.size())};
+                    allowed_branches =
+                        math::signbit(allowed_branches) ? 0 : allowed_branches;
+
+                    // Create new branches
+                    n_branches =
+                        math::min(n_branches,
+                                  static_cast<unsigned int>(allowed_branches));
+                    for (unsigned int i = 0u; i < n_branches; ++i) {
+                        // Clone current navigation stream for new branch with
+                        // updated track parameters
+                        nav_streams.emplace_back(
+                            nav_stream.navigation,
+                            candidates[i + 1u].filtered_params);
+
+                        // Get the measurement trace for the new branch
+                        const std::size_t branch_idx{nav_streams.size() - 1u};
+                        auto& branch = traces[seed_idx * n_max_nav_streams + branch_idx];
+
+                        // Copy metadata from original track candidate to branch
+                        branch.parent_idx = br_idx;
+                        branch.branch_meas_idx = static_cast<unsigned int>(parent.meas_indices.size()) - 1u;
+                        branch.n_meas = parent.n_meas;
+                        branch.n_skipped = parent.n_skipped;
+
+                        // Add new measurement
+                        branch.meas_indices.reserve(config.max_track_candidates_per_track - branch.n_meas);
+                        branch.meas_indices.push_back(candidates[i + 1u].meas_idx);
+                    }
+                }
+                candidates.clear();
+            }
+
+            /*******************************************************
+             * Propagate all tracks of this seed to the next surface
+             *******************************************************/
+            for (auto& nav_stream : nav_streams) {
+                // Propagation is no longer alive (track finished or hit error)
+                if (!nav_stream.navigation.is_alive()) {
+                    continue;
+                }
+                assert(nav_stream.navigation.is_on_sensitive());
+
+                typename propagator_type::non_owning_state propagation(
+                    nav_stream.track_params, field, nav_stream.navigation);
+                propagation.set_particle(detail::correct_particle_hypothesis(
+                    config.ptc_hypothesis, nav_stream.track_params));
+                propagation._heartbeat = true;
+
+                // Update distance to next surface after KF
+                propagation._heartbeat &= navigator_t{}.update(
+                    propagation, config.propagation.navigation);
+                propagation._stepping._prev_step_size = nav_stream.navigation();
+                propagation._stepping._step_size = nav_stream.navigation();
+
+                assert(propagation._heartbeat);
+                assert(nav_stream.navigation.is_alive());
+
+                // Create actor states
+                // TODO: This does not work, the actor states need to be kept
+                // alive as well
+                typename aborter::state s0{
+                    config.propagation.stepping.path_limit};
+                typename transporter::state s1;
+                typename interactor::state s2;
+                typename resetter::state s3;
+
+                // Propagate to the next surface
+                propagator.propagate_to_next(propagation,
+                                             detray::tie(s0, s1, s2, s3));
+
+                assert(nav_stream.navigation.is_complete() ||
+                       nav_stream.navigation.is_on_sensitive());
+
+                // TODO: Find a way to not copy the track params all the time
+                nav_stream.track_params = propagation._stepping._bound_params;
+            }
+        }
+    }
+
+    /**********************
+     * Build tracks
+     **********************/
+
+    // @TODO: Remove once multi-trajectory container is available
+    track_candidate_container_types::host output_candidates;
+    output_candidates.reserve(2u * n_seeds);
+
+    // Map the position of a branch in the output container to its index in the
+    // trace vector
+    std::map<unsigned int, std::size_t> branch_to_track_map{};
+
+    // Step through all track candidates for a given seed
+    for (unsigned int seed_idx = 0u; seed_idx < n_seeds; seed_idx++) {
+        for (unsigned int br_idx = 0u;
+            br_idx < nav_streams_per_seed[seed_idx].size(); ++br_idx) {
+
+            const unsigned int trc_idx{seed_idx * n_max_nav_streams + br_idx};
+            const auto& trace = traces[trc_idx];
+
+            std::cout << "Testing: " << trc_idx << std::endl;
+
+            // Not enough measurements found to make a track candidate
+            if (trace.n_meas < config.min_track_candidates_per_track) {
+                std::cout << "Problem:" << trace.n_skipped << std::endl;
+                continue;
+            }
+
+            vecmem::vector<measurement> trk_measurements{};
+            trk_measurements.reserve(trace.n_meas);
+
+            // Get the relevant measurement collection from the parent
+            // Later branches appear at the back of the collection, so the 
+            // parent is already fully assembled in the output container
+            if (trace.parent_idx < traces.size()) {
+                const auto parent_trk_idx{branch_to_track_map.at(trace.parent_idx)};
+                const auto& [_, parent_trk] = output_candidates.at(parent_trk_idx);
+
+                std::ranges::copy_n(std::ranges::begin(parent_trk), trace.branch_meas_idx, std::ranges::begin(trk_measurements));
+            }
+
+            // Add the measurements collected on this branch
+            for (unsigned int meas_idx : trace.meas_indices) {
+                trk_measurements.push_back(measurements[meas_idx]);
+            }
+
+            // All measurements have been transcribed, move to final container
+            branch_to_track_map[br_idx] = output_candidates.size();
+            output_candidates.push_back(
+                bound_track_parameters{seeds[seed_idx]}, std::move(trk_measurements));
+        }
+    }
+
+    return output_candidates;
+}
+
+}  // namespace traccc

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -87,7 +87,7 @@ TRACCC_DEVICE inline void propagate_to_next_surface(
     typename propagator_t::state propagation(in_par, payload.field_data, det);
     propagation.set_particle(
         detail::correct_particle_hypothesis(cfg.ptc_hypothesis, in_par));
-    propagation._stepping
+    propagation.stepping()
         .template set_constraint<detray::step::constraint::e_accuracy>(
             cfg.propagation.stepping.step_constraint);
 
@@ -110,14 +110,14 @@ TRACCC_DEVICE inline void propagate_to_next_surface(
 
     // @TODO: Should be removed once detray is fixed to set the volume in the
     // constructor
-    propagation._navigation.set_volume(in_par.surface_link().volume());
+    propagation.navigation().set_volume(in_par.surface_link().volume());
 
     // Propagate to the next surface
     propagator.propagate_sync(propagation, detray::tie(s0, s1, s2, s3, s4));
 
     // If a surface found, add the parameter for the next step
     if (s4.success) {
-        params[param_id] = propagation._stepping.bound_params();
+        params[param_id] = propagation.stepping().bound_params();
 
         if (payload.step == cfg.max_track_candidates_per_track - 1) {
             tips.push_back({payload.step, param_id});

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -26,8 +26,6 @@
 #include "traccc/utils/projections.hpp"
 
 // detray include(s).
-#include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/rk_stepper.hpp"
@@ -409,12 +407,20 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 }
 
 // Explicit template instantiation
-using default_detector_type =
-    detray::detector<detray::default_metadata, detray::device_container_types>;
-using default_stepper_type =
+using debug_stepper_type =
     detray::rk_stepper<covfie::field<detray::bfield::const_bknd_t>::view_t,
                        traccc::default_algebra, detray::constrained_step<>>;
-using default_navigator_type = detray::navigator<const default_detector_type>;
+using default_stepper_type =
+    detray::rk_stepper<covfie::field<detray::bfield::const_bknd_t>::view_t,
+                       traccc::default_algebra>;
+
+using default_navigator_type =
+    detray::navigator<const traccc::default_detector::device>;
+using toy_navigator_type =
+    detray::navigator<const traccc::toy_detector::device>;
+
+template class finding_algorithm<debug_stepper_type, default_navigator_type>;
 template class finding_algorithm<default_stepper_type, default_navigator_type>;
+template class finding_algorithm<default_stepper_type, toy_navigator_type>;
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/fitting/fitting_algorithm.cu
+++ b/device/cuda/src/fitting/fitting_algorithm.cu
@@ -12,9 +12,9 @@
 #include "traccc/fitting/device/fill_sort_keys.hpp"
 #include "traccc/fitting/device/fit.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+#include "traccc/geometry/detector.hpp"
 
 // detray include(s).
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/propagator/rk_stepper.hpp"
 
@@ -126,14 +126,26 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
 }
 
 // Explicit template instantiation
-using default_detector_type =
-    detray::detector<detray::default_metadata, detray::device_container_types>;
-using default_stepper_type =
+using debug_stepper_type =
     detray::rk_stepper<covfie::field<detray::bfield::const_bknd_t>::view_t,
                        default_algebra, detray::constrained_step<>>;
-using default_navigator_type = detray::navigator<const default_detector_type>;
+using default_stepper_type =
+    detray::rk_stepper<covfie::field<detray::bfield::const_bknd_t>::view_t,
+                       traccc::default_algebra>;
+using default_navigator_type =
+    detray::navigator<const traccc::default_detector::device>;
+using toy_navigator_type =
+    detray::navigator<const traccc::toy_detector::device>;
+
+using debug_fitter_type =
+    kalman_fitter<debug_stepper_type, default_navigator_type>;
 using default_fitter_type =
     kalman_fitter<default_stepper_type, default_navigator_type>;
+using toy_det_fitter_type =
+    kalman_fitter<default_stepper_type, toy_navigator_type>;
+
+template class fitting_algorithm<debug_fitter_type>;
 template class fitting_algorithm<default_fitter_type>;
+template class fitting_algorithm<toy_det_fitter_type>;
 
 }  // namespace traccc::cuda

--- a/simulation/include/traccc/simulation/simulator.hpp
+++ b/simulation/include/traccc/simulation/simulator.hpp
@@ -105,9 +105,10 @@ struct simulator {
                 propagator_type p(m_cfg.propagation);
 
                 // Set overstep tolerance and stepper constraint
-                propagation._stepping.template set_constraint<
-                    detray::step::constraint::e_accuracy>(
-                    m_cfg.propagation.stepping.step_constraint);
+                propagation.stepping()
+                    .template set_constraint<
+                        detray::step::constraint::e_accuracy>(
+                        m_cfg.propagation.stepping.step_constraint);
 
                 p.propagate(propagation, actor_states);
 

--- a/simulation/include/traccc/simulation/smearing_writer.hpp
+++ b/simulation/include/traccc/simulation/smearing_writer.hpp
@@ -109,8 +109,8 @@ struct smearing_writer : detray::actor {
     void operator()(state& writer_state,
                     propagator_state_t& propagation) const {
 
-        auto& navigation = propagation._navigation;
-        auto& stepping = propagation._stepping;
+        auto& navigation = propagation.navigation();
+        auto& stepping = propagation.stepping();
 
         // triggered only for sensitive surfaces
         if (navigation.is_on_sensitive()) {

--- a/tests/common/tests/kalman_fitting_test.hpp
+++ b/tests/common/tests/kalman_fitting_test.hpp
@@ -64,9 +64,7 @@ class KalmanFittingTests
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t, traccc::default_algebra,
                            detray::constrained_step<>>;
-    using host_navigator_type =
-        detray::navigator<const host_detector_type,
-                          detray::navigation::default_cache_size>;
+    using host_navigator_type = detray::navigator<const host_detector_type>;
     using host_fitter_type =
         kalman_fitter<rk_stepper_type, host_navigator_type>;
     using device_navigator_type = detray::navigator<const device_detector_type>;

--- a/tests/common/tests/kalman_fitting_test.hpp
+++ b/tests/common/tests/kalman_fitting_test.hpp
@@ -19,6 +19,7 @@
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/propagator.hpp"
 #include "detray/propagator/rk_stepper.hpp"
+#include "detray/test/utils/inspectors.hpp"
 #include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 
 // GTest include(s).
@@ -63,7 +64,9 @@ class KalmanFittingTests
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t, traccc::default_algebra,
                            detray::constrained_step<>>;
-    using host_navigator_type = detray::navigator<const host_detector_type>;
+    using host_navigator_type =
+        detray::navigator<const host_detector_type,
+                          detray::navigation::default_cache_size>;
     using host_fitter_type =
         kalman_fitter<rk_stepper_type, host_navigator_type>;
     using device_navigator_type = detray::navigator<const device_detector_type>;
@@ -75,7 +78,7 @@ class KalmanFittingTests
         detray::detail::random_numbers<scalar,
                                        std::uniform_real_distribution<scalar>>;
 
-    /// Verify that pull distribtions follow the normal distribution
+    /// Verify that pull distributions follow the normal distribution
     ///
     /// @param file_name The name of the file holding the distributions
     /// @param hist_names The names of the histograms to process

--- a/tests/cpu/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cpu/test_ckf_combinatorics_telescope.cpp
@@ -174,6 +174,12 @@ TEST_P(CpuCkfCombinatoricsTelescopeTests, Run) {
                   std::pow(n_truth_tracks, plane_positions.size() + 1));
         ASSERT_EQ(track_candidates_limit.size(),
                   n_truth_tracks * cfg_limit.max_num_branches_per_seed);
+        for (std::size_t i = 0u; i < track_candidates.size(); ++i) {
+            const auto& [seed, track] = track_candidates[i];
+            ASSERT_EQ(track.size(), plane_positions.size());
+            const auto& [lim_seed, lim_track] = track_candidates[i];
+            ASSERT_EQ(track.size(), plane_positions.size());
+        }
     }
 }
 

--- a/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
@@ -141,8 +141,6 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     // Iterate over events
     for (std::size_t i_evt = 0; i_evt < n_events; i_evt++) {
 
-        // std::cout << i_evt << std::endl;
-
         // Truth Track Candidates
         traccc::event_data evt_data(path, i_evt, host_mr);
         traccc::track_candidate_container_types::host truth_track_candidates =

--- a/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
@@ -141,6 +141,8 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     // Iterate over events
     for (std::size_t i_evt = 0; i_evt < n_events; i_evt++) {
 
+        // std::cout << i_evt << std::endl;
+
         // Truth Track Candidates
         traccc::event_data evt_data(path, i_evt, host_mr);
         traccc::track_candidate_container_types::host truth_track_candidates =
@@ -165,12 +167,12 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
             host_det, field, vecmem::get_data(measurements_per_event),
             vecmem::get_data(seeds));
 
-        ASSERT_EQ(track_candidates.size(), n_truth_tracks);
+        EXPECT_EQ(track_candidates.size(), n_truth_tracks);
 
         // Run fitting
         auto track_states = host_fitting(host_det, field, track_candidates);
 
-        ASSERT_EQ(track_states.size(), n_truth_tracks);
+        EXPECT_EQ(track_states.size(), n_truth_tracks);
 
         for (unsigned int i_trk = 0; i_trk < n_truth_tracks; i_trk++) {
 


### PR DESCRIPTION
This is just a test to see what would need to be modified, in order to keep the navigation state alive and use candaidate caching in the navigator. So far, it only holds the 256 byte navigation state in addition to the bound track parameters and not the entire propagation state. This means, however, that the track parameters need to be copied in and out of the propagation state at every step  and for every branch. This ckf implementation needs some additional changes in detray before it will compile.

Additionally, it sorts the valid measurements at every step, so that the best matching measurements get assign to the original branch and any new branches, in case the number of branches is limited to e.g. one or two.

The memory handling and the way the measurements are traces is not particularly smart, as that was not the focus of this example PR