### PR TITLE
ref: Update to detray version 0.87.0

### DIFF
--- a/benchmarks/cpu/toy_detector_cpu.cpp
+++ b/benchmarks/cpu/toy_detector_cpu.cpp
@@ -50,7 +50,7 @@ BENCHMARK_F(ToyDetectorBenchmark, CPU)(benchmark::State& state) {
         sim_dir + "toy_detector_surface_grids.json");
 
     // B field
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<scalar_type>(B);
 
     // Algorithms
     traccc::seeding_algorithm sa(seeding_cfg, grid_cfg, filter_cfg, host_mr);

--- a/benchmarks/cuda/toy_detector_cuda.cpp
+++ b/benchmarks/cuda/toy_detector_cuda.cpp
@@ -43,10 +43,9 @@
 BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
 
     // Type declarations
-    using rk_stepper_type =
-        detray::rk_stepper<b_field_t::view_t,
-                           typename detector_type::algebra_type,
-                           detray::constrained_step<>>;
+    using rk_stepper_type = detray::rk_stepper<
+        b_field_t::view_t, typename detector_type::algebra_type,
+        detray::constrained_step<typename detector_type::scalar_type>>;
     using host_detector_type = traccc::default_detector::host;
     using device_detector_type = traccc::default_detector::device;
     using device_navigator_type = detray::navigator<const device_detector_type>;
@@ -73,7 +72,8 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
         sim_dir + "toy_detector_surface_grids.json");
 
     // B field
