### PR TITLE
Add structured configuration printing

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,6 +7,7 @@
 # Project include(s).
 include( traccc-compiler-options-cpp )
 
+add_subdirectory(utils)
 add_subdirectory(options)
 add_subdirectory(run)
 add_subdirectory(io)

--- a/examples/options/CMakeLists.txt
+++ b/examples/options/CMakeLists.txt
@@ -48,4 +48,5 @@ target_link_libraries( traccc_options
       Boost::program_options
       traccc::io
       traccc::performance
+      traccc::utils
 )

--- a/examples/options/include/traccc/options/accelerator.hpp
+++ b/examples/options/include/traccc/options/accelerator.hpp
@@ -27,10 +27,7 @@ class accelerator : public interface {
     /// Constructor
     accelerator();
 
-    private:
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
+    std::unique_ptr<configuration_printable> as_printable() const override;
 };  // struct accelerator
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/clusterization.hpp
+++ b/examples/options/include/traccc/options/clusterization.hpp
@@ -29,6 +29,8 @@ class clusterization
     operator clustering_config() const override;
     operator host::clusterization_algorithm::config_type() const override;
 
+    std::unique_ptr<configuration_printable> as_printable() const override;
+
     private:
     /// @name Options
     /// @{
@@ -38,10 +40,6 @@ class clusterization
     unsigned int target_cells_per_thread;
     unsigned int backup_size_multiplier;
     /// @}
-
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
 };  // class clusterization
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/details/interface.hpp
+++ b/examples/options/include/traccc/options/details/interface.hpp
@@ -7,11 +7,14 @@
 
 #pragma once
 
+#include "traccc/examples/utils/printable.hpp"
+
 // Boost include(s).
 #include <boost/program_options.hpp>
 
 // System include(s).
 #include <iosfwd>
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -35,20 +38,13 @@ class interface {
     ///
     virtual void read(const boost::program_options::variables_map& vm);
 
-    /// Helper for printing the options to an output stream
-    ///
-    /// @param out The output stream to print to
-    /// @return The output stream
-    ///
-    std::ostream& print(std::ostream& out) const;
+    /// Helper for turning an interface into a printable set of options.
+    virtual std::unique_ptr<configuration_printable> as_printable() const = 0;
 
     /// Get the description of this program option group
     const boost::program_options::options_description& options() const;
 
     protected:
-    /// Print the specific options of the derived class
-    virtual std::ostream& print_impl(std::ostream& out) const;
-
     /// (Boost) Description of this program option group
     boost::program_options::options_description m_desc;
 
@@ -57,8 +53,4 @@ class interface {
     std::string m_description;
 
 };  // class interface
-
-/// Printout helper for @c traccc::opts::interface and types derived from it
-std::ostream& operator<<(std::ostream& out, const interface& opt);
-
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/detector.hpp
+++ b/examples/options/include/traccc/options/detector.hpp
@@ -40,10 +40,7 @@ class detector : public interface {
     /// Constructor
     detector();
 
-    private:
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
+    std::unique_ptr<configuration_printable> as_printable() const override;
 };  // struct detector
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/generation.hpp
+++ b/examples/options/include/traccc/options/generation.hpp
@@ -69,10 +69,7 @@ class generation : public interface {
     ///
     void read(const boost::program_options::variables_map& vm) override;
 
-    private:
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
+    std::unique_ptr<configuration_printable> as_printable() const override;
 };  // struct generation
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/input_data.hpp
+++ b/examples/options/include/traccc/options/input_data.hpp
@@ -46,10 +46,7 @@ class input_data : public interface {
     ///
     void read(const boost::program_options::variables_map& vm) override;
 
-    private:
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
+    std::unique_ptr<configuration_printable> as_printable() const override;
 };  // class input_data
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/output_data.hpp
+++ b/examples/options/include/traccc/options/output_data.hpp
@@ -45,10 +45,7 @@ class output_data : public interface {
     ///
     void read(const boost::program_options::variables_map& vm) override;
 
-    private:
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
+    std::unique_ptr<configuration_printable> as_printable() const override;
 };  // class output_data
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/performance.hpp
+++ b/examples/options/include/traccc/options/performance.hpp
@@ -27,10 +27,7 @@ class performance : public interface {
     /// Constructor
     performance();
 
-    private:
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
+    std::unique_ptr<configuration_printable> as_printable() const override;
 };  // struct performance
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/telescope_detector.hpp
+++ b/examples/options/include/traccc/options/telescope_detector.hpp
@@ -46,10 +46,7 @@ class telescope_detector : public interface {
     ///
     void read(const boost::program_options::variables_map& vm) override;
 
-    private:
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
+    std::unique_ptr<configuration_printable> as_printable() const override;
 };  // ckass telescope_detector
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/threading.hpp
+++ b/examples/options/include/traccc/options/threading.hpp
@@ -36,10 +36,7 @@ class threading : public interface {
     ///
     void read(const boost::program_options::variables_map& vm) override;
 
-    private:
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
+    std::unique_ptr<configuration_printable> as_printable() const override;
 };  // struct threading
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/throughput.hpp
+++ b/examples/options/include/traccc/options/throughput.hpp
@@ -37,10 +37,7 @@ class throughput : public interface {
     /// Constructor
     throughput();
 
-    private:
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
+    std::unique_ptr<configuration_printable> as_printable() const override;
 };  // class throughput
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/track_finding.hpp
+++ b/examples/options/include/traccc/options/track_finding.hpp
@@ -31,6 +31,8 @@ class track_finding : public interface, public config_provider<finding_config> {
     /// Configuration conversion operators
     operator finding_config() const override;
 
+    std::unique_ptr<configuration_printable> as_printable() const override;
+
     private:
     /// @name Options
     /// @{
@@ -55,10 +57,6 @@ class track_finding : public interface, public config_provider<finding_config> {
     /// PDG number for particle hypothesis (Default: muon)
     int pdg_number = 13;
     /// @}
-
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
 };  // class track_finding
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/track_propagation.hpp
+++ b/examples/options/include/traccc/options/track_propagation.hpp
@@ -34,15 +34,14 @@ class track_propagation : public interface,
     /// Configuration provider
     operator detray::propagation::config() const override;
 
+    std::unique_ptr<configuration_printable> as_printable() const override;
+
     private:
     /// @name Options
     /// @{
     /// Propagation configuration object
     detray::propagation::config config;
     /// @}
-
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
 
     /// Search window (helper variable)
     value_array<unsigned int, 2> m_search_window = {0u, 0u};

--- a/examples/options/include/traccc/options/track_resolution.hpp
+++ b/examples/options/include/traccc/options/track_resolution.hpp
@@ -27,10 +27,7 @@ class track_resolution : public interface {
     /// Constructor
     track_resolution();
 
-    private:
-    /// Print the specific options of this class
-    std::ostream& print_impl(std::ostream& out) const override;
-
+    std::unique_ptr<configuration_printable> as_printable() const override;
 };  // class track_resolution
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/track_seeding.hpp
+++ b/examples/options/include/traccc/options/track_seeding.hpp
@@ -33,6 +33,7 @@ class track_seeding : public interface {
     /// Constructor
     track_seeding();
 
+    std::unique_ptr<configuration_printable> as_printable() const override;
 };  // struct track_seeding
 
 }  // namespace traccc::opts

--- a/examples/options/src/accelerator.cpp
+++ b/examples/options/src/accelerator.cpp
@@ -8,6 +8,8 @@
 // Local include(s).
 #include "traccc/options/accelerator.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
+
 // System include(s).
 #include <iostream>
 
@@ -20,10 +22,15 @@ accelerator::accelerator() : interface("Accelerator Options") {
                          "Compare accelerator output with that of the CPU");
 }
 
-std::ostream& accelerator::print_impl(std::ostream& out) const {
+std::unique_ptr<configuration_printable> accelerator::as_printable() const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>("Accelerator options");
 
-    out << "  Compare with CPU results: " << (compare_with_cpu ? "yes" : "no");
-    return out;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Compare with CPU output", compare_with_cpu ? "yes" : "no"));
+
+    return cat;
 }
 
 }  // namespace traccc::opts

