### PR TITLE
Backward filter for Two-filter Smoothing

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -74,6 +74,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/fitting/kalman_filter/kalman_fitter.hpp"
   "include/traccc/fitting/kalman_filter/kalman_step_aborter.hpp"
   "include/traccc/fitting/kalman_filter/statistics_updater.hpp"
+  "include/traccc/fitting/kalman_filter/two_filters_smoother.hpp"
   "include/traccc/fitting/details/fit_tracks.hpp"
   "include/traccc/fitting/kalman_fitting_algorithm.hpp"
   "src/fitting/kalman_fitting_algorithm.cpp"

--- a/core/include/traccc/edm/track_parameters.hpp
+++ b/core/include/traccc/edm/track_parameters.hpp
@@ -48,4 +48,20 @@ inline void wrap_phi(bound_track_parameters& param) {
     param.set_phi(phi);
 }
 
+/// Covariance inflation used for track fitting
+TRACCC_HOST_DEVICE
+inline void inflate_covariance(bound_track_parameters& param,
+                               const traccc::scalar inf_fac) {
+    auto& cov = param.covariance();
+    for (unsigned int i = 0; i < e_bound_size; i++) {
+        for (unsigned int j = 0; j < e_bound_size; j++) {
+            if (i == j) {
+                getter::element(cov, i, i) *= inf_fac;
+            } else {
+                getter::element(cov, i, j) = 0.f;
+            }
+        }
+    }
+}
+
 }  // namespace traccc

--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -37,6 +37,14 @@ struct fitting_result {
     // The number of holes (The number of sensitive surfaces which do not have a
     // measurement for the track pattern)
     unsigned int n_holes{0u};
+
+    /// Reset the statistics
+    TRACCC_HOST_DEVICE
+    void reset_statistics() {
+        ndf = 0.f;
+        chi2 = 0.f;
+        n_holes = 0u;
+    }
 };
 
 /// Fitting result per measurement
@@ -160,6 +168,14 @@ struct track_state {
     TRACCC_HOST_DEVICE
     inline const scalar_type& filtered_chi2() const { return m_filtered_chi2; }
 
+    /// @return the non-const chi square of backward filter
+    TRACCC_HOST_DEVICE
+    inline scalar_type& backward_chi2() { return m_backward_chi2; }
+
+    /// @return the const chi square of backward filter
+    TRACCC_HOST_DEVICE
+    inline scalar_type backward_chi2() const { return m_backward_chi2; }
+
     /// @return the non-const filtered parameter
     TRACCC_HOST_DEVICE
     inline bound_track_parameters_type& filtered() { return m_filtered; }
@@ -200,6 +216,7 @@ struct track_state {
     bound_track_parameters_type m_filtered;
     scalar_type m_smoothed_chi2 = 0.f;
     bound_track_parameters_type m_smoothed;
+    scalar_type m_backward_chi2 = 0.f;
 };
 
 /// Declare all track_state collection types

--- a/core/include/traccc/fitting/fitting_config.hpp
+++ b/core/include/traccc/fitting/fitting_config.hpp
@@ -25,6 +25,10 @@ struct fitting_config {
     /// Particle hypothesis
     detray::pdg_particle<traccc::scalar> ptc_hypothesis =
         detray::muon<traccc::scalar>();
+
+    /// Smoothing with backward filter
+    bool use_backward_filter = false;
+    traccc::scalar covariance_inflation_factor = 1e3f;
 };
 
 }  // namespace traccc

