### PR TITLE
Thrust Usage Update, main branch (2024.12.02.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,12 +176,8 @@ if( TRACCC_SETUP_THRUST )
       add_subdirectory( extern/cccl )
    endif()
 endif()
-# Set up an IMPORTED library on top of the Thrust library/libraries. One that
-# the TRACCC/Detray code could depend on publicly.
-set( TRACCC_THRUST_OPTIONS "" CACHE STRING
-   "Extra options for configuring how Thrust should be used" )
-mark_as_advanced( TRACCC_THRUST_OPTIONS )
-thrust_create_target( traccc::Thrust ${TRACCC_THRUST_OPTIONS} )
+add_library( traccc::Thrust INTERFACE IMPORTED )
+target_link_libraries( traccc::Thrust INTERFACE Thrust::Thrust )
 
 # Set up rocThrust.
 option( TRACCC_SETUP_ROCTHRUST

--- a/cmake/traccc-config.cmake.in
+++ b/cmake/traccc-config.cmake.in
@@ -56,8 +56,8 @@ endif()
 
 # Set up the traccc::Thrust target.
 if ( NOT TARGET traccc::Thrust )
-   set( TRACCC_THRUST_OPTIONS @TRACCC_THRUST_OPTIONS@ )
-   thrust_create_target( traccc::Thrust ${TRACCC_THRUST_OPTIONS} )
+   add_library( traccc::Thrust INTERFACE IMPORTED )
+   target_link_libraries( traccc::Thrust INTERFACE Thrust::Thrust )
 endif()
 
 # Include the file listing all the imported targets and options.

--- a/device/common/include/traccc/finding/device/find_tracks.hpp
+++ b/device/common/include/traccc/finding/device/find_tracks.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,9 +18,6 @@
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/finding/finding_config.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
-
-// Thrust include(s)
-#include <thrust/binary_search.h>
 
 namespace traccc::device {
 template <typename detector_t>

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,6 +21,7 @@
 
 // Thrust include(s)
 #include <thrust/binary_search.h>
+#include <thrust/execution_policy.h>
 
 namespace traccc::device {
 

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -106,7 +106,14 @@ target_compile_options( traccc_cuda
   PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr> )
 target_link_libraries( traccc_cuda
   PUBLIC traccc::core detray::core vecmem::core covfie::core
-  PRIVATE CUDA::cudart traccc::Thrust traccc::device_common vecmem::cuda )
+  PRIVATE CUDA::cudart traccc::device_common vecmem::cuda )
+
+# Set up Thrust specifically for the traccc::cuda library.
+thrust_create_target( traccc::cuda_thrust
+  HOST CPP
+  DEVICE CUDA )
+target_link_libraries( traccc_cuda
+  PRIVATE traccc::cuda_thrust )
 
 # For CUDA 11 turn on separable compilation. This is necessary for using
 # Thrust 2.1.0.

--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -51,3 +51,10 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
 target_link_libraries( traccc_sycl
   PUBLIC traccc::core detray::core vecmem::core covfie::core
   PRIVATE traccc::device_common vecmem::sycl oneDPL )
+
+# Set up Thrust specifically for the traccc::sycl library.
+thrust_create_target( traccc::sycl_thrust
+  HOST CPP
+  DEVICE CPP )
+target_link_libraries( traccc_sycl
+  PRIVATE traccc::sycl_thrust )

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -23,6 +23,11 @@ target_link_libraries(
     GTest::gtest
 )
 
+# Set up Thrust specifically for the CUDA unit tests.
+thrust_create_target( traccc_test_cuda_thrust
+  HOST CPP
+  DEVICE CUDA )
+
 traccc_add_test(
     cuda
 
@@ -48,7 +53,7 @@ traccc_add_test(
 
     LINK_LIBRARIES
     CUDA::cudart
-    traccc::Thrust
+    traccc_test_cuda_thrust
     GTest::gtest
     vecmem::cuda
     detray::core


### PR DESCRIPTION
Changed how [Thrust](https://nvidia.github.io/cccl/thrust/) would be used in the build.

Instead of setting up a single `traccc::Thrust` target that would take care of everything related to Thrust, the code rather sets up `traccc::Thrust` in a way that allows very little access in `traccc::core` to Thrust.

Instead, `traccc::cuda` and `traccc::sycl` (and also `traccc_test_cuda`) privately link against Thrust in specific ways. So that the appropriate "device headers" would get included everywhere.

Note that this shall not only help the SYCL developments (the commit comes directly from #773...), but the HIP ones as well. (Pinging @flg and @StewMH.)