### PR TITLE
ref: Update to detray version 0.85.0 and adapt to new algebra-plugins API

### DIFF
--- a/core/include/traccc/definitions/primitives.hpp
+++ b/core/include/traccc/definitions/primitives.hpp
@@ -14,7 +14,7 @@
 #elif ALGEBRA_PLUGINS_INCLUDE_SMATRIX
 #include "traccc/plugins/algebra/smatrix_definitions.hpp"
 #elif ALGEBRA_PLUGINS_INCLUDE_VC
-#include "traccc/plugins/algebra/vc_definitions.hpp"
+#include "traccc/plugins/algebra/vc_aos_definitions.hpp"
 #elif ALGEBRA_PLUGINS_INCLUDE_VECMEM
 #include "traccc/plugins/algebra/vecmem_definitions.hpp"
 #endif
@@ -40,7 +40,9 @@ using point3 = detray::dpoint3D<default_algebra>;
 using vector3 = detray::dvector3D<default_algebra>;
 using variance3 = point3;
 using transform3 = detray::dtransform3D<default_algebra>;
-template <std::size_t ROW, std::size_t COL>
-using matrix = detray::dmatrix<default_algebra, ROW, COL>;
+
+namespace getter = detray::getter;
+namespace vector = detray::vector;
+namespace matrix = detray::matrix;
 
 }  // namespace traccc

--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/container.hpp"
 #include "traccc/edm/measurement.hpp"
