### PR TITLE
Simulation Tweaks, main branch (2025.01.08.)

### DIFF
--- a/simulation/include/traccc/simulation/measurement_smearer.hpp
+++ b/simulation/include/traccc/simulation/measurement_smearer.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -35,7 +35,7 @@ struct measurement_smearer {
                         const scalar_type stddev_local1)
         : stddev({stddev_local0, stddev_local1}) {}
 
-    measurement_smearer(measurement_smearer& smearer)
+    measurement_smearer(const measurement_smearer& smearer)
         : stddev(smearer.stddev), generator(smearer.generator) {}
 
     void set_seed(const uint_fast64_t sd) { generator.seed(sd); }

--- a/simulation/include/traccc/simulation/smearing_writer.hpp
+++ b/simulation/include/traccc/simulation/smearing_writer.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -26,6 +26,10 @@
 #include <dfe/dfe_io_dsv.hpp>
 #include <dfe/dfe_namedtuple.hpp>
 
+// System include(s).
+#include <filesystem>
+#include <string>
+
 namespace traccc {
 
 template <typename smearer_t>
@@ -45,18 +49,25 @@ struct smearing_writer : detray::actor {
     };
 
     struct state {
-        state(std::size_t event_id, config&& writer_cfg,
+        state(std::size_t event_id, const config& writer_cfg,
               const std::string directory)
-            : m_particle_writer(directory +
-                                traccc::io::get_event_filename(
-                                    event_id, "-particles_initial.csv")),
-              m_hit_writer(directory + traccc::io::get_event_filename(
-                                           event_id, "-hits.csv")),
-              m_meas_writer(directory + traccc::io::get_event_filename(
-                                            event_id, "-measurements.csv")),
+            : m_particle_writer((std::filesystem::path{directory} /
+                                 traccc::io::get_event_filename(
+                                     event_id, "-particles_initial.csv"))
+                                    .native()),
+              m_hit_writer(
+                  (std::filesystem::path{directory} /
+                   traccc::io::get_event_filename(event_id, "-hits.csv"))
+                      .native()),
+              m_meas_writer((std::filesystem::path{directory} /
+                             traccc::io::get_event_filename(
+                                 event_id, "-measurements.csv"))
+                                .native()),
               m_measurement_hit_id_writer(
-                  directory + traccc::io::get_event_filename(
-                                  event_id, "-measurement-simhit-map.csv")),
+                  (std::filesystem::path{directory} /
+                   traccc::io::get_event_filename(
+                       event_id, "-measurement-simhit-map.csv"))
+                      .native()),
               m_meas_smearer(writer_cfg.smearer) {}
 
         uint64_t particle_id = 0u;


### PR DESCRIPTION
Small improvements to the simulation code, taken from #773.

Made `traccc::smearing_writer` use [std::filesystem](https://en.cppreference.com/w/cpp/filesystem) for a little bit of additional robustness, and removed some awkwardness from the parameter passing in these classes.

To be honest, I don't remember anymore why I did this in #773. I **think** it helped with the CKF tests writing their test files into a more reasonable location...? :confused:

P.S. The two `const`-ness changes are very much related to each other. I think the rvalue reference in `smearing_writer` was added because of the missing `const` in `measurement_smearer`. :thinking: Note that a copy is being made of the smearer no matter what. We just don't require a non-const original for the copy anymore.