### PR TITLE
Count the number of holes in the KF

### DIFF
--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -32,6 +32,10 @@ struct fitting_result {
 
     /// Chi square of fitted track
     scalar_type chi2{0};
+
+    // The number of holes (The number of sensitive surfaces which do not have a
+    // measurement for the track pattern)
+    unsigned int n_holes{0u};
 };
 
 /// Fitting result per measurement

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -54,6 +54,15 @@ struct kalman_actor : detray::actor {
         TRACCC_HOST_DEVICE
         void next() { m_it++; }
 
+        /// @return true if the iterator reaches the end of vector
+        TRACCC_HOST_DEVICE
+        bool is_complete() const {
+            if (m_it == m_track_states.end()) {
+                return true;
+            }
+            return false;
+        }
+
         // vector of track states
         vector_t<track_state_type> m_track_states;
 
@@ -75,6 +84,12 @@ struct kalman_actor : detray::actor {
 
         auto& stepping = propagation._stepping;
         auto& navigation = propagation._navigation;
+
+        // If the iterator reaches the end, terminate the propagation
+        if (actor_state.is_complete()) {
+            propagation._heartbeat &= navigation.abort();
+            return;
+        }
 
         // triggered only for sensitive surfaces
         if (navigation.is_on_sensitive()) {

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -96,6 +96,8 @@ struct kalman_actor : detray::actor {
 
             auto& trk_state = actor_state();
 
+            // Increase the hole counts if the propagator fails to find the next
+            // measurement
             if (navigation.barcode() != trk_state.surface_link()) {
                 actor_state.n_holes++;
                 return;

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -239,6 +239,9 @@ class kalman_fitter {
 
         // Subtract the NDoF with the degree of freedom of the bound track (=5)
         fit_res.ndf = fit_res.ndf - 5.f;
+
+        // The number of holes
+        fit_res.n_holes = fitter_state.m_fit_actor_state.n_holes;
     }
 
     private:

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -13,6 +13,7 @@ traccc_add_test(cpu
     "test_ckf_sparse_tracks_telescope.cpp"
     "test_clusterization_resolution.cpp"
     "test_copy.cpp"
+    "test_kalman_fitter_hole_count.cpp"
     "test_kalman_fitter_telescope.cpp"
     "test_kalman_fitter_wire_chamber.cpp"
     "test_ranges.cpp"

--- a/tests/cpu/test_kalman_fitter_hole_count.cpp
+++ b/tests/cpu/test_kalman_fitter_hole_count.cpp
@@ -164,8 +164,10 @@ TEST_P(KalmanFittingHoleCountTests, Run) {
     ASSERT_EQ(n_tracks, n_truth_tracks);
 
     // Check the number of holes
+    // The three holes at the end are not counted as KF aborts once it goes
+    // through all track candidates
     const auto& fit_res = track_states.at(0u).header;
-    ASSERT_EQ(fit_res.n_holes, 8u);
+    ASSERT_EQ(fit_res.n_holes, 5u);
 
     // Some sanity checks
     ASSERT_EQ(track_states.at(0u).items.size(), n_planes - fit_res.n_holes);

--- a/tests/cpu/test_kalman_fitter_hole_count.cpp
+++ b/tests/cpu/test_kalman_fitter_hole_count.cpp
@@ -170,9 +170,9 @@ TEST_P(KalmanFittingHoleCountTests, Run) {
     ASSERT_EQ(fit_res.n_holes, 5u);
 
     // Some sanity checks
-    ASSERT_EQ(track_states.at(0u).items.size(), n_planes - fit_res.n_holes);
-    ASSERT_FLOAT_EQ(static_cast<float>(fit_res.ndf),
-                    static_cast<float>(n_planes - fit_res.n_holes) * 2.f - 5.f);
+    ASSERT_FLOAT_EQ(
+        static_cast<float>(fit_res.ndf),
+        static_cast<float>(track_states.at(0u).items.size()) * 2.f - 5.f);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpu/test_kalman_fitter_hole_count.cpp
+++ b/tests/cpu/test_kalman_fitter_hole_count.cpp
@@ -148,9 +148,9 @@ TEST_P(KalmanFittingHoleCountTests, Run) {
     cands.erase(cands.begin() + 2);
     cands.erase(cands.begin() + 2);
     cands.erase(cands.begin() + 7);
-    cands.erase(cands.end() - 1);
-    cands.erase(cands.end() - 1);
-    cands.erase(cands.end() - 1);
+    cands.pop_back();
+    cands.pop_back();
+    cands.pop_back();
 
     // A sanity check on the number of candidiates
     ASSERT_EQ(cands.size(), n_planes - 8u);

--- a/tests/cpu/test_kalman_fitter_hole_count.cpp
+++ b/tests/cpu/test_kalman_fitter_hole_count.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -33,7 +33,9 @@
 
 using namespace traccc;
 
-TEST_P(KalmanFittingTelescopeTests, Run) {
+class KalmanFittingHoleCountTests : public KalmanFittingTelescopeTests {};
+
+TEST_P(KalmanFittingHoleCountTests, Run) {
 
     // Get the parameters
     const std::string name = std::get<0>(GetParam());
@@ -48,10 +50,9 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     const unsigned int n_events = std::get<8>(GetParam());
     const bool random_charge = std::get<9>(GetParam());
 
-    // Performance writer
-    traccc::fitting_performance_writer::config fit_writer_cfg;
-    fit_writer_cfg.file_path = "performance_track_fitting_" + name + ".root";
-    traccc::fitting_performance_writer fit_performance_writer(fit_writer_cfg);
+    // We only test one track of one event
+    ASSERT_EQ(n_truth_tracks, 1u);
+    ASSERT_EQ(n_events, 1u);
 
     /*****************************
      * Build a telescope geometry
@@ -125,104 +126,57 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     fit_cfg.propagation.navigation.max_mask_tolerance = 1.f * unit<float>::mm;
     traccc::host::kalman_fitting_algorithm fitting(fit_cfg, host_mr);
 
-    // Iterate over events
-    for (std::size_t i_evt = 0; i_evt < n_events; i_evt++) {
+    // Event map
+    traccc::event_data evt_data(path, 0u, host_mr);
 
-        // Event map
-        traccc::event_data evt_data(path, i_evt, host_mr);
-        // Truth Track Candidates
-        traccc::track_candidate_container_types::host track_candidates =
-            evt_data.generate_truth_candidates(sg, host_mr);
+    // Truth Track Candidates
+    traccc::track_candidate_container_types::host track_candidates =
+        evt_data.generate_truth_candidates(sg, host_mr);
+    // Candidate vector
+    auto& cands = track_candidates.at(0u).items;
 
-        // n_trakcs = 100
-        ASSERT_EQ(track_candidates.size(), n_truth_tracks);
+    // Some sanity checks
+    ASSERT_EQ(track_candidates.size(), n_truth_tracks);
+    const auto n_planes = std::get<11>(GetParam());
+    ASSERT_EQ(cands.size(), n_planes);
 
-        // Run fitting
-        auto track_states =
-            fitting(host_det, field, traccc::get_data(track_candidates));
+    // Pop some track candidates to create holes
+    // => The number of holes = 8
+    ASSERT_TRUE(cands.size() > 8u);
+    cands.erase(cands.begin());
+    cands.erase(cands.begin());
+    cands.erase(cands.begin() + 2);
+    cands.erase(cands.begin() + 2);
+    cands.erase(cands.begin() + 7);
+    cands.erase(cands.end() - 1);
+    cands.erase(cands.end() - 1);
+    cands.erase(cands.end() - 1);
 
-        // Iterator over tracks
-        const std::size_t n_tracks = track_states.size();
+    // A sanity check on the number of candidiates
+    ASSERT_EQ(cands.size(), n_planes - 8u);
 
-        // n_trakcs = 100
-        ASSERT_EQ(n_tracks, n_truth_tracks);
+    // Run fitting
+    auto track_states =
+        fitting(host_det, field, traccc::get_data(track_candidates));
 
-        for (std::size_t i_trk = 0; i_trk < n_tracks; i_trk++) {
+    // A sanity check
+    const std::size_t n_tracks = track_states.size();
+    ASSERT_EQ(n_tracks, n_truth_tracks);
 
-            const auto& track_states_per_track = track_states[i_trk].items;
-            const auto& fit_res = track_states[i_trk].header;
+    // Check the number of holes
+    const auto& fit_res = track_states.at(0u).header;
+    ASSERT_EQ(fit_res.n_holes, 8u);
 
-            consistency_tests(track_states_per_track);
-
-            ndf_tests(fit_res, track_states_per_track);
-
-            ASSERT_EQ(fit_res.n_holes, 0u);
-
-            fit_performance_writer.write(track_states_per_track, fit_res,
-                                         host_det, evt_data);
-        }
-    }
-
-    fit_performance_writer.finalize();
-
-    /********************
-     * Pull value test
-     ********************/
-
-    static const std::vector<std::string> pull_names{
-        "pull_d0", "pull_z0", "pull_phi", "pull_theta", "pull_qop"};
-    pull_value_tests(fit_writer_cfg.file_path, pull_names);
-
-    /********************
-     * Success rate test
-     ********************/
-
-    float success_rate = static_cast<float>(n_success) /
-                         static_cast<float>(n_truth_tracks * n_events);
-
-    ASSERT_FLOAT_EQ(success_rate, 1.00f);
+    // Some sanity checks
+    ASSERT_EQ(track_states.at(0u).items.size(), n_planes - fit_res.n_holes);
+    ASSERT_FLOAT_EQ(fit_res.ndf,
+                    static_cast<scalar>(n_planes - fit_res.n_holes) * 2.f - 5u);
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    KalmanFitTelescopeValidation0, KalmanFittingTelescopeTests,
+    KalmanFittingHoleCount, KalmanFittingHoleCountTests,
     ::testing::Values(std::make_tuple(
         "telescope_1_GeV_0_phi_muon", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
         std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f},
-        detray::muon<scalar>(), 100, 100, false, 20.f, 9u, 20.f)));
-
-INSTANTIATE_TEST_SUITE_P(
-    KalmanFitTelescopeValidation1, KalmanFittingTelescopeTests,
-    ::testing::Values(std::make_tuple(
-        "telescope_10_GeV_0_phi_muon", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 2u>{10.f, 10.f}, std::array<scalar, 2u>{0.f, 0.f},
-        std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 100, 100,
-        false, 20.f, 9u, 20.f)));
-
-INSTANTIATE_TEST_SUITE_P(
-    KalmanFitTelescopeValidation2, KalmanFittingTelescopeTests,
-    ::testing::Values(std::make_tuple(
-        "telescope_100_GeV_0_phi_muon", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 2u>{100.f, 100.f}, std::array<scalar, 2u>{0.f, 0.f},
-        std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 100, 100,
-        false, 20.f, 9u, 20.f)));
-
-INSTANTIATE_TEST_SUITE_P(
-    KalmanFitTelescopeValidation3, KalmanFittingTelescopeTests,
-    ::testing::Values(std::make_tuple(
-        "telescope_1_GeV_0_phi_anti_muon",
-        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
-        std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f},
-        detray::antimuon<scalar>(), 100, 100, false, 20.f, 9u, 20.f)));
-
-INSTANTIATE_TEST_SUITE_P(
-    KalmanFitTelescopeValidation4, KalmanFittingTelescopeTests,
-    ::testing::Values(std::make_tuple(
-        "telescope_1_GeV_0_random_charge",
-        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
-        std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f},
-        detray::antimuon<scalar>(), 100, 100, true, 20.f, 9u, 20.f)));
+        detray::muon<scalar>(), 1, 1, false, 20.f, 20u, 20.f)));

--- a/tests/cpu/test_kalman_fitter_hole_count.cpp
+++ b/tests/cpu/test_kalman_fitter_hole_count.cpp
@@ -169,8 +169,8 @@ TEST_P(KalmanFittingHoleCountTests, Run) {
 
     // Some sanity checks
     ASSERT_EQ(track_states.at(0u).items.size(), n_planes - fit_res.n_holes);
-    ASSERT_FLOAT_EQ(fit_res.ndf,
-                    static_cast<scalar>(n_planes - fit_res.n_holes) * 2.f - 5u);
+    ASSERT_FLOAT_EQ(static_cast<float>(fit_res.ndf),
+                    static_cast<float>(n_planes - fit_res.n_holes) * 2.f - 5.f);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Based on #774 

The number of holes will be required in the ambiguity solver.
To count the number of holes even after all track candidates are visited, the abort condition in the KF is removed. This will increase the CPU computing time but impact on the GPU KF will be much smaller.

Also added a test to make sure the new feature works correctly

