### PR TITLE
Acts 38.0.0 Update, main branch (2024.12.02.)

### DIFF
--- a/extern/acts/CMakeLists.txt
+++ b/extern/acts/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,7 +18,7 @@ message( STATUS "Building Acts as part of the TRACCC project" )
 
 # Declare where to get Acts from.
 set( TRACCC_ACTS_SOURCE
-   "URL;https://github.com/acts-project/acts/archive/refs/tags/v37.3.0.tar.gz;URL_MD5;95cf54fe7986cece23ca7004d1138b01"
+   "URL;https://github.com/acts-project/acts/archive/refs/tags/v38.0.0.tar.gz;URL_MD5;295c73b1069e571af92e6d853a069e65"
    CACHE STRING "Source for Acts, when built as part of this project" )
 mark_as_advanced( TRACCC_ACTS_SOURCE )
 


### PR DESCRIPTION
Update to [Acts 38.0.0](https://github.com/acts-project/acts/releases/tag/v38.0.0). It's main purpose (to me) is: https://github.com/acts-project/acts/pull/3846 To make it possible to use oneAPI 2025.0.0 for building this project. (Making it very relevant for #773.)