-    auto field = detray::bfield::create_const_field(B);
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(B);
 
     // Algorithms
     traccc::cuda::seeding_algorithm sa_cuda(seeding_cfg, grid_cfg, filter_cfg,

--- a/core/include/traccc/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/core/include/traccc/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -28,12 +28,14 @@ namespace traccc::host {
 class combinatorial_kalman_filter_algorithm
     : public algorithm<track_candidate_container_types::host(
           const default_detector::host&,
-          const detray::bfield::const_field_t::view_t&,
+          const detray::bfield::const_field_t<
+              default_detector::host::scalar_type>::view_t&,
           const measurement_collection_types::const_view&,
           const bound_track_parameters_collection_types::const_view&)>,
       public algorithm<track_candidate_container_types::host(
           const telescope_detector::host&,
-          const detray::bfield::const_field_t::view_t&,
+          const detray::bfield::const_field_t<
+              telescope_detector::host::scalar_type>::view_t&,
           const measurement_collection_types::const_view&,
           const bound_track_parameters_collection_types::const_view&)> {
 
@@ -58,7 +60,8 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const default_detector::host& det,
-        const detray::bfield::const_field_t::view_t& field,
+        const detray::bfield::const_field_t<
+            default_detector::host::scalar_type>::view_t& field,
         const measurement_collection_types::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;
@@ -75,7 +78,8 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const telescope_detector::host& det,
-        const detray::bfield::const_field_t::view_t& field,
+        const detray::bfield::const_field_t<
+            telescope_detector::host::scalar_type>::view_t& field,
         const measurement_collection_types::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;

--- a/core/include/traccc/finding/details/find_tracks.hpp
+++ b/core/include/traccc/finding/details/find_tracks.hpp
@@ -65,12 +65,13 @@ track_candidate_container_types::host find_tracks(
      *****************************************************************/
 
     using algebra_type = typename navigator_t::detector_type::algebra_type;
+    using scalar_type = detray::dscalar<algebra_type>;
 
     using transporter_type = detray::parameter_transporter<algebra_type>;
     using interactor_type = detray::pointwise_material_interactor<algebra_type>;
 
     using actor_type = detray::actor_chain<
-        detray::tuple, detray::pathlimit_aborter, transporter_type,
+        detray::tuple, detray::pathlimit_aborter<scalar_type>, transporter_type,
         interaction_register<interactor_type>, interactor_type, ckf_aborter>;
 
     using propagator_type =
@@ -304,7 +305,7 @@ track_candidate_container_types::host find_tracks(
                 .template set_constraint<detray::step::constraint::e_accuracy>(
                     config.propagation.stepping.step_constraint);
 
-            detray::pathlimit_aborter::state s0;
+            typename detray::pathlimit_aborter<scalar_type>::state s0;
             typename detray::parameter_transporter<algebra_type>::state s1;
             typename interactor_type::state s3;
             typename interaction_register<interactor_type>::state s2{s3};

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -58,7 +58,7 @@ class kalman_fitter {
     using bfield_type = typename stepper_t::magnetic_field_type;
 
     // Actor types
-    using aborter = detray::pathlimit_aborter;
+    using aborter = detray::pathlimit_aborter<scalar_type>;
     using transporter = detray::parameter_transporter<algebra_type>;
     using interactor = detray::pointwise_material_interactor<algebra_type>;
     using fit_actor = traccc::kalman_actor<algebra_type, vector_type>;

--- a/core/include/traccc/fitting/kalman_fitting_algorithm.hpp
+++ b/core/include/traccc/fitting/kalman_fitting_algorithm.hpp
@@ -29,11 +29,13 @@ namespace traccc::host {
 class kalman_fitting_algorithm
     : public algorithm<track_state_container_types::host(
           const default_detector::host&,
-          const detray::bfield::const_field_t::view_t&,
+          const detray::bfield::const_field_t<
+              default_detector::host::scalar_type>::view_t&,
           const track_candidate_container_types::const_view&)>,
       public algorithm<track_state_container_types::host(
           const telescope_detector::host&,
-          const detray::bfield::const_field_t::view_t&,
+          const detray::bfield::const_field_t<
+              telescope_detector::host::scalar_type>::view_t&,
           const track_candidate_container_types::const_view&)> {
 
     public:
@@ -57,10 +59,12 @@ class kalman_fitting_algorithm
     ///
     /// @return A container of the fitted track states
     ///
-    output_type operator()(const default_detector::host& det,
-                           const detray::bfield::const_field_t::view_t& field,
-                           const track_candidate_container_types::const_view&
-                               track_candidates) const override;
+    output_type operator()(
+        const default_detector::host& det,
+        const detray::bfield::const_field_t<
+            default_detector::host::scalar_type>::view_t& field,
+        const track_candidate_container_types::const_view& track_candidates)
+        const override;
 
     /// Execute the algorithm
     ///
@@ -70,10 +74,12 @@ class kalman_fitting_algorithm
     ///
     /// @return A container of the fitted track states
     ///
-    output_type operator()(const telescope_detector::host& det,
-                           const detray::bfield::const_field_t::view_t& field,
-                           const track_candidate_container_types::const_view&
-                               track_candidates) const override;
+    output_type operator()(
+        const telescope_detector::host& det,
+        const detray::bfield::const_field_t<
+            telescope_detector::host::scalar_type>::view_t& field,
+        const track_candidate_container_types::const_view& track_candidates)
+        const override;
 
     private:
     /// Algorithm configuration

--- a/core/include/traccc/geometry/detector.hpp
+++ b/core/include/traccc/geometry/detector.hpp
@@ -7,8 +7,12 @@
 
 #pragma once
 
+// Project include(s).
+#include "traccc/definitions/primitives.hpp"
+
 // Detray include(s).
 #include <detray/core/detector.hpp>
+#include <detray/detectors/default_metadata.hpp>
 #include <detray/detectors/telescope_metadata.hpp>
 #include <detray/detectors/toy_metadata.hpp>
 
@@ -38,12 +42,14 @@ struct detector {
 };  // struct default_detector
 
 /// Default detector (also used for ODD)
-using default_detector = detector<detray::default_metadata>;
+using default_detector =
+    detector<detray::default_metadata<traccc::default_algebra>>;
 
 /// Telescope detector
-using telescope_detector = detector<detray::telescope_metadata<> >;
+using telescope_detector = detector<
+    detray::telescope_metadata<traccc::default_algebra, detray::rectangle2D>>;
 
 /// Toy detector
-using toy_detector = detector<detray::toy_metadata>;
+using toy_detector = detector<detray::toy_metadata<traccc::default_algebra>>;
 
 }  // namespace traccc

--- a/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.cpp
+++ b/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.cpp
@@ -20,15 +20,18 @@ namespace traccc::host {
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
     const default_detector::host& det,
-    const detray::bfield::const_field_t::view_t& field,
+    const detray::bfield::const_field_t<
+        default_detector::host::scalar_type>::view_t& field,
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
+    using scalar_type = default_detector::host::scalar_type;
+
     // Perform the track finding using the templated implementation.
     return details::find_tracks<
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
                            default_detector::host::algebra_type,
-                           detray::constrained_step<>>,
+                           detray::constrained_step<scalar_type>>,
         detray::navigator<const default_detector::host>>(
         det, field, measurements, seeds, m_config);
 }

--- a/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.cpp
+++ b/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.cpp
@@ -20,15 +20,18 @@ namespace traccc::host {
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
     const telescope_detector::host& det,
-    const detray::bfield::const_field_t::view_t& field,
+    const detray::bfield::const_field_t<
+        telescope_detector::host::scalar_type>::view_t& field,
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
+    using scalar_type = telescope_detector::host::scalar_type;
+
     // Perform the track finding using the templated implementation.
     return details::find_tracks<
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
                            telescope_detector::host::algebra_type,
-                           detray::constrained_step<>>,
+                           detray::constrained_step<scalar_type>>,
         detray::navigator<const telescope_detector::host>>(
         det, field, measurements, seeds, m_config);
 }

--- a/core/src/fitting/kalman_fitting_algorithm_constant_field_default_detector.cpp
+++ b/core/src/fitting/kalman_fitting_algorithm_constant_field_default_detector.cpp
@@ -18,14 +18,17 @@ namespace traccc::host {
 
 kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
     const default_detector::host& det,
-    const detray::bfield::const_field_t::view_t& field,
+    const detray::bfield::const_field_t<
+        traccc::default_detector::host::scalar_type>::view_t& field,
     const track_candidate_container_types::const_view& track_candidates) const {
+
+    using scalar_type = traccc::default_detector::host::scalar_type;
 
     // Create the fitter object.
     kalman_fitter<
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
                            traccc::default_detector::host::algebra_type,
-                           detray::constrained_step<>>,
+                           detray::constrained_step<scalar_type>>,
         detray::navigator<const traccc::default_detector::host>>
         fitter{det, field, m_config};
 

--- a/core/src/fitting/kalman_fitting_algorithm_constant_field_telescope_detector.cpp
+++ b/core/src/fitting/kalman_fitting_algorithm_constant_field_telescope_detector.cpp
@@ -18,14 +18,17 @@ namespace traccc::host {
 
 kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
     const telescope_detector::host& det,
-    const detray::bfield::const_field_t::view_t& field,
+    const detray::bfield::const_field_t<
+        traccc::telescope_detector::host::scalar_type>::view_t& field,
     const track_candidate_container_types::const_view& track_candidates) const {
+
+    using scalar_type = traccc::telescope_detector::host::scalar_type;
 
     // Create the fitter object.
     kalman_fitter<
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
                            traccc::telescope_detector::host::algebra_type,
-                           detray::constrained_step<>>,
+                           detray::constrained_step<scalar_type>>,
         detray::navigator<const traccc::telescope_detector::host>>
         fitter{det, field, m_config};
 

--- a/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
@@ -60,11 +60,10 @@ class finding_algorithm
     using interactor = detray::pointwise_material_interactor<algebra_type>;
 
     /// Actor chain for propagate to the next surface and its propagator type
-    using actor_type =
-        detray::actor_chain<detray::dtuple, detray::pathlimit_aborter,
-                            detray::parameter_transporter<algebra_type>,
-                            interaction_register<interactor>, interactor,
-                            ckf_aborter>;
+    using actor_type = detray::actor_chain<
+        detray::dtuple, detray::pathlimit_aborter<scalar_type>,
+        detray::parameter_transporter<algebra_type>,
+        interaction_register<interactor>, interactor, ckf_aborter>;
 
     using propagator_type =
         detray::propagator<stepper_t, navigator_t, actor_type>;

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -23,11 +23,10 @@
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/device/sort_key.hpp"
 #include "traccc/finding/candidate_link.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/utils/projections.hpp"
 
 // detray include(s).
-#include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/rk_stepper.hpp"
@@ -409,11 +408,12 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 }
 
 // Explicit template instantiation
-using default_detector_type =
-    detray::detector<detray::default_metadata, detray::device_container_types>;
-using default_stepper_type =
-    detray::rk_stepper<covfie::field<detray::bfield::const_bknd_t>::view_t,
-                       traccc::default_algebra, detray::constrained_step<>>;
+using default_detector_type = traccc::default_detector::device;
+using default_stepper_type = detray::rk_stepper<
+    covfie::field<detray::bfield::const_bknd_t<
+        default_detector_type::scalar_type>>::view_t,
+    default_detector_type::algebra_type,
+    detray::constrained_step<default_detector_type::scalar_type>>;
 using default_navigator_type = detray::navigator<const default_detector_type>;
 template class finding_algorithm<default_stepper_type, default_navigator_type>;
 

--- a/device/cuda/src/finding/kernels/specializations/types.hpp
+++ b/device/cuda/src/finding/kernels/specializations/types.hpp
@@ -22,11 +22,12 @@
 
 namespace traccc::cuda::kernels {
 
-using default_detector_type =
-    detray::detector<detray::default_metadata, detray::device_container_types>;
-using default_stepper_type =
-    detray::rk_stepper<covfie::field<detray::bfield::const_bknd_t>::view_t,
-                       traccc::default_algebra, detray::constrained_step<>>;
+using default_detector_type = traccc::default_detector::device;
+using default_stepper_type = detray::rk_stepper<
+    covfie::field<detray::bfield::const_bknd_t<
+        default_detector_type::scalar_type>>::view_t,
+    default_detector_type::algebra_type,
+    detray::constrained_step<default_detector_type::scalar_type>>;
 using default_navigator_type = detray::navigator<const default_detector_type>;
 
 using default_finding_algorithm =

--- a/device/cuda/src/fitting/fitting_algorithm.cu
+++ b/device/cuda/src/fitting/fitting_algorithm.cu
@@ -13,9 +13,9 @@
 #include "traccc/fitting/device/fill_sort_keys.hpp"
 #include "traccc/fitting/device/fit.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+#include "traccc/geometry/detector.hpp"
 
 // detray include(s).
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/propagator/rk_stepper.hpp"
 
@@ -126,11 +126,12 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
 }
 
 // Explicit template instantiation
-using default_detector_type =
-    detray::detector<detray::default_metadata, detray::device_container_types>;
-using default_stepper_type =
-    detray::rk_stepper<covfie::field<detray::bfield::const_bknd_t>::view_t,
-                       default_algebra, detray::constrained_step<>>;
+using default_detector_type = traccc::default_detector::device;
+using default_stepper_type = detray::rk_stepper<
+    covfie::field<detray::bfield::const_bknd_t<
+        default_detector_type::scalar_type>>::view_t,
+    default_detector_type::algebra_type,
+    detray::constrained_step<default_detector_type::scalar_type>>;
 using default_navigator_type = detray::navigator<const default_detector_type>;
 using default_fitter_type =
     kalman_fitter<default_stepper_type, default_navigator_type>;

--- a/device/sycl/include/traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -34,12 +34,14 @@ namespace traccc::sycl {
 class combinatorial_kalman_filter_algorithm
     : public algorithm<track_candidate_container_types::buffer(
           const default_detector::view&,
-          const detray::bfield::const_field_t::view_t&,
+          const detray::bfield::const_field_t<
+              default_detector::device::scalar_type>::view_t&,
           const measurement_collection_types::const_view&,
           const bound_track_parameters_collection_types::const_view&)>,
       public algorithm<track_candidate_container_types::buffer(
           const telescope_detector::view&,
-          const detray::bfield::const_field_t::view_t&,
+          const detray::bfield::const_field_t<
+              telescope_detector::device::scalar_type>::view_t&,
           const measurement_collection_types::const_view&,
           const bound_track_parameters_collection_types::const_view&)> {
 
@@ -66,7 +68,8 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const default_detector::view& det,
-        const detray::bfield::const_field_t::view_t& field,
+        const detray::bfield::const_field_t<
+            default_detector::device::scalar_type>::view_t& field,
         const measurement_collection_types::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;
@@ -83,7 +86,8 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const telescope_detector::view& det,
-        const detray::bfield::const_field_t::view_t& field,
+        const detray::bfield::const_field_t<
+            telescope_detector::device::scalar_type>::view_t& field,
         const measurement_collection_types::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;

--- a/device/sycl/include/traccc/sycl/fitting/kalman_fitting_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/fitting/kalman_fitting_algorithm.hpp
@@ -33,11 +33,13 @@ namespace traccc::sycl {
 class kalman_fitting_algorithm
     : public algorithm<track_state_container_types::buffer(
           const default_detector::view&,
-          const detray::bfield::const_field_t::view_t&,
+          const detray::bfield::const_field_t<
+              default_detector::device::scalar_type>::view_t&,
           const track_candidate_container_types::const_view&)>,
       public algorithm<track_state_container_types::buffer(
           const telescope_detector::view&,
-          const detray::bfield::const_field_t::view_t&,
+          const detray::bfield::const_field_t<
+              telescope_detector::device::scalar_type>::view_t&,
           const track_candidate_container_types::const_view&)> {
 
     public:
@@ -62,10 +64,12 @@ class kalman_fitting_algorithm
     ///
     /// @return A container of the fitted track states
     ///
-    output_type operator()(const default_detector::view& det,
-                           const detray::bfield::const_field_t::view_t& field,
-                           const track_candidate_container_types::const_view&
-                               track_candidates) const override;
+    output_type operator()(
+        const default_detector::view& det,
+        const detray::bfield::const_field_t<
+            default_detector::device::scalar_type>::view_t& field,
+        const track_candidate_container_types::const_view& track_candidates)
+        const override;
 
     /// Execute the algorithm
     ///
@@ -75,10 +79,12 @@ class kalman_fitting_algorithm
     ///
     /// @return A container of the fitted track states
     ///
-    output_type operator()(const telescope_detector::view& det,
-                           const detray::bfield::const_field_t::view_t& field,
-                           const track_candidate_container_types::const_view&
-                               track_candidates) const override;
+    output_type operator()(
+        const telescope_detector::view& det,
+        const detray::bfield::const_field_t<
+            telescope_detector::device::scalar_type>::view_t& field,
+        const track_candidate_container_types::const_view& track_candidates)
+        const override;
 
     private:
     /// Algorithm configuration

--- a/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.sycl
+++ b/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.sycl
@@ -24,15 +24,18 @@ struct ckf_constant_field_default_detector;
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
     const default_detector::view& det,
-    const detray::bfield::const_field_t::view_t& field,
+    const detray::bfield::const_field_t<
+        default_detector::device::scalar_type>::view_t& field,
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
+    using scalar_type = default_detector::device::scalar_type;
+
     // Perform the track finding using the templated implementation.
     return details::find_tracks<
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
                            default_detector::device::algebra_type,
-                           detray::constrained_step<>>,
+                           detray::constrained_step<scalar_type>>,
         detray::navigator<const default_detector::device>,
         kernels::ckf_constant_field_default_detector>(
         det, field, measurements, seeds, m_config, m_mr, m_copy,

--- a/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.sycl
+++ b/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.sycl
@@ -24,15 +24,18 @@ struct ckf_constant_field_telescope_detector;
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
     const telescope_detector::view& det,
-    const detray::bfield::const_field_t::view_t& field,
+    const detray::bfield::const_field_t<
+        telescope_detector::device::scalar_type>::view_t& field,
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
+    using scalar_type = telescope_detector::device::scalar_type;
+
     // Perform the track finding using the templated implementation.
     return details::find_tracks<
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
                            telescope_detector::device::algebra_type,
-                           detray::constrained_step<>>,
+                           detray::constrained_step<scalar_type>>,
         detray::navigator<const telescope_detector::device>,
         kernels::ckf_constant_field_telescope_detector>(
         det, field, measurements, seeds, m_config, m_mr, m_copy,

--- a/device/sycl/src/finding/find_tracks.hpp
+++ b/device/sycl/src/finding/find_tracks.hpp
@@ -356,10 +356,13 @@ track_candidate_container_types::buffer find_tracks(
             /// Actor types
             using algebra_type =
                 typename navigator_t::detector_type::algebra_type;
+            using scalar_type =
+                typename navigator_t::detector_type::scalar_type;
             using interactor_type =
                 detray::pointwise_material_interactor<algebra_type>;
             using actor_type =
-                detray::actor_chain<detray::dtuple, detray::pathlimit_aborter,
+                detray::actor_chain<detray::dtuple,
+                                    detray::pathlimit_aborter<scalar_type>,
                                     detray::parameter_transporter<algebra_type>,
                                     interaction_register<interactor_type>,
                                     interactor_type, ckf_aborter>;

--- a/device/sycl/src/fitting/kalman_fitting_algorithm_constant_field_default_detector.sycl
+++ b/device/sycl/src/fitting/kalman_fitting_algorithm_constant_field_default_detector.sycl
@@ -27,14 +27,17 @@ struct fit_tracks_constant_field_default_detector;
 
 kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
     const default_detector::view& det,
-    const detray::bfield::const_field_t::view_t& field,
+    const detray::bfield::const_field_t<
+        default_detector::device::scalar_type>::view_t& field,
     const track_candidate_container_types::const_view& track_candidates) const {
+
+    using scalar_type = default_detector::device::scalar_type;
 
     // Construct the fitter type.
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
                            default_detector::device::algebra_type,
-                           detray::constrained_step<>>;
+                           detray::constrained_step<scalar_type>>;
     using navigator_type = detray::navigator<const default_detector::device>;
     using fitter_type = kalman_fitter<stepper_type, navigator_type>;
 

--- a/device/sycl/src/fitting/kalman_fitting_algorithm_constant_field_telescope_detector.sycl
+++ b/device/sycl/src/fitting/kalman_fitting_algorithm_constant_field_telescope_detector.sycl
@@ -27,14 +27,17 @@ struct fit_tracks_constant_field_telescope_detector;
 
 kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
     const telescope_detector::view& det,
-    const detray::bfield::const_field_t::view_t& field,
+    const detray::bfield::const_field_t<
+        telescope_detector::device::scalar_type>::view_t& field,
     const track_candidate_container_types::const_view& track_candidates) const {
+
+    using scalar_type = telescope_detector::device::scalar_type;
 
     // Construct the fitter type.
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
                            telescope_detector::device::algebra_type,
-                           detray::constrained_step<>>;
+                           detray::constrained_step<scalar_type>>;
     using navigator_type = detray::navigator<const telescope_detector::device>;
     using fitter_type = kalman_fitter<stepper_type, navigator_type>;
 

--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -15,6 +15,7 @@
 #include "traccc/efficiency/nseed_performance_writer.hpp"
 #include "traccc/efficiency/seeding_performance_writer.hpp"
 #include "traccc/efficiency/track_filter.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/read_detector.hpp"
 #include "traccc/io/read_measurements.hpp"
 #include "traccc/io/read_spacepoints.hpp"
@@ -36,7 +37,6 @@
 // Detray include(s).
 #include "alpaka/example/ExampleDefaultAcc.hpp"
 #include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/navigator.hpp"

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -114,8 +114,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
         traccc::io::read_detector(
             host_detector, host_mr, detector_opts.detector_file,
             detector_opts.material_file, detector_opts.grid_file);
-        device_detector =
-            detray::get_buffer(detray::get_data(host_detector), mr.main, copy);
+        device_detector = detray::get_buffer(host_detector, mr.main, copy);
         device_detector_view = detray::get_data(device_detector);
     }
 

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -20,6 +20,7 @@
 
 #include "traccc/clusterization/clusterization_algorithm.hpp"
 #include "traccc/efficiency/seeding_performance_writer.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_detector.hpp"
 #include "traccc/io/read_detector_description.hpp"

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// Project include(s)
+#include "traccc/geometry/detector.hpp"
+
 // Command line option include(s).
 #include "traccc/options/clusterization.hpp"
 #include "traccc/options/detector.hpp"

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// Project include(s)
+#include "traccc/geometry/detector.hpp"
+
 // Command line option include(s).
 #include "traccc/options/clusterization.hpp"
 #include "traccc/options/detector.hpp"

--- a/examples/run/cpu/full_chain_algorithm.cpp
+++ b/examples/run/cpu/full_chain_algorithm.cpp
@@ -20,7 +20,8 @@ full_chain_algorithm::full_chain_algorithm(
     const silicon_detector_description::host& det_descr,
     detector_type* detector)
     : m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
-      m_field(detray::bfield::create_const_field(m_field_vec)),
+      m_field(detray::bfield::create_const_field<
+              typename detector_type::scalar_type>(m_field_vec)),
       m_det_descr(det_descr),
       m_detector(detector),
       m_clusterization(mr),

--- a/examples/run/cpu/full_chain_algorithm.hpp
+++ b/examples/run/cpu/full_chain_algorithm.hpp
@@ -91,7 +91,7 @@ class full_chain_algorithm : public algorithm<track_state_container_types::host(
     /// Constant B field for the (seed) track parameter estimation
     traccc::vector3 m_field_vec;
     /// Constant B field for the track finding and fitting
-    detray::bfield::const_field_t m_field;
+    detray::bfield::const_field_t<typename detector_type::scalar_type> m_field;
 
     /// Detector description
     std::reference_wrapper<const silicon_detector_description::host>

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -8,6 +8,7 @@
 // Project include(s).
 #include "traccc/definitions/common.hpp"
 #include "traccc/definitions/primitives.hpp"
+#include "traccc/geometry/detector.hpp"
 
 // io
 #include "traccc/io/read_detector.hpp"
@@ -40,7 +41,6 @@
 
 // Detray include(s).
 #include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -96,7 +96,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * detray::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
 
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host detector{host_mr};

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// core
+#include "traccc/geometry/detector.hpp"
+
 // io
 #include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_detector.hpp"
@@ -40,7 +43,6 @@
 #include "traccc/options/track_seeding.hpp"
 
 // Detray include(s).
-#include "detray/core/detector.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -107,8 +109,8 @@ int seq_run(const traccc::opts::input_data& input_opts,
     // Constant B field for the track finding and fitting
     const traccc::vector3 field_vec = {0.f, 0.f,
                                        seeding_opts.seedfinder.bFieldInZ};
-    const detray::bfield::const_field_t field =
-        detray::bfield::create_const_field(field_vec);
+    const detray::bfield::const_field_t<traccc::scalar> field =
+        detray::bfield::create_const_field<traccc::scalar>(field_vec);
 
     // Algorithm configuration(s).
     detray::propagation::config propagation_config(propagation_opts);

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -11,6 +11,7 @@
 #include "traccc/efficiency/finding_performance_writer.hpp"
 #include "traccc/finding/combinatorial_kalman_filter_algorithm.hpp"
 #include "traccc/fitting/kalman_fitting_algorithm.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/read_detector.hpp"
 #include "traccc/io/read_detector_description.hpp"
 #include "traccc/io/read_measurements.hpp"
@@ -26,7 +27,6 @@
 
 // Detray include(s).
 #include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -67,7 +67,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * detray::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
 
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host detector{host_mr};

--- a/examples/run/cpu/truth_fitting_example.cpp
+++ b/examples/run/cpu/truth_fitting_example.cpp
@@ -22,7 +22,6 @@
 
 // Detray include(s).
 #include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -73,7 +72,7 @@ int main(int argc, char* argv[]) {
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * detray::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
 
     // Read the detector
     detray::io::detector_reader_config reader_cfg{};

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -88,8 +88,8 @@ full_chain_algorithm::full_chain_algorithm(
     // Copy the detector (description) to the device.
     m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->ignore();
     if (m_detector != nullptr) {
-        m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
-                                               m_device_mr, m_copy);
+        m_device_detector =
+            detray::get_buffer(*m_detector, m_device_mr, m_copy);
         m_device_detector_view = detray::get_data(m_device_detector);
     }
 }
@@ -135,8 +135,8 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
     // Copy the detector (description) to the device.
     m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->ignore();
     if (m_detector != nullptr) {
-        m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
-                                               m_device_mr, m_copy);
+        m_device_detector =
+            detray::get_buffer(*m_detector, m_device_mr, m_copy);
         m_device_detector_view = detray::get_data(m_device_detector);
     }
 }

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -44,7 +44,9 @@ full_chain_algorithm::full_chain_algorithm(
           std::make_unique<vecmem::binary_page_memory_resource>(m_device_mr)),
       m_copy(m_stream.cudaStream()),
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
-      m_field(detray::bfield::create_const_field(m_field_vec)),
+      m_field(
+          detray::bfield::create_const_field<host_detector_type::scalar_type>(
+              m_field_vec)),
       m_det_descr(det_descr),
       m_device_det_descr(
           static_cast<silicon_detector_description::buffer::size_type>(

--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -60,11 +60,13 @@ class full_chain_algorithm
     /// (Device) Detector type used during track finding and fitting
     using device_detector_type = traccc::default_detector::device;
 
+    using scalar_type = device_detector_type::scalar_type;
+
     /// Stepper type used by the track finding and fitting algorithms
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
                            device_detector_type::algebra_type,
-                           detray::constrained_step<>>;
+                           detray::constrained_step<scalar_type>>;
     /// Navigator type used by the track finding and fitting algorithms
     using navigator_type = detray::navigator<const device_detector_type>;
     /// Spacepoint formation algorithm type
@@ -133,7 +135,7 @@ class full_chain_algorithm
     /// Constant B field for the (seed) track parameter estimation
     traccc::vector3 m_field_vec;
     /// Constant B field for the track finding and fitting
-    detray::bfield::const_field_t m_field;
+    detray::bfield::const_field_t<traccc::scalar> m_field;
 
     /// Detector description
     std::reference_wrapper<const silicon_detector_description::host>

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -20,6 +20,7 @@
 #include "traccc/finding/combinatorial_kalman_filter_algorithm.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 #include "traccc/fitting/kalman_fitting_algorithm.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/read_detector.hpp"
 #include "traccc/io/read_detector_description.hpp"
 #include "traccc/io/read_measurements.hpp"
@@ -40,8 +41,6 @@
 #include "traccc/seeding/track_params_estimation.hpp"
 
 // Detray include(s).
-#include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -72,11 +71,12 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             const traccc::opts::accelerator& accelerator_opts) {
 
     /// Type declarations
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t>;
-    using rk_stepper_type = detray::rk_stepper<
-        b_field_t::view_t,
-        typename traccc::default_detector::host::algebra_type,
-        detray::constrained_step<>>;
+    using scalar_t = traccc::default_detector::host::scalar_type;
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_t>>;
+    using rk_stepper_type =
+        detray::rk_stepper<b_field_t::view_t,
+                           traccc::default_detector::host::algebra_type,
+                           detray::constrained_step<scalar_t>>;
     using device_navigator_type =
         detray::navigator<const traccc::default_detector::device>;
     using device_fitter_type =
@@ -123,7 +123,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * detray::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
 
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host host_det{mng_mr};

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -103,8 +103,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
         traccc::io::read_detector(
             host_detector, host_mr, detector_opts.detector_file,
             detector_opts.material_file, detector_opts.grid_file);
-        device_detector = detray::get_buffer(detray::get_data(host_detector),
-                                             device_mr, copy);
+        device_detector = detray::get_buffer(host_detector, device_mr, copy);
         stream.synchronize();
         device_detector_view = detray::get_data(device_detector);
     }

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -20,6 +20,7 @@
 #include "traccc/finding/combinatorial_kalman_filter_algorithm.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 #include "traccc/fitting/kalman_fitting_algorithm.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_detector.hpp"
 #include "traccc/io/read_detector_description.hpp"
@@ -41,7 +42,6 @@
 #include "traccc/seeding/track_params_estimation.hpp"
 
 // Detray include(s).
-#include "detray/core/detector.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -123,15 +123,16 @@ int seq_run(const traccc::opts::detector& detector_opts,
     uint64_t n_fitted_tracks_cuda = 0;
 
     // Type definitions
+    using scalar_type = traccc::default_detector::host::scalar_type;
     using host_spacepoint_formation_algorithm =
         traccc::host::silicon_pixel_spacepoint_formation_algorithm;
     using device_spacepoint_formation_algorithm =
         traccc::cuda::spacepoint_formation_algorithm<
             traccc::default_detector::device>;
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
                            traccc::default_detector::host::algebra_type,
-                           detray::constrained_step<>>;
+                           detray::constrained_step<scalar_type>>;
     using device_navigator_type =
         detray::navigator<const traccc::default_detector::device>;
 
@@ -156,8 +157,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
     // Constant B field for the track finding and fitting
     const traccc::vector3 field_vec = {0.f, 0.f,
                                        seeding_opts.seedfinder.bFieldInZ};
-    const detray::bfield::const_field_t field =
-        detray::bfield::create_const_field(field_vec);
+    const detray::bfield::const_field_t<traccc::scalar> field =
+        detray::bfield::create_const_field<traccc::scalar>(field_vec);
 
     traccc::host::clusterization_algorithm ca(host_mr);
     host_spacepoint_formation_algorithm sf(host_mr);

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -17,6 +17,7 @@
 #include "traccc/finding/combinatorial_kalman_filter_algorithm.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 #include "traccc/fitting/kalman_fitting_algorithm.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/read_detector.hpp"
 #include "traccc/io/read_detector_description.hpp"
 #include "traccc/io/read_measurements.hpp"
@@ -35,8 +36,6 @@
 #include "traccc/utils/seed_generator.hpp"
 
 // detray include(s).
-#include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -65,10 +64,11 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
             const traccc::opts::accelerator& accelerator_opts) {
 
     /// Type declarations
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t>;
+    using scalar_type = traccc::default_detector::device::scalar_type;
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_type>>;
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t, traccc::default_algebra,
-                           detray::constrained_step<>>;
+                           detray::constrained_step<scalar_type>>;
     using device_navigator_type =
         detray::navigator<const traccc::default_detector::device>;
     using device_fitter_type =
@@ -100,7 +100,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * detray::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
 
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host detector{mng_mr};

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -31,8 +31,6 @@
 #include "traccc/utils/seed_generator.hpp"
 
 // detray include(s).
-#include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -75,10 +73,11 @@ int main(int argc, char* argv[]) {
     using host_detector_type = traccc::default_detector::host;
     using device_detector_type = traccc::default_detector::device;
 
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t>;
+    using scalar_type = device_detector_type::scalar_type;
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_type>>;
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t, traccc::default_algebra,
-                           detray::constrained_step<>>;
+                           detray::constrained_step<scalar_type>>;
     using device_navigator_type = detray::navigator<const device_detector_type>;
     using device_fitter_type =
         traccc::kalman_fitter<rk_stepper_type, device_navigator_type>;
@@ -105,7 +104,7 @@ int main(int argc, char* argv[]) {
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * detray::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
 
     // Read the detector
     detray::io::detector_reader_config reader_cfg{};

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -7,6 +7,7 @@
 
 // Project include(s).
 #include "traccc/efficiency/seeding_performance_writer.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/read_detector.hpp"
 #include "traccc/io/read_spacepoints.hpp"
 #include "traccc/kokkos/seeding/spacepoint_binning.hpp"

--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -130,7 +130,7 @@ class full_chain_algorithm
     /// Constant B field for the (seed) track parameter estimation
     traccc::vector3 m_field_vec;
     /// Constant B field for the track finding and fitting
-    detray::bfield::const_field_t m_field;
+    detray::bfield::const_field_t<scalar_type> m_field;
 
     /// Detector description
     std::reference_wrapper<const silicon_detector_description::host>

--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -21,7 +21,6 @@
 #include "traccc/utils/algorithm.hpp"
 
 // Detray include(s).
-#include "detray/core/detector.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/propagator.hpp"
@@ -60,10 +59,11 @@ class full_chain_algorithm
     using device_detector_type = traccc::default_detector::device;
 
     /// Stepper type used by the track finding and fitting algorithms
+    using scalar_type = device_detector_type::scalar_type;
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t::view_t,
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
                            device_detector_type::algebra_type,
-                           detray::constrained_step<>>;
+                           detray::constrained_step<scalar_type>>;
     /// Navigator type used by the track finding and fitting algorithms
     using navigator_type = detray::navigator<const device_detector_type>;
     /// Spacepoint formation algorithm type

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -65,7 +65,9 @@ full_chain_algorithm::full_chain_algorithm(
       m_cached_device_mr{m_device_mr},
       m_copy{&(m_data->m_queue)},
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
-      m_field{detray::bfield::create_const_field(m_field_vec)},
+      m_field{
+          detray::bfield::create_const_field<host_detector_type::scalar_type>(
+              m_field_vec)},
       m_det_descr(det_descr),
       m_device_det_descr{
           static_cast<silicon_detector_description::buffer::size_type>(
@@ -106,8 +108,8 @@ full_chain_algorithm::full_chain_algorithm(
     // Copy the detector (description) to the device.
     m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->wait();
     if (m_detector != nullptr) {
-        m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
-                                               m_device_mr, m_copy);
+        m_device_detector =
+            detray::get_buffer(*m_detector, m_device_mr, m_copy);
         m_device_detector_view = detray::get_data(m_device_detector);
     }
 }
@@ -156,8 +158,8 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
     // Copy the detector (description) to the device.
     m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->wait();
     if (m_detector != nullptr) {
-        m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
-                                               m_device_mr, m_copy);
+        m_device_detector =
+            detray::get_buffer(*m_detector, m_device_mr, m_copy);
         m_device_detector_view = detray::get_data(m_device_detector);
     }
 }

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -95,8 +95,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
         traccc::io::read_detector(
             host_det, host_mr, detector_opts.detector_file,
             detector_opts.material_file, detector_opts.grid_file);
-        device_det =
-            detray::get_buffer(detray::get_data(host_det), device_mr, copy);
+        device_det = detray::get_buffer(host_det, device_mr, copy);
         q.wait_and_throw();
         device_det_view = detray::get_data(device_det);
     }

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -8,6 +8,9 @@
 // SYCL include(s)
 #include <sycl/sycl.hpp>
 
+// core
+#include "traccc/geometry/detector.hpp"
+
 // algorithms
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
@@ -33,8 +36,6 @@
 #include "traccc/options/track_seeding.hpp"
 
 // Detray include(s).
-#include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/propagator.hpp"

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -8,6 +8,9 @@
 // SYCL include(s)
 #include <sycl/sycl.hpp>
 
+// core
+#include "traccc/geometry/detector.hpp"
+
 // io
 #include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_detector.hpp"
@@ -44,9 +47,6 @@
 #include "traccc/options/track_finding.hpp"
 #include "traccc/options/track_propagation.hpp"
 #include "traccc/options/track_seeding.hpp"
-
-// Detray include(s).
-#include "detray/core/detector_metadata.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -123,8 +123,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
         traccc::io::read_detector(
             host_detector, host_mr, detector_opts.detector_file,
             detector_opts.material_file, detector_opts.grid_file);
-        device_detector = detray::get_buffer(detray::get_data(host_detector),
-                                             device_mr, copy);
+        device_detector = detray::get_buffer(host_detector, device_mr, copy);
         q.wait_and_throw();
         device_detector_view = detray::get_data(device_detector);
     }
@@ -141,10 +140,11 @@ int seq_run(const traccc::opts::detector& detector_opts,
     uint64_t n_found_tracks_sycl = 0;
 
     // Constant B field for the track finding and fitting
+    using scalar_type = traccc::default_detector::host::scalar_type;
     const traccc::vector3 field_vec = {0.f, 0.f,
                                        seeding_opts.seedfinder.bFieldInZ};
-    const detray::bfield::const_field_t field =
-        detray::bfield::create_const_field(field_vec);
+    const detray::bfield::const_field_t<scalar_type> field =
+        detray::bfield::create_const_field<scalar_type>(field_vec);
 
     // Algorithm configuration(s).
     detray::propagation::config propagation_config(propagation_opts);

--- a/examples/simulation/simulate.cpp
+++ b/examples/simulation/simulate.cpp
@@ -8,6 +8,7 @@
 // Project include(s).
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/track_parameters.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/utils.hpp"
 #include "traccc/options/detector.hpp"
 #include "traccc/options/generation.hpp"
@@ -19,8 +20,6 @@
 #include "traccc/simulation/smearing_writer.hpp"
 
 // Detray include(s).
-#include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -52,7 +51,7 @@ int main(int argc, char* argv[]) {
         argv};
 
     /// Type declarations
-    using host_detector_type = detray::detector<>;
+    using host_detector_type = traccc::default_detector::host;
     using uniform_gen_t =
         detray::detail::random_numbers<scalar,
                                        std::uniform_real_distribution<scalar>>;
@@ -62,9 +61,10 @@ int main(int argc, char* argv[]) {
 
     // B field value and its type
     // @TODO: Set B field as argument
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t>;
+    using b_field_t =
+        covfie::field<detray::bfield::const_bknd_t<traccc::scalar>>;
     const traccc::vector3 B{0, 0, 2 * detray::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
 
     // Read the detector
     detray::io::detector_reader_config reader_cfg{};

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -69,9 +69,9 @@ int simulate(const traccc::opts::generation& generation_opts,
     }
 
     // B field value and its type
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t>;
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar>>;
     const vector3 B{0, 0, 2 * detray::unit<scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<scalar>(B);
 
     // Set material and thickness
     detray::material<scalar> mat;
@@ -84,10 +84,10 @@ int simulate(const traccc::opts::generation& generation_opts,
     const scalar thickness = telescope_opts.thickness;
 
     // Use rectangle surfaces
-    detray::mask<detray::rectangle2D> rectangle{0u, telescope_opts.half_length,
-                                                telescope_opts.half_length};
+    detray::mask<detray::rectangle2D, traccc::default_algebra> rectangle{
+        0u, telescope_opts.half_length, telescope_opts.half_length};
 
-    detray::tel_det_config<> tel_cfg{rectangle};
+    detray::tel_det_config tel_cfg{rectangle};
     tel_cfg.positions(plane_positions);
     tel_cfg.module_material(mat);
     tel_cfg.mat_thickness(thickness);

--- a/examples/simulation/simulate_toy_detector.cpp
+++ b/examples/simulation/simulate_toy_detector.cpp
@@ -8,6 +8,7 @@
 // Project include(s).
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/track_parameters.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/utils.hpp"
 #include "traccc/options/generation.hpp"
 #include "traccc/options/output_data.hpp"
@@ -48,20 +49,21 @@ int simulate(const traccc::opts::generation& generation_opts,
      *****************************/
 
     // Detector type
-    using detector_type = detray::detector<detray::toy_metadata>;
+    using detector_type = traccc::toy_detector::host;
 
     // B field value and its type
     // @TODO: Set B field as argument
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t>;
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar>>;
     const vector3 B{0, 0, 2 * detray::unit<scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<scalar>(B);
 
     // Create the toy geometry
-    detray::toy_det_config toy_cfg{};
+    detray::toy_det_config<scalar> toy_cfg{};
     toy_cfg.n_brl_layers(4u).n_edc_layers(7u);
     // @TODO: Increase the material budget again
     toy_cfg.module_mat_thickness(0.11f * detray::unit<scalar>::mm);
-    const auto [det, name_map] = detray::build_toy_detector(host_mr, toy_cfg);
+    const auto [det, name_map] =
+        detray::build_toy_detector<traccc::default_algebra>(host_mr, toy_cfg);
 
     /***************************
      * Generate simulation data

--- a/examples/simulation/simulate_wire_chamber.cpp
+++ b/examples/simulation/simulate_wire_chamber.cpp
@@ -8,6 +8,7 @@
 // Project include(s).
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/track_parameters.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/utils.hpp"
 #include "traccc/options/generation.hpp"
 #include "traccc/options/output_data.hpp"
@@ -48,21 +49,22 @@ int simulate(const traccc::opts::generation& generation_opts,
      *****************************/
 
     // Detector type
-    using detector_type = detray::detector<>;
+    using detector_type = traccc::default_detector::host;
 
     // B field value and its type
     // @TODO: Set B field as argument
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t>;
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar>>;
     const vector3 B{0, 0, 2 * detray::unit<scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<scalar>(B);
 
     // Set Configuration
-    detray::wire_chamber_config wire_chamber_cfg{};
+    detray::wire_chamber_config<scalar> wire_chamber_cfg{};
     wire_chamber_cfg.n_layers(20u);
 
     // Create the toy geometry
     const auto [det, name_map] =
-        detray::build_wire_chamber(host_mr, wire_chamber_cfg);
+        detray::build_wire_chamber<detector_type::algebra_type>(
+            host_mr, wire_chamber_cfg);
 
     /***************************
      * Generate simulation data

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Algebra Plugins as part of the TRACCC project" )
 
 # Declare where to get Algebra Plugins from.
 set( TRACCC_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.26.0.tar.gz;URL_MD5;004d53433ee781b7ce0c1c3eef8cd224"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.26.2.tar.gz;URL_MD5;607bd0b8beffcf7981b10c03f237e550"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced( TRACCC_ALGEBRA_PLUGINS_SOURCE )
 FetchContent_Declare( AlgebraPlugins SYSTEM ${TRACCC_ALGEBRA_PLUGINS_SOURCE} )

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.86.0.tar.gz;URL_MD5;675cab4911f1769c6efd7ac38ce73c7c"
+"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.87.0.tar.gz;URL_MD5;0e30107edebfd41fbb3fc1974f665ea9"
    CACHE STRING "Source for Detray, when built as part of this project" )
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
 FetchContent_Declare( Detray SYSTEM ${TRACCC_DETRAY_SOURCE} )

--- a/io/include/traccc/io/write.hpp
+++ b/io/include/traccc/io/write.hpp
@@ -12,12 +12,10 @@
 #include "traccc/edm/silicon_cell_collection.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/edm/track_candidate.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/silicon_detector_description.hpp"
 #include "traccc/io/data_format.hpp"
 #include "traccc/io/digitization_config.hpp"
-
-// Detray include(s).
-#include "detray/core/detector.hpp"
 
 // System include(s).
 #include <cstddef>
@@ -86,7 +84,7 @@ void write(std::size_t event, std::string_view directory,
 void write(std::size_t event, std::string_view directory,
            traccc::data_format format,
            track_candidate_container_types::const_view tracks,
-           const detray::detector<>& detector);
+           const traccc::default_detector::host& detector);
 
 /// Write a digitization configuration to a file
 ///

--- a/io/src/obj/write_track_candidates.cpp
+++ b/io/src/obj/write_track_candidates.cpp
@@ -17,7 +17,7 @@ namespace traccc::io::obj {
 void write_track_candidates(
     std::string_view filename,
     track_candidate_container_types::const_view tracks_view,
-    const detray::detector<>& detector) {
+    const traccc::default_detector::host& detector) {
 
     // Open the output file.
     std::ofstream file{filename.data()};

--- a/io/src/obj/write_track_candidates.hpp
+++ b/io/src/obj/write_track_candidates.hpp
@@ -9,9 +9,7 @@
 
 // Project include(s).
 #include "traccc/edm/track_candidate.hpp"
-
-// Detray include(s).
-#include "detray/core/detector.hpp"
+#include "traccc/geometry/detector.hpp"
 
 // System include(s).
 #include <string_view>
@@ -26,6 +24,6 @@ namespace traccc::io::obj {
 ///
 void write_track_candidates(std::string_view filename,
                             track_candidate_container_types::const_view tracks,
-                            const detray::detector<>& detector);
+                            const traccc::default_detector::host& detector);
 
 }  // namespace traccc::io::obj

--- a/io/src/read_geometry.cpp
+++ b/io/src/read_geometry.cpp
@@ -8,11 +8,11 @@
 // Local include(s).
 #include "traccc/io/read_geometry.hpp"
 
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/details/read_surfaces.hpp"
 #include "traccc/io/utils.hpp"
 
 // Detray include(s).
-#include <detray/core/detector.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 
 // VecMem include(s).
@@ -41,7 +41,8 @@ read_json_geometry(std::string_view filename) {
         detray::io::detector_reader_config reader_cfg{};
         reader_cfg.add_file(std::string{filename});
         auto [detector, _] =
-            detray::io::read_detector<detray::detector<>>(host_mr, reader_cfg);
+            detray::io::read_detector<traccc::default_detector::host>(
+                host_mr, reader_cfg);
 
         // Construct an "old style geometry" from the detector object.
         surface_transforms = traccc::io::alt_read_geometry(detector);

--- a/io/src/write.cpp
+++ b/io/src/write.cpp
@@ -116,7 +116,7 @@ void write(std::size_t event, std::string_view directory,
 void write(std::size_t event, std::string_view directory,
            traccc::data_format format,
            track_candidate_container_types::const_view tracks,
-           const detray::detector<>& detector) {
+           const traccc::default_detector::host& detector) {
 
     switch (format) {
         case data_format::obj:

--- a/performance/include/traccc/utils/event_data.hpp
+++ b/performance/include/traccc/utils/event_data.hpp
@@ -14,6 +14,7 @@
 #include "traccc/edm/silicon_cluster_collection.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/edm/track_candidate.hpp"
+#include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/silicon_detector_description.hpp"
 #include "traccc/io/csv/cell.hpp"
 #include "traccc/io/csv/hit.hpp"
@@ -24,7 +25,6 @@
 #include "traccc/utils/seed_generator.hpp"
 
 // Detray include(s).
-#include "detray/core/detector.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 
 // Vecmem include(s).
@@ -40,8 +40,7 @@ struct event_data {
 
     public:
     // Type definitions
-    using detector_type = detray::detector<detray::default_metadata,
-                                           detray::host_container_types>;
+    using detector_type = traccc::default_detector::host;
 
     event_data() = delete;
 

--- a/plugins/algebra/array/include/traccc/plugins/algebra/array_definitions.hpp
+++ b/plugins/algebra/array/include/traccc/plugins/algebra/array_definitions.hpp
@@ -23,6 +23,8 @@
 #include <map>
 #include <tuple>
 
+#define ALGEBRA_PLUGIN detray::array
+
 namespace traccc {
 
 using scalar = TRACCC_CUSTOM_SCALARTYPE;

--- a/plugins/algebra/eigen/include/traccc/plugins/algebra/eigen_definitions.hpp
+++ b/plugins/algebra/eigen/include/traccc/plugins/algebra/eigen_definitions.hpp
@@ -20,6 +20,8 @@
 #include <map>
 #include <tuple>
 
+#define ALGEBRA_PLUGIN detray::eigen
+
 namespace traccc {
 
 using scalar = TRACCC_CUSTOM_SCALARTYPE;

--- a/plugins/algebra/smatrix/include/traccc/plugins/algebra/smatrix_definitions.hpp
+++ b/plugins/algebra/smatrix/include/traccc/plugins/algebra/smatrix_definitions.hpp
@@ -23,6 +23,8 @@
 #include <map>
 #include <tuple>
 
+#define ALGEBRA_PLUGIN detray::smatrix
+
 namespace traccc {
 
 using scalar = TRACCC_CUSTOM_SCALARTYPE;

--- a/plugins/algebra/vc_aos/include/traccc/plugins/algebra/vc_aos_definitions.hpp
+++ b/plugins/algebra/vc_aos/include/traccc/plugins/algebra/vc_aos_definitions.hpp
@@ -23,6 +23,8 @@
 #include <map>
 #include <tuple>
 
+#define ALGEBRA_PLUGIN detray::vc_aos
+
 namespace traccc {
 
 using scalar = TRACCC_CUSTOM_SCALARTYPE;

--- a/plugins/algebra/vecmem/include/traccc/plugins/algebra/vecmem_definitions.hpp
+++ b/plugins/algebra/vecmem/include/traccc/plugins/algebra/vecmem_definitions.hpp
@@ -18,6 +18,9 @@
 #include <map>
 #include <tuple>
 
+// vecmem plugin does not exist in detray yet
+#define ALGEBRA_PLUGIN detray::array
+
 namespace traccc {
 
 using scalar = TRACCC_CUSTOM_SCALARTYPE;

--- a/simulation/include/traccc/simulation/simulator.hpp
+++ b/simulation/include/traccc/simulation/simulator.hpp
@@ -52,9 +52,9 @@ struct simulator {
                             detray::parameter_resetter<algebra_type>, writer_t>;
 
     using navigator_type = detray::navigator<detector_t>;
-    using stepper_type =
-        detray::rk_stepper<typename bfield_type::view_t, algebra_type,
-                           detray::constrained_step<>>;
+    using stepper_type = detray::rk_stepper<
+        typename bfield_type::view_t, algebra_type,
+        detray::constrained_step<detray::dscalar<algebra_type>>>;
     using propagator_type =
         detray::propagator<stepper_type, navigator_type, actor_chain_type>;
 

--- a/tests/common/tests/kalman_fitting_telescope_test.hpp
+++ b/tests/common/tests/kalman_fitting_telescope_test.hpp
@@ -54,8 +54,8 @@ class KalmanFittingTelescopeTests
     static constexpr scalar thickness = 0.5f * detray::unit<scalar>::mm;
 
     // Rectangle mask for the telescope geometry
-    static constexpr detray::mask<detray::rectangle2D> rectangle{0u, 100000.f,
-                                                                 100000.f};
+    static constexpr detray::mask<detray::rectangle2D, traccc::default_algebra>
+        rectangle{0u, 100000.f, 100000.f};
 
     /// Measurement smearing parameters
     static constexpr std::array<scalar, 2u> smearing{
@@ -94,7 +94,7 @@ class KalmanFittingTelescopeTests
                                           unit<scalar>::mm);
         }
 
-        detray::tel_det_config<> tel_cfg{rectangle};
+        detray::tel_det_config tel_cfg{rectangle};
         tel_cfg.positions(plane_positions);
         tel_cfg.module_material(mat);
         tel_cfg.mat_thickness(thickness);

--- a/tests/common/tests/kalman_fitting_test.hpp
+++ b/tests/common/tests/kalman_fitting_test.hpp
@@ -10,10 +10,9 @@
 // Project include(s).
 #include "traccc/definitions/common.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+#include "traccc/geometry/detector.hpp"
 
 // detray include(s).
-#include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/definitions/pdg_particle.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -34,16 +33,14 @@ namespace traccc {
 class KalmanFittingTests : public testing::Test {
     public:
     /// Type declarations
-    using host_detector_type = detray::detector<detray::default_metadata,
-                                                detray::host_container_types>;
-    using device_detector_type =
-        detray::detector<detray::default_metadata,
-                         detray::device_container_types>;
+    using host_detector_type = traccc::default_detector::host;
+    using device_detector_type = traccc::default_detector::device;
 
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t>;
+    using scalar_type = device_detector_type::scalar_type;
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_type>>;
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t, traccc::default_algebra,
-                           detray::constrained_step<>>;
+                           detray::constrained_step<scalar_type>>;
     using host_navigator_type = detray::navigator<const host_detector_type>;
     using host_fitter_type =
         kalman_fitter<rk_stepper_type, host_navigator_type>;

--- a/tests/common/tests/kalman_fitting_toy_detector_test.hpp
+++ b/tests/common/tests/kalman_fitting_toy_detector_test.hpp
@@ -74,11 +74,13 @@ class KalmanFittingToyDetectorTests
     virtual void SetUp() override {
         vecmem::host_memory_resource host_mr;
 
-        detray::toy_det_config toy_cfg{};
+        detray::toy_det_config<scalar> toy_cfg{};
         toy_cfg.n_brl_layers(n_barrels).n_edc_layers(n_endcaps).do_check(false);
 
         // Create the toy geometry
-        auto [det, name_map] = detray::build_toy_detector(host_mr, toy_cfg);
+        auto [det, name_map] =
+            detray::build_toy_detector<traccc::default_algebra>(host_mr,
+                                                                toy_cfg);
 
         // Write detector file
         auto writer_cfg = detray::io::detector_writer_config{}

--- a/tests/common/tests/kalman_fitting_wire_chamber_test.hpp
+++ b/tests/common/tests/kalman_fitting_wire_chamber_test.hpp
@@ -85,7 +85,7 @@ class KalmanFittingWireChamberTests
     virtual void SetUp() override {
         vecmem::host_memory_resource host_mr;
 
-        detray::wire_chamber_config wire_chamber_cfg;
+        detray::wire_chamber_config<scalar> wire_chamber_cfg;
         wire_chamber_cfg.n_layers(n_wire_layers);
         wire_chamber_cfg.half_z(half_z);
 
@@ -94,7 +94,8 @@ class KalmanFittingWireChamberTests
         // wire_chamber_cfg.m_thickness = 100.f * detray::unit<scalar>::um;
 
         // Create telescope detector
-        auto [det, name_map] = build_wire_chamber(host_mr, wire_chamber_cfg);
+        auto [det, name_map] = build_wire_chamber<traccc::default_algebra>(
+            host_mr, wire_chamber_cfg);
 
         // Write detector file
         auto writer_cfg = detray::io::detector_writer_config{}

--- a/tests/cpu/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cpu/test_ckf_combinatorics_telescope.cpp
@@ -64,7 +64,9 @@ TEST_P(CpuCkfCombinatoricsTelescopeTests, Run) {
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
 
-    auto field = detray::bfield::create_const_field(std::get<13>(GetParam()));
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+            std::get<13>(GetParam()));
 
     /***************************
      * Generate simulation data

--- a/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
@@ -71,7 +71,9 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
 
-    auto field = detray::bfield::create_const_field(std::get<13>(GetParam()));
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+            std::get<13>(GetParam()));
 
     /***************************
      * Generate simulation data

--- a/tests/cpu/test_kalman_fitter_hole_count.cpp
+++ b/tests/cpu/test_kalman_fitter_hole_count.cpp
@@ -69,7 +69,9 @@ TEST_P(KalmanFittingHoleCountTests, Run) {
 
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
-    auto field = detray::bfield::create_const_field(std::get<13>(GetParam()));
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+            std::get<13>(GetParam()));
 
     /***************************
      * Generate simulation data

--- a/tests/cpu/test_kalman_fitter_telescope.cpp
+++ b/tests/cpu/test_kalman_fitter_telescope.cpp
@@ -68,7 +68,9 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
 
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
-    auto field = detray::bfield::create_const_field(std::get<13>(GetParam()));
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+            std::get<13>(GetParam()));
 
     /***************************
      * Generate simulation data

--- a/tests/cpu/test_kalman_fitter_wire_chamber.cpp
+++ b/tests/cpu/test_kalman_fitter_wire_chamber.cpp
@@ -65,7 +65,8 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
 
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
-    auto field = detray::bfield::create_const_field(B);
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(B);
 
     /***************************
      * Generate simulation data

--- a/tests/cpu/test_simulation.cpp
+++ b/tests/cpu/test_simulation.cpp
@@ -37,10 +37,10 @@ constexpr scalar tol{1e-7f};
 
 TEST(traccc_simulation, simulation) {
 
-    const detray::mask<detray::line<false>> ln{
+    const detray::mask<detray::line<false>, traccc::default_algebra> ln{
         0u, 10.f * detray::unit<scalar>::mm, 50.f * detray::unit<scalar>::mm};
 
-    const detray::mask<detray::rectangle2D> re{
+    const detray::mask<detray::rectangle2D, traccc::default_algebra> re{
         0u, 10.f * detray::unit<scalar>::mm, 10.f * detray::unit<scalar>::mm};
 
     detray::bound_track_parameters<traccc::default_algebra> bound_params{};
@@ -70,13 +70,14 @@ GTEST_TEST(traccc_simulation, toy_detector_simulation) {
     vecmem::host_memory_resource host_mr;
 
     // Create B field
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t>;
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar>>;
     const vector3 B{0.f, 0.f, 2.f * detray::unit<scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<scalar>(B);
 
     // Create geometry
-    detray::toy_det_config toy_cfg{};
-    const auto [detector, names] = detray::build_toy_detector(host_mr, toy_cfg);
+    detray::toy_det_config<scalar> toy_cfg{};
+    const auto [detector, names] =
+        detray::build_toy_detector<traccc::default_algebra>(host_mr, toy_cfg);
 
     using geo_cxt_t = typename decltype(detector)::geometry_context;
     const geo_cxt_t ctx{};
@@ -210,8 +211,9 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
     // energy (or non-relativistic) particle due to the large scattering
     const scalar thickness = 0.005f * detray::unit<scalar>::cm;
 
-    detray::tel_det_config<detray::rectangle2D> tel_cfg{
-        1000.f * detray::unit<scalar>::mm, 1000.f * detray::unit<scalar>::mm};
+    detray::tel_det_config<traccc::default_algebra, detray::rectangle2D>
+        tel_cfg{1000.f * detray::unit<scalar>::mm,
+                1000.f * detray::unit<scalar>::mm};
     tel_cfg.positions(positions).mat_thickness(thickness);
 
     const auto [detector, names] =
@@ -222,9 +224,9 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
     std::filesystem::create_directory(directory);
 
     // Field
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t>;
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar>>;
     const vector3 B{0.f, 0.f, 2.f * detray::unit<scalar>::T};
-    auto field = detray::bfield::create_const_field(B);
+    auto field = detray::bfield::create_const_field<scalar>(B);
 
     // Momentum
     const scalar mom = std::get<1>(GetParam());

--- a/tests/cpu/test_spacepoint_formation.cpp
+++ b/tests/cpu/test_spacepoint_formation.cpp
@@ -29,7 +29,7 @@ TEST(spacepoint_formation, cpu) {
     vecmem::host_memory_resource host_mr;
 
     // Use rectangle surfaces
-    detray::mask<detray::rectangle2D> rectangle{
+    detray::mask<detray::rectangle2D, traccc::default_algebra> rectangle{
         0u, 10000.f * detray::unit<scalar>::mm,
         10000.f * detray::unit<scalar>::mm};
 
@@ -40,7 +40,7 @@ TEST(spacepoint_formation, cpu) {
     std::vector<scalar> plane_positions = {20.f,  40.f,  60.f,  80.f, 100.f,
                                            120.f, 140.f, 160.f, 180.f};
 
-    detray::tel_det_config<> tel_cfg{rectangle};
+    detray::tel_det_config tel_cfg{rectangle};
     tel_cfg.positions(plane_positions);
     tel_cfg.pilot_track(traj);
 

--- a/tests/cuda/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cuda/test_ckf_combinatorics_telescope.cpp
@@ -73,7 +73,9 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
     auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
 
-    auto field = detray::bfield::create_const_field(std::get<13>(GetParam()));
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+            std::get<13>(GetParam()));
 
     // Detector view object
     auto det_view = detray::get_data(host_det);

--- a/tests/cuda/test_ckf_toy_detector.cpp
+++ b/tests/cuda/test_ckf_toy_detector.cpp
@@ -70,7 +70,8 @@ TEST_P(CkfToyDetectorTests, Run) {
     auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
 
-    auto field = detray::bfield::create_const_field(B);
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(B);
 
     // Detector view object
     auto det_view = detray::get_data(host_det);

--- a/tests/cuda/test_kalman_fitter_telescope.cpp
+++ b/tests/cuda/test_kalman_fitter_telescope.cpp
@@ -83,7 +83,9 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     // Detector view object
     auto det_view = detray::get_data(host_det);
 
-    auto field = detray::bfield::create_const_field(std::get<13>(GetParam()));
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+            std::get<13>(GetParam()));
 
     /***************************
      * Generate simulation data

--- a/tests/cuda/test_spacepoint_formation.cpp
+++ b/tests/cuda/test_spacepoint_formation.cpp
@@ -9,6 +9,7 @@
 #include "traccc/cuda/seeding/spacepoint_formation_algorithm.hpp"
 #include "traccc/definitions/common.hpp"
 #include "traccc/edm/spacepoint.hpp"
+#include "traccc/geometry/detector.hpp"
 
 // Detray include(s).
 #include "detray/navigation/detail/ray.hpp"
@@ -38,7 +39,7 @@ TEST(CUDASpacepointFormation, cuda) {
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
     // Use rectangle surfaces
-    detray::mask<detray::rectangle2D> rectangle{
+    detray::mask<detray::rectangle2D, traccc::default_algebra> rectangle{
         0u, 10000.f * detray::unit<scalar>::mm,
         10000.f * detray::unit<scalar>::mm};
 
@@ -50,15 +51,13 @@ TEST(CUDASpacepointFormation, cuda) {
     std::vector<scalar> plane_positions = {20.f,  40.f,  60.f,  80.f, 100.f,
                                            120.f, 140.f, 160.f, 180.f};
 
-    detray::tel_det_config<> tel_cfg{rectangle};
+    detray::tel_det_config tel_cfg{rectangle};
     tel_cfg.positions(plane_positions);
     tel_cfg.pilot_track(traj);
 
     // Create telescope geometry
     auto [det, name_map] = build_telescope_detector(mng_mr, tel_cfg);
-    using device_detector_type =
-        detray::detector<detray::telescope_metadata<detray::rectangle2D>,
-                         detray::device_container_types>;
+    using device_detector_type = traccc::telescope_detector::device;
 
     // Surface lookup
     auto surfaces = det.surfaces();

--- a/tests/io/test_csv.cpp
+++ b/tests/io/test_csv.cpp
@@ -6,6 +6,7 @@
  */
 
 // Project include(s).
+#include "traccc/geometry/detector.hpp"
 #include "traccc/io/details/read_surfaces.hpp"
 #include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_detector.hpp"

--- a/tests/io/test_event_data.cpp
+++ b/tests/io/test_event_data.cpp
@@ -24,8 +24,7 @@
 TEST(event_data, acts_odd) {
 
     /// Type declarations
-    using host_detector_type = detray::detector<detray::default_metadata,
-                                                detray::host_container_types>;
+    using host_detector_type = traccc::default_detector::host;
 
     vecmem::host_memory_resource resource;
 
@@ -86,8 +85,7 @@ TEST(event_data, mock_data) {
      */
 
     /// Type declarations
-    using host_detector_type = detray::detector<detray::default_metadata,
-                                                detray::host_container_types>;
+    using host_detector_type = traccc::default_detector::host;
 
     vecmem::host_memory_resource resource;
 

--- a/tests/sycl/test_ckf_combinatorics_telescope.cpp
+++ b/tests/sycl/test_ckf_combinatorics_telescope.cpp
@@ -83,7 +83,9 @@ TEST_P(CkfCombinatoricsTelescopeTests, Run) {
         (path / "telescope_detector_geometry.json").native(),
         (path / "telescope_detector_homogeneous_material.json").native(), "");
 
-    auto field = detray::bfield::create_const_field(std::get<13>(GetParam()));
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+            std::get<13>(GetParam()));
 
     // Detector view object
     auto det_view = detray::get_data(host_det);

--- a/tests/sycl/test_ckf_toy_detector.cpp
+++ b/tests/sycl/test_ckf_toy_detector.cpp
@@ -79,7 +79,8 @@ TEST_P(CkfToyDetectorTests, Run) {
         (path / "toy_detector_homogeneous_material.json").native(),
         (path / "toy_detector_surface_grids.json").native());
 
-    auto field = detray::bfield::create_const_field(B);
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(B);
 
     // Detector view object
     auto det_view = detray::get_data(host_det);

--- a/tests/sycl/test_kalman_fitter_telescope.sycl
+++ b/tests/sycl/test_kalman_fitter_telescope.sycl
@@ -105,7 +105,8 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
 
     // Detector view object
     auto det_view = detray::get_data(host_det);
-    auto field = detray::bfield::create_const_field(B);
+    auto field =
+        detray::bfield::create_const_field<host_detector_type::scalar_type>(B);
 
     /***************************
      * Generate simulation data

--- a/tests/sycl/test_spacepoint_formation.sycl
+++ b/tests/sycl/test_spacepoint_formation.sycl
@@ -53,7 +53,7 @@ TEST(SYCLSpacepointFormation, sycl) {
     vecmem::sycl::copy copy{&q};
 
     // Use rectangle surfaces
-    detray::mask<detray::rectangle2D> rectangle{
+    detray::mask<detray::rectangle2D, traccc::default_algebra> rectangle{
         0u, 10000.f * detray::unit<scalar>::mm,
         10000.f * detray::unit<scalar>::mm};
 
@@ -65,7 +65,7 @@ TEST(SYCLSpacepointFormation, sycl) {
     std::vector<scalar> plane_positions = {20.f,  40.f,  60.f,  80.f, 100.f,
                                            120.f, 140.f, 160.f, 180.f};
 
-    detray::tel_det_config<> tel_cfg{rectangle};
+    detray::tel_det_config tel_cfg{rectangle};
     tel_cfg.positions(plane_positions);
     tel_cfg.pilot_track(traj);
 


### PR DESCRIPTION
Update to detray version 0.87.0 and algebra plugins version 0.26.2, which mainly contain the full algebra templating of detray