### PR TITLE
Fix broken assertion in prune tracks kernel

### DIFF
--- a/device/common/include/traccc/finding/device/impl/prune_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/prune_tracks.ipp
@@ -19,7 +19,7 @@ TRACCC_DEVICE inline void prune_tracks(const global_index_t globalIndex,
     track_candidate_container_types::device prune_candidates(
         payload.prune_candidates_view);
 
-    assert(valid_indices.size() == prune_candidates.size());
+    assert(valid_indices.size() >= prune_candidates.size());
 
     if (globalIndex >= prune_candidates.size()) {
         return;


### PR DESCRIPTION
Mea culpa, I made a mistake in a recent assertion added to the `prune_tracks` kernel which was too assertive, requiring an equality relation rather than a greater-or-equal relation between the number of tips and the number of tracks.