### PR TITLE
Add deterministic processing mode to examples

### DIFF
--- a/examples/options/include/traccc/options/throughput.hpp
+++ b/examples/options/include/traccc/options/throughput.hpp
@@ -29,6 +29,11 @@ class throughput : public interface {
     /// them in the performance measurements
     std::size_t cold_run_events = 10;
 
+    /// Enable or disable the randomization of event processing
+    bool deterministic_event_order = false;
+    /// Set the random event processing seed
+    unsigned int random_seed = 0;
+
     /// Output log file
     std::string log_file;
 

--- a/examples/options/src/throughput.cpp
+++ b/examples/options/src/throughput.cpp
@@ -28,6 +28,13 @@ throughput::throughput() : interface("Throughput Measurement Options") {
         "cold-run-events",
         po::value(&cold_run_events)->default_value(cold_run_events),
         "Number of events to run 'cold'");
+    m_desc.add_options()("deterministic",
+                         po::bool_switch(&deterministic_event_order)
+                             ->default_value(deterministic_event_order),
+                         "Process events in deterministic order");
+    m_desc.add_options()("random-seed",
+                         po::value(&random_seed)->default_value(random_seed),
+                         "Seed for event randomization (0 to use time)");
     m_desc.add_options()(
         "log-file", po::value(&log_file),
         "File where result logs will be printed (in append mode).");
@@ -46,6 +53,14 @@ std::unique_ptr<configuration_printable> throughput::as_printable() const {
             "Processed events", std::to_string(processed_events)));
     dynamic_cast<configuration_category &>(*cat).add_child(
         std::make_unique<configuration_kv_pair>("Log file", log_file));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Deterministic ordering",
+            deterministic_event_order ? "yes" : "no"));
+    dynamic_cast<configuration_category &>(*cat).add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Random seed",
+            random_seed == 0 ? "time-based" : std::to_string(random_seed)));
 
     return cat;
 }

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -190,7 +190,11 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
     tbb::task_group group;
 
     // Seed the random number generator.
-    std::srand(static_cast<unsigned int>(std::time(0)));
+    if (throughput_opts.random_seed == 0u) {
+        std::srand(static_cast<unsigned int>(std::time(0)));
+    } else {
+        std::srand(throughput_opts.random_seed);
+    }
 
     // Dummy count uses output of tp algorithm to ensure the compiler
     // optimisations don't skip any step
@@ -215,7 +219,10 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
 
             // Choose which event to process.
             const std::size_t event =
-                static_cast<std::size_t>(std::rand()) % input_opts.events;
+                (throughput_opts.deterministic_event_order
+                     ? i
+                     : static_cast<std::size_t>(std::rand())) %
+                input_opts.events;
 
             // Launch the processing of the event.
             arena.execute([&, event]() {
@@ -253,7 +260,10 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
 
             // Choose which event to process.
             const std::size_t event =
-                static_cast<std::size_t>(std::rand()) % input_opts.events;
+                (throughput_opts.deterministic_event_order
+                     ? i
+                     : static_cast<std::size_t>(std::rand())) %
+                input_opts.events;
 
             // Launch the processing of the event.
             arena.execute([&, event]() {

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -129,7 +129,11 @@ int throughput_st(std::string_view description, int argc, char* argv[],
         (detector_opts.use_detray_detector ? &detector : nullptr));
 
     // Seed the random number generator.
-    std::srand(static_cast<unsigned int>(std::time(0)));
+    if (throughput_opts.random_seed == 0) {
+        std::srand(static_cast<unsigned int>(std::time(0)));
+    } else {
+        std::srand(throughput_opts.random_seed);
+    }
 
     // Dummy count uses output of tp algorithm to ensure the compiler
     // optimisations don't skip any step
@@ -154,7 +158,10 @@ int throughput_st(std::string_view description, int argc, char* argv[],
 
             // Choose which event to process.
             const std::size_t event =
-                static_cast<std::size_t>(std::rand()) % input_opts.events;
+                (throughput_opts.deterministic_event_order
+                     ? i
+                     : static_cast<std::size_t>(std::rand())) %
+                input_opts.events;
 
             // Process one event.
             rec_track_params += (*alg)(input[event]).size();
@@ -182,7 +189,10 @@ int throughput_st(std::string_view description, int argc, char* argv[],
 
             // Choose which event to process.
             const std::size_t event =
-                static_cast<std::size_t>(std::rand()) % input_opts.events;
+                (throughput_opts.deterministic_event_order
+                     ? i
+                     : static_cast<std::size_t>(std::rand())) %
+                input_opts.events;
 
             // Process one event.
             rec_track_params += (*alg)(input[event]).size();


### PR DESCRIPTION
This commit adds an optional deterministic processing mode to the throughput examples. It also makes the seed configurable. The default behaviour of the examples remains as it is now, but passing the `--deterministic` flag will simply cycle through events in order, and the `--random-seed` flag allows users to configure their own random seed. If the random seed is 0 (the default) then a time-based seed is used instead.