@@ -43,12 +44,11 @@ template <typename algebra_t>
 struct track_state {
 
     using scalar_type = detray::dscalar<algebra_t>;
+    using size_type = detray::dsize_type<algebra_t>;
 
     using bound_track_parameters_type =
         detray::bound_track_parameters<algebra_t>;
     using bound_matrix = detray::bound_matrix<algebra_t>;
-    using matrix_operator = detray::dmatrix_operator<algebra_t>;
-    using size_type = detray::dsize_type<algebra_t>;
     template <size_type ROWS, size_type COLS>
     using matrix_type = detray::dmatrix<algebra_t, ROWS, COLS>;
 
@@ -85,17 +85,15 @@ struct track_state {
         matrix_type<D, 1> ret;
         switch (m_measurement.subs.get_indices()[0]) {
             case e_bound_loc0:
-                matrix_operator().element(ret, 0, 0) = m_measurement.local[0];
+                getter::element(ret, 0, 0) = m_measurement.local[0];
                 if constexpr (D == 2u) {
-                    matrix_operator().element(ret, 1, 0) =
-                        m_measurement.local[1];
+                    getter::element(ret, 1, 0) = m_measurement.local[1];
                 }
                 break;
             case e_bound_loc1:
-                matrix_operator().element(ret, 0, 0) = m_measurement.local[1];
+                getter::element(ret, 0, 0) = m_measurement.local[1];
                 if constexpr (D == 2u) {
-                    matrix_operator().element(ret, 1, 0) =
-                        m_measurement.local[0];
+                    getter::element(ret, 1, 0) = m_measurement.local[0];
                 }
                 break;
             default:
@@ -115,23 +113,19 @@ struct track_state {
         matrix_type<D, D> ret;
         switch (m_measurement.subs.get_indices()[0]) {
             case e_bound_loc0:
-                matrix_operator().element(ret, 0, 0) =
-                    m_measurement.variance[0];
+                getter::element(ret, 0, 0) = m_measurement.variance[0];
                 if constexpr (D == 2u) {
-                    matrix_operator().element(ret, 0, 1) = 0.f;
-                    matrix_operator().element(ret, 1, 0) = 0.f;
-                    matrix_operator().element(ret, 1, 1) =
-                        m_measurement.variance[1];
+                    getter::element(ret, 0, 1) = 0.f;
+                    getter::element(ret, 1, 0) = 0.f;
+                    getter::element(ret, 1, 1) = m_measurement.variance[1];
                 }
                 break;
             case e_bound_loc1:
-                matrix_operator().element(ret, 0, 0) =
-                    m_measurement.variance[1];
+                getter::element(ret, 0, 0) = m_measurement.variance[1];
                 if constexpr (D == 2u) {
-                    matrix_operator().element(ret, 0, 1) = 0.f;
-                    matrix_operator().element(ret, 1, 0) = 0.f;
-                    matrix_operator().element(ret, 1, 1) =
-                        m_measurement.variance[0];
+                    getter::element(ret, 0, 1) = 0.f;
+                    getter::element(ret, 1, 0) = 0.f;
+                    getter::element(ret, 1, 1) = m_measurement.variance[0];
                 }
                 break;
             default:
@@ -200,8 +194,7 @@ struct track_state {
     private:
     detray::geometry::barcode m_surface_link;
     measurement m_measurement;
-    bound_matrix m_jacobian =
-        matrix_operator().template zero<e_bound_size, e_bound_size>();
+    bound_matrix m_jacobian = matrix::zero<bound_matrix>();
     bound_track_parameters_type m_predicted;
     scalar_type m_filtered_chi2 = 0.f;
     bound_track_parameters_type m_filtered;

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
@@ -21,10 +21,11 @@ struct gain_matrix_smoother {
 
     // Type declarations
     using scalar_type = detray::dscalar<algebra_t>;
-    using matrix_operator = detray::dmatrix_operator<algebra_t>;
     using size_type = detray::dsize_type<algebra_t>;
     template <size_type ROWS, size_type COLS>
     using matrix_type = detray::dmatrix<algebra_t, ROWS, COLS>;
+    using bound_vector_type = detray::bound_vector<algebra_t>;
+    using bound_matrix_type = detray::bound_matrix<algebra_t>;
 
     /// Gain matrix smoother operation
     ///
@@ -69,44 +70,38 @@ struct gain_matrix_smoother {
         const auto& cur_filtered = cur_state.filtered();
 
         // Next track state parameters
-        const matrix_type<e_bound_size, e_bound_size>& next_jacobian =
-            next_state.jacobian();
-        const matrix_type<e_bound_size, 1>& next_smoothed_vec =
-            next_smoothed.vector();
-        const matrix_type<e_bound_size, e_bound_size>& next_smoothed_cov =
-            next_smoothed.covariance();
-        const matrix_type<e_bound_size, 1>& next_predicted_vec =
-            next_predicted.vector();
-        const matrix_type<e_bound_size, e_bound_size>& next_predicted_cov =
+        const bound_matrix_type& next_jacobian = next_state.jacobian();
+        const bound_vector_type& next_smoothed_vec = next_smoothed.vector();
+        const bound_matrix_type& next_smoothed_cov = next_smoothed.covariance();
+        const bound_vector_type& next_predicted_vec = next_predicted.vector();
+        const bound_matrix_type& next_predicted_cov =
             next_predicted.covariance();
 
         // Current track state parameters
-        const matrix_type<e_bound_size, 1>& cur_filtered_vec =
-            cur_filtered.vector();
-        const matrix_type<e_bound_size, e_bound_size>& cur_filtered_cov =
-            cur_filtered.covariance();
+        const bound_vector_type& cur_filtered_vec = cur_filtered.vector();
+        const bound_matrix_type& cur_filtered_cov = cur_filtered.covariance();
 
         // Regularization matrix for numerical stability
-        static constexpr scalar_type epsilon = 1e-13f;
-        const matrix_type<e_bound_size, e_bound_size> regularization =
-            matrix_operator().template identity<e_bound_size, e_bound_size>() *
-            epsilon;
-        const matrix_type<e_bound_size, e_bound_size>
-            regularized_predicted_cov = next_predicted_cov + regularization;
+        constexpr scalar_type epsilon = 1e-13f;
+        const auto regularization =
+            matrix::identity<bound_matrix_type>() * epsilon;
+        const bound_matrix_type regularized_predicted_cov =
+            next_predicted_cov + regularization;
 
         // Calculate smoothed parameter for current state
-        const matrix_type<e_bound_size, e_bound_size> A =
-            cur_filtered_cov * matrix_operator().transpose(next_jacobian) *
-            matrix_operator().inverse(regularized_predicted_cov);
+        const bound_matrix_type A = cur_filtered_cov *
+                                    matrix::transpose(next_jacobian) *
+                                    matrix::inverse(regularized_predicted_cov);
 
-        const matrix_type<e_bound_size, 1> smt_vec =
+        const bound_vector_type smt_vec =
             cur_filtered_vec + A * (next_smoothed_vec - next_predicted_vec);
-        const matrix_type<e_bound_size, e_bound_size> smt_cov =
-            cur_filtered_cov + A * (next_smoothed_cov - next_predicted_cov) *
-                                   matrix_operator().transpose(A);
+        const bound_matrix_type smt_cov =
+            cur_filtered_cov +
+            A * (next_smoothed_cov - next_predicted_cov) * matrix::transpose(A);
 
         cur_state.smoothed().set_vector(smt_vec);
         cur_state.smoothed().set_covariance(smt_cov);
+
         // Wrap the phi in the range of [-pi, pi]
         wrap_phi(cur_state.smoothed());
 
@@ -127,12 +122,11 @@ struct gain_matrix_smoother {
         const matrix_type<D, D>& V =
             cur_state.template measurement_covariance<D>();
         const matrix_type<D, 1> residual = meas_local - H * smt_vec;
-        const matrix_type<D, D> R =
-            V - H * smt_cov * matrix_operator().transpose(H);
-        const matrix_type<1, 1> chi2 = matrix_operator().transpose(residual) *
-                                       matrix_operator().inverse(R) * residual;
+        const matrix_type<D, D> R = V - H * smt_cov * matrix::transpose(H);
+        const matrix_type<1, 1> chi2 =
+            matrix::transpose(residual) * matrix::inverse(R) * residual;
 
-        cur_state.smoothed_chi2() = matrix_operator().element(chi2, 0, 0);
+        cur_state.smoothed_chi2() = getter::element(chi2, 0, 0);
 
         return;
     }

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -19,10 +19,11 @@ template <typename algebra_t>
 struct gain_matrix_updater {
 
     // Type declarations
-    using matrix_operator = detray::dmatrix_operator<algebra_t>;
     using size_type = detray::dsize_type<algebra_t>;
     template <size_type ROWS, size_type COLS>
     using matrix_type = detray::dmatrix<algebra_t, ROWS, COLS>;
+    using bound_vector_type = detray::bound_vector<algebra_t>;
+    using bound_matrix_type = detray::bound_matrix<algebra_t>;
 
     /// Gain matrix updater operation
     ///
@@ -70,12 +71,9 @@ struct gain_matrix_updater {
         const auto meas = trk_state.get_measurement();
 
         // Some identity matrices
-        // @Note: Make constexpr work
-        const matrix_type<e_bound_size, e_bound_size> I66 =
-            matrix_operator().template identity<e_bound_size, e_bound_size>();
-
-        const matrix_type<D, D> I_m =
-            matrix_operator().template identity<D, D>();
+        // @TODO: Make constexpr work
+        const auto I66 = matrix::identity<bound_matrix_type>();
+        const auto I_m = matrix::identity<matrix_type<D, D>>();
 
         matrix_type<D, e_bound_size> H = meas.subs.template projector<D>();
 
@@ -84,12 +82,10 @@ struct gain_matrix_updater {
             trk_state.template measurement_local<D>();
 
         // Predicted vector of bound track parameters
-        const matrix_type<e_bound_size, 1>& predicted_vec =
-            bound_params.vector();
+        const bound_vector_type& predicted_vec = bound_params.vector();
 
         // Predicted covaraince of bound track parameters
-        const matrix_type<e_bound_size, e_bound_size>& predicted_cov =
-            bound_params.covariance();
+        const bound_matrix_type& predicted_cov = bound_params.covariance();
 
         // Set track state parameters
         trk_state.predicted().set_vector(predicted_vec);
@@ -108,12 +104,11 @@ struct gain_matrix_updater {
             trk_state.template measurement_covariance<D>();
 
         const matrix_type<D, D> M =
-            H * predicted_cov * matrix_operator().transpose(H) + V;
+            H * predicted_cov * matrix::transpose(H) + V;
 
         // Kalman gain matrix
-        const matrix_type<6, D> K = predicted_cov *
-                                    matrix_operator().transpose(H) *
-                                    matrix_operator().inverse(M);
+        const matrix_type<6, D> K =
+            predicted_cov * matrix::transpose(H) * matrix::inverse(M);
 
         // Calculate the filtered track parameters
         const matrix_type<6, 1> filtered_vec =
@@ -125,8 +120,8 @@ struct gain_matrix_updater {
 
         // Calculate the chi square
         const matrix_type<D, D> R = (I_m - H * K) * V;
-        const matrix_type<1, 1> chi2 = matrix_operator().transpose(residual) *
-                                       matrix_operator().inverse(R) * residual;
+        const matrix_type<1, 1> chi2 =
+            matrix::transpose(residual) * matrix::inverse(R) * residual;
 
         // Return false if track is parallel to z-axis or phi is not finite
         const scalar theta = bound_params.theta();
@@ -138,7 +133,7 @@ struct gain_matrix_updater {
         // Set the track state parameters
         trk_state.filtered().set_vector(filtered_vec);
         trk_state.filtered().set_covariance(filtered_cov);
-        trk_state.filtered_chi2() = matrix_operator().element(chi2, 0, 0);
+        trk_state.filtered_chi2() = getter::element(chi2, 0, 0);
 
         // Wrap the phi in the range of [-pi, pi]
         wrap_phi(trk_state.filtered());

--- a/core/include/traccc/seeding/detail/seeding_config.hpp
+++ b/core/include/traccc/seeding/detail/seeding_config.hpp
@@ -105,7 +105,7 @@ struct seedfinder_config {
 
     TRACCC_HOST_DEVICE
     size_t get_num_rbins() const {
-        return static_cast<size_t>(rMax + getter::norm(beamPos));
+        return static_cast<size_t>(rMax + vector::norm(beamPos));
     }
 
     TRACCC_HOST_DEVICE

--- a/core/include/traccc/seeding/spacepoint_binning_helper.hpp
+++ b/core/include/traccc/seeding/spacepoint_binning_helper.hpp
@@ -120,7 +120,7 @@ inline TRACCC_HOST_DEVICE size_t is_valid_sp(const seedfinder_config& config,
     if (spPhi > config.phiMax || spPhi < config.phiMin) {
         return detray::detail::invalid_value<size_t>();
     }
-    size_t r_index = static_cast<size_t>(getter::perp(
+    size_t r_index = static_cast<size_t>(vector::perp(
         vector2{sp.x() - config.beamPos[0], sp.y() - config.beamPos[1]}));
 
     if (r_index < config.get_num_rbins()) {

--- a/core/include/traccc/seeding/track_params_estimation_helper.hpp
+++ b/core/include/traccc/seeding/track_params_estimation_helper.hpp
@@ -86,22 +86,22 @@ seed_to_bound_vector(const spacepoint_collection_t& sp_collection,
     scalar B = uv2[1] - A * uv2[0];
 
     // Radius (with a sign)
-    scalar R = -getter::perp(vector2{1.f, A}) / (2.f * B);
+    scalar R = -vector::perp(vector2{1.f, A}) / (2.f * B);
     // The (1/tanTheta) of momentum in the new frame
     scalar invTanTheta =
-        local2[2] / (2.f * R * math::asin(getter::perp(local2) / (2.f * R)));
+        local2[2] / (2.f * R * math::asin(vector::perp(local2) / (2.f * R)));
 
     // The momentum direction in the new frame (the center of the circle
     // has the coordinate (-1.*A/(2*B), 1./(2*B)))
     vector3 transDirection =
-        vector3({1.f, A, scalar(getter::perp(vector2{1.f, A})) * invTanTheta});
+        vector3({1.f, A, scalar(vector::perp(vector2{1.f, A})) * invTanTheta});
     // Transform it back to the original frame
     vector3 direction =
         transform3::rotate(trans._data, vector::normalize(transDirection));
 
     // The estimated phi and theta
-    getter::element(params, e_bound_phi, 0) = getter::phi(direction);
-    getter::element(params, e_bound_theta, 0) = getter::theta(direction);
+    getter::element(params, e_bound_phi, 0) = vector::phi(direction);
+    getter::element(params, e_bound_theta, 0) = vector::theta(direction);
 
     // The measured loc0 and loc1
     const auto& meas_for_spB = spB.meas;
@@ -110,10 +110,10 @@ seed_to_bound_vector(const spacepoint_collection_t& sp_collection,
 
     // The estimated q/pt in [GeV/c]^-1 (note that the pt is the
     // projection of momentum on the transverse plane of the new frame)
-    scalar qOverPt = 1.f / (R * getter::norm(bfield));
+    scalar qOverPt = 1.f / (R * vector::norm(bfield));
     // The estimated q/p in [GeV/c]^-1
     getter::element(params, e_bound_qoverp, 0) =
-        qOverPt / getter::perp(vector2{1.f, invTanTheta});
+        qOverPt / vector::perp(vector2{1.f, invTanTheta});
 
     // Make sure the time is a finite value
     assert(std::isfinite(getter::element(params, e_bound_time, 0)));

--- a/core/include/traccc/utils/seed_generator.hpp
+++ b/core/include/traccc/utils/seed_generator.hpp
@@ -30,7 +30,6 @@ namespace traccc {
 template <typename detector_t>
 struct seed_generator {
     using algebra_type = typename detector_t::algebra_type;
-    using matrix_operator = detray::dmatrix_operator<algebra_type>;
     using cxt_t = typename detector_t::geometry_context;
 
     /// Constructor with detector
@@ -58,9 +57,7 @@ struct seed_generator {
 
         const cxt_t ctx{};
         auto bound_vec = sf.free_to_bound_vector(ctx, free_param);
-
-        auto bound_cov =
-            matrix_operator().template zero<e_bound_size, e_bound_size>();
+        auto bound_cov = matrix::zero<detray::bound_matrix<algebra_type>>();
 
         bound_track_parameters bound_param{surface_link, bound_vec, bound_cov};
 
@@ -82,7 +79,7 @@ struct seed_generator {
             bound_param[i] = std::normal_distribution<scalar>(
                 bound_param[i], m_stddevs[i])(m_generator);
 
-            matrix_operator().element(bound_param.covariance(), i, i) =
+            getter::element(bound_param.covariance(), i, i) =
                 m_stddevs[i] * m_stddevs[i];
         }
 

--- a/core/include/traccc/utils/subspace.hpp
+++ b/core/include/traccc/utils/subspace.hpp
@@ -26,7 +26,6 @@ struct subspace {
 
     public:
     // Type declarations
-    using matrix_operator = detray::dmatrix_operator<algebra_t>;
     using size_type = detray::dsize_type<algebra_t>;
     template <size_type ROWS, size_type COLS>
     using matrix_type = detray::dmatrix<algebra_t, ROWS, COLS>;
@@ -36,8 +35,8 @@ struct subspace {
     using projection_matrix = matrix_type<kSize, kFullSize>;
     using expansion_matrix = matrix_type<kFullSize, kSize>;
 
-    static const size_type size = kSize;
-    static const size_type fullSize = kFullSize;
+    static constexpr size_type size = kSize;
+    static constexpr size_type fullSize = kFullSize;
 
     /// Construct from a container of axis indices.
     ///
@@ -76,8 +75,7 @@ struct subspace {
                       "The dimension of projection should be smaller than "
                       "subspace dimension");
 
-        matrix_type<D, kFullSize> proj =
-            matrix_operator().template zero<D, kFullSize>();
+        auto proj = matrix::zero<matrix_type<D, kFullSize>>();
 
         for (size_type i = 0u; i < D; ++i) {
             getter::element(proj, i, m_axes[i]) = 1;
@@ -92,8 +90,7 @@ struct subspace {
                       "The dimension of projection should be smaller than "
                       "subspace dimension");
 
-        matrix_type<kFullSize, D> expn =
-            matrix_operator().template zero<kFullSize, D>();
+        auto expn = matrix::zero<matrix_type<kFullSize, D>>();
 
         for (size_type i = 0u; i < kSize; ++i) {
             getter::element(expn, m_axes[i], i) = 1;

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Algebra Plugins as part of the TRACCC project" )
 
 # Declare where to get Algebra Plugins from.
 set( TRACCC_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/krasznaa/algebra-plugins/archive/refs/tags/v0.25.1.tar.gz;URL_MD5;fa75a55330ad37ec812842fd7a07eb15"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.26.0.tar.gz;URL_MD5;004d53433ee781b7ce0c1c3eef8cd224"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced( TRACCC_ALGEBRA_PLUGINS_SOURCE )
 FetchContent_Declare( AlgebraPlugins SYSTEM ${TRACCC_ALGEBRA_PLUGINS_SOURCE} )

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.84.0.tar.gz;URL_MD5;81e809ebd9b04b6e06e11bab4eeb830d"
+"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.85.0.tar.gz;URL_MD5;983de0f04feac425bbc5893f7f5a0339"
    CACHE STRING "Source for Detray, when built as part of this project" )
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
 FetchContent_Declare( Detray SYSTEM ${TRACCC_DETRAY_SOURCE} )

--- a/io/src/csv/make_measurement_edm.cpp
+++ b/io/src/csv/make_measurement_edm.cpp
@@ -19,7 +19,7 @@ traccc::measurement make_measurement_edm(
 
     // Construct the measurement object.
     traccc::measurement meas;
-    std::array<typename transform3::size_type, 2u> indices{0u, 0u};
+    std::array<detray::dsize_type<default_algebra>, 2u> indices{0u, 0u};
     meas.meas_dim = 0u;
 
     // Local key is a 8 bit char and first and last bit are dummy value. 2 -

--- a/io/src/csv/read_measurements.cpp
+++ b/io/src/csv/read_measurements.cpp
@@ -44,7 +44,7 @@ void read_measurements(measurement_collection_types::host& measurements,
 
         // Construct the measurement object.
         traccc::measurement meas;
-        std::array<typename transform3::size_type, 2u> indices{0u, 0u};
+        std::array<detray::dsize_type<default_algebra>, 2u> indices{0u, 0u};
         meas.meas_dim = 0u;
 
         // Local key is a 8 bit char and first and last bit are dummy value. 2 -

--- a/performance/include/traccc/efficiency/nseed_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/nseed_performance_writer.hpp
@@ -85,9 +85,9 @@ class nseed_performance_writer {
                 }
             }
 
-            const scalar eta = getter::eta(ptc.momentum);
-            const scalar phi = getter::phi(ptc.momentum);
-            const scalar pT = getter::perp(ptc.momentum);
+            const scalar eta = vector::eta(ptc.momentum);
+            const scalar phi = vector::phi(ptc.momentum);
+            const scalar pT = vector::perp(ptc.momentum);
 
             write_track_row(ev, ptc.particle_id, pass, ptc.charge, eta, phi,
                             pT);

--- a/performance/include/traccc/resolution/fitting_performance_writer.hpp
+++ b/performance/include/traccc/resolution/fitting_performance_writer.hpp
@@ -93,11 +93,11 @@ class fitting_performance_writer {
         // Return value
         bound_track_parameters truth_param{};
         truth_param.set_bound_local(truth_bound);
-        truth_param.set_phi(getter::phi(global_mom));
-        truth_param.set_theta(getter::theta(global_mom));
+        truth_param.set_phi(vector::phi(global_mom));
+        truth_param.set_theta(vector::theta(global_mom));
         // @todo: Assign a proper value to time
         truth_param.set_time(0.f);
-        truth_param.set_qop(ptc.charge / getter::norm(global_mom));
+        truth_param.set_qop(ptc.charge / vector::norm(global_mom));
 
         // For the moment, only fill with the first measurements
         if (fit_res.ndf > 0 && !trk_state.is_hole) {

--- a/performance/src/efficiency/duplication_plot_tool.hpp
+++ b/performance/src/efficiency/duplication_plot_tool.hpp
@@ -109,9 +109,9 @@ class duplication_plot_tool {
     /// @param nDuplicatedTracks the number of duplicated tracks
     void fill(duplication_plot_cache& cache, const particle& truth_particle,
               size_t n_duplicated_tracks) const {
-        const auto t_phi = getter::phi(truth_particle.momentum);
-        const auto t_eta = getter::eta(truth_particle.momentum);
-        const auto t_pT = getter::perp(
+        const auto t_phi = vector::phi(truth_particle.momentum);
+        const auto t_eta = vector::eta(truth_particle.momentum);
+        const auto t_pT = vector::perp(
             vector2{truth_particle.momentum[0], truth_particle.momentum[1]});
 
         // Avoid unused variable warnings when building the code without ROOT.

--- a/performance/src/efficiency/eff_plot_tool.hpp
+++ b/performance/src/efficiency/eff_plot_tool.hpp
@@ -86,9 +86,9 @@ class eff_plot_tool {
     void fill(eff_plot_cache& cache, const particle& truth_particle,
               bool status) const {
 
-        const auto t_phi = getter::phi(truth_particle.momentum);
-        const auto t_eta = getter::eta(truth_particle.momentum);
-        const auto t_pT = getter::perp(
+        const auto t_phi = vector::phi(truth_particle.momentum);
+        const auto t_eta = vector::eta(truth_particle.momentum);
+        const auto t_pT = vector::perp(
             vector2{truth_particle.momentum[0], truth_particle.momentum[1]});
 
         // Avoid unused variable warnings when building the code without ROOT.

--- a/performance/src/efficiency/fake_tracks_plot_tool.hpp
+++ b/performance/src/efficiency/fake_tracks_plot_tool.hpp
@@ -108,9 +108,9 @@ class fake_tracks_plot_tool {
     /// @param nDuplicatedTracks the number of fake tracks
     void fill(fake_tracks_plot_cache& cache, const particle& truth_particle,
               size_t n_fake_tracks) const {
-        const auto t_phi = getter::phi(truth_particle.momentum);
-        const auto t_eta = getter::eta(truth_particle.momentum);
-        const auto t_pT = getter::perp(
+        const auto t_phi = vector::phi(truth_particle.momentum);
+        const auto t_eta = vector::eta(truth_particle.momentum);
+        const auto t_pT = vector::perp(
             vector2{truth_particle.momentum[0], truth_particle.momentum[1]});
 
         // Avoid unused variable warnings when building the code without ROOT.

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -213,9 +213,9 @@ void finding_performance_writer::write_common(
     for (auto const& [pid, ptc] : evt_data.m_particle_map) {
 
         // Count only charged particles which satisfy pT_cut
-        if (ptc.charge == 0 || getter::perp(ptc.momentum) < m_cfg.pT_cut ||
+        if (ptc.charge == 0 || vector::perp(ptc.momentum) < m_cfg.pT_cut ||
             ptc.vertex[2] < m_cfg.z_min || ptc.vertex[2] > m_cfg.z_max ||
-            getter::perp(ptc.vertex) > m_cfg.r_max) {
+            vector::perp(ptc.vertex) > m_cfg.r_max) {
             continue;
         }
 

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -97,9 +97,9 @@ void seeding_performance_writer::write(
     for (auto const& [pid, ptc] : evt_data.m_particle_map) {
 
         // Count only charged particles which satisfiy pT_cut
-        if (ptc.charge == 0 || getter::perp(ptc.momentum) < m_cfg.pT_cut ||
+        if (ptc.charge == 0 || vector::perp(ptc.momentum) < m_cfg.pT_cut ||
             ptc.vertex[2] < m_cfg.z_min || ptc.vertex[2] > m_cfg.z_max ||
-            getter::perp(ptc.vertex) > m_cfg.r_max) {
+            vector::perp(ptc.vertex) > m_cfg.r_max) {
             continue;
         }
 

--- a/performance/src/efficiency/track_filter.cpp
+++ b/performance/src/efficiency/track_filter.cpp
@@ -22,8 +22,8 @@ std::string simple_charged_eta_pt_cut::get_name() const {
 }
 
 bool simple_charged_eta_pt_cut::operator()(const particle& p) const {
-    const scalar eta = getter::eta(p.momentum);
-    const scalar pT = getter::perp(p.momentum);
+    const scalar eta = vector::eta(p.momentum);
+    const scalar pT = vector::perp(p.momentum);
 
     return p.charge != 0 && std::abs(eta) <= m_eta && pT >= m_pT;
 }

--- a/performance/src/resolution/res_plot_tool.cpp
+++ b/performance/src/resolution/res_plot_tool.cpp
@@ -100,7 +100,7 @@ void res_plot_tool::fill(res_plot_cache& cache,
                          const particle& ptc) const {
 
     // Find index of eta and pT for resolution histogram
-    const scalar eta = getter::eta(ptc.momentum);
+    const scalar eta = vector::eta(ptc.momentum);
     const scalar pT = std::hypot(ptc.momentum[0], ptc.momentum[1]);
 
     // Avoid unused variable warnings when building the code without ROOT.

--- a/plugins/algebra/CMakeLists.txt
+++ b/plugins/algebra/CMakeLists.txt
@@ -33,6 +33,6 @@ endif()
 
 # Make use of algebra::vc_aos, if it is available.
 if( ALGEBRA_PLUGINS_INCLUDE_VC )
-  add_subdirectory( vc )
+  add_subdirectory( vc_aos )
   target_link_libraries( traccc_algebra INTERFACE traccc::vc_aos )
 endif()

--- a/plugins/algebra/array/include/traccc/plugins/algebra/array_definitions.hpp
+++ b/plugins/algebra/array/include/traccc/plugins/algebra/array_definitions.hpp
@@ -42,7 +42,8 @@ using dmap = std::map<key_type, value_type>;
 template <class... types>
 using dtuple = std::tuple<types...>;
 
-namespace getter = algebra::getter;
-namespace vector = algebra::vector;
+using algebra::cmath::operator*;
+using algebra::cmath::operator-;
+using algebra::cmath::operator+;
 
 }  // namespace traccc

--- a/plugins/algebra/eigen/include/traccc/plugins/algebra/eigen_definitions.hpp
+++ b/plugins/algebra/eigen/include/traccc/plugins/algebra/eigen_definitions.hpp
@@ -39,7 +39,4 @@ using dmap = std::map<key_type, value_type>;
 template <class... types>
 using dtuple = std::tuple<types...>;
 
-namespace getter = algebra::getter;
-namespace vector = algebra::vector;
-
 }  // namespace traccc

--- a/plugins/algebra/smatrix/include/traccc/plugins/algebra/smatrix_definitions.hpp
+++ b/plugins/algebra/smatrix/include/traccc/plugins/algebra/smatrix_definitions.hpp
@@ -39,7 +39,4 @@ using dmap = std::map<key_type, value_type>;
 template <class... types>
 using dtuple = std::tuple<types...>;
 
-namespace getter = algebra::getter;
-namespace vector = algebra::vector;
-
 }  // namespace traccc

--- a/plugins/algebra/vc_aos/CMakeLists.txt
+++ b/plugins/algebra/vc_aos/CMakeLists.txt
@@ -6,8 +6,8 @@
 
 # Set up the "build" of the traccc::vc_aos library.
 traccc_add_library( traccc_vc_aos vc_aos TYPE INTERFACE
-  "include/traccc/plugins/algebra/vc_definitions.hpp" )
+  "include/traccc/plugins/algebra/vc_aos_definitions.hpp" )
 target_link_libraries( traccc_vc_aos
-  INTERFACE algebra::vc_cmath detray::algebra_vc_aos vecmem::core )
+  INTERFACE algebra::vc_aos detray::algebra_vc_aos vecmem::core )
 target_compile_definitions( traccc_vc_aos
   INTERFACE TRACCC_CUSTOM_SCALARTYPE=${TRACCC_CUSTOM_SCALARTYPE} )

--- a/plugins/algebra/vc_aos/include/traccc/plugins/algebra/vc_aos_definitions.hpp
+++ b/plugins/algebra/vc_aos/include/traccc/plugins/algebra/vc_aos_definitions.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 // Detray include(s).
-#include "detray/plugins/algebra/vc_array_definitions.hpp"
+#include "detray/plugins/algebra/vc_aos_definitions.hpp"
 
 // Algebra Plugins include(s).
 #include <algebra/vc_vc.hpp>
@@ -38,8 +38,5 @@ using dmap = std::map<key_type, value_type>;
 
 template <class... types>
 using dtuple = std::tuple<types...>;
-
-namespace getter = algebra::getter;
-namespace vector = algebra::vector;
 
 }  // namespace traccc

--- a/plugins/algebra/vecmem/include/traccc/plugins/algebra/vecmem_definitions.hpp
+++ b/plugins/algebra/vecmem/include/traccc/plugins/algebra/vecmem_definitions.hpp
@@ -34,7 +34,8 @@ using dmap = std::map<key_type, value_type>;
 template <class... types>
 using dtuple = std::tuple<types...>;
 
-namespace getter = algebra::getter;
-namespace vector = algebra::vector;
+using algebra::cmath::operator*;
+using algebra::cmath::operator-;
+using algebra::cmath::operator+;
 
 }  // namespace traccc

--- a/simulation/include/traccc/simulation/measurement_smearer.hpp
+++ b/simulation/include/traccc/simulation/measurement_smearer.hpp
@@ -27,7 +27,6 @@ template <typename algebra_t>
 struct measurement_smearer {
 
     using algebra_type = algebra_t;
-    using matrix_operator = detray::dmatrix_operator<algebra_t>;
     using scalar_type = detray::dscalar<algebra_t>;
     template <std::size_t ROWS, std::size_t COLS>
     using matrix_type = detray::dmatrix<algebra_t, ROWS, COLS>;
@@ -96,26 +95,25 @@ struct measurement_smearer {
             if constexpr (std::is_same_v<
                               typename mask_t::local_frame,
                               detray::line2D<traccc::default_algebra>>) {
-                iomeas.local0 = static_cast<float>(
-                    std::max(std::abs(matrix_operator().element(meas, 0u, 0u)) +
-                                 offset[0],
-                             scalar_type(0.f)));
+                iomeas.local0 = static_cast<float>(std::max(
+                    std::abs(getter::element(meas, 0u, 0u)) + offset[0],
+                    scalar_type(0.f)));
             } else if constexpr (std::is_same_v<typename mask_t::shape,
                                                 detray::annulus2D>) {
                 iomeas.local1 = static_cast<float>(
-                    matrix_operator().element(meas, 0u, 0u) + offset[0]);
+                    getter::element(meas, 0u, 0u) + offset[0]);
             } else {
                 iomeas.local0 = static_cast<float>(
-                    matrix_operator().element(meas, 0u, 0u) + offset[0]);
+                    getter::element(meas, 0u, 0u) + offset[0]);
             }
         } else if (meas_dim == 2u) {
             const auto proj = subs.projector<2u>();
             matrix_type<2u, 1u> meas = proj * bound_params.vector();
 
-            iomeas.local0 = static_cast<float>(
-                matrix_operator().element(meas, 0u, 0u) + offset[0]);
-            iomeas.local1 = static_cast<float>(
-                matrix_operator().element(meas, 1u, 0u) + offset[1]);
+            iomeas.local0 =
+                static_cast<float>(getter::element(meas, 0u, 0u) + offset[0]);
+            iomeas.local1 =
+                static_cast<float>(getter::element(meas, 1u, 0u) + offset[1]);
         }
 
         return;

--- a/tests/cpu/test_track_params_estimation.cpp
+++ b/tests/cpu/test_track_params_estimation.cpp
@@ -43,7 +43,7 @@ TEST(track_params_estimation, helix_negative_charge) {
 
     // Make a helix
     detray::detail::helix<traccc::default_algebra> hlx(
-        pos, time, vector::normalize(mom), q / getter::norm(mom), &B);
+        pos, time, vector::normalize(mom), q / vector::norm(mom), &B);
 
     // Make three spacepoints with the helix
     spacepoint_collection_types::host spacepoints;
@@ -62,7 +62,7 @@ TEST(track_params_estimation, helix_negative_charge) {
     // Make sure that the reconstructed momentum is equal to the original
     // momentum
     ASSERT_EQ(bound_params.size(), 1u);
-    ASSERT_NEAR(bound_params[0].p(q), getter::norm(mom), 2.f * 1e-4);
+    ASSERT_NEAR(bound_params[0].p(q), vector::norm(mom), 2.f * 1e-4);
     ASSERT_TRUE(bound_params[0].qop() < 0.f);
 }
 
@@ -80,7 +80,7 @@ TEST(track_params_estimation, helix_positive_charge) {
 
     // Make a helix
     detray::detail::helix<traccc::default_algebra> hlx(
-        pos, time, vector::normalize(mom), q / getter::norm(mom), &B);
+        pos, time, vector::normalize(mom), q / vector::norm(mom), &B);
 
     // Make three spacepoints with the helix
     spacepoint_collection_types::host spacepoints;
@@ -99,6 +99,6 @@ TEST(track_params_estimation, helix_positive_charge) {
     // Make sure that the reconstructed momentum is equal to the original
     // momentum
     ASSERT_EQ(bound_params.size(), 1u);
-    ASSERT_NEAR(bound_params[0].p(q), getter::norm(mom), 2.f * 1e-4);
+    ASSERT_NEAR(bound_params[0].p(q), vector::norm(mom), 2.f * 1e-4);
     ASSERT_TRUE(bound_params[0].qop() > 0.f);
 }


### PR DESCRIPTION
Test if the new algebra plugin integration works.

Edit: It turns out that algebra plugins has included the arithmetic operators for ```std::array``` vector types in the global namespace from where they were picked up in the ACTS VectorHelper by Eigen types. The operators are now moved into the algebra namespace and from there imported into the detray and traccc namspaces.