### PR TITLE
ref: Make the interaction register an observing actor

### DIFF
--- a/core/include/traccc/finding/actors/interaction_register.hpp
+++ b/core/include/traccc/finding/actors/interaction_register.hpp
@@ -16,29 +16,25 @@
 
 namespace traccc {
 
-template <typename interactor_t>
 struct interaction_register : detray::actor {
-    struct state {
-        typename interactor_t::state &interactor_state;
-    };
 
-    template <typename propagator_state_t>
-    DETRAY_HOST_DEVICE void operator()(state &s,
-                                       propagator_state_t &prop_state) const {
+    template <typename interactor_state_t, typename propagator_state_t>
+    DETRAY_HOST_DEVICE void operator()(
+        interactor_state_t &s, const propagator_state_t &prop_state) const {
 
-        auto &navigation = prop_state._navigation;
+        const auto &navigation = prop_state._navigation;
 
         // Do not apply material interaction on the sensitive surface - it is
         // applied outside the propagator
         if (navigation.is_on_sensitive()) {
-            s.interactor_state.do_energy_loss = false;
-            s.interactor_state.do_multiple_scattering = false;
-            s.interactor_state.do_covariance_transport = false;
+            s.do_energy_loss = false;
+            s.do_multiple_scattering = false;
+            s.do_covariance_transport = false;
         } else if (!navigation.is_on_sensitive() &&
                    navigation.encountered_sf_material()) {
-            s.interactor_state.do_energy_loss = true;
-            s.interactor_state.do_multiple_scattering = true;
-            s.interactor_state.do_covariance_transport = true;
+            s.do_energy_loss = true;
+            s.do_multiple_scattering = true;
+            s.do_covariance_transport = true;
         }
     }
 };

--- a/core/src/finding/find_tracks.hpp
+++ b/core/src/finding/find_tracks.hpp
@@ -68,10 +68,15 @@ track_candidate_container_types::host find_tracks(
 
     using transporter_type = detray::parameter_transporter<algebra_type>;
     using interactor_type = detray::pointwise_material_interactor<algebra_type>;
+    // The interaction register 'observes' the pointwise interactor
+    using material_interactor_t =
+        detray::composite_actor<detray::tuple, interactor_type,
+                                interaction_register>;
 
-    using actor_type = detray::actor_chain<
-        detray::tuple, detray::pathlimit_aborter, transporter_type,
-        interaction_register<interactor_type>, interactor_type, ckf_aborter>;
+    using actor_type =
+        detray::actor_chain<detray::tuple, detray::pathlimit_aborter,
+                            transporter_type, material_interactor_t,
+                            ckf_aborter>;
 
     using propagator_type =
         detray::propagator<stepper_t, navigator_t, actor_type>;
@@ -307,36 +312,34 @@ track_candidate_container_types::host find_tracks(
 
             detray::pathlimit_aborter::state s0;
             typename detray::parameter_transporter<algebra_type>::state s1;
-            typename interactor_type::state s3;
-            typename interaction_register<interactor_type>::state s2{s3};
-            typename ckf_aborter::state s4;
-            s4.min_step_length = config.min_step_length_for_next_surface;
-            s4.max_count = config.max_step_counts_for_next_surface;
+            typename interactor_type::state s2;
+            typename ckf_aborter::state s3;
+            s3.min_step_length = config.min_step_length_for_next_surface;
+            s3.max_count = config.max_step_counts_for_next_surface;
 
             // @TODO: Should be removed once detray is fixed to set the
             // volume in the constructor
             propagation._navigation.set_volume(param.surface_link().volume());
 
             // Propagate to the next surface
-            propagator.propagate_sync(propagation,
-                                      detray::tie(s0, s1, s2, s3, s4));
+            propagator.propagate_sync(propagation, detray::tie(s0, s1, s2, s3));
 
             // If a surface found, add the parameter for the next
             // step
-            if (s4.success) {
+            if (s3.success) {
                 out_params.push_back(propagation._stepping.bound_params());
                 param_to_link[step].push_back(link_id);
             }
             // Unless the track found a surface, it is considered a
             // tip
-            else if (!s4.success &&
+            else if (!s3.success &&
                      (step >= (config.min_track_candidates_per_track - 1u))) {
                 tips.push_back({step, link_id});
             }
 
             // If no more CKF step is expected, current candidate is
             // kept as a tip
-            if (s4.success &&
+            if (s3.success &&
                 (step == (config.max_track_candidates_per_track - 1u))) {
                 tips.push_back({step, link_id});
             }

--- a/core/src/finding/find_tracks.hpp
+++ b/core/src/finding/find_tracks.hpp
@@ -310,36 +310,45 @@ track_candidate_container_types::host find_tracks(
                 .template set_constraint<detray::step::constraint::e_accuracy>(
                     config.propagation.stepping.step_constraint);
 
-            detray::pathlimit_aborter::state s0;
-            typename detray::parameter_transporter<algebra_type>::state s1;
-            typename interactor_type::state s2;
-            typename ckf_aborter::state s3;
-            s3.min_step_length = config.min_step_length_for_next_surface;
-            s3.max_count = config.max_step_counts_for_next_surface;
+            // Generate actor states and references to the states
+            auto [actors_states, actor_chain_state] =
+                actor_type::make_actor_states();
+
+            auto& path_abrt_state =
+                detray::detail::get<detray::pathlimit_aborter::state>(
+                    actors_states);
+            path_abrt_state.set_path_limit(
+                config.propagation.stepping.path_limit);
+
+            auto& ckf_abrt_state =
+                detray::detail::get<ckf_aborter::state>(actors_states);
+            ckf_abrt_state.min_step_length =
+                config.min_step_length_for_next_surface;
+            ckf_abrt_state.max_count = config.max_step_counts_for_next_surface;
 
             // @TODO: Should be removed once detray is fixed to set the
             // volume in the constructor
             propagation._navigation.set_volume(param.surface_link().volume());
 
             // Propagate to the next surface
-            propagator.propagate_sync(propagation, detray::tie(s0, s1, s2, s3));
+            propagator.propagate_sync(propagation, actor_chain_state);
 
             // If a surface found, add the parameter for the next
             // step
-            if (s3.success) {
+            if (ckf_abrt_state.success) {
                 out_params.push_back(propagation._stepping.bound_params());
                 param_to_link[step].push_back(link_id);
             }
             // Unless the track found a surface, it is considered a
             // tip
-            else if (!s3.success &&
+            else if (!ckf_abrt_state.success &&
                      (step >= (config.min_track_candidates_per_track - 1u))) {
                 tips.push_back({step, link_id});
             }
 
             // If no more CKF step is expected, current candidate is
             // kept as a tip
-            if (s3.success &&
+            if (ckf_abrt_state.success &&
                 (step == (config.max_track_candidates_per_track - 1u))) {
                 tips.push_back({step, link_id});
             }

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -100,23 +100,21 @@ TRACCC_DEVICE inline void propagate_to_next_surface(
         s0{};
     typename detray::detail::tuple_element<1, actor_list_type>::type::state
         s1{};
-    typename detray::detail::tuple_element<3, actor_list_type>::type::state
-        s3{};
-    typename detray::detail::tuple_element<2, actor_list_type>::type::state s2{
-        s3};
-    typename detray::detail::tuple_element<4, actor_list_type>::type::state s4;
-    s4.min_step_length = cfg.min_step_length_for_next_surface;
-    s4.max_count = cfg.max_step_counts_for_next_surface;
+    typename detray::detail::tuple_element<2, actor_list_type>::type::state
+        s2{};
+    typename detray::detail::tuple_element<3, actor_list_type>::type::state s3;
+    s3.min_step_length = cfg.min_step_length_for_next_surface;
+    s3.max_count = cfg.max_step_counts_for_next_surface;
 
     // @TODO: Should be removed once detray is fixed to set the volume in the
     // constructor
     propagation._navigation.set_volume(in_par.surface_link().volume());
 
     // Propagate to the next surface
-    propagator.propagate_sync(propagation, detray::tie(s0, s1, s2, s3, s4));
+    propagator.propagate_sync(propagation, detray::tie(s0, s1, s2, s3));
 
     // If a surface found, add the parameter for the next step
-    if (s4.success) {
+    if (s3.success) {
         params[param_id] = propagation._stepping.bound_params();
 
         if (payload.step == cfg.max_track_candidates_per_track - 1) {

--- a/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
@@ -58,13 +58,16 @@ class finding_algorithm
 
     /// Actor types
     using interactor = detray::pointwise_material_interactor<algebra_type>;
+    // The interaction register 'observes' the pointwise interactor
+    using material_interactor_t =
+        detray::composite_actor<detray::tuple, interactor,
+                                interaction_register>;
 
     /// Actor chain for propagate to the next surface and its propagator type
     using actor_type =
         detray::actor_chain<detray::dtuple, detray::pathlimit_aborter,
                             detray::parameter_transporter<algebra_type>,
-                            interaction_register<interactor>, interactor,
-                            ckf_aborter>;
+                            material_interactor_t, ckf_aborter>;
 
     using propagator_type =
         detray::propagator<stepper_t, navigator_t, actor_type>;


### PR DESCRIPTION
Make the interaction_register actor an observing actor to the pointwise_material_interactor in order to break the dependency on the interactor state during state construction. Also uses a utility function from the detray actor chain to contruct the sate tuple and the state reference tuple if all states are default constructible.