### PR TITLE
Add traccc tuple and pair types

### DIFF
--- a/core/include/traccc/edm/details/container_base.hpp
+++ b/core/include/traccc/edm/details/container_base.hpp
@@ -10,12 +10,10 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/details/container_element.hpp"
+#include "traccc/utils/pair.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
-
-// Thrust include(s).
-#include <thrust/pair.h>
 
 // System include(s).
 #include <cassert>
@@ -38,7 +36,7 @@ namespace traccc {
 template <typename header_t, typename item_t,
           template <typename> class vector_t,
           template <typename> class jagged_vector_t,
-          template <typename, typename> class pair_t = thrust::pair>
+          template <typename, typename> class pair_t = traccc::pair>
 class container_base {
     public:
     /// @name Type definitions

--- a/core/include/traccc/finding/candidate_link.hpp
+++ b/core/include/traccc/finding/candidate_link.hpp
@@ -9,9 +9,7 @@
 
 // Project include(s).
 #include "traccc/edm/measurement.hpp"
-
-// Thrust include(s).
-#include <thrust/pair.h>
+#include "traccc/utils/pair.hpp"
 
 namespace traccc {
 
@@ -20,7 +18,7 @@ namespace traccc {
 struct candidate_link {
 
     // Type of index
-    using link_index_type = thrust::pair<unsigned int, unsigned int>;
+    using link_index_type = traccc::pair<unsigned int, unsigned int>;
 
     // Index of link from the previous step
     link_index_type previous;

--- a/core/include/traccc/utils/pair.hpp
+++ b/core/include/traccc/utils/pair.hpp
@@ -1,0 +1,20 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc {
+template <typename T1, typename T2>
+struct pair {
+    public:
+    using first_type = T1;
+    using second_type = T2;
+
+    T1 first;
+    T2 second;
+};
+}  // namespace traccc

--- a/core/include/traccc/utils/tuple.hpp
+++ b/core/include/traccc/utils/tuple.hpp
@@ -1,0 +1,88 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include "traccc/definitions/qualifiers.hpp"
+
+namespace traccc {
+
+template <typename... Ts>
+struct tuple {};
+
+template <typename T, typename... Ts>
+struct tuple<T, Ts...> {
+
+    TRACCC_HOST_DEVICE constexpr tuple(){};
+
+    constexpr tuple(const tuple &o) requires(
+        std::is_copy_constructible_v<T> &&
+        (std::is_copy_constructible_v<Ts> && ...)) = default;
+
+    template <typename U, typename... Us>
+    requires std::is_constructible_v<T, U &&>
+        &&std::is_constructible_v<tuple<Ts...>, Us &&...>
+            TRACCC_HOST_DEVICE explicit constexpr tuple(
+                const tuple<U, Us...> &o)
+        : v(o.v), r(o.r) {}
+
+    constexpr tuple(tuple &&o) noexcept
+        requires(std::is_move_constructible_v<T> &&
+                 (std::is_move_constructible_v<Ts> && ...)) = default;
+
+    template <typename U, typename... Us>
+    requires std::is_constructible_v<T, U &&>
+        &&std::is_constructible_v<tuple<Ts...>, Us &&...>
+            TRACCC_HOST_DEVICE explicit constexpr tuple(tuple<U, Us...> &&o)
+        : v(std::move(o.v)), r(std::move(o.r)) {}
+
+    template <typename U, typename... Us>
+        requires std::is_constructible_v<T, U &&>
+            &&std::is_constructible_v<tuple<Ts...>, Us &&...> &&
+        (!(std::is_same_v<tuple, U> ||
+           (std::is_same_v<tuple, Us> || ...))) TRACCC_HOST_DEVICE
+        explicit constexpr tuple(U &&_v, Us &&... _r)
+        : v(std::forward<U>(_v)),
+    r(std::forward<Us>(_r)...) {}
+
+    constexpr ~tuple() noexcept = default;
+
+    constexpr tuple &operator=(const tuple &other) requires(
+        std::is_copy_assignable_v<T> &&
+        (std::is_copy_assignable_v<Ts> && ...)) = default;
+
+    template <typename U, typename... Us>
+    TRACCC_HOST_DEVICE constexpr tuple &
+    operator=(const tuple<U, Us...> &other) requires(
+        std::is_assignable_v<T &, const U &> &&
+        (std::is_assignable_v<Ts &, const Us &> && ...)) {
+        v = other.v;
+        r = other.r;
+        return *this;
+    }
+
+    constexpr tuple &operator=(tuple &&other) noexcept
+        requires(std::is_move_assignable_v<T> &&
+                 (std::is_move_assignable_v<Ts> && ...)) = default;
+
+    template <typename U, typename... Us>
+    TRACCC_HOST_DEVICE constexpr tuple &operator=(
+        tuple<U, Us...> &&other) requires(std::is_assignable_v<T &, U> &&
+                                          (std::is_assignable_v<Ts &, Us> &&
+                                           ...)) {
+        v = std::move(other.v);
+        r = std::move(other.r);
+        return *this;
+    }
+
+    T v;
+    tuple<Ts...> r;
+};
+}  // namespace traccc


### PR DESCRIPTION
This commit replaces the Thrust tuple and pair types from the traccc core library, as this dependency on Thrust is causing a lot of build headaches. Since we use the Thrust dependencies very sparsely in core, it is easier to remove them than to try to work around them.