### PR TITLE
CMake Updates, main branch (2024.11.09.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,7 +384,7 @@ add_subdirectory( plugins )
 
 if ( TRACCC_BUILD_EXAMPLES )
    # Find Boost.
-   find_package( Boost REQUIRED COMPONENTS program_options filesystem)
+   find_package( Boost CONFIG REQUIRED COMPONENTS program_options filesystem )
    if ( NOT TRACCC_BUILD_IO )
       message(FATAL_ERROR "traccc::io is disabled, but it is required to build the examples.")
    endif()
@@ -402,7 +402,7 @@ endif()
 # Set up the benchmark(s).
 if( TRACCC_BUILD_BENCHMARKS )
    # Find Boost.
-   find_package( Boost REQUIRED COMPONENTS filesystem)
+   find_package( Boost CONFIG REQUIRED COMPONENTS filesystem )
    if ( NOT TRACCC_BUILD_IO )
       message(FATAL_ERROR "traccc::io is disabled, but it is required to build the tests.")
    endif()

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -29,15 +29,9 @@ set( ALGEBRA_PLUGINS_BUILD_TESTING FALSE CACHE BOOL
    "Turn off the build of the Algebra Plugins unit tests" )
 set( ALGEBRA_PLUGINS_INCLUDE_EIGEN TRUE CACHE BOOL
    "Turn on the build of algebra::eigen" )
-set( ALGEBRA_PLUGINS_INCLUDE_VC TRUE CACHE BOOL
-   "Turn on the build of algebra::vc_array" )
 set( ALGEBRA_PLUGINS_INCLUDE_VECMEM TRUE CACHE BOOL
    "Turn on the build of algebra::vecmem_array" )
 
-set( ALGEBRA_PLUGINS_SETUP_VC TRUE CACHE BOOL
-   "Have Algebra Plugins set up Vc for itself" )
-set( ALGEBRA_PLUGINS_USE_SYSTEM_VC FALSE CACHE BOOL
-   "Have Algebra Plugins build Vc itself" )
 set( ALGEBRA_PLUGINS_SETUP_EIGEN3 FALSE CACHE BOOL
    "Do not set up Eigen4=3 in Algebra Plugins" )
 set( ALGEBRA_PLUGINS_SETUP_VECMEM FALSE CACHE BOOL

--- a/extern/benchmark/CMakeLists.txt
+++ b/extern/benchmark/CMakeLists.txt
@@ -33,8 +33,10 @@ mark_as_advanced( TRACCC_BENCHMARK_SOURCE_FULL )
 FetchContent_Declare(Benchmark ${TRACCC_BENCHMARK_SOURCE_FULL})
 
 # Options used in the build of Google Benchmark.
+set(BUILD_SHARED_LIBS FALSE)
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Turn off the tests in Google Benchmark")
 set(BENCHMARK_ENABLE_WERROR OFF CACHE BOOL "Turn off the -Werror for Release build")
+set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "Do not install Google Benchmark")
 
 # Get it into the current directory.
 FetchContent_MakeAvailable(Benchmark)

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -49,8 +49,6 @@ set( DETRAY_BUILD_TUTORIALS FALSE CACHE BOOL
    "Turn off the build of the Detray tutorials" )
 set( DETRAY_EIGEN_PLUGIN TRUE CACHE BOOL
    "Turn on the build of the Detray Eigen code" )
-set( DETRAY_VC_AOS_PLUGIN TRUE CACHE BOOL
-   "Turn on the build of the Detray Vc AoS code" )
 
 # Needed for 'performance', 'simulation', 'examples', 'tests' and 'benchmarks'
 if( TRACCC_BUILD_IO OR TRACCC_BUILD_EXAMPLES OR (BUILD_TESTING AND TRACCC_BUILD_TESTING) OR TRACCC_BUILD_BENCHMARKS )

--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -35,9 +35,7 @@ endif()
 set( CMAKE_MACOSX_RPATH TRUE )
 
 # Get it into the current directory.
-FetchContent_Populate( GoogleTest )
-add_subdirectory( "${googletest_SOURCE_DIR}" "${googletest_BINARY_DIR}"
-   EXCLUDE_FROM_ALL )
+FetchContent_MakeAvailable( GoogleTest )
 
 # Set up aliases for the GTest targets with the same name that they have
 # when we find GTest pre-installed.


### PR DESCRIPTION
This is to try to remove some pesky CMake warnings that have showed up with modern CMake versions over some period of time. The goal is that this PR + #765 would allow us to configure the build of the project without any warnings with CMake 3.30.X.

Things done:
  - I disabled the build of [Vc](https://github.com/VcDevel/Vc). We've not been using it for anything really in this project so far. We'll be able to re-enable it once needed, but until then this gets rid of all the warnings from its old CMake code.
  - Switched to finding [Boost](https://www.boost.org/) using its own CMake code. (See: [CMP0167](https://cmake.org/cmake/help/latest/policy/CMP0167.html))
  - Stopped using [FetchContent_Populate](https://cmake.org/cmake/help/latest/module/FetchContent.html) with [GoogleTest](https://github.com/google/googletest/). (See: [CMP0169](https://cmake.org/cmake/help/latest/policy/CMP0169.html))
    * The original reason for doing this is void by now anyway... (It's a longer story.)
  - Stopped installing [GoogleBenhmark](https://github.com/google/benchmark) together with the project. At the same time turned its libraries into static ones, since when we install benchmark executables, they should still remain usable. (Without creating possible conflicts with other installed GoogleBenchmark installations.)
    * I noticed this while showing @CarloVarni the project, which would eventually lead to #765. 😄