### PR TITLE
chore: Remove obsolete ACTS include for JSON

### DIFF
--- a/io/src/json/read_digitization_config.cpp
+++ b/io/src/json/read_digitization_config.cpp
@@ -11,7 +11,6 @@
 // Acts include(s).
 #include <Acts/Plugins/Json/ActsJson.hpp>
 #include <Acts/Plugins/Json/GeometryHierarchyMapJsonConverter.hpp>
-#include <Acts/Plugins/Json/UtilitiesJsonConverter.hpp>
 
 // System include(s).
 #include <fstream>


### PR DESCRIPTION
This will be dropped in ACTS v39