### PR TITLE
Update NVIDIA CCCL to v2.7.0

### DIFF
--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -7,6 +7,17 @@
 
 #pragma once
 
+// HACK: Fix for intel/llvm#15544
+// As of Intel LLVM 2025.0, enabling an AMD SYCL target inadvertently sets the
+// `__CUDA_ARCH__` preprocessor definition which breaks all sorts of internal
+// logic in Thrust. Thus, we very selectively undefine the `__CUDA_ARCH__`
+// definition when we are are compiling SYCL code using the Intel LLVM
+// compiler. This can be removed when intel/llvm#15443 makes it into a OneAPI
+// release.
+#if defined(__INTEL_LLVM_COMPILER) && defined(SYCL_LANGUAGE_VERSION)
+#undef __CUDA_ARCH__
+#endif
+
 // Project include(s).
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
 

--- a/extern/cccl/CMakeLists.txt
+++ b/extern/cccl/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building CCCL as part of the TRACCC project" )
 
 # Declare where to get Thrust from.
 set( TRACCC_CCCL_SOURCE
-   "GIT_REPOSITORY;https://github.com/stephenswat/cccl.git;GIT_TAG;build/allow_installing_when_downstream"
+   "URL;https://github.com/NVIDIA/cccl/archive/refs/tags/v2.7.0.tar.gz;URL_MD5;83e431ebcb0a5c055fbd927754bec951"
    CACHE STRING "Source for CCCL, when built as part of this project" )
 mark_as_advanced( TRACCC_CCCL_SOURCE )
 # Note that we must not use SYSTEM here. Otherwise nvcc would pick up Thrust


### PR DESCRIPTION
This commit updates NVIDIA CCCL to version 2.7.0 and starts following the official repository rather than my fork.

Closes #660.

Depends on #815.