### PR TITLE
Fix global counter conversion issue in Kokkos

### DIFF
--- a/device/kokkos/src/seeding/spacepoint_binning.cpp
+++ b/device/kokkos/src/seeding/spacepoint_binning.cpp
@@ -57,9 +57,10 @@ spacepoint_binning::output_type spacepoint_binning::operator()(
                 Kokkos::TeamThreadRange(team_member, num_threads),
                 [&](const int& thr) {
                     device::count_grid_capacities(
-                        static_cast<std::size_t>(team_member.league_rank() *
-                                                     team_member.team_size() +
-                                                 thr),
+                        static_cast<device::global_index_t>(
+                            team_member.league_rank() *
+                                team_member.team_size() +
+                            thr),
                         config, axes.first, axes.second, spacepoints_view,
                         grid_capacities_view);
                 });


### PR DESCRIPTION
PR #810 added the global index type definition, but missed a spot where this type should have been used in the Kokkos code. This commit amends the issue by adding a static cast.