### PR TITLE
Fix zero-track edge case bug in CUDA track finding

### DIFF
--- a/device/common/include/traccc/finding/device/impl/prune_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/prune_tracks.ipp
@@ -19,6 +19,8 @@ TRACCC_DEVICE inline void prune_tracks(const global_index_t globalIndex,
     track_candidate_container_types::device prune_candidates(
         payload.prune_candidates_view);
 
+    assert(valid_indices.size() == prune_candidates.size());
+
     if (globalIndex >= prune_candidates.size()) {
         return;
     }

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -357,7 +357,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
     vecmem::data::vector_buffer<unsigned int> valid_indices_buffer(n_tips_total,
                                                                    m_mr.main);
 
-    unsigned int n_valid_tracks;
+    unsigned int n_valid_tracks = 0;
 
     // @Note: nBlocks can be zero in case there is no tip. This happens when
     // chi2_max config is set tightly and no tips are found


### PR DESCRIPTION
This commit fixes a bug discovered by Neza; if the track finding finds exactly zero tips, it never sets the total number of track candidates to zero, which causes it to use an uninitialized value in a later kernel. This, in turn, leads to an assertion error. In this commit, we fix the bug and add an assertion to protect against any future errors.