### PR TITLE
consistently use io::get_absolute_path when dealing with user-input f…

### DIFF
--- a/examples/run/cpu/truth_fitting_example.cpp
+++ b/examples/run/cpu/truth_fitting_example.cpp
@@ -87,15 +87,15 @@ int main(int argc, char* argv[]) {
 
     // Read the detector
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file(traccc::io::get_absolute_path(
-                        detector_opts.detector_file));
+    reader_cfg.add_file(
+        traccc::io::get_absolute_path(detector_opts.detector_file));
     if (!detector_opts.material_file.empty()) {
-        reader_cfg.add_file(traccc::io::get_absolute_path(
-                            detector_opts.material_file));
+        reader_cfg.add_file(
+            traccc::io::get_absolute_path(detector_opts.material_file));
     }
     if (!detector_opts.grid_file.empty()) {
-        reader_cfg.add_file(traccc::io::get_absolute_path(
-                            detector_opts.grid_file));
+        reader_cfg.add_file(
+            traccc::io::get_absolute_path(detector_opts.grid_file));
     }
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);

--- a/examples/run/cpu/truth_fitting_example.cpp
+++ b/examples/run/cpu/truth_fitting_example.cpp
@@ -87,15 +87,15 @@ int main(int argc, char* argv[]) {
 
     // Read the detector
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file(traccc::io::data_directory() +
-                        detector_opts.detector_file);
+    reader_cfg.add_file(traccc::io::get_absolute_path(
+                        detector_opts.detector_file));
     if (!detector_opts.material_file.empty()) {
-        reader_cfg.add_file(traccc::io::data_directory() +
-                            detector_opts.material_file);
+        reader_cfg.add_file(traccc::io::get_absolute_path(
+                            detector_opts.material_file));
     }
     if (!detector_opts.grid_file.empty()) {
-        reader_cfg.add_file(traccc::io::data_directory() +
-                            detector_opts.grid_file);
+        reader_cfg.add_file(traccc::io::get_absolute_path(
+                            detector_opts.grid_file));
     }
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -114,15 +114,15 @@ int main(int argc, char* argv[]) {
 
     // Read the detector
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file(traccc::io::data_directory() +
-                        detector_opts.detector_file);
+    reader_cfg.add_file(traccc::io::get_absolute_path(
+                        detector_opts.detector_file));
     if (!detector_opts.material_file.empty()) {
-        reader_cfg.add_file(traccc::io::data_directory() +
-                            detector_opts.material_file);
+        reader_cfg.add_file(traccc::io::get_absolute_path(
+                            detector_opts.material_file));
     }
     if (!detector_opts.grid_file.empty()) {
-        reader_cfg.add_file(traccc::io::data_directory() +
-                            detector_opts.grid_file);
+        reader_cfg.add_file(traccc::io::get_absolute_path(
+                            detector_opts.grid_file));
     }
     auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -114,15 +114,15 @@ int main(int argc, char* argv[]) {
 
     // Read the detector
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file(traccc::io::get_absolute_path(
-                        detector_opts.detector_file));
+    reader_cfg.add_file(
+        traccc::io::get_absolute_path(detector_opts.detector_file));
     if (!detector_opts.material_file.empty()) {
-        reader_cfg.add_file(traccc::io::get_absolute_path(
-                            detector_opts.material_file));
+        reader_cfg.add_file(
+            traccc::io::get_absolute_path(detector_opts.material_file));
     }
     if (!detector_opts.grid_file.empty()) {
-        reader_cfg.add_file(traccc::io::get_absolute_path(
-                            detector_opts.grid_file));
+        reader_cfg.add_file(
+            traccc::io::get_absolute_path(detector_opts.grid_file));
     }
     auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);

--- a/examples/simulation/simulate.cpp
+++ b/examples/simulation/simulate.cpp
@@ -68,13 +68,13 @@ int main(int argc, char* argv[]) {
 
     // Read the detector
     detray::io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file(traccc::io::data_directory() + det_opts.detector_file);
+    reader_cfg.add_file(traccc::io::get_absolute_path(det_opts.detector_file));
     if (!det_opts.material_file.empty()) {
-        reader_cfg.add_file(traccc::io::data_directory() +
-                            det_opts.material_file);
+        reader_cfg.add_file(traccc::io::get_absolute_path(
+                            det_opts.material_file));
     }
     if (!det_opts.grid_file.empty()) {
-        reader_cfg.add_file(traccc::io::data_directory() + det_opts.grid_file);
+        reader_cfg.add_file(traccc::io::get_absolute_path(det_opts.grid_file));
     }
 
     // Memory resource used by the EDM.

--- a/examples/simulation/simulate.cpp
+++ b/examples/simulation/simulate.cpp
@@ -70,8 +70,8 @@ int main(int argc, char* argv[]) {
     detray::io::detector_reader_config reader_cfg{};
     reader_cfg.add_file(traccc::io::get_absolute_path(det_opts.detector_file));
     if (!det_opts.material_file.empty()) {
-        reader_cfg.add_file(traccc::io::get_absolute_path(
-                            det_opts.material_file));
+        reader_cfg.add_file(
+            traccc::io::get_absolute_path(det_opts.material_file));
     }
     if (!det_opts.grid_file.empty()) {
         reader_cfg.add_file(traccc::io::get_absolute_path(det_opts.grid_file));

--- a/io/src/read_detector.cpp
+++ b/io/src/read_detector.cpp
@@ -28,12 +28,12 @@ void read_detector(detector_t& detector, vecmem::memory_resource& mr,
 
     // Set up the detector reader configuration.
     detray::io::detector_reader_config cfg;
-    cfg.add_file(traccc::io::data_directory() + std::string{geometry_file});
+    cfg.add_file(traccc::io::get_absolute_path(geometry_file));
     if (material_file.empty() == false) {
-        cfg.add_file(traccc::io::data_directory() + std::string{material_file});
+        cfg.add_file(traccc::io::get_absolute_path(material_file));
     }
     if (grid_file.empty() == false) {
-        cfg.add_file(traccc::io::data_directory() + std::string{grid_file});
+        cfg.add_file(traccc::io::get_absolute_path(grid_file));
     }
 
     // Read the detector.

--- a/io/src/read_detector_description.cpp
+++ b/io/src/read_detector_description.cpp
@@ -45,8 +45,8 @@ void read_csv_dd(traccc::silicon_detector_description::host& dd,
 
     // Read the geometry description as a map of surface tranformations.
     const std::map<traccc::geometry_id, traccc::transform3> surfaces =
-        traccc::io::csv::read_surfaces(traccc::io::get_absolute_path(
-                                       geometry_file.data()));
+        traccc::io::csv::read_surfaces(
+            traccc::io::get_absolute_path(geometry_file.data()));
 
     // Fill the detector description with information about the (sensitive)
     // surfaces, and the digitization configurations belonging to those

--- a/io/src/read_detector_description.cpp
+++ b/io/src/read_detector_description.cpp
@@ -45,8 +45,8 @@ void read_csv_dd(traccc::silicon_detector_description::host& dd,
 
     // Read the geometry description as a map of surface tranformations.
     const std::map<traccc::geometry_id, traccc::transform3> surfaces =
-        traccc::io::csv::read_surfaces(traccc::io::data_directory() +
-                                       geometry_file.data());
+        traccc::io::csv::read_surfaces(traccc::io::get_absolute_path(
+                                       geometry_file.data()));
 
     // Fill the detector description with information about the (sensitive)
     // surfaces, and the digitization configurations belonging to those


### PR DESCRIPTION
minor change to handle absolute paths in example user input, as it was for digitization file