### PR TITLE
Use Switch Instead of If, main branch (2024.12.04.)

### DIFF
--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -79,14 +79,11 @@ struct track_state {
     TRACCC_HOST_DEVICE inline matrix_type<D, 1> measurement_local() const {
         static_assert(((D == 1u) || (D == 2u)),
                       "The measurement dimension should be 1 or 2");
+        assert((m_measurement.subs.get_indices()[0] == e_bound_loc0) ||
+               (m_measurement.subs.get_indices()[0] == e_bound_loc1));
 
         matrix_type<D, 1> ret;
         switch (m_measurement.subs.get_indices()[0]) {
-            default:
-                assert(
-                    "The measurement index out of e_bound_loc0 and "
-                    "e_bound_loc1 should not happen.");
-                [[fallthrough]];
             case e_bound_loc0:
                 matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
                 if constexpr (D == 2u) {
@@ -101,6 +98,8 @@ struct track_state {
                         m_measurement.local[0];
                 }
                 break;
+            default:
+                __builtin_unreachable();
         }
         return ret;
     }
@@ -110,14 +109,11 @@ struct track_state {
     TRACCC_HOST_DEVICE inline matrix_type<D, D> measurement_covariance() const {
         static_assert(((D == 1u) || (D == 2u)),
                       "The measurement dimension should be 1 or 2");
+        assert((m_measurement.subs.get_indices()[0] == e_bound_loc0) ||
+               (m_measurement.subs.get_indices()[0] == e_bound_loc1));
 
         matrix_type<D, D> ret;
         switch (m_measurement.subs.get_indices()[0]) {
-            default:
-                assert(
-                    "The measurement index out of e_bound_loc0 and "
-                    "e_bound_loc1 should not happen.");
-                [[fallthrough]];
             case e_bound_loc0:
                 matrix_operator().element(ret, 0, 0) =
                     m_measurement.variance[0];
@@ -138,6 +134,8 @@ struct track_state {
                         m_measurement.variance[0];
                 }
                 break;
+            default:
+                __builtin_unreachable();
         }
         return ret;
     }

--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -81,26 +81,27 @@ struct track_state {
                       "The measurement dimension should be 1 or 2");
 
         matrix_type<D, 1> ret;
-        if (m_measurement.subs.get_indices()[0] == e_bound_loc0) {
-            matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
-            if constexpr (D == 2u) {
-                matrix_operator().element(ret, 1, 0) = m_measurement.local[1];
-            }
-        } else if (m_measurement.subs.get_indices()[0] == e_bound_loc1) {
-            matrix_operator().element(ret, 0, 0) = m_measurement.local[1];
-            if constexpr (D == 2u) {
-                matrix_operator().element(ret, 1, 0) = m_measurement.local[0];
-            }
-        } else {
-            assert(
-                "The measurement index out of e_bound_loc0 and e_bound_loc1 "
-                "should not happen.");
-            matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
-            if constexpr (D == 2u) {
-                matrix_operator().element(ret, 1, 0) = m_measurement.local[1];
-            }
+        switch (m_measurement.subs.get_indices()[0]) {
+            default:
+                assert(
+                    "The measurement index out of e_bound_loc0 and "
+                    "e_bound_loc1 should not happen.");
+                [[fallthrough]];
+            case e_bound_loc0:
+                matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
+                if constexpr (D == 2u) {
+                    matrix_operator().element(ret, 1, 0) =
+                        m_measurement.local[1];
+                }
+                break;
+            case e_bound_loc1:
+                matrix_operator().element(ret, 0, 0) = m_measurement.local[1];
+                if constexpr (D == 2u) {
+                    matrix_operator().element(ret, 1, 0) =
+                        m_measurement.local[0];
+                }
+                break;
         }
-
         return ret;
     }
 
@@ -111,36 +112,32 @@ struct track_state {
                       "The measurement dimension should be 1 or 2");
 
         matrix_type<D, D> ret;
-        if (m_measurement.subs.get_indices()[0] == e_bound_loc0) {
-
-            matrix_operator().element(ret, 0, 0) = m_measurement.variance[0];
-            if constexpr (D == 2u) {
-                matrix_operator().element(ret, 0, 1) = 0.f;
-                matrix_operator().element(ret, 1, 0) = 0.f;
-                matrix_operator().element(ret, 1, 1) =
-                    m_measurement.variance[1];
-            }
-
-        } else if (m_measurement.subs.get_indices()[0] == e_bound_loc1) {
-
-            matrix_operator().element(ret, 0, 0) = m_measurement.variance[1];
-            if constexpr (D == 2u) {
-                matrix_operator().element(ret, 0, 1) = 0.f;
-                matrix_operator().element(ret, 1, 0) = 0.f;
-                matrix_operator().element(ret, 1, 1) =
+        switch (m_measurement.subs.get_indices()[0]) {
+            default:
+                assert(
+                    "The measurement index out of e_bound_loc0 and "
+                    "e_bound_loc1 should not happen.");
+                [[fallthrough]];
+            case e_bound_loc0:
+                matrix_operator().element(ret, 0, 0) =
                     m_measurement.variance[0];
-            }
-        } else {
-            assert(
-                "The measurement index out of e_bound_loc0 and e_bound_loc1 "
-                "should not happen.");
-            matrix_operator().element(ret, 0, 0) = m_measurement.variance[0];
-            if constexpr (D == 2u) {
-                matrix_operator().element(ret, 0, 1) = 0.f;
-                matrix_operator().element(ret, 1, 0) = 0.f;
-                matrix_operator().element(ret, 1, 1) =
+                if constexpr (D == 2u) {
+                    matrix_operator().element(ret, 0, 1) = 0.f;
+                    matrix_operator().element(ret, 1, 0) = 0.f;
+                    matrix_operator().element(ret, 1, 1) =
+                        m_measurement.variance[1];
+                }
+                break;
+            case e_bound_loc1:
+                matrix_operator().element(ret, 0, 0) =
                     m_measurement.variance[1];
-            }
+                if constexpr (D == 2u) {
+                    matrix_operator().element(ret, 0, 1) = 0.f;
+                    matrix_operator().element(ret, 1, 0) = 0.f;
+                    matrix_operator().element(ret, 1, 1) =
+                        m_measurement.variance[0];
+                }
+                break;
         }
         return ret;
     }

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -45,13 +45,14 @@ struct gain_matrix_updater {
 
         const auto D = trk_state.get_measurement().meas_dim;
         assert(D == 1u || D == 2u);
-        if (D == 1u) {
-            return update<1u, shape_type>(trk_state, bound_params);
-        } else if (D == 2u) {
-            return update<2u, shape_type>(trk_state, bound_params);
+        switch (D) {
+            case 1u:
+                return update<1u, shape_type>(trk_state, bound_params);
+            case 2u:
+                return update<2u, shape_type>(trk_state, bound_params);
+            default:
+                return false;
         }
-
-        return false;
     }
 
     template <size_type D, typename shape_t>

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -45,14 +45,18 @@ struct gain_matrix_updater {
 
         const auto D = trk_state.get_measurement().meas_dim;
         assert(D == 1u || D == 2u);
+        bool result = false;
         switch (D) {
             case 1u:
-                return update<1u, shape_type>(trk_state, bound_params);
+                result = update<1u, shape_type>(trk_state, bound_params);
+                break;
             case 2u:
-                return update<2u, shape_type>(trk_state, bound_params);
+                result = update<2u, shape_type>(trk_state, bound_params);
+                break;
             default:
-                return false;
+                __builtin_unreachable();
         }
+        return result;
     }
 
     template <size_type D, typename shape_t>


### PR DESCRIPTION
As a bit of a palette cleanser between larger / messier PRs, I present this simple one. :smile:

I came across these `if(...)` blocks while working on the SoA-ification of `traccc::measurement`. :thinking: I think these changes should allow the compiler to generate more efficient code. Though probably not by a whole lot.