### PR TITLE
Track Finding Cleanup, main branch (2025.01.07.)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022-2024 CERN for the benefit of the ACTS project
+# (c) 2022-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -15,6 +15,7 @@ stages:
     - git clone $CLONE_URL src
     - git -C src checkout $HEAD_SHA
     - source ./src/.github/ci_setup.sh ${TRACCC_BUILD_TYPE}
+    - export CTEST_PARALLEL_LEVEL=2
 
 # Build job template.
 .build_template: &build_job

--- a/device/common/include/traccc/device/globalIndex.hpp
+++ b/device/common/include/traccc/device/globalIndex.hpp
@@ -1,0 +1,16 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::device {
+
+/// Type for passing "global indices" to device functions
+using globalIndex_t = unsigned int;
+
+}  // namespace traccc::device

--- a/device/common/include/traccc/device/global_index.hpp
+++ b/device/common/include/traccc/device/global_index.hpp
@@ -11,6 +11,6 @@
 namespace traccc::device {
 
 /// Type for passing "global indices" to device functions
-using globalIndex_t = unsigned int;
+using global_index_t = unsigned int;
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/finding/device/apply_interaction.hpp
+++ b/device/common/include/traccc/finding/device/apply_interaction.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Local include(s).
-#include "traccc/device/globalIndex.hpp"
+#include "traccc/device/global_index.hpp"
 
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
@@ -54,7 +54,7 @@ struct apply_interaction_payload {
 ///
 template <typename detector_t>
 TRACCC_DEVICE inline void apply_interaction(
-    globalIndex_t globalIndex, const finding_config& cfg,
+    global_index_t globalIndex, const finding_config& cfg,
     const apply_interaction_payload<detector_t>& payload);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/finding/device/apply_interaction.hpp
+++ b/device/common/include/traccc/finding/device/apply_interaction.hpp
@@ -1,20 +1,26 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
+// Local include(s).
+#include "traccc/device/globalIndex.hpp"
+
 // Project include(s).
-#include "detray/navigation/navigator.hpp"
-#include "detray/propagator/actors/pointwise_material_interactor.hpp"
 #include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/track_parameters.hpp"
 #include "traccc/finding/finding_config.hpp"
-#include "traccc/utils/particle.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
 
 namespace traccc::device {
+
+/// (Event Data) Payload for the @c traccc::device::apply_interaction function
 template <typename detector_t>
 struct apply_interaction_payload {
     /**
@@ -25,7 +31,7 @@ struct apply_interaction_payload {
     /**
      * @brief Total number of input parameters (including non-live ones)
      */
-    const int n_params;
+    unsigned int n_params;
 
     /**
      * @brief View object to the vector of bound track parameters
@@ -39,16 +45,19 @@ struct apply_interaction_payload {
     vecmem::data::vector_view<const unsigned int> params_liveness_view;
 };
 
-/// Function applying the Pre material interaction to tracks spawned by bound
-/// track parameters
+/// Function applying the material interaction to tracks spawned described by
+/// bound track parameters
 ///
 /// @param[in] globalIndex     The index of the current thread
 /// @param[in] cfg             Track finding config object
 /// @param[inout] payload      The function call payload
+///
 template <typename detector_t>
 TRACCC_DEVICE inline void apply_interaction(
-    std::size_t globalIndex, const finding_config& cfg,
+    globalIndex_t globalIndex, const finding_config& cfg,
     const apply_interaction_payload<detector_t>& payload);
+
 }  // namespace traccc::device
 
+// Include the implementation.
 #include "./impl/apply_interaction.ipp"

--- a/device/common/include/traccc/finding/device/build_tracks.hpp
+++ b/device/common/include/traccc/finding/device/build_tracks.hpp
@@ -1,11 +1,14 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
+
+// Local include(s).
+#include "traccc/device/globalIndex.hpp"
 
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
@@ -13,8 +16,15 @@
 #include "traccc/edm/track_candidate.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/finding_config.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/data/jagged_vector_view.hpp>
+#include <vecmem/containers/data/vector_view.hpp>
 
 namespace traccc::device {
+
+/// (Event Data) Payload for the @c traccc::device::build_tracks function
 struct build_tracks_payload {
     /**
      * @brief View object to the vector of measurements
@@ -64,11 +74,12 @@ struct build_tracks_payload {
 /// @param[in] globalIndex         The index of the current thread
 /// @param[in] cfg                    Track finding config object
 /// @param[inout] payload      The function call payload
-template <typename config_t>
-TRACCC_DEVICE inline void build_tracks(std::size_t globalIndex,
-                                       const config_t cfg,
+///
+TRACCC_DEVICE inline void build_tracks(globalIndex_t globalIndex,
+                                       const finding_config& cfg,
                                        const build_tracks_payload& payload);
 
 }  // namespace traccc::device
 
+// Include the implementation.
 #include "./impl/build_tracks.ipp"

--- a/device/common/include/traccc/finding/device/build_tracks.hpp
+++ b/device/common/include/traccc/finding/device/build_tracks.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Local include(s).
-#include "traccc/device/globalIndex.hpp"
+#include "traccc/device/global_index.hpp"
 
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
@@ -75,7 +75,7 @@ struct build_tracks_payload {
 /// @param[in] cfg                    Track finding config object
 /// @param[inout] payload      The function call payload
 ///
-TRACCC_DEVICE inline void build_tracks(globalIndex_t globalIndex,
+TRACCC_DEVICE inline void build_tracks(global_index_t globalIndex,
                                        const finding_config& cfg,
                                        const build_tracks_payload& payload);
 

--- a/device/common/include/traccc/finding/device/fill_sort_keys.hpp
+++ b/device/common/include/traccc/finding/device/fill_sort_keys.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Local include(s).
-#include "traccc/device/globalIndex.hpp"
+#include "traccc/device/global_index.hpp"
 
 // Project include(s).
 #include "traccc/edm/device/sort_key.hpp"
@@ -44,7 +44,7 @@ struct fill_sort_keys_payload {
 /// @param[inout] payload      The function call payload
 ///
 TRACCC_HOST_DEVICE inline void fill_sort_keys(
-    globalIndex_t globalIndex, const fill_sort_keys_payload& payload);
+    global_index_t globalIndex, const fill_sort_keys_payload& payload);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/finding/device/fill_sort_keys.hpp
+++ b/device/common/include/traccc/finding/device/fill_sort_keys.hpp
@@ -1,17 +1,25 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
+// Local include(s).
+#include "traccc/device/globalIndex.hpp"
+
 // Project include(s).
 #include "traccc/edm/device/sort_key.hpp"
-#include "traccc/edm/track_candidate.hpp"
+#include "traccc/edm/track_parameters.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
 
 namespace traccc::device {
+
+/// (Event Data) Payload for the @c traccc::device::fill_sort_keys function
 struct fill_sort_keys_payload {
     /**
      * @brief View object to the vector of bound track parameters
@@ -34,8 +42,11 @@ struct fill_sort_keys_payload {
 ///
 /// @param[in] globalIndex   The index of the current thread
 /// @param[inout] payload      The function call payload
+///
 TRACCC_HOST_DEVICE inline void fill_sort_keys(
-    std::size_t globalIndex, const fill_sort_keys_payload& payload);
+    globalIndex_t globalIndex, const fill_sort_keys_payload& payload);
+
 }  // namespace traccc::device
 
+// Include the implementation.
 #include "./impl/fill_sort_keys.ipp"

--- a/device/common/include/traccc/finding/device/find_tracks.hpp
+++ b/device/common/include/traccc/finding/device/find_tracks.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,12 +14,18 @@
 #include "traccc/device/concepts/thread_id.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/edm/track_parameters.hpp"
-#include "traccc/edm/track_state.hpp"
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/finding/finding_config.hpp"
-#include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
+
+// System include(s).
+#include <utility>
 
 namespace traccc::device {
+
+/// (Global Event Data) Payload for the @c traccc::device::find_tracks function
 template <typename detector_t>
 struct find_tracks_payload {
     /**
@@ -48,7 +54,7 @@ struct find_tracks_payload {
     /**
      * @brief The total number of input parameters
      */
-    const unsigned int n_in_params;
+    unsigned int n_in_params;
 
     /**
      * @brief View object to the vector of barcodes for each measurement
@@ -69,12 +75,12 @@ struct find_tracks_payload {
     /**
      * @brief The current step identifier
      */
-    const unsigned int step;
+    unsigned int step;
 
     /**
      * @brief The maximum number of new tracks to find
      */
-    const unsigned int n_max_candidates;
+    unsigned int n_max_candidates;
 
     /**
      * @brief View object to the output track parameter vector
@@ -98,6 +104,7 @@ struct find_tracks_payload {
     unsigned int* n_total_candidates;
 };
 
+/// (Shared Event Data) Payload for the @c traccc::device::find_tracks function
 struct find_tracks_shared_payload {
     /**
      * @brief Shared-memory vector with the number of measurements found per
@@ -129,12 +136,15 @@ struct find_tracks_shared_payload {
 /// @param[in] cfg                Track finding config object
 /// @param[inout] payload         The global memory payload
 /// @param[inout] shared_payload  The shared memory payload
-template <concepts::thread_id1 thread_id_t, concepts::barrier barrier_t,
-          typename detector_t, typename config_t>
+///
+template <typename detector_t, concepts::thread_id1 thread_id_t,
+          concepts::barrier barrier_t>
 TRACCC_DEVICE inline void find_tracks(
-    thread_id_t& thread_id, barrier_t& barrier, const config_t cfg,
+    thread_id_t& thread_id, barrier_t& barrier, const finding_config& cfg,
     const find_tracks_payload<detector_t>& payload,
     const find_tracks_shared_payload& shared_payload);
+
 }  // namespace traccc::device
 
+// Include the implementation.
 #include "./impl/find_tracks.ipp"

--- a/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
+++ b/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
@@ -18,7 +18,7 @@ namespace traccc::device {
 
 template <typename detector_t>
 TRACCC_DEVICE inline void apply_interaction(
-    const globalIndex_t globalIndex, const finding_config& cfg,
+    const global_index_t globalIndex, const finding_config& cfg,
     const apply_interaction_payload<detector_t>& payload) {
 
     // Type definitions

--- a/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
+++ b/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,17 +8,17 @@
 #pragma once
 
 // Project include(s).
-#include "detray/navigation/navigator.hpp"
-#include "detray/propagator/actors/pointwise_material_interactor.hpp"
-#include "traccc/definitions/qualifiers.hpp"
-#include "traccc/finding/finding_config.hpp"
 #include "traccc/utils/particle.hpp"
+
+// Detray include(s).
+#include <detray/navigation/navigator.hpp>
+#include <detray/propagator/actors/pointwise_material_interactor.hpp>
 
 namespace traccc::device {
 
 template <typename detector_t>
 TRACCC_DEVICE inline void apply_interaction(
-    std::size_t globalIndex, const finding_config& cfg,
+    const globalIndex_t globalIndex, const finding_config& cfg,
     const apply_interaction_payload<detector_t>& payload) {
 
     // Type definitions

--- a/device/common/include/traccc/finding/device/impl/build_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/build_tracks.ipp
@@ -1,37 +1,29 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-// Project include(s).
-#include "traccc/definitions/qualifiers.hpp"
-#include "traccc/edm/measurement.hpp"
-#include "traccc/edm/track_candidate.hpp"
-#include "traccc/edm/track_parameters.hpp"
-#include "traccc/finding/candidate_link.hpp"
-
 namespace traccc::device {
 
-template <typename config_t>
-TRACCC_DEVICE inline void build_tracks(std::size_t globalIndex,
-                                       const config_t cfg,
+TRACCC_DEVICE inline void build_tracks(const globalIndex_t globalIndex,
+                                       const finding_config& cfg,
                                        const build_tracks_payload& payload) {
 
-    measurement_collection_types::const_device measurements(
+    const measurement_collection_types::const_device measurements(
         payload.measurements_view);
 
-    bound_track_parameters_collection_types::const_device seeds(
+    const bound_track_parameters_collection_types::const_device seeds(
         payload.seeds_view);
 
-    vecmem::jagged_device_vector<const candidate_link> links(
+    const vecmem::jagged_device_vector<const candidate_link> links(
         payload.links_view);
 
-    vecmem::device_vector<const typename candidate_link::link_index_type> tips(
-        payload.tips_view);
+    const vecmem::device_vector<const typename candidate_link::link_index_type>
+        tips(payload.tips_view);
 
     track_candidate_container_types::device track_candidates(
         payload.track_candidates_view);

--- a/device/common/include/traccc/finding/device/impl/build_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/build_tracks.ipp
@@ -9,7 +9,7 @@
 
 namespace traccc::device {
 
-TRACCC_DEVICE inline void build_tracks(const globalIndex_t globalIndex,
+TRACCC_DEVICE inline void build_tracks(const global_index_t globalIndex,
                                        const finding_config& cfg,
                                        const build_tracks_payload& payload) {
 

--- a/device/common/include/traccc/finding/device/impl/fill_sort_keys.ipp
+++ b/device/common/include/traccc/finding/device/impl/fill_sort_keys.ipp
@@ -1,22 +1,18 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-// Project include(s).
-#include "traccc/edm/device/sort_key.hpp"
-#include "traccc/edm/track_candidate.hpp"
-
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE inline void fill_sort_keys(
-    std::size_t globalIndex, const fill_sort_keys_payload& payload) {
+    const globalIndex_t globalIndex, const fill_sort_keys_payload& payload) {
 
-    bound_track_parameters_collection_types::const_device params(
+    const bound_track_parameters_collection_types::const_device params(
         payload.params_view);
 
     // Keys
@@ -29,10 +25,8 @@ TRACCC_HOST_DEVICE inline void fill_sort_keys(
         return;
     }
 
-    keys_device.at(static_cast<unsigned int>(globalIndex)) =
-        device::get_sort_key(params.at(static_cast<unsigned int>(globalIndex)));
-    ids_device.at(static_cast<unsigned int>(globalIndex)) =
-        static_cast<unsigned int>(globalIndex);
+    keys_device.at(globalIndex) = device::get_sort_key(params.at(globalIndex));
+    ids_device.at(globalIndex) = globalIndex;
 }
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/finding/device/impl/fill_sort_keys.ipp
+++ b/device/common/include/traccc/finding/device/impl/fill_sort_keys.ipp
@@ -10,7 +10,7 @@
 namespace traccc::device {
 
 TRACCC_HOST_DEVICE inline void fill_sort_keys(
-    const globalIndex_t globalIndex, const fill_sort_keys_payload& payload) {
+    const global_index_t globalIndex, const fill_sort_keys_payload& payload) {
 
     const bound_track_parameters_collection_types::const_device params(
         payload.params_view);

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,27 +8,18 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/definitions/primitives.hpp"
-#include "traccc/definitions/qualifiers.hpp"
-#include "traccc/device/concepts/barrier.hpp"
-#include "traccc/device/concepts/thread_id.hpp"
-#include "traccc/edm/measurement.hpp"
-#include "traccc/edm/track_parameters.hpp"
-#include "traccc/edm/track_state.hpp"
-#include "traccc/finding/candidate_link.hpp"
-#include "traccc/finding/finding_config.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
 
-// Thrust include(s)
+// Thrust include(s).
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 
 namespace traccc::device {
 
-template <concepts::thread_id1 thread_id_t, concepts::barrier barrier_t,
-          typename detector_t, typename config_t>
+template <typename detector_t, concepts::thread_id1 thread_id_t,
+          concepts::barrier barrier_t>
 TRACCC_DEVICE inline void find_tracks(
-    thread_id_t& thread_id, barrier_t& barrier, const config_t cfg,
+    thread_id_t& thread_id, barrier_t& barrier, const finding_config& cfg,
     const find_tracks_payload<detector_t>& payload,
     const find_tracks_shared_payload& shared_payload) {
 

--- a/device/common/include/traccc/finding/device/impl/make_barcode_sequence.ipp
+++ b/device/common/include/traccc/finding/device/impl/make_barcode_sequence.ipp
@@ -10,7 +10,7 @@
 namespace traccc::device {
 
 TRACCC_DEVICE inline void make_barcode_sequence(
-    const globalIndex_t globalIndex,
+    const global_index_t globalIndex,
     const make_barcode_sequence_payload& payload) {
 
     const measurement_collection_types::const_device uniques(

--- a/device/common/include/traccc/finding/device/impl/make_barcode_sequence.ipp
+++ b/device/common/include/traccc/finding/device/impl/make_barcode_sequence.ipp
@@ -1,23 +1,20 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-// Project include(s).
-#include "traccc/definitions/primitives.hpp"
-#include "traccc/definitions/qualifiers.hpp"
-#include "traccc/edm/measurement.hpp"
-
 namespace traccc::device {
 
 TRACCC_DEVICE inline void make_barcode_sequence(
-    std::size_t globalIndex, const make_barcode_sequence_payload& payload) {
+    const globalIndex_t globalIndex,
+    const make_barcode_sequence_payload& payload) {
 
-    measurement_collection_types::const_device uniques(payload.uniques_view);
+    const measurement_collection_types::const_device uniques(
+        payload.uniques_view);
     vecmem::device_vector barcodes(payload.barcodes_view);
     assert(uniques.size() >= barcodes.size());
 

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -17,7 +17,7 @@ namespace traccc::device {
 
 template <typename propagator_t, typename bfield_t>
 TRACCC_DEVICE inline void propagate_to_next_surface(
-    const globalIndex_t globalIndex, const finding_config& cfg,
+    const global_index_t globalIndex, const finding_config& cfg,
     const propagate_to_next_surface_payload<propagator_t, bfield_t>& payload) {
 
     if (globalIndex >= payload.n_in_params) {

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,21 +8,16 @@
 #pragma once
 
 // Project include(s).
-#include "detray/core/detail/tuple_container.hpp"
-#include "detray/propagator/constrained_step.hpp"
-#include "detray/utils/tuple.hpp"
-#include "traccc/definitions/primitives.hpp"
-#include "traccc/definitions/qualifiers.hpp"
-#include "traccc/edm/measurement.hpp"
-#include "traccc/edm/track_parameters.hpp"
-#include "traccc/finding/candidate_link.hpp"
 #include "traccc/utils/particle.hpp"
+
+// Detray include(s).
+#include "detray/utils/tuple.hpp"
 
 namespace traccc::device {
 
-template <typename propagator_t, typename bfield_t, typename config_t>
+template <typename propagator_t, typename bfield_t>
 TRACCC_DEVICE inline void propagate_to_next_surface(
-    std::size_t globalIndex, const config_t cfg,
+    const globalIndex_t globalIndex, const finding_config& cfg,
     const propagate_to_next_surface_payload<propagator_t, bfield_t>& payload) {
 
     if (globalIndex >= payload.n_in_params) {

--- a/device/common/include/traccc/finding/device/impl/prune_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/prune_tracks.ipp
@@ -1,25 +1,20 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-// Project include(s).
-#include "traccc/definitions/primitives.hpp"
-#include "traccc/definitions/qualifiers.hpp"
-#include "traccc/edm/track_candidate.hpp"
-
 namespace traccc::device {
 
-TRACCC_DEVICE inline void prune_tracks(std::size_t globalIndex,
+TRACCC_DEVICE inline void prune_tracks(const globalIndex_t globalIndex,
                                        const prune_tracks_payload& payload) {
 
-    track_candidate_container_types::const_device track_candidates(
+    const track_candidate_container_types::const_device track_candidates(
         payload.track_candidates_view);
-    vecmem::device_vector<const unsigned int> valid_indices(
+    const vecmem::device_vector<const unsigned int> valid_indices(
         payload.valid_indices_view);
     track_candidate_container_types::device prune_candidates(
         payload.prune_candidates_view);

--- a/device/common/include/traccc/finding/device/impl/prune_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/prune_tracks.ipp
@@ -9,7 +9,7 @@
 
 namespace traccc::device {
 
-TRACCC_DEVICE inline void prune_tracks(const globalIndex_t globalIndex,
+TRACCC_DEVICE inline void prune_tracks(const global_index_t globalIndex,
                                        const prune_tracks_payload& payload) {
 
     const track_candidate_container_types::const_device track_candidates(

--- a/device/common/include/traccc/finding/device/make_barcode_sequence.hpp
+++ b/device/common/include/traccc/finding/device/make_barcode_sequence.hpp
@@ -1,18 +1,29 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
+// Local include(s).
+#include "traccc/device/globalIndex.hpp"
+
 // Project include(s).
-#include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/measurement.hpp"
 
+// Detray include(s).
+#include <detray/geometry/barcode.hpp>
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
+
 namespace traccc::device {
+
+/// (Event Data) Payload for the @c traccc::device::make_barcode_sequence
+/// function
 struct make_barcode_sequence_payload {
     /**
      * @brief View object to the vector of unique measurement indices
@@ -29,8 +40,11 @@ struct make_barcode_sequence_payload {
 ///
 /// @param[in] globalIndex   The index of the current thread
 /// @param[inout] payload      The function call payload
+///
 TRACCC_DEVICE inline void make_barcode_sequence(
-    std::size_t globalIndex, const make_barcode_sequence_payload& payload);
+    globalIndex_t globalIndex, const make_barcode_sequence_payload& payload);
+
 }  // namespace traccc::device
 
+// Include the implementation.
 #include "./impl/make_barcode_sequence.ipp"

--- a/device/common/include/traccc/finding/device/make_barcode_sequence.hpp
+++ b/device/common/include/traccc/finding/device/make_barcode_sequence.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Local include(s).
-#include "traccc/device/globalIndex.hpp"
+#include "traccc/device/global_index.hpp"
 
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
@@ -42,7 +42,7 @@ struct make_barcode_sequence_payload {
 /// @param[inout] payload      The function call payload
 ///
 TRACCC_DEVICE inline void make_barcode_sequence(
-    globalIndex_t globalIndex, const make_barcode_sequence_payload& payload);
+    global_index_t globalIndex, const make_barcode_sequence_payload& payload);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -1,21 +1,27 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
+// Local include(s).
+#include "traccc/device/globalIndex.hpp"
+
 // Project include(s).
-#include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
-#include "traccc/edm/measurement.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/finding/candidate_link.hpp"
-#include "traccc/utils/particle.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
 
 namespace traccc::device {
+
+/// (Event Data) Payload for the @c traccc::device::propagate_to_next_surface
+/// function
 template <typename propagator_t, typename bfield_t>
 struct propagate_to_next_surface_payload {
     /**
@@ -41,7 +47,7 @@ struct propagate_to_next_surface_payload {
     /**
      * @brief View object to the access order of parameters so they are sorted
      */
-    const vecmem::data::vector_view<const unsigned int> param_ids_view;
+    vecmem::data::vector_view<const unsigned int> param_ids_view;
 
     /**
      * @brief View object to the vector of candidate links
@@ -51,12 +57,12 @@ struct propagate_to_next_surface_payload {
     /**
      * @brief Current CKF step number
      */
-    const unsigned int step;
+    unsigned int step;
 
     /**
      * @brief Total number of input track parameters
      */
-    const unsigned int n_in_params;
+    unsigned int n_in_params;
 
     /**
      * @brief View object to the vector of tips
@@ -81,10 +87,13 @@ struct propagate_to_next_surface_payload {
 /// @param[in] globalIndex        The index of the current thread
 /// @param[in] cfg                Track finding config object
 /// @param[inout] payload      The function call payload
-template <typename propagator_t, typename bfield_t, typename config_t>
+///
+template <typename propagator_t, typename bfield_t>
 TRACCC_DEVICE inline void propagate_to_next_surface(
-    std::size_t globalIndex, const config_t cfg,
+    globalIndex_t globalIndex, const finding_config& cfg,
     const propagate_to_next_surface_payload<propagator_t, bfield_t>& payload);
+
 }  // namespace traccc::device
 
+// Include the implementation.
 #include "./impl/propagate_to_next_surface.ipp"

--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Local include(s).
-#include "traccc/device/globalIndex.hpp"
+#include "traccc/device/global_index.hpp"
 
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
@@ -90,7 +90,7 @@ struct propagate_to_next_surface_payload {
 ///
 template <typename propagator_t, typename bfield_t>
 TRACCC_DEVICE inline void propagate_to_next_surface(
-    globalIndex_t globalIndex, const finding_config& cfg,
+    global_index_t globalIndex, const finding_config& cfg,
     const propagate_to_next_surface_payload<propagator_t, bfield_t>& payload);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/finding/device/prune_tracks.hpp
+++ b/device/common/include/traccc/finding/device/prune_tracks.hpp
@@ -1,19 +1,25 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
+// Local include(s).
+#include "traccc/device/globalIndex.hpp"
+
 // Project include(s).
-#include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/track_candidate.hpp"
 
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
+
 namespace traccc::device {
 
+/// (Event Data) Payload for the @c traccc::device::prune_tracks function
 struct prune_tracks_payload {
     /**
      * @brief View object to the vector of track candidates
@@ -35,8 +41,11 @@ struct prune_tracks_payload {
 ///
 /// @param[in] globalIndex         The index of the current thread
 /// @param[inout] payload      The function call payload
-TRACCC_DEVICE inline void prune_tracks(std::size_t globalIndex,
+///
+TRACCC_DEVICE inline void prune_tracks(globalIndex_t globalIndex,
                                        const prune_tracks_payload& payload);
+
 }  // namespace traccc::device
 
+// Include the implementation.
 #include "./impl/prune_tracks.ipp"

--- a/device/common/include/traccc/finding/device/prune_tracks.hpp
+++ b/device/common/include/traccc/finding/device/prune_tracks.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Local include(s).
-#include "traccc/device/globalIndex.hpp"
+#include "traccc/device/global_index.hpp"
 
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
@@ -42,7 +42,7 @@ struct prune_tracks_payload {
 /// @param[in] globalIndex         The index of the current thread
 /// @param[inout] payload      The function call payload
 ///
-TRACCC_DEVICE inline void prune_tracks(globalIndex_t globalIndex,
+TRACCC_DEVICE inline void prune_tracks(global_index_t globalIndex,
                                        const prune_tracks_payload& payload);
 
 }  // namespace traccc::device

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -189,8 +189,8 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 
             kernels::apply_interaction<std::decay_t<detector_type>>
                 <<<nBlocks, nThreads, 0, stream>>>(
-                    m_cfg, {det_view, static_cast<int>(n_in_params),
-                            in_params_buffer, param_liveness_buffer});
+                    m_cfg, {det_view, n_in_params, in_params_buffer,
+                            param_liveness_buffer});
             TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
         }
 

--- a/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,8 +29,7 @@ __global__ void find_tracks(const finding_config cfg,
     cuda::barrier barrier;
     cuda::thread_id1 thread_id;
 
-    device::find_tracks<cuda::thread_id1, cuda::barrier, detector_t,
-                        finding_config>(
+    device::find_tracks<detector_t>(
         thread_id, barrier, cfg, payload,
         {shared_num_candidates, shared_candidates, shared_candidates_size});
 }

--- a/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,10 +18,8 @@ __global__ void propagate_to_next_surface(
     const finding_config cfg,
     device::propagate_to_next_surface_payload<propagator_t, bfield_t> payload) {
 
-    int gid = threadIdx.x + blockIdx.x * blockDim.x;
-
-    device::propagate_to_next_surface<propagator_t, bfield_t, finding_config>(
-        gid, cfg, payload);
+    device::propagate_to_next_surface<propagator_t, bfield_t>(
+        threadIdx.x + blockIdx.x * blockDim.x, cfg, payload);
 }
 
 }  // namespace traccc::cuda::kernels


### PR DESCRIPTION
As one of the final steps before finalizing #773, this PR is meant to make all the necessary changes in the common device track finding code that SYCL needs.
   - Introduced `traccc::device::globalIndex_t` to refer to the type of the "global index" that is given to most device functions. (Practically all the ones that don't receive a templated "thread ID" object.)
   - Updated all track finding functions to use `traccc::device::globalIndex_t`.
   - Removed some unnecessary templating from the code.
     * These were left over from the time when the track finding configuration was not yet the simple struct that it is today.
   - Changed some `const` types here and there.
     * Removed some unnecessary `const` statements from the "payload types". Payload objects are already given to the functions through const references. Making some (simple scalar) members of these payload objects as `const` has no upside in my mind.
     * Added some extra `const` statements on some device vectors here and there.
     * Marked the "global index" variables as `const` in the `.ipp` files. I just personally like this formalism, where in the `.hpp` files we don't bother with adding a `const` (since adding it or not makes no difference for the user of the function), but add it in the implementation for a little extra security. (Making sure that we wouldn't change these values by mistake.)
   - Tried to clean up the include statements a little. :thinking:
   - Made some small updates in the CUDA track finding code to account for the changes in the common code.
     * These are all meant to be simplifications. :wink: