### PR TITLE
small fix required for SYCL/clang20

### DIFF
--- a/device/sycl/src/utils/make_prefix_sum_buff.sycl
+++ b/device/sycl/src/utils/make_prefix_sum_buff.sycl
@@ -43,8 +43,8 @@ vecmem::data::vector_buffer<device::prefix_sum_element_t> make_prefix_sum_buff(
             h.parallel_for<kernels::fill_prefix_sum>(
                 ::sycl::nd_range<1>(((sizes_sum_view.size() / 32) + 1) * 32,
                                     32),
-                [sizes_sum_view, prefix_sum_view](::sycl::id<1> idx) {
-                    device::fill_prefix_sum(idx, sizes_sum_view,
+                [sizes_sum_view, prefix_sum_view](const ::sycl::nd_item<1> idx) {
+                    device::fill_prefix_sum(idx.get_global_id(), sizes_sum_view,
                                             prefix_sum_view);
                 });
         })

--- a/device/sycl/src/utils/make_prefix_sum_buff.sycl
+++ b/device/sycl/src/utils/make_prefix_sum_buff.sycl
@@ -43,7 +43,8 @@ vecmem::data::vector_buffer<device::prefix_sum_element_t> make_prefix_sum_buff(
             h.parallel_for<kernels::fill_prefix_sum>(
                 ::sycl::nd_range<1>(((sizes_sum_view.size() / 32) + 1) * 32,
                                     32),
-                [sizes_sum_view, prefix_sum_view](const ::sycl::nd_item<1> idx) {
+                [sizes_sum_view,
+                 prefix_sum_view](const ::sycl::nd_item<1> idx) {
                     device::fill_prefix_sum(idx.get_global_id(), sizes_sum_view,
                                             prefix_sum_view);
                 });


### PR DESCRIPTION
Sycl/clang20 range index could no longer be convert to sycl::id so changed it to sycl::nd_item.
Not sure this is the best way to do it, happy to be advised by experts.

Error showed up with recent version of SYCL compiler:
```
$ clang++ -v
Intel(R) oneAPI DPC++/C++ Compiler 2025.0.1 (2025.0.1.20241113)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/intel/oneapi/compiler/2025.0/bin/compiler
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/11
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/13
Selected GCC installation: /usr/lib/gcc/x86_64-linux-gnu/13
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Candidate multilib: x32;@mx32
Selected multilib: .;@m64
Found HIP installation: /opt/rocm, version 6.2.41134
```
from 24/11/2024 daily release of Intel's LLVM:
https://github.com/intel/llvm/releases/download/nightly-2024-11-24/sycl_linux.tar.gz