### PR TITLE
Remove Thrust pair type from prefix sum code

### DIFF
--- a/device/common/include/traccc/device/fill_prefix_sum.hpp
+++ b/device/common/include/traccc/device/fill_prefix_sum.hpp
@@ -10,18 +10,16 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/container.hpp"
+#include "traccc/utils/pair.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/utils/copy.hpp>
 
-// Thrust include(s).
-#include <thrust/pair.h>
-
 namespace traccc::device {
 
 /// Type for the individual elements in the prefix sum vector
-typedef thrust::pair<unsigned int, unsigned int> prefix_sum_element_t;
+typedef traccc::pair<unsigned int, unsigned int> prefix_sum_element_t;
 
 /// Convenience type definition for the return value of the helper function
 typedef vecmem::vector<prefix_sum_element_t> prefix_sum_t;

--- a/device/common/include/traccc/device/impl/fill_prefix_sum.ipp
+++ b/device/common/include/traccc/device/impl/fill_prefix_sum.ipp
@@ -28,7 +28,7 @@ inline void fill_prefix_sum(
     const prefix_sum_size_t current =
         sizes[static_cast<unsigned int>(globalIndex)];
     for (prefix_sum_size_t i = 0; i < current - previous; ++i) {
-        result.at(previous + i) = {globalIndex, i};
+        result.at(previous + i) = {static_cast<unsigned int>(globalIndex), i};
     }
 }
 


### PR DESCRIPTION
It turns out (see #816) that simply removing Thrust from the core library is not enough; it needs to be further removed from the common device code, too. Although this commit is unlikely to resolve the issue (as some Thrust functions are still called in the common device code), removing the last use of the Thrust pair type serves to make me feel better.