--- a/examples/options/src/clusterization.cpp
+++ b/examples/options/src/clusterization.cpp
@@ -9,6 +9,7 @@
 #include "traccc/options/clusterization.hpp"
 
 #include "traccc/clusterization/clusterization_algorithm.hpp"
+#include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
 #include <iostream>
@@ -50,12 +51,25 @@ clusterization::operator host::clusterization_algorithm::config_type() const {
     return {};
 }
 
-std::ostream& clusterization::print_impl(std::ostream& out) const {
-    out << "  Threads per partition:      " << threads_per_partition << "\n";
-    out << "  Target cells per thread:    " << target_cells_per_thread << "\n";
-    out << "  Max cells per thread:       " << max_cells_per_thread << "\n";
-    out << "  Scratch space size mult.:   " << backup_size_multiplier;
-    return out;
-}
+std::unique_ptr<configuration_printable> clusterization::as_printable() const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>("Clustering options");
 
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Threads per partition", std::to_string(threads_per_partition)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Target cells per thread",
+            std::to_string(target_cells_per_thread)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Max cells per thread", std::to_string(max_cells_per_thread)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Scratch space multiplier",
+            std::to_string(backup_size_multiplier)));
+
+    return cat;
+}
 }  // namespace traccc::opts

--- a/examples/options/src/details/interface.cpp
+++ b/examples/options/src/details/interface.cpp
@@ -15,25 +15,8 @@ interface::interface(std::string_view group_desc)
 
 void interface::read(const boost::program_options::variables_map&) {}
 
-std::ostream& interface::print(std::ostream& out) const {
-
-    out << ">>> " << m_description << " <<<\n";
-    return print_impl(out);
-}
-
 const boost::program_options::options_description& interface::options() const {
 
     return m_desc;
 }
-
-std::ostream& interface::print_impl(std::ostream& out) const {
-
-    return (out << "  None");
-}
-
-std::ostream& operator<<(std::ostream& out, const interface& opt) {
-
-    return opt.print(out);
-}
-
 }  // namespace traccc::opts

--- a/examples/options/src/detector.cpp
+++ b/examples/options/src/detector.cpp
@@ -8,6 +8,8 @@
 // Project include(s).
 #include "traccc/options/detector.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
+
 // System include(s).
 #include <iostream>
 
@@ -37,15 +39,27 @@ detector::detector() : interface("Detector Options") {
         "Digitization file");
 }
 
-std::ostream& detector::print_impl(std::ostream& out) const {
+std::unique_ptr<configuration_printable> detector::as_printable() const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>("Detector options");
 
-    out << "  Detector file       : " << detector_file << "\n"
-        << "  Material file       : " << material_file << "\n"
-        << "  Surface grid file   : " << grid_file << "\n"
-        << "  Use detray::detector: " << (use_detray_detector ? "yes" : "no")
-        << "\n"
-        << "  Digitization file   : " << digitization_file;
-    return out;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Detector file",
+                                                detector_file));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Material file",
+                                                material_file));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Surface grid file",
+                                                grid_file));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Use detray detector", use_detray_detector ? "yes" : "no"));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Digitization file",
+                                                digitization_file));
+
+    return cat;
 }
 
 }  // namespace traccc::opts

--- a/examples/options/src/generation.cpp
+++ b/examples/options/src/generation.cpp
@@ -8,6 +8,7 @@
 // Project include(s).
 #include "traccc/options/generation.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
 #include "traccc/utils/particle.hpp"
 #include "traccc/utils/ranges.hpp"
 
@@ -59,7 +60,7 @@ generation::generation() : interface("Particle Generation Options") {
                          "PDG number for the particle type");
 }
 