--- a/core/include/traccc/fitting/kalman_filter/statistics_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/statistics_updater.hpp
@@ -30,7 +30,8 @@ struct statistics_updater {
     TRACCC_HOST_DEVICE inline void operator()(
         const mask_group_t& /*mask_group*/, const index_t& /*index*/,
         fitting_result<algebra_t>& fit_res,
-        const track_state<algebra_t>& trk_state) {
+        const track_state<algebra_t>& trk_state,
+        const bool use_backward_filter) {
 
         if (!trk_state.is_hole) {
 
@@ -41,7 +42,11 @@ struct statistics_updater {
             fit_res.ndf += static_cast<scalar_type>(D);
 
             // total_chi2 = total_chi2 + chi2
-            fit_res.chi2 += trk_state.smoothed_chi2();
+            if (use_backward_filter) {
+                fit_res.chi2 += trk_state.backward_chi2();
+            } else {
+                fit_res.chi2 += trk_state.filtered_chi2();
+            }
         }
     }
 };

--- a/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
@@ -1,0 +1,172 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/definitions/track_parametrization.hpp"
+#include "traccc/edm/track_state.hpp"
+
+namespace traccc {
+
+/// Type unrolling functor for two-filters smoother
+template <typename algebra_t>
+struct two_filters_smoother {
+
+    // Type declarations
+    using size_type = detray::dsize_type<algebra_t>;
+    template <size_type ROWS, size_type COLS>
+    using matrix_type = detray::dmatrix<algebra_t, ROWS, COLS>;
+
+    /// Two-filters smoother operation
+    ///
+    /// @param mask_group mask group that contains the mask of surface
+    /// @param index mask index of surface
+    /// @param trk_state track state of the surface
+    /// @param bound_params bound parameter
+    ///
+    /// @return true if the update succeeds
+    template <typename mask_group_t, typename index_t>
+    TRACCC_HOST_DEVICE inline bool operator()(
+        const mask_group_t& /*mask_group*/, const index_t& /*index*/,
+        track_state<algebra_t>& trk_state,
+        bound_track_parameters& bound_params) const {
+
+        using shape_type = typename mask_group_t::value_type::shape;
+
+        const auto D = trk_state.get_measurement().meas_dim;
+        assert(D == 1u || D == 2u);
+        if (D == 1u) {
+            return smoothe<1u, shape_type>(trk_state, bound_params);
+        } else if (D == 2u) {
+            return smoothe<2u, shape_type>(trk_state, bound_params);
+        }
+
+        return false;
+    }
+
+    // Reference: The Optimun Linear Smoother as a Combination of Two Optimum
+    // Linear Filters
+    template <size_type D, typename shape_t>
+    TRACCC_HOST_DEVICE inline bool smoothe(
+        track_state<algebra_t>& trk_state,
+        bound_track_parameters& bound_params) const {
+
+        assert(trk_state.filtered().surface_link() ==
+               bound_params.surface_link());
+
+        static_assert(((D == 1u) || (D == 2u)),
+                      "The measurement dimension should be 1 or 2");
+
+        const auto meas = trk_state.get_measurement();
+
+        matrix_type<D, e_bound_size> H = meas.subs.template projector<D>();
+
+        // Measurement data on surface
+        const matrix_type<D, 1>& meas_local =
+            trk_state.template measurement_local<D>();
+
+        // Predicted vector of bound track parameters
+        const matrix_type<e_bound_size, 1> predicted_vec =
+            bound_params.vector();
+
+        // Predicted covaraince of bound track parameters
+        const matrix_type<e_bound_size, e_bound_size> predicted_cov =
+            bound_params.covariance();
+
+        const matrix_type<e_bound_size, e_bound_size> predicted_cov_inv =
+            matrix::inverse(predicted_cov);
+        const matrix_type<e_bound_size, e_bound_size> filtered_cov_inv =
+            matrix::inverse(trk_state.filtered().covariance());
+
+        // Eq (3.38) of "Pattern Recognition, Tracking and Vertex
+        // Reconstruction in Particle Detectors"
+        const matrix_type<e_bound_size, e_bound_size> smoothed_cov_inv =
+            predicted_cov_inv + filtered_cov_inv;
+
+        const matrix_type<e_bound_size, e_bound_size> smoothed_cov =
+            matrix::inverse(smoothed_cov_inv);
+
+        // Eq (3.38) of "Pattern Recognition, Tracking and Vertex
+        // Reconstruction in Particle Detectors"
+        const matrix_type<e_bound_size, 1u> smoothed_vec =
+            smoothed_cov * (filtered_cov_inv * trk_state.filtered().vector() +
+                            predicted_cov_inv * predicted_vec);
+
+        trk_state.smoothed().set_vector(smoothed_vec);
+        trk_state.smoothed().set_covariance(smoothed_cov);
+
+        const matrix_type<D, 1> residual_smt = meas_local - H * smoothed_vec;
+
+        // Spatial resolution (Measurement covariance)
+        const matrix_type<D, D> V =
+            trk_state.template measurement_covariance<D>();
+
+        // Eq (3.39) of "Pattern Recognition, Tracking and Vertex
+        // Reconstruction in Particle Detectors"
+        const matrix_type<D, D> R_smt =
+            V - H * smoothed_cov * matrix::transpose(H);
+
+        // Eq (3.40) of "Pattern Recognition, Tracking and Vertex
+        // Reconstruction in Particle Detectors"
+        const matrix_type<1, 1> chi2_smt = matrix::transpose(residual_smt) *
+                                           matrix::inverse(R_smt) *
+                                           residual_smt;
+
+        trk_state.smoothed_chi2() = getter::element(chi2_smt, 0, 0);
+
+        /*************************************
+         *  Set backward filtered parameter
+         *************************************/
+
+        const auto I66 =
+            matrix::identity<matrix_type<e_bound_size, e_bound_size>>();
+        const auto I_m = matrix::identity<matrix_type<D, D>>();
+
+        const matrix_type<D, D> M =
+            H * predicted_cov * matrix::transpose(H) + V;
+
+        // Kalman gain matrix
+        const matrix_type<6, D> K =
+            predicted_cov * matrix::transpose(H) * matrix::inverse(M);
+
+        // Calculate the filtered track parameters
+        const matrix_type<6, 1> filtered_vec =
+            predicted_vec + K * (meas_local - H * predicted_vec);
+        const matrix_type<6, 6> filtered_cov = (I66 - K * H) * predicted_cov;
+
+        // Residual between measurement and (projected) filtered vector
+        const matrix_type<D, 1> residual = meas_local - H * filtered_vec;
+
+        // Calculate backward chi2
+        const matrix_type<D, D> R = (I_m - H * K) * V;
+        const matrix_type<1, 1> chi2 =
+            matrix::transpose(residual) * matrix::inverse(R) * residual;
+
+        // Return false if track is parallel to z-axis or phi is not finite
+        const scalar theta = bound_params.theta();
+        if (theta <= 0.f || theta >= constant<traccc::scalar>::pi ||
+            !std::isfinite(bound_params.phi())) {
+            return false;
+        }
+
+        // Update the bound track parameters
+        bound_params.set_vector(filtered_vec);
+        bound_params.set_covariance(filtered_cov);
+
+        // Set backward chi2
+        trk_state.backward_chi2() = getter::element(chi2, 0, 0);
+
+        // Wrap the phi in the range of [-pi, pi]
+        wrap_phi(bound_params);
+
+        return true;
+    }
+};
+
+}  // namespace traccc

--- a/performance/include/traccc/resolution/stat_plot_tool_config.hpp
+++ b/performance/include/traccc/resolution/stat_plot_tool_config.hpp
@@ -24,7 +24,7 @@ struct stat_plot_tool_config {
         {"ndf", plot_helpers::binning("ndf", 35, -5.f, 30.f)},
         {"chi2", plot_helpers::binning("chi2", 100, 0.f, 50.f)},
         {"reduced_chi2", plot_helpers::binning("chi2/ndf", 100, 0.f, 10.f)},
-        {"pval", plot_helpers::binning("pval", 100, 0.f, 1.f)},
+        {"pval", plot_helpers::binning("pval", 50, 0.f, 1.f)},
         {"chi2_local", plot_helpers::binning("chi2", 100, 0.f, 10.f)}};
 };
 

