### PR TITLE
Collection Comparison Progress Bar, main branch (2024.11.27.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,8 +352,13 @@ if( TRACCC_SETUP_BENCHMARKS )
 endif()
 
 # Set up indicators.
+set( _indicatorsDefault FALSE )
+if( TRACCC_BUILD_EXAMPLES OR TRACCC_BUILD_IO )
+   set( _indicatorsDefault TRUE )
+endif()
 option( TRACCC_SETUP_INDICATORS
-   "Set up the indicators target(s) explicitly" ${TRACCC_BUILD_EXAMPLES} )
+   "Set up the indicators target(s) explicitly" ${_indicatorsDefault} )
+unset( _indicatorsDefault )
 option( TRACCC_USE_SYSTEM_INDICATORS
    "Pick up an existing installation of indicators from the build environment"
    ${TRACCC_USE_SYSTEM_LIBS} )

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022-2023 CERN for the benefit of the ACTS project
+# (c) 2022-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -36,7 +36,7 @@ traccc_add_library( traccc_performance performance TYPE SHARED
    "include/traccc/utils/ranges.hpp"
    "include/traccc/utils/helpers.hpp"
    "src/utils/helpers.hpp"
-   "src/utils/helpers.cpp"  
+   "src/utils/helpers.cpp"
    # Value/object comparison code.
    "include/traccc/performance/details/is_same_angle.hpp"
    "src/performance/details/is_same_angle.cpp"
@@ -53,6 +53,8 @@ traccc_add_library( traccc_performance performance TYPE SHARED
    "include/traccc/performance/impl/comparator_factory.ipp"
    "include/traccc/performance/impl/seed_comparator_factory.ipp"
    "src/performance/details/comparator_factory.cpp"
+   "include/traccc/performance/details/comparison_progress.hpp"
+   "src/performance/details/comparison_progress.cpp"
    # Collection/container comparison code.
    "include/traccc/performance/collection_comparator.hpp"
    "include/traccc/performance/impl/collection_comparator.ipp"
@@ -66,7 +68,8 @@ traccc_add_library( traccc_performance performance TYPE SHARED
    "include/traccc/performance/throughput.hpp"
    "src/performance/throughput.cpp" )
 target_link_libraries( traccc_performance
-   PUBLIC traccc::core traccc::io covfie::core detray::test_utils )
+   PUBLIC traccc::core traccc::io covfie::core detray::test_utils
+   PRIVATE indicators::indicators )
 
 # Use ROOT in traccc::performance, if requested.
 if( TRACCC_USE_ROOT )

--- a/performance/include/traccc/performance/details/comparison_progress.hpp
+++ b/performance/include/traccc/performance/details/comparison_progress.hpp
@@ -1,0 +1,43 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// System include(s).
+#include <iostream>
+#include <memory>
+#include <string_view>
+
+namespace traccc::details {
+
+/// Internal data used by @c comparison_progress
+struct comparison_progress_data;
+
+/// Class for tracking the progress of a comparison operation
+///
+/// It's really just a wrapper around the indicators::progress_bar class.
+/// It's here to not expose a public dependency on the indicators library.
+///
+class comparison_progress {
+
+    public:
+    /// Constructor with the total number of steps
+    comparison_progress(std::size_t steps, std::ostream& out = std::cout,
+                        std::string_view description = "Running comparison ");
+    /// Destructor
+    ~comparison_progress();
+
+    /// Mark one step done with the progress
+    void tick();
+
+    private:
+    /// Opaque internal data
+    std::unique_ptr<comparison_progress_data> m_data;
+
+};  // class comparison_progress
+
+}  // namespace traccc::details

--- a/performance/include/traccc/performance/impl/collection_comparator.ipp
+++ b/performance/include/traccc/performance/impl/collection_comparator.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,6 +8,7 @@
 #pragma once
 
 // Library include(s).
+#include "traccc/performance/details/comparison_progress.hpp"
 #include "traccc/performance/details/is_same_object.hpp"
 
 // Project include(s).
@@ -52,6 +53,10 @@ void collection_comparator<TYPE>::operator()(
                 << " (" << m_lhs_type << "), " << rhs_coll.size() << " ("
                 << m_rhs_type << ")\n";
 
+    // Create a progress bar.
+    details::comparison_progress progress{
+        lhs_coll.size() * m_uncertainties.size(), m_out.get()};
+
     // Calculate the agreements at various uncertainties.
     std::vector<scalar> agreements;
     agreements.reserve(m_uncertainties.size());
@@ -66,6 +71,7 @@ void collection_comparator<TYPE>::operator()(
                                  obj, uncertainty)) != rhs_coll.end()) {
                 ++matched;
             }
+            progress.tick();
         }
         // Calculate the agreement value.
         agreements.push_back(

--- a/performance/src/performance/details/comparison_progress.cpp
+++ b/performance/src/performance/details/comparison_progress.cpp
@@ -1,0 +1,44 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "traccc/performance/details/comparison_progress.hpp"
+
+// Indicators include(s).
+#include <indicators/progress_bar.hpp>
+
+namespace traccc::details {
+
+struct comparison_progress_data {
+
+    /// Progress bar used internally
+    std::unique_ptr<indicators::ProgressBar> m_bar;
+
+};  // struct comparison_progress_data
+
+comparison_progress::comparison_progress(std::size_t steps, std::ostream& out,
+                                         std::string_view description)
+    : m_data(std::make_unique<comparison_progress_data>()) {
+
+    // Set up the progress bar.
+    m_data->m_bar = std::make_unique<indicators::ProgressBar>(
+        indicators::option::BarWidth{50},
+        indicators::option::PrefixText{description.data()},
+        indicators::option::ShowPercentage{true},
+        indicators::option::ShowRemainingTime{true},
+        indicators::option::MaxProgress{steps},
+        indicators::option::Stream{out});
+}
+
+comparison_progress::~comparison_progress() = default;
+
+void comparison_progress::tick() {
+
+    m_data->m_bar->tick();
+}
+
+}  // namespace traccc::details


### PR DESCRIPTION
Added a progress bar for the collection comparisons.

For high object counts these comparisons can take a while. To give some feedback to the user about the progress of a comparison, added a progress bar that would provide this information. Now that we have access to such a thing. (#780)

And for why this is really necessary:

![image](https://github.com/user-attachments/assets/9218764d-a0b5-42c2-9af7-f546fcc0767c)

Hopefully this will help (at least in morals) with debugging the current ITk weirdnesses.