-void generation::read(const po::variables_map& vm) {
+void generation::read(const po::variables_map &vm) {
 
     vertex *= detray::unit<float>::mm;
     vertex_stddev *= detray::unit<float>::mm;
@@ -81,23 +82,50 @@ void generation::read(const po::variables_map& vm) {
     ptc_type = detail::particle_from_pdg_number<traccc::scalar>(pdg_number);
 }
 
-std::ostream& generation::print_impl(std::ostream& out) const {
+std::unique_ptr<configuration_printable> generation::as_printable() const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>("Particle generation options");
 
-    out << "  Number of events to generate   : " << events << "\n"
-        << "  Number of particles to generate: " << gen_nparticles << "\n"
-        << "  Vertex                         : "
-        << vertex / detray::unit<float>::mm << " mm\n"
-        << "  Vertex standard deviation      : "
-        << vertex_stddev / detray::unit<float>::mm << " mm\n"
-        << "  Momentum range                 : "
-        << mom_range / detray::unit<float>::GeV << " GeV\n"
-        << "  Phi range                      : "
-        << phi_range / detray::unit<float>::degree << " deg\n"
-        << "  Eta range                      : " << eta_range << "\n"
-        << "  Theta range                    : "
-        << theta_range / detray::unit<float>::degree << " deg\n"
-        << "  PDG Number                     : " << pdg_number;
-    return out;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Number of events",
+                                                std::to_string(events)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Number of particles", std::to_string(gen_nparticles)));
+    std::stringstream vertex_ss;
+    vertex_ss << vertex / detray::unit<float>::mm << " mm";
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Vertex", vertex_ss.str()));
+    std::stringstream vertex_dev_ss;
+    vertex_dev_ss << vertex_stddev / detray::unit<float>::mm << " mm";
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Vertex standard deviation",
+                                                vertex_dev_ss.str()));
+    std::stringstream mom_range_ss;
+    mom_range_ss << mom_range / detray::unit<float>::GeV << " GeV";
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Momentum range",
+                                                mom_range_ss.str()));
+    std::stringstream phi_range_ss;
+    phi_range_ss << phi_range / detray::unit<float>::degree << " deg";
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Phi range",
+                                                phi_range_ss.str()));
+    std::stringstream eta_range_ss;
+    eta_range_ss << eta_range;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Eta range",
+                                                eta_range_ss.str()));
+    std::stringstream theta_range_ss;
+    theta_range_ss << theta_range / detray::unit<float>::degree << " deg";
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Theta range",
+                                                theta_range_ss.str()));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("PGD number",
+                                                std::to_string(pdg_number)));
+
+    return cat;
 }
 
 }  // namespace traccc::opts

--- a/examples/options/src/input_data.cpp
+++ b/examples/options/src/input_data.cpp
@@ -8,6 +8,8 @@
 // Local include(s).
 #include "traccc/options/input_data.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
+
 // System include(s).
 #include <iostream>
 #include <stdexcept>
@@ -20,7 +22,7 @@ namespace po = boost::program_options;
 /// Type alias for the data format enumeration
 using data_format_type = std::string;
 /// Name of the data format option
-static const char* data_format_option = "input-data-format";
+static const char *data_format_option = "input-data-format";
 
 input_data::input_data() : interface("Input Data Options") {
 
@@ -41,7 +43,7 @@ input_data::input_data() : interface("Input Data Options") {
                          "Number of input events to skip");
 }
 
-void input_data::read(const po::variables_map& vm) {
+void input_data::read(const po::variables_map &vm) {
 
     // Decode the input data format.
     if (vm.count(data_format_option)) {
@@ -59,15 +61,28 @@ void input_data::read(const po::variables_map& vm) {
     }
 }
 
-std::ostream& input_data::print_impl(std::ostream& out) const {
+std::unique_ptr<configuration_printable> input_data::as_printable() const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>("Input data options");
 
-    out << "  Use ACTS geometry source      : "
-        << (use_acts_geom_source ? "yes" : "no") << "\n"
-        << "  Input data format             : " << format << "\n"
-        << "  Input directory               : " << directory << "\n"
-        << "  Number of input events        : " << events << "\n"
-        << "  Number of input events to skip: " << skip;
-    return out;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Use ACTS geometry source", use_acts_geom_source ? "yes" : "no"));
+    std::stringstream format_ss;
+    format_ss << format;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Input data format",
+                                                format_ss.str()));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Input directory", directory));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Number of input events",
+                                                std::to_string(events)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Number of skipped events",
+                                                std::to_string(skip)));
+
+    return cat;
 }
 
 }  // namespace traccc::opts

