### PR TITLE
Fix several SYCL, OneDPL, and Kokkos build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,22 @@ option( TRACCC_USE_SYSTEM_DPL
    ${TRACCC_USE_SYSTEM_LIBS} )
 if( TRACCC_SETUP_DPL )
    if( TRACCC_USE_SYSTEM_DPL )
-      find_package( DPL REQUIRED )
+      # OneDPL determines whether SYCL is supported by asking the C++ compiler
+      # rather than the SYCL compiler, as a dedicated SYCL compiler is a non-
+      # standard traccc idea. To override the default behaviour (i.e. OneDPL
+      # testing the C++ compiler and finding that it does _not_ support SYCL)
+      # we simply override the support flags. This is fragile, as the flags
+      # are internal to OneDPL, but it's the best we can do. Note thr flag was
+      # renamed in https://github.com/uxlfoundation/oneDPL/pull/1949.
+      set(_sycl_support ON)
+      set(SYCL_SUPPORT ON)
+      find_package( oneDPL REQUIRED )
+      # OneDPL attaches the `-fsycl` flag to the C++ compiler, which causes
+      # it to incorrectly trigger some preprocessor definitions, thereby
+      # loading SYCL-specific header files which do not exist for e.g. a
+      # generic clang installation. Therefore, we have to manually wipe the
+      # compile flags that OneDPL sets.
+      set_target_properties(oneDPL PROPERTIES INTERFACE_COMPILE_OPTIONS "")
    else()
       add_subdirectory( extern/dpl )
    endif()
@@ -220,6 +235,12 @@ option( TRACCC_USE_SYSTEM_KOKKOS
 if( TRACCC_SETUP_KOKKOS )
    if( TRACCC_USE_SYSTEM_KOKKOS )
       find_package( Kokkos REQUIRED )
+      # Kokkos likes to determine the host architecture at installation time
+      # and propagate the corresponding `-march` flag through the CMake
+      # configuration which cases compiler errors when we use e.g. ICPX which
+      # dislikes it when you set two different microarchitectures (traccc sets
+      # a generic x86 target).
+      set_target_properties(Kokkos::kokkoscore PROPERTIES INTERFACE_COMPILE_OPTIONS "")
    else()
       add_subdirectory( extern/kokkos )
    endif()

--- a/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
+++ b/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
@@ -10,8 +10,16 @@
 #include "traccc/sycl/clusterization/measurement_sorting_algorithm.hpp"
 
 // oneDPL include(s).
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
+#pragma clang diagnostic ignored "-Wsign-compare"
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
+#pragma clang diagnostic pop
 
 // SYCL include(s).
 #include <sycl/sycl.hpp>

--- a/device/sycl/src/finding/find_tracks.hpp
+++ b/device/sycl/src/finding/find_tracks.hpp
@@ -44,8 +44,17 @@
 #include <vecmem/utils/sycl/local_accessor.hpp>
 
 // oneDPL include(s).
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
+#pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
+#pragma clang diagnostic ignored "-Wsign-compare"
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
+#pragma clang diagnostic pop
 
 // SYCL include(s).
 #include <sycl/sycl.hpp>

--- a/device/sycl/src/fitting/fit_tracks.hpp
+++ b/device/sycl/src/fitting/fit_tracks.hpp
@@ -24,8 +24,17 @@
 #include <vecmem/utils/copy.hpp>
 
 // oneDPL include(s).
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
+#pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
+#pragma clang diagnostic ignored "-Wsign-compare"
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
+#pragma clang diagnostic pop
 
 // SYCL include(s).
 #include <sycl/sycl.hpp>

--- a/tests/sycl/test_dpl.sycl
+++ b/tests/sycl/test_dpl.sycl
@@ -6,8 +6,18 @@
  */
 
 // DPL include(s).
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
+#pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
+#pragma clang diagnostic ignored "-Wsign-compare"
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
+#pragma clang diagnostic pop
 
 // SYCL include(s).
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
It turns out that the SYCL build system is in a significantly worse state than I though it was, and needs some urgent fixing. This commit fixes four primary issues:

1. OneDPL was previously being required as "DPL" but the actual package name is "oneDPL" so it was impossible to find.
2. OneDPL and Kokkos both set a bunch of unwanted interface compiler flags which we need to manually remove.
3. OneDPL cannot be configured with the traccc standard of having a separate C++ compiler and a SYCL compiler, so it needs to be tricked into thinking the SYCL compiler works.
4. OneDPL contains a boatload of compiler warnings which I had to silence with diagnostics pragmas.