--- a/tests/common/tests/kalman_fitting_telescope_test.hpp
+++ b/tests/common/tests/kalman_fitting_telescope_test.hpp
@@ -63,11 +63,11 @@ class KalmanFittingTelescopeTests
 
     /// Standard deviations for seed track parameters
     static constexpr std::array<scalar, e_bound_size> stddevs = {
-        0.03f * detray::unit<scalar>::mm,
-        0.03f * detray::unit<scalar>::mm,
+        0.1f * detray::unit<scalar>::mm,
+        0.1f * detray::unit<scalar>::mm,
         0.017f,
         0.017f,
-        0.001f / detray::unit<scalar>::GeV,
+        0.05f / detray::unit<scalar>::GeV,
         1.f * detray::unit<scalar>::ns};
 
     void consistency_tests(const track_state_collection_types::host&

--- a/tests/common/tests/kalman_fitting_test.hpp
+++ b/tests/common/tests/kalman_fitting_test.hpp
@@ -64,6 +64,12 @@ class KalmanFittingTests : public testing::Test {
     void pull_value_tests(std::string_view file_name,
                           const std::vector<std::string>& hist_names) const;
 
+    /// Verify that P value distribtions follow the uniform
+    ///
+    /// @param file_name The name of the file holding the distributions
+    ///
+    void p_value_tests(std::string_view file_name) const;
+
     /// Validadte the NDF
     ///
     /// @param host_det Detector object

--- a/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
@@ -111,6 +111,9 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
         -100.f * unit<float>::um;
     sim.get_config().propagation.navigation.max_mask_tolerance =
         1.f * unit<float>::mm;
+    sim.get_config().propagation.stepping.rk_error_tol =
+        1e-8f * unit<float>::mm;
+
     sim.run();
 
     /*****************************
@@ -123,9 +126,10 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     // Finding algorithm configuration
     typename traccc::finding_config cfg;
     cfg.ptc_hypothesis = ptc;
-    cfg.chi2_max = 30.f;
+    cfg.chi2_max = 200.f;
     cfg.propagation.navigation.overstep_tolerance = -100.f * unit<float>::um;
     cfg.propagation.navigation.max_mask_tolerance = 1.f * unit<float>::mm;
+    cfg.propagation.stepping.rk_error_tol = 1e-8f * unit<float>::mm;
 
     // Finding algorithm object
     traccc::host::combinatorial_kalman_filter_algorithm host_finding(cfg);
@@ -136,6 +140,8 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     fit_cfg.propagation.navigation.overstep_tolerance =
         -100.f * unit<float>::um;
     fit_cfg.propagation.navigation.max_mask_tolerance = 1.f * unit<float>::mm;
+    fit_cfg.propagation.stepping.rk_error_tol = 1e-8f * unit<float>::mm;
+    fit_cfg.use_backward_filter = true;
     traccc::host::kalman_fitting_algorithm host_fitting(fit_cfg, host_mr);
 
     // Iterate over events
@@ -198,6 +204,12 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     pull_value_tests(fit_writer_cfg.file_path, pull_names);
 
     /********************
+     * P-value test
+     ********************/
+
+    p_value_tests(fit_writer_cfg.file_path);
+
+    /********************
      * Success rate test
      ********************/
 
@@ -211,44 +223,44 @@ INSTANTIATE_TEST_SUITE_P(
     CkfSparseTrackTelescopeValidation0, CkfSparseTrackTelescopeTests,
     ::testing::Values(std::make_tuple(
         "telescope_single_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 200.f, 200.f},
+        std::array<scalar, 3u>{0.f, 400.f, 400.f},
         std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 1, 5000,
-        false, 20.f, 9u, 20.f, vector3{2 * detray::unit<scalar>::T, 0, 0})));
+        false, 20.f, 9u, 20.f, vector3{0, 0, 2 * detray::unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CkfSparseTrackTelescopeValidation1, CkfSparseTrackTelescopeTests,
     ::testing::Values(std::make_tuple(
         "telescope_double_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 200.f, 200.f},
+        std::array<scalar, 3u>{0.f, 400.f, 400.f},
         std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 2, 2500,
-        false, 20.f, 9u, 20.f, vector3{2 * detray::unit<scalar>::T, 0, 0})));
+        false, 20.f, 9u, 20.f, vector3{0, 0, 2 * detray::unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CkfSparseTrackTelescopeValidation2, CkfSparseTrackTelescopeTests,
     ::testing::Values(std::make_tuple(
         "telescope_quadra_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 200.f, 200.f},
+        std::array<scalar, 3u>{0.f, 400.f, 400.f},
         std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 4, 1250,
-        false, 20.f, 9u, 20.f, vector3{2 * detray::unit<scalar>::T, 0, 0})));
+        false, 20.f, 9u, 20.f, vector3{0, 0, 2 * detray::unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CkfSparseTrackTelescopeValidation3, CkfSparseTrackTelescopeTests,
     ::testing::Values(std::make_tuple(
         "telescope_decade_tracks", std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 200.f, 200.f},
+        std::array<scalar, 3u>{0.f, 400.f, 400.f},
         std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 10, 500,
-        false, 20.f, 9u, 20.f, vector3{2 * detray::unit<scalar>::T, 0, 0})));
+        false, 20.f, 9u, 20.f, vector3{0, 0, 2 * detray::unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CkfSparseTrackTelescopeValidation4, CkfSparseTrackTelescopeTests,
     ::testing::Values(std::make_tuple(
         "telescope_decade_tracks_random_charge",
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 200.f, 200.f},
+        std::array<scalar, 3u>{0.f, 400.f, 400.f},
         std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 10, 500, true,
-        20.f, 9u, 20.f, vector3{2 * detray::unit<scalar>::T, 0, 0})));
+        20.f, 9u, 20.f, vector3{0, 0, 2 * detray::unit<scalar>::T})));