--- a/examples/options/src/output_data.cpp
+++ b/examples/options/src/output_data.cpp
@@ -8,6 +8,8 @@
 // Local include(s).
 #include "traccc/options/output_data.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
+
 // System include(s).
 #include <iostream>
 #include <stdexcept>
@@ -53,11 +55,19 @@ void output_data::read(const boost::program_options::variables_map& vm) {
     }
 }
 
-std::ostream& output_data::print_impl(std::ostream& out) const {
+std::unique_ptr<configuration_printable> output_data::as_printable() const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>("Output data options");
 
-    out << "  Output data format: " << format << "\n"
-        << "  Output directory  : " << directory;
-    return out;
+    std::stringstream format_ss;
+    format_ss << format;
+    dynamic_cast<configuration_category&>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Output data format",
+                                                format_ss.str()));
+    dynamic_cast<configuration_category&>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Output directory", directory));
+
+    return cat;
 }
 
 }  // namespace traccc::opts

--- a/examples/options/src/performance.cpp
+++ b/examples/options/src/performance.cpp
@@ -8,6 +8,8 @@
 // Local include(s).
 #include "traccc/options/performance.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
+
 // System include(s).
 #include <iostream>
 
@@ -20,10 +22,15 @@ performance::performance() : interface("Performance Measurement Options") {
                          "Run performance checks");
 }
 
-std::ostream& performance::print_impl(std::ostream& out) const {
+std::unique_ptr<configuration_printable> performance::as_printable() const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>(
+            "Performance measurement options");
 
-    out << "  Run performance checks: " << (run ? "yes" : "no");
-    return out;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Run performance checks",
+                                                run ? "yes" : "no"));
+
+    return cat;
 }
-
 }  // namespace traccc::opts

--- a/examples/options/src/program_options.cpp
+++ b/examples/options/src/program_options.cpp
@@ -8,6 +8,8 @@
 // Local include(s).
 #include "traccc/options/program_options.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
+
 // System include(s).
 #include <cstdlib>
 #include <iostream>
@@ -55,9 +57,15 @@ program_options::program_options(
 
     // Tell the user what's happening.
     std::cout << "\nRunning " << description << "\n\n";
+
+    configuration_list cl;
+
     for (const auto& opt : options) {
-        std::cout << opt << "\n";
+        cl.add_child(opt.get().as_printable());
     }
+
+    cl.print();
+
     std::cout << std::endl;
 }
 

--- a/examples/options/src/telescope_detector.cpp
+++ b/examples/options/src/telescope_detector.cpp
@@ -8,6 +8,8 @@
 // Project include(s).
 #include "traccc/options/telescope_detector.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
+
 // Detray include(s).
 #include "detray/definitions/units.hpp"
 
@@ -45,7 +47,7 @@ telescope_detector::telescope_detector()
                          "Vector for plane placement");
 }
 
-void telescope_detector::read(const po::variables_map&) {
+void telescope_detector::read(const po::variables_map &) {
 
     thickness *= detray::unit<float>::mm;
     spacing *= detray::unit<float>::mm;
@@ -53,20 +55,40 @@ void telescope_detector::read(const po::variables_map&) {
     half_length *= detray::unit<float>::mm;
 }
 
-std::ostream& telescope_detector::print_impl(std::ostream& out) const {
+std::unique_ptr<configuration_printable> telescope_detector::as_printable()
+    const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>("Telescope detector options");
 
-    out << "  Empty material  : " << (empty_material ? "true" : "false") << "\n"
-        << "  Number of planes: " << n_planes << "\n"
-        << "  Slab thickness  : " << thickness / detray::unit<float>::mm
-        << " [mm]\n"
-        << "  Spacing         : " << spacing / detray::unit<float>::mm
-        << " [mm]\n"
-        << "  Smearing        : " << smearing / detray::unit<float>::um
-        << " [um]\n"
-        << "  Half length     : " << half_length / detray::unit<float>::mm
-        << " [mm]"
-        << "  Align axis      : " << align_vector << " \n";
-    return out;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Empty material",
+                                                empty_material ? "yes" : "no"));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Number of planes",
+                                                std::to_string(n_planes)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Slab thickness",
+            std::to_string(thickness / detray::unit<float>::mm) + " mm"));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Spacing",
+            std::to_string(spacing / detray::unit<float>::mm) + " mm"));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Smearing",
+            std::to_string(thickness / detray::unit<float>::um) + " um"));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Half length",
+            std::to_string(half_length / detray::unit<float>::mm) + " mm"));
+    std::stringstream align_ss;
+    align_ss << align_vector;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Alignment axis",
+                                                align_ss.str()));
+
+    return cat;
 }
 
 }  // namespace traccc::opts

