### PR TITLE
ITk Processing Fixes, main branch (2024.11.22.)

### DIFF
--- a/core/include/traccc/fitting/details/fit_tracks.hpp
+++ b/core/include/traccc/fitting/details/fit_tracks.hpp
@@ -51,7 +51,7 @@ track_state_container_types::host fit_tracks(
 
         // Make a vector of track states for this track.
         vecmem::vector<track_state<typename fitter_t::algebra_type> >
-            input_states;
+            input_states{&mr};
         input_states.reserve(track_candidates.get_items()[i].size());
         for (auto& measurement : track_candidates.get_items()[i]) {
             input_states.emplace_back(measurement);

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -159,9 +159,11 @@ int seq_run(const traccc::opts::detector& detector_opts,
                 traccc::performance::timer t("File reading  (cpu)",
                                              elapsedTimes);
                 // Read the cells from the relevant event file into host memory.
+                static constexpr bool DEDUPLICATE = true;
                 traccc::io::read_cells(cells_per_event, event,
                                        input_opts.directory, &host_det_descr,
-                                       input_opts.format);
+                                       input_opts.format, DEDUPLICATE,
+                                       input_opts.use_acts_geom_source);
             }  // stop measuring file reading timer
 
             n_cells += cells_per_event.size();

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -92,10 +92,13 @@ int throughput_st(std::string_view description, int argc, char* argv[],
         performance::timer t{"File reading", times};
         // Read the input cells into memory event-by-event.
         input.reserve(input_opts.events);
-        for (std::size_t i = 0; i < input_opts.events; ++i) {
+        for (std::size_t i = input_opts.skip;
+             i < input_opts.skip + input_opts.events; ++i) {
             input.push_back({uncached_host_mr});
+            static constexpr bool DEDUPLICATE = true;
             io::read_cells(input.back(), i, input_opts.directory, &det_descr,
-                           input_opts.format);
+                           input_opts.format, DEDUPLICATE,
+                           input_opts.use_acts_geom_source);
         }
     }
 

--- a/examples/run/cpu/full_chain_algorithm.cpp
+++ b/examples/run/cpu/full_chain_algorithm.cpp
@@ -66,9 +66,8 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
             *m_detector, m_field, measurements_view, track_params_view);
 
         // Run the track fitting, and return its results.
-        const track_candidate_container_types::const_view
-            track_candidates_view = get_data(track_candidates);
-        return m_fitting(*m_detector, m_field, track_candidates_view);
+        const auto track_candidates_data = get_data(track_candidates);
+        return m_fitting(*m_detector, m_field, track_candidates_data);
     }
     // If not, just return an empty object.
     else {

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -170,9 +170,11 @@ int seq_run(const traccc::opts::input_data& input_opts,
             {
                 traccc::performance::timer timer{"Read cells", elapsedTimes};
                 // Read the cells from the relevant event file
+                static constexpr bool DEDUPLICATE = true;
                 traccc::io::read_cells(cells_per_event, event,
                                        input_opts.directory, &det_descr,
-                                       input_opts.format);
+                                       input_opts.format, DEDUPLICATE,
+                                       input_opts.use_acts_geom_source);
             }
 
             /*-------------------

--- a/examples/run/cpu/throughput_mt.cpp
+++ b/examples/run/cpu/throughput_mt.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,6 +13,8 @@
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
+    static constexpr bool USE_HOST_CACHING = false;
     return traccc::throughput_mt<traccc::full_chain_algorithm>(
-        "Multi-threaded host-only throughput tests", argc, argv);
+        "Multi-threaded host-only throughput tests", argc, argv,
+        USE_HOST_CACHING);
 }

--- a/examples/run/cpu/throughput_st.cpp
+++ b/examples/run/cpu/throughput_st.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,6 +13,8 @@
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
+    static constexpr bool USE_HOST_CACHING = false;
     return traccc::throughput_st<traccc::full_chain_algorithm>(
-        "Single-threaded host-only throughput tests", argc, argv);
+        "Single-threaded host-only throughput tests", argc, argv,
+        USE_HOST_CACHING);
 }

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -224,9 +224,11 @@ int seq_run(const traccc::opts::detector& detector_opts,
                 traccc::performance::timer t("File reading  (cpu)",
                                              elapsedTimes);
                 // Read the cells from the relevant event file into host memory.
+                static constexpr bool DEDUPLICATE = true;
                 traccc::io::read_cells(cells_per_event, event,
                                        input_opts.directory, &host_det_descr,
-                                       input_opts.format);
+                                       input_opts.format, DEDUPLICATE,
+                                       input_opts.use_acts_geom_source);
             }  // stop measuring file reading timer
 
             n_cells += cells_per_event.size();

--- a/examples/run/openmp/par_example.cpp
+++ b/examples/run/openmp/par_example.cpp
@@ -83,8 +83,10 @@ int par_run(const traccc::opts::input_data& input_opts,
 
         // Read the cells from the relevant event file
         traccc::edm::silicon_cell_collection::host cells_per_event{resource};
+        static constexpr bool DEDUPLICATE = true;
         traccc::io::read_cells(cells_per_event, event, input_opts.directory,
-                               &det_descr, input_opts.format);
+                               &det_descr, input_opts.format, DEDUPLICATE,
+                               input_opts.use_acts_geom_source);
 
         /*-------------------
             Clusterization

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -191,9 +191,11 @@ int seq_run(const traccc::opts::detector& detector_opts,
                 traccc::performance::timer t("File reading  (cpu)",
                                              elapsedTimes);
                 // Read the cells from the relevant event file into host memory.
+                static constexpr bool DEDUPLICATE = true;
                 traccc::io::read_cells(cells_per_event, event,
                                        input_opts.directory, &host_det_descr,
-                                       input_opts.format);
+                                       input_opts.format, DEDUPLICATE,
+                                       input_opts.use_acts_geom_source);
             }  // stop measuring file reading timer
 
             n_cells += cells_per_event.size();


### PR DESCRIPTION
This is a collection of changes I made to be able to use the files produced by @paradajzblond in the example applications.
  - Had to teach all (relevant) executables to respect the `--input-skip` and `--use-acts-geom-source` command line flags;
  - Turned off memory caching for the host-based throughput applications. I just noticed it while debugging an issue (see next bullet point) that we've been unnecessarily using caching with those applications so far. :thinking:
  - I had to find that with #756 I introduced a bug into `traccc::host::full_chain_algorithm`. :frowning: (Which would allow the code to access invalid memory.) This PR now fixes that.
    * While debugging that, I also found a minor issue in `traccc::host::details::fit_tracks(...)`, where it would use the default memory resource instead of the explicitly provided one for one of the temporary containers,

With all this in place, I'm able to exercise all the executables on Neza's files. :smile: