### PR TITLE
Adapt seeding cpu test to acts v37.3.0

### DIFF
--- a/extern/acts/CMakeLists.txt
+++ b/extern/acts/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building Acts as part of the TRACCC project" )
 
 # Declare where to get Acts from.
 set( TRACCC_ACTS_SOURCE
-   "URL;https://github.com/acts-project/acts/archive/refs/tags/v27.0.0.tar.gz;URL_MD5;7ad320590fe5ac70cc8ca7887261f91d"
+   "URL;https://github.com/acts-project/acts/archive/refs/tags/v37.3.0.tar.gz;URL_MD5;95cf54fe7986cece23ca7004d1138b01"
    CACHE STRING "Source for Acts, when built as part of this project" )
 mark_as_advanced( TRACCC_ACTS_SOURCE )
 

--- a/tests/common/tests/atlas_cuts.hpp
+++ b/tests/common/tests/atlas_cuts.hpp
@@ -21,8 +21,7 @@ class ATLASCuts : public IExperimentCuts<SpacePoint> {
     /// @param middle middle space point of the current seed
     /// @param top top space point of the current seed
     /// @return seed weight to be added to the seed's weight
-    float seedWeight(const SpacePoint& bottom,
-                     const SpacePoint& middle,
+    float seedWeight(const SpacePoint& bottom, const SpacePoint& middle,
                      const SpacePoint& top) const override;
     /// @param weight the current seed weight
     /// @param bottom bottom space point of the current seed
@@ -30,26 +29,23 @@ class ATLASCuts : public IExperimentCuts<SpacePoint> {
     /// @param top top space point of the current seed
     /// @return true if the seed should be kept, false if the seed should be
     /// discarded
-    bool singleSeedCut(
-        float weight, const SpacePoint& bottom,
-        const SpacePoint& /*middle*/,
-        const SpacePoint& /*top*/) const override;
+    bool singleSeedCut(float weight, const SpacePoint& bottom,
+                       const SpacePoint& /*middle*/,
+                       const SpacePoint& /*top*/) const override;
 
     /// @param seedCandidates contains collection of seed candidates created for
     /// one middle space point in a std::tuple format
     /// @return vector of seeds that pass the cut
-    std::vector<typename CandidatesForMiddleSp<
-        const SpacePoint>::value_type>
-    cutPerMiddleSP(std::vector<typename CandidatesForMiddleSp<
-                       const SpacePoint>::value_type>
+    std::vector<typename CandidatesForMiddleSp<const SpacePoint>::value_type>
+    cutPerMiddleSP(std::vector<
+                   typename CandidatesForMiddleSp<const SpacePoint>::value_type>
                        seedCandidates) const override;
 };
 
 template <typename SpacePoint>
-float ATLASCuts<SpacePoint>::seedWeight(
-    const SpacePoint& bottom,
-    const SpacePoint& /*middle*/,
-    const SpacePoint& top) const {
+float ATLASCuts<SpacePoint>::seedWeight(const SpacePoint& bottom,
+                                        const SpacePoint& /*middle*/,
+                                        const SpacePoint& top) const {
     float weight = 0;
     if (bottom.radius() > 150) {
         weight = 400;
@@ -61,22 +57,18 @@ float ATLASCuts<SpacePoint>::seedWeight(
 }
 
 template <typename SpacePoint>
-bool ATLASCuts<SpacePoint>::singleSeedCut(
-    float weight, const SpacePoint& b,
-    const SpacePoint& /*m*/,
-    const SpacePoint& /*t*/) const {
+bool ATLASCuts<SpacePoint>::singleSeedCut(float weight, const SpacePoint& b,
+                                          const SpacePoint& /*m*/,
+                                          const SpacePoint& /*t*/) const {
     return !(b.radius() > 150. && weight < 380.);
 }
 
 template <typename SpacePoint>
-std::vector<typename CandidatesForMiddleSp<
-    const SpacePoint>::value_type>
+std::vector<typename CandidatesForMiddleSp<const SpacePoint>::value_type>
 ATLASCuts<SpacePoint>::cutPerMiddleSP(
-    std::vector<typename CandidatesForMiddleSp<
-        const SpacePoint>::value_type>
+    std::vector<typename CandidatesForMiddleSp<const SpacePoint>::value_type>
         seedCandidates) const {
-    std::vector<typename CandidatesForMiddleSp<
-        const SpacePoint>::value_type>
+    std::vector<typename CandidatesForMiddleSp<const SpacePoint>::value_type>
         newSeedsVector;
     if (seedCandidates.size() <= 1) {
         return seedCandidates;

--- a/tests/common/tests/atlas_cuts.hpp
+++ b/tests/common/tests/atlas_cuts.hpp
@@ -21,9 +21,9 @@ class ATLASCuts : public IExperimentCuts<SpacePoint> {
     /// @param middle middle space point of the current seed
     /// @param top top space point of the current seed
     /// @return seed weight to be added to the seed's weight
-    float seedWeight(const InternalSpacePoint<SpacePoint>& bottom,
-                     const InternalSpacePoint<SpacePoint>& middle,
-                     const InternalSpacePoint<SpacePoint>& top) const override;
+    float seedWeight(const SpacePoint& bottom,
+                     const SpacePoint& middle,
+                     const SpacePoint& top) const override;
     /// @param weight the current seed weight
     /// @param bottom bottom space point of the current seed
     /// @param middle middle space point of the current seed
@@ -31,25 +31,25 @@ class ATLASCuts : public IExperimentCuts<SpacePoint> {
     /// @return true if the seed should be kept, false if the seed should be
     /// discarded
     bool singleSeedCut(
-        float weight, const InternalSpacePoint<SpacePoint>& bottom,
-        const InternalSpacePoint<SpacePoint>& /*middle*/,
-        const InternalSpacePoint<SpacePoint>& /*top*/) const override;
+        float weight, const SpacePoint& bottom,
+        const SpacePoint& /*middle*/,
+        const SpacePoint& /*top*/) const override;
 
     /// @param seedCandidates contains collection of seed candidates created for
     /// one middle space point in a std::tuple format
     /// @return vector of seeds that pass the cut
     std::vector<typename CandidatesForMiddleSp<
-        const InternalSpacePoint<SpacePoint>>::value_type>
+        const SpacePoint>::value_type>
     cutPerMiddleSP(std::vector<typename CandidatesForMiddleSp<
-                       const InternalSpacePoint<SpacePoint>>::value_type>
+                       const SpacePoint>::value_type>
                        seedCandidates) const override;
 };
 
 template <typename SpacePoint>
 float ATLASCuts<SpacePoint>::seedWeight(
-    const InternalSpacePoint<SpacePoint>& bottom,
-    const InternalSpacePoint<SpacePoint>& /*middle*/,
-    const InternalSpacePoint<SpacePoint>& top) const {
+    const SpacePoint& bottom,
+    const SpacePoint& /*middle*/,
+    const SpacePoint& top) const {
     float weight = 0;
     if (bottom.radius() > 150) {
         weight = 400;
@@ -62,21 +62,21 @@ float ATLASCuts<SpacePoint>::seedWeight(
 
 template <typename SpacePoint>
 bool ATLASCuts<SpacePoint>::singleSeedCut(
-    float weight, const InternalSpacePoint<SpacePoint>& b,
-    const InternalSpacePoint<SpacePoint>& /*m*/,
-    const InternalSpacePoint<SpacePoint>& /*t*/) const {
+    float weight, const SpacePoint& b,
+    const SpacePoint& /*m*/,
+    const SpacePoint& /*t*/) const {
     return !(b.radius() > 150. && weight < 380.);
 }
 
 template <typename SpacePoint>
 std::vector<typename CandidatesForMiddleSp<
-    const InternalSpacePoint<SpacePoint>>::value_type>
+    const SpacePoint>::value_type>
 ATLASCuts<SpacePoint>::cutPerMiddleSP(
     std::vector<typename CandidatesForMiddleSp<
-        const InternalSpacePoint<SpacePoint>>::value_type>
+        const SpacePoint>::value_type>
         seedCandidates) const {
     std::vector<typename CandidatesForMiddleSp<
-        const InternalSpacePoint<SpacePoint>>::value_type>
+        const SpacePoint>::value_type>
         newSeedsVector;
     if (seedCandidates.size() <= 1) {
         return seedCandidates;

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -13,7 +13,7 @@
 #include "traccc/seeding/spacepoint_binning.hpp"
 
 // tests
-//#include "tests/atlas_cuts.hpp"
+#include "tests/atlas_cuts.hpp"
 #include "tests/space_point.hpp"
 
 // acts
@@ -208,11 +208,11 @@ TEST_P(CompareWithActsSeedingTests, Run) {
     // there are a lot more variables here tbh
 
     // We also need some atlas-specific cut
-    //    Acts::ATLASCuts<SpacePoint> atlasCuts = Acts::ATLASCuts<SpacePoint>();
+    Acts::ATLASCuts<spacepoint_t> atlasCuts;
     
     // Start creating the seed finder object. It needs a Config option
     seedfinderconfig_t acts_config;
-    acts_config.seedFilter = std::make_shared<seedfilter_t>(sfconf.toInternalUnits()); //, &atlasCuts);
+    acts_config.seedFilter = std::make_shared<seedfilter_t>(sfconf.toInternalUnits(), &atlasCuts);
     // Phi range go from -pi to +pi
     acts_config.phiMin = traccc_config.phiMin;
     acts_config.phiMax = traccc_config.phiMax;

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -1,4 +1,4 @@
-/** TRACCC library, part of the ACTS projAect (R&D line)
+/** TRACCC library, part of the ACTS project (R&D line)
  *
  * (c) 2021-2024 CERN for the benefit of the ACTS project
  *

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -53,7 +53,7 @@ public:
   friend Acts::SpacePointContainer<SpacePointCollector, Acts::detail::RefHolder>;
   using ValueType = SpacePoint;
   
-  SpacePointCollector(std::vector<const ValueType*>& externalCollection)
+  explicit SpacePointCollector(std::vector<const ValueType*>& externalCollection)
     : m_storage(&externalCollection)
   {}
 
@@ -75,7 +75,7 @@ public:
     case "TopStripCenterPosition"_hash:
       return Acts::Vector3( {0, 0, 0} );
     default:
-      throw std::runtime_error("no such component " + std::to_string(key));	  
+      throw std::invalid_argument("no such component " + std::to_string(key));	  
     }
   }  
   
@@ -232,8 +232,8 @@ TEST_P(CompareWithActsSeedingTests, Run) {
     acts_config.rMaxMiddle = std::numeric_limits<float>::max();
     acts_config.useVariableMiddleSPRange = false;
     acts_config.rRangeMiddleSP = {};
-    acts_config.deltaRMiddleMinSPRange = 10 * Acts::UnitConstants::mm;
-    acts_config.deltaRMiddleMaxSPRange = 10 * Acts::UnitConstants::mm;    
+    acts_config.deltaRMiddleMinSPRange = 10.f; // mm
+    acts_config.deltaRMiddleMaxSPRange = 10.f; // mm
     acts_config.deltaRMin = traccc_config.deltaRMin;
     acts_config.deltaRMax = traccc_config.deltaRMax;    
     acts_config.deltaRMinTopSP = traccc_config.deltaRMin;
@@ -338,7 +338,6 @@ TEST_P(CompareWithActsSeedingTests, Run) {
     // the constructor can accept a mixture of all of these types
     int numPhiNeighbors = 1;
     int numRadiusNeighbors = 0;
-    // TODO: set some reasonable values here!!!
     std::vector<std::pair<int, int>> zBinNeighborsTop{};
     std::vector<std::pair<int, int>> zBinNeighborsBottom{};
     


### PR DESCRIPTION
This adapts the seeding cpu test and the atlas cuts to Acts v37.3.0. since the ACTS seeding has changed quite a lot, I've also added some comments to explain what we do.

From local test, the seed matching between Acts and traccc is ~0.9995

@krasznaa 