### PR TITLE
Remove obsolete Thrust functionality check

### DIFF
--- a/extern/cccl/CMakeLists.txt
+++ b/extern/cccl/CMakeLists.txt
@@ -41,24 +41,3 @@ set ( CUB_ENABLE_HEADER_TESTING OFF CACHE BOOL "Disable CUB header testing" )
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( CCCL )
-
-# Check if <thrust/pair.h> works out of the box.
-include( CheckCXXSourceCompiles )
-set( CMAKE_REQUIRED_INCLUDES
-   "${CCCL_SOURCE_DIR}/thrust"
-   "${CCCL_SOURCE_DIR}/libcudacxx/include" )
-set( _THRUST_TEST_SOURCE "#include <thrust/pair.h>\nint main() { return 0; }" )
-check_cxx_source_compiles( "${_THRUST_TEST_SOURCE}" TRACCC_THRUST_WORKS )
-# If not, check if the _LIBCUDACXX_STRING_H_HAS_CONST_OVERLOADS flag makes it
-# work.
-if( NOT TRACCC_THRUST_WORKS )
-   set( CMAKE_REQUIRED_DEFINITIONS -D_LIBCUDACXX_STRING_H_HAS_CONST_OVERLOADS )
-   check_cxx_source_compiles( "${_THRUST_TEST_SOURCE}"
-      TRACCC_THRUST_WORKS_WITH_PATCH )
-   if( TRACCC_THRUST_WORKS_WITH_PATCH )
-      target_compile_definitions( _Thrust_Thrust
-         INTERFACE _LIBCUDACXX_STRING_H_HAS_CONST_OVERLOADS )
-   else()
-      message( WARNING "Thrust does not seem to work. The build may fail." )
-   endif()
-endif()


### PR DESCRIPTION
This check was possibly useful in the past, but now produces spurious warnings. As the code runs fine even without this check on the Thrust installation, the easiest solution is simply to remove it.