--- a/tests/cpu/test_kalman_fitter_telescope.cpp
+++ b/tests/cpu/test_kalman_fitter_telescope.cpp
@@ -108,6 +108,8 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
         -100.f * unit<float>::um;
     sim.get_config().propagation.navigation.max_mask_tolerance =
         1.f * unit<float>::mm;
+    sim.get_config().propagation.stepping.rk_error_tol =
+        1e-8f * unit<float>::mm;
     sim.run();
 
     /***************
@@ -123,6 +125,8 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     fit_cfg.propagation.navigation.overstep_tolerance =
         -100.f * unit<float>::um;
     fit_cfg.propagation.navigation.max_mask_tolerance = 1.f * unit<float>::mm;
+    fit_cfg.propagation.stepping.rk_error_tol = 1e-8f * unit<float>::mm;
+    fit_cfg.use_backward_filter = true;
     traccc::host::kalman_fitting_algorithm fitting(fit_cfg, host_mr);
 
     // Iterate over events
@@ -174,6 +178,12 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     pull_value_tests(fit_writer_cfg.file_path, pull_names);
 
     /********************
+     * P-value test
+     ********************/
+
+    p_value_tests(fit_writer_cfg.file_path);
+
+    /********************
      * Success rate test
      ********************/
 
@@ -189,8 +199,8 @@ INSTANTIATE_TEST_SUITE_P(
         "telescope_1_GeV_0_phi_muon", std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
         std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f},