--- a/examples/options/src/threading.cpp
+++ b/examples/options/src/threading.cpp
@@ -8,6 +8,8 @@
 // Local include(s).
 #include "traccc/options/threading.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
+
 // System include(s).
 #include <iostream>
 #include <stdexcept>
@@ -22,17 +24,22 @@ threading::threading() : interface("Multi-Threading Options") {
         "The number of CPU threads to use");
 }
 
-void threading::read(const boost::program_options::variables_map&) {
+void threading::read(const boost::program_options::variables_map &) {
 
     if (threads == 0) {
         throw std::invalid_argument{"Must use threads>0"};
     }
 }
 
-std::ostream& threading::print_impl(std::ostream& out) const {
+std::unique_ptr<configuration_printable> threading::as_printable() const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>("Multithreading options");
 
-    out << "  CPU threads: " << threads;
-    return out;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Number of CPU thread",
+                                                std::to_string(threads)));
+
+    return cat;
 }
 
 }  // namespace traccc::opts

--- a/examples/options/src/throughput.cpp
+++ b/examples/options/src/throughput.cpp
@@ -8,6 +8,8 @@
 // Library include(s).
 #include "traccc/options/throughput.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
+
 // System include(s).
 #include <iostream>
 
@@ -31,12 +33,21 @@ throughput::throughput() : interface("Throughput Measurement Options") {
         "File where result logs will be printed (in append mode).");
 }
 
-std::ostream& throughput::print_impl(std::ostream& out) const {
+std::unique_ptr<configuration_printable> throughput::as_printable() const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>(
+            "Throughput measurement options");
 
-    out << "  Cold run event(s) : " << cold_run_events << "\n"
-        << "  Processed event(s): " << processed_events << "\n"
-        << "  Log file          : " << log_file;
-    return out;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Cold run events", std::to_string(cold_run_events)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Processed events", std::to_string(processed_events)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Log file", log_file));
+
+    return cat;
 }
 
 }  // namespace traccc::opts

--- a/examples/options/src/track_finding.cpp
+++ b/examples/options/src/track_finding.cpp
@@ -8,6 +8,7 @@
 // Project include(s).
 #include "traccc/options/track_finding.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
 #include "traccc/utils/particle.hpp"
 
 // System include(s).
@@ -84,23 +85,45 @@ track_finding::operator finding_config() const {
     return out;
 }
 
-std::ostream& track_finding::print_impl(std::ostream& out) const {
+std::unique_ptr<configuration_printable> track_finding::as_printable() const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>("Track finding options");
 
-    out << "  Max number of branches per seed: " << max_num_branches_per_seed
-        << "\n"
-        << "  Max number of branches per surface: "
-        << max_num_branches_per_surface << "\n"
-        << "  Track candidates range   : " << track_candidates_range << "\n"
-        << "  Minimum step length for the next surface: "
-        << min_step_length_for_next_surface << " [mm] \n"
-        << "  Maximum step counts for the next surface: "
-        << max_step_counts_for_next_surface << "\n"
-        << "  Maximum Chi2             : " << chi2_max << "\n"
-        << "  Maximum branches per step: " << nmax_per_seed << "\n"
-        << "  Maximum number of skipped steps per candidates: "
-        << max_num_skipping_per_cand << "\n"
-        << "  PDG Number: " << pdg_number;
-    return out;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Max branches per seed",
+            std::to_string(max_num_branches_per_seed)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Max branches at surface",
+            std::to_string(max_num_branches_per_surface)));
+    std::stringstream candidate_ss;
+    candidate_ss << track_candidates_range;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Track candidate range",
+                                                candidate_ss.str()));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Min step length to next surface",
+            std::to_string(min_step_length_for_next_surface) + " mm"));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Max step count to next surface",
+            std::to_string(max_step_counts_for_next_surface)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Max Chi2",
+                                                std::to_string(chi2_max)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Max branches per step",
+                                                std::to_string(nmax_per_seed)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Max holes per candidate",
+            std::to_string(max_num_skipping_per_cand)));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("PDG number",
+                                                std::to_string(pdg_number)));
+
+    return cat;
 }
