### PR TITLE
ref: Do not copy the bound track parameters for the gain matrix updater

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -78,7 +78,7 @@ struct kalman_actor : detray::actor {
     TRACCC_HOST_DEVICE void operator()(state& actor_state,
                                        propagator_state_t& propagation) const {
 
-        const auto& stepping = propagation._stepping;
+        auto& stepping = propagation._stepping;
         auto& navigation = propagation._navigation;
 
         // If the iterator reaches the end, terminate the propagation
@@ -113,6 +113,9 @@ struct kalman_actor : detray::actor {
                 propagation._heartbeat &= navigation.abort();
                 return;
             }
+
+            // Update the propagation flow
+            stepping.bound_params() = trk_state.filtered();
 
             // Set full jacobian
             trk_state.jacobian() = stepping.full_jacobian();

--- a/core/src/finding/find_tracks.hpp
+++ b/core/src/finding/find_tracks.hpp
@@ -239,10 +239,9 @@ track_candidate_container_types::host find_tracks(
                 track_state<algebra_type> trk_state(meas);
 
                 // Run the Kalman update on a copy of the track parameters
-                bound_track_parameters bound_param(in_param);
                 const bool res =
                     sf.template visit_mask<gain_matrix_updater<algebra_type>>(
-                        trk_state, bound_param);
+                        trk_state, in_param);
 
                 // The chi2 from Kalman update should be less than chi2_max
                 if (res && trk_state.filtered_chi2() < config.chi2_max) {

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -182,7 +182,7 @@ TRACCC_DEVICE inline void find_tracks(
                 owner_local_thread_id +
                 thread_id.getBlockDimX() * thread_id.getBlockIdX();
             assert(in_params_liveness.at(owner_global_thread_id) != 0u);
-            bound_track_parameters in_par =
+            const bound_track_parameters& in_par =
                 in_params.at(owner_global_thread_id);
             const unsigned int meas_idx =
                 shared_payload.shared_candidates[thread_id.getLocalThreadIdX()]


### PR DESCRIPTION
Try to avoid the copying of the bound track parameters when doing the CKF Kalman update