-        detray::muon<scalar>(), 100, 100, false, 20.f, 9u, 20.f,
-        vector3{2 * detray::unit<scalar>::T, 0, 0})));
+        detray::muon<scalar>(), 100, 100, false, 20.f, 20u, 20.f,
+        vector3{0, 0, 2 * detray::unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation1, KalmanFittingTelescopeTests,
@@ -199,7 +209,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{10.f, 10.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 100, 100,
-        false, 20.f, 9u, 20.f, vector3{2 * detray::unit<scalar>::T, 0, 0})));
+        false, 20.f, 9u, 20.f, vector3{0, 0, 2 * detray::unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation2, KalmanFittingTelescopeTests,
@@ -208,7 +218,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::array<scalar, 3u>{0.f, 0.f, 0.f},
         std::array<scalar, 2u>{100.f, 100.f}, std::array<scalar, 2u>{0.f, 0.f},
         std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 100, 100,
-        false, 20.f, 9u, 20.f, vector3{2 * detray::unit<scalar>::T, 0, 0})));
+        false, 20.f, 9u, 20.f, vector3{0, 0, 2 * detray::unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation3, KalmanFittingTelescopeTests,
@@ -218,7 +228,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
         std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f},
         detray::antimuon<scalar>(), 100, 100, false, 20.f, 9u, 20.f,