-
 }  // namespace traccc::opts

--- a/examples/options/src/track_resolution.cpp
+++ b/examples/options/src/track_resolution.cpp
@@ -8,6 +8,8 @@
 // Local include(s).
 #include "traccc/options/track_resolution.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
+
 // System include(s).
 #include <iostream>
 
@@ -24,10 +26,16 @@ track_resolution::track_resolution()
                          "Perform track ambiguity resolution");
 }
 
-std::ostream& track_resolution::print_impl(std::ostream& out) const {
+std::unique_ptr<configuration_printable> track_resolution::as_printable()
+    const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>(
+            "Ambiguity resolution options");
 
-    out << "  Run ambiguity resolution : " << (run ? "yes" : "no");
-    return out;
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>("Run ambiguity resolution",
+                                                run ? "yes" : "no"));
+
+    return cat;
 }
-
 }  // namespace traccc::opts

--- a/examples/options/src/track_seeding.cpp
+++ b/examples/options/src/track_seeding.cpp
@@ -8,8 +8,15 @@
 // Local include(s).
 #include "traccc/options/track_seeding.hpp"
 
+#include "traccc/examples/utils/printable.hpp"
+
 namespace traccc::opts {
 
 track_seeding::track_seeding() : interface("Track Seeding Options") {}
 
+std::unique_ptr<configuration_printable> track_seeding::as_printable() const {
+    std::unique_ptr<configuration_printable> cat =
+        std::make_unique<configuration_category>("Track seeding options");
+    return cat;
+}
 }  // namespace traccc::opts

--- a/examples/utils/CMakeLists.txt
+++ b/examples/utils/CMakeLists.txt
@@ -1,0 +1,9 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2022-2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+traccc_add_library( traccc_utils utils TYPE SHARED
+  "src/printable.cpp"
+)

--- a/examples/utils/include/traccc/examples/utils/printable.hpp
+++ b/examples/utils/include/traccc/examples/utils/printable.hpp
@@ -1,0 +1,82 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace traccc {
+class configuration_printable {
+    public:
+    virtual void print() const;
+
+    virtual void print_impl(std::string self_prefix, std::string child_prefix,
+                            std::size_t prefix_len,
+                            std::size_t max_key_width) const = 0;
+
+    virtual std::size_t get_max_key_width_impl() const = 0;
+
+    virtual ~configuration_printable();
+};
+
+class configuration_category final : public configuration_printable {
+    public:
+    explicit configuration_category(std::string n);
+
+    void add_child(std::unique_ptr<configuration_printable>&& elem);
+
+    void print_impl(std::string self_prefix, std::string child_prefix,
+                    std::size_t prefix_len,
+                    std::size_t max_key_width) const final;
+
+    std::size_t get_max_key_width_impl() const final;
+
+    ~configuration_category() final;
+
+    private:
+    std::string name;
+    std::vector<std::unique_ptr<configuration_printable>> elements;
+};
+
+class configuration_list final : public configuration_printable {
+    public:
+    configuration_list();
+
+    void add_child(std::unique_ptr<configuration_printable>&& elem);
+
+    void print_impl(std::string self_prefix, std::string child_prefix,
+                    std::size_t prefix_len,
+                    std::size_t max_key_width) const final;
+
+    std::size_t get_max_key_width_impl() const final;
+
+    ~configuration_list() final;
+
+    private:
+    std::vector<std::unique_ptr<configuration_printable>> elements;
+};
+
+class configuration_kv_pair final : public configuration_printable {
+    public:
+    configuration_kv_pair(std::string k, std::string v);
+
+    void print_impl(std::string self_prefix, std::string,
+                    std::size_t prefix_len,
+                    std::size_t max_key_width) const final;
+
+    std::size_t get_max_key_width_impl() const final;
+
+    ~configuration_kv_pair() final;
+
+    private:
+    std::string key;
+    std::string value;
+};
+}  // namespace traccc

