### PR TITLE
Measurement Comparison Fix, main branch (2025.01.07.)

### DIFF
--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -88,14 +88,14 @@ inline bool operator==(const measurement& lhs, const measurement& rhs) {
 /// Comparator based on detray barcode value
 struct measurement_sort_comp {
     TRACCC_HOST_DEVICE
-    bool operator()(const measurement& lhs, const measurement& rhs) {
+    bool operator()(const measurement& lhs, const measurement& rhs) const {
         return lhs.surface_link < rhs.surface_link;
     }
 };
 
 struct measurement_equal_comp {
     TRACCC_HOST_DEVICE
-    bool operator()(const measurement& lhs, const measurement& rhs) {
+    bool operator()(const measurement& lhs, const measurement& rhs) const {
         return lhs.surface_link == rhs.surface_link;
     }
 };


### PR DESCRIPTION
Made the `traccc::measurement` comparison functors const-correct. Which is necessary for using them with [oneDPL](https://github.com/oneapi-src/oneDPL). (See: #773)