-        vector3{2 * detray::unit<scalar>::T, 0, 0})));
+        vector3{0, 0, 2 * detray::unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     KalmanFitTelescopeValidation4, KalmanFittingTelescopeTests,
@@ -228,14 +238,4 @@ INSTANTIATE_TEST_SUITE_P(
         std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
         std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f},
         detray::antimuon<scalar>(), 100, 100, true, 20.f, 9u, 20.f,
-        vector3{2 * detray::unit<scalar>::T, 0, 0})));
-
-INSTANTIATE_TEST_SUITE_P(
-    KalmanFitTelescopeValidation5, KalmanFittingTelescopeTests,
-    ::testing::Values(std::make_tuple(
-        "telescope_1_GeV_0_phi_muon_z_Bfield",
-        std::array<scalar, 3u>{0.f, 0.f, 0.f},
-        std::array<scalar, 3u>{0.f, 0.f, 0.f}, std::array<scalar, 2u>{1.f, 1.f},
-        std::array<scalar, 2u>{0.f, 0.f}, std::array<scalar, 2u>{0.f, 0.f},
-        detray::muon<scalar>(), 100, 100, false, 20.f, 9u, 20.f,
         vector3{0, 0, 2 * detray::unit<scalar>::T})));

--- a/tests/cpu/test_kalman_fitter_wire_chamber.cpp
+++ b/tests/cpu/test_kalman_fitter_wire_chamber.cpp
@@ -124,6 +124,7 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
         static_cast<float>(mask_tolerance);
     fit_cfg.propagation.navigation.search_window = search_window;
     fit_cfg.ptc_hypothesis = ptc;
+    fit_cfg.covariance_inflation_factor = 1.f;
     traccc::host::kalman_fitting_algorithm fitting(fit_cfg, host_mr);
 
     // Iterate over events

--- a/tests/cuda/test_kalman_fitter_telescope.cpp
+++ b/tests/cuda/test_kalman_fitter_telescope.cpp
@@ -152,6 +152,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     fit_cfg.propagation.navigation.overstep_tolerance =
         -100.f * unit<float>::um;
     fit_cfg.propagation.navigation.max_mask_tolerance = 1.f * unit<float>::mm;
+    fit_cfg.use_backward_filter = true;
     traccc::cuda::fitting_algorithm<device_fitter_type> device_fitting(
         fit_cfg, mr, copy, stream);
 
@@ -210,6 +211,12 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     pull_value_tests(fit_writer_cfg.file_path, pull_names);
 
     /********************
+     * P-value test
+     ********************/
+
+    p_value_tests(fit_writer_cfg.file_path);
+
+    /********************
      * Success rate test
      ********************/
 