--- a/examples/utils/src/printable.cpp
+++ b/examples/utils/src/printable.cpp
@@ -1,0 +1,105 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "traccc/examples/utils/printable.hpp"
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace traccc {
+void configuration_printable::print() const {
+    std::size_t mkw = get_max_key_width_impl();
+    print_impl("", "", 0, mkw);
+};
+
+configuration_printable::~configuration_printable() = default;
+
+configuration_category::configuration_category(std::string n) : name(n) {}
+
+void configuration_category::add_child(
+    std::unique_ptr<configuration_printable>&& elem) {
+    elements.push_back(std::move(elem));
+}
+
+void configuration_category::print_impl(std::string self_prefix,
+                                        std::string child_prefix,
+                                        std::size_t prefix_len,
+                                        std::size_t max_key_width) const {
+    std::cout << (self_prefix + name + ":") << std::endl;
+
+    for (std::size_t i = 0; i < elements.size(); i++) {
+        if (i == elements.size() - 1) {
+            elements[i]->print_impl(child_prefix + "└ ", child_prefix + "  ",
+                                    prefix_len + 2, max_key_width);
+        } else {
+            elements[i]->print_impl(child_prefix + "├ ", child_prefix + "│ ",
+                                    prefix_len + 2, max_key_width);
+        }
+    }
+}
+
+std::size_t configuration_category::get_max_key_width_impl() const {
+    std::size_t res = 0;
+
+    for (auto& i : elements) {
+        res = std::max(res, 2 + i->get_max_key_width_impl());
+    }
+
+    return res;
+}
+
+configuration_category::~configuration_category() = default;
+
+configuration_list::configuration_list() = default;
+
+void configuration_list::add_child(
+    std::unique_ptr<configuration_printable>&& elem) {
+    elements.push_back(std::move(elem));
+}
+
+void configuration_list::print_impl(std::string self_prefix,
+                                    std::string child_prefix,
+                                    std::size_t prefix_len,
+                                    std::size_t max_key_width) const {
+    for (auto& i : elements) {
+        i->print_impl(self_prefix, child_prefix, prefix_len, max_key_width);
+    }
+}
+
+std::size_t configuration_list::get_max_key_width_impl() const {
+    std::size_t res = 0;
+
+    for (auto& i : elements) {
+        res = std::max(res, i->get_max_key_width_impl());
+    }
+
+    return res;
+}
+
+configuration_list::~configuration_list() = default;
+
+configuration_kv_pair::configuration_kv_pair(std::string k, std::string v)
+    : key(k), value(v) {}
+
+void configuration_kv_pair::print_impl(std::string self_prefix, std::string,
+                                       std::size_t prefix_len,
+                                       std::size_t max_key_width) const {
+    std::cout << (self_prefix + key + ": " +
+                  std::string((max_key_width - (prefix_len + key.length())),
+                              ' ') +
+                  value)
+              << std::endl;
+}
+
+std::size_t configuration_kv_pair::get_max_key_width_impl() const {
+    return key.length();
+}
+
+configuration_kv_pair::~configuration_kv_pair() = default;
+}  // namespace traccc


### PR DESCRIPTION
The current configuration printing code is a hodgepodge of unstructured printing which facilitates reading by neither humans nor machines. This commit replaces the existing output system by a much more structured, JSON-like format which pretty prints the output and will, in the future, allow us to very easily output configurations in machine-readable formats.