### PR TITLE
Make Thrust a private dependency of the CUDA library

### DIFF
--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -113,7 +113,7 @@ thrust_create_target( traccc::cuda_thrust
   HOST CPP
   DEVICE CUDA )
 target_link_libraries( traccc::cuda_thrust INTERFACE CUDA::cudart )
-target_link_libraries( traccc_cuda PUBLIC traccc::cuda_thrust )
+target_link_libraries( traccc_cuda PRIVATE traccc::cuda_thrust )
 
 # For CUDA 11 turn on separable compilation. This is necessary for using
 # Thrust 2.1.0.

--- a/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
@@ -30,9 +30,6 @@
 #include <vecmem/utils/copy.hpp>
 #include <vecmem/utils/cuda/copy.hpp>
 
-// Thrust Library
-#include <thrust/pair.h>
-
 namespace traccc::cuda {
 
 /// Track Finding algorithm for a set of tracks


### PR DESCRIPTION
This was previously a public dependency due to a lingering include of the Thrust pair code in a header, but this dependency is no longer necessary. Thus, we can remove the include from the header file and thereby turn Thrust into a private dependency of the CUDA library. This should also fix the install interface, which is currently broken due to the lack of Thrust setup code.