@@ -227,7 +234,7 @@ INSTANTIATE_TEST_SUITE_P(
             std::array<scalar, 3u>{0.f, 0.f, 0.f},
             std::array<scalar, 2u>{1.f, 1.f}, std::array<scalar, 2u>{0.f, 0.f},
             std::array<scalar, 2u>{0.f, 0.f}, detray::muon<scalar>(), 100, 100,
-            false, 20.f, 9u, 20.f, vector3{2 * detray::unit<scalar>::T, 0, 0}),
+            false, 20.f, 9u, 20.f, vector3{0, 0, 2 * detray::unit<scalar>::T}),
         std::make_tuple("cuda_telescope_10_GeV_0_phi",
                         std::array<scalar, 3u>{0.f, 0.f, 0.f},
                         std::array<scalar, 3u>{0.f, 0.f, 0.f},
@@ -235,7 +242,7 @@ INSTANTIATE_TEST_SUITE_P(
                         std::array<scalar, 2u>{0.f, 0.f},
                         std::array<scalar, 2u>{0.f, 0.f},
                         detray::muon<scalar>(), 100, 100, false, 20.f, 9u, 20.f,
-                        vector3{2 * detray::unit<scalar>::T, 0, 0}),
+                        vector3{0, 0, 2 * detray::unit<scalar>::T}),
         std::make_tuple("cuda_telescope_100_GeV_0_phi",
                         std::array<scalar, 3u>{0.f, 0.f, 0.f},
                         std::array<scalar, 3u>{0.f, 0.f, 0.f},
@@ -243,7 +250,7 @@ INSTANTIATE_TEST_SUITE_P(
                         std::array<scalar, 2u>{0.f, 0.f},
                         std::array<scalar, 2u>{0.f, 0.f},
                         detray::muon<scalar>(), 100, 100, false, 20.f, 9u, 20.f,
-                        vector3{2 * detray::unit<scalar>::T, 0, 0}),
+                        vector3{0, 0, 2 * detray::unit<scalar>::T}),
         std::make_tuple("cuda_telescope_1_GeV_0_phi_antimuon",
                         std::array<scalar, 3u>{0.f, 0.f, 0.f},
                         std::array<scalar, 3u>{0.f, 0.f, 0.f},
@@ -251,7 +258,7 @@ INSTANTIATE_TEST_SUITE_P(
                         std::array<scalar, 2u>{0.f, 0.f},
                         std::array<scalar, 2u>{0.f, 0.f},
                         detray::antimuon<scalar>(), 100, 100, false, 20.f, 9u,
-                        20.f, vector3{2 * detray::unit<scalar>::T, 0, 0}),
+                        20.f, vector3{0, 0, 2 * detray::unit<scalar>::T}),
         std::make_tuple("cuda_telescope_1_GeV_0_phi_random_charge",
                         std::array<scalar, 3u>{0.f, 0.f, 0.f},
                         std::array<scalar, 3u>{0.f, 0.f, 0.f},
@@ -259,4 +266,4 @@ INSTANTIATE_TEST_SUITE_P(
                         std::array<scalar, 2u>{0.f, 0.f},
                         std::array<scalar, 2u>{0.f, 0.f},
                         detray::muon<scalar>(), 100, 100, true, 20.f, 9u, 20.f,
-                        vector3{2 * detray::unit<scalar>::T, 0, 0})));
+                        vector3{0, 0, 2 * detray::unit<scalar>::T})));


### PR DESCRIPTION
This PR implements the two-filters smoother where a smoothed state is calculated by taking a weighted average between filtered state from the forward filter and predicted state from the backward filter (See Eq (3.38) of [Pattern Recognition, Tracking and Vertex Reconstruction in Particle Detectors](https://link.springer.com/book/10.1007/978-3-030-65771-0))

Following changes are made to implement the two-filters method:
1. Backward propagator, whose detray actor sequence is reversed, is implemented to run the backward filter
2. Initial covariance is always inflated for both forward and backward filter
3. Test for the uniform distribution of p-values is also added

However, the default smoothing algorithm will still be the RTS smoother (i.e. smoothing algorithm which is already implemented) until we improve the two-filters method with the DirectNavigator of ACTS. The DirectNavigator is required to make sure that forward and backward filter propagate through the same set of surfaces.