### PR TITLE
Use configuration types as SSOT for defaults

### DIFF
--- a/examples/options/include/traccc/options/clusterization.hpp
+++ b/examples/options/include/traccc/options/clusterization.hpp
@@ -32,14 +32,8 @@ class clusterization
     std::unique_ptr<configuration_printable> as_printable() const override;
 
     private:
-    /// @name Options
-    /// @{
-    /// The number of cells to merge in a partition
-    unsigned int threads_per_partition;
-    unsigned int max_cells_per_thread;
-    unsigned int target_cells_per_thread;
-    unsigned int backup_size_multiplier;
-    /// @}
+    /// Internal configuration object
+    clustering_config m_config;
 };  // class clusterization
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/track_finding.hpp
+++ b/examples/options/include/traccc/options/track_finding.hpp
@@ -34,29 +34,11 @@ class track_finding : public interface, public config_provider<finding_config> {
     std::unique_ptr<configuration_printable> as_printable() const override;
 
     private:
-    /// @name Options
-    /// @{
-    /// Max number of branches per seed
-    unsigned int max_num_branches_per_seed = 10;
-    /// Max number of branches per surface
-    unsigned int max_num_branches_per_surface = 10;
-    /// Number of track candidates per seed
-    opts::value_array<unsigned int, 2> track_candidates_range{3, 100};
-    /// Minimum step length that track should make to reach the next surface. It
-    /// should be set higher than the overstep tolerance not to make it stay on
-    /// the same surface
-    float min_step_length_for_next_surface = 0.5f * detray::unit<float>::mm;
-    /// Maximum step counts that track can make to reach the next surface
-    unsigned int max_step_counts_for_next_surface = 100;
-    /// Maximum chi2 for a measurement to be included in the track
-    float chi2_max = 10.f;
-    /// Maximum number of branches which each initial seed can have at a step
-    unsigned int nmax_per_seed = 10;
-    /// Maximum allowed number of skipped steps per candidate
-    unsigned int max_num_skipping_per_cand = 3;
-    /// PDG number for particle hypothesis (Default: muon)
-    int pdg_number = 13;
-    /// @}
+    /// The internal configuration
+    finding_config m_config;
+    /// Additional variables which we cannot simply store in the config
+    opts::value_array<unsigned int, 2> m_track_candidates_range{0, 0};
+    int m_pdg_number = 0;
 };  // class track_finding
 
 }  // namespace traccc::opts

--- a/examples/options/include/traccc/options/track_propagation.hpp
+++ b/examples/options/include/traccc/options/track_propagation.hpp
@@ -40,7 +40,7 @@ class track_propagation : public interface,
     /// @name Options
     /// @{
     /// Propagation configuration object
-    detray::propagation::config config;
+    detray::propagation::config m_config;
     /// @}
 
     /// Search window (helper variable)

--- a/examples/options/src/clusterization.cpp
+++ b/examples/options/src/clusterization.cpp
@@ -18,33 +18,30 @@ namespace traccc::opts {
 
 clusterization::clusterization() : interface("Clusterization Options") {
 
-    m_desc.add_options()("threads-per-partition",
-                         boost::program_options::value(&threads_per_partition)
-                             ->default_value(256),
-                         "The number of threads per partition");
+    m_desc.add_options()(
+        "threads-per-partition",
+        boost::program_options::value(&m_config.threads_per_partition)
+            ->default_value(m_config.threads_per_partition),
+        "The number of threads per partition");
     m_desc.add_options()(
         "max-cells-per-thread",
-        boost::program_options::value(&max_cells_per_thread)->default_value(16),
+        boost::program_options::value(&m_config.max_cells_per_thread)
+            ->default_value(m_config.max_cells_per_thread),
         "The maximum number of cells per thread");
-    m_desc.add_options()("target-cells-per-thread",
-                         boost::program_options::value(&target_cells_per_thread)
-                             ->default_value(8),
-                         "The target number of cells per thread");
-    m_desc.add_options()("backup-size-multiplier",
-                         boost::program_options::value(&backup_size_multiplier)
-                             ->default_value(256),
-                         "The size multiplier of the backup scratch space");
+    m_desc.add_options()(
+        "target-cells-per-thread",
+        boost::program_options::value(&m_config.target_cells_per_thread)
+            ->default_value(m_config.target_cells_per_thread),
+        "The target number of cells per thread");
+    m_desc.add_options()(
+        "backup-size-multiplier",
+        boost::program_options::value(&m_config.backup_size_multiplier)
+            ->default_value(m_config.backup_size_multiplier),
+        "The size multiplier of the backup scratch space");
 }
 
 clusterization::operator clustering_config() const {
-    clustering_config rv;
-
-    rv.threads_per_partition = threads_per_partition;
-    rv.max_cells_per_thread = max_cells_per_thread;
-    rv.target_cells_per_thread = target_cells_per_thread;
-    rv.backup_size_multiplier = backup_size_multiplier;
-
-    return rv;
+    return m_config;
 }
 
 clusterization::operator host::clusterization_algorithm::config_type() const {
@@ -57,18 +54,20 @@ std::unique_ptr<configuration_printable> clusterization::as_printable() const {
 
     dynamic_cast<configuration_category &>(*cat).add_child(
         std::make_unique<configuration_kv_pair>(
-            "Threads per partition", std::to_string(threads_per_partition)));
+            "Threads per partition",
+            std::to_string(m_config.threads_per_partition)));
     dynamic_cast<configuration_category &>(*cat).add_child(
         std::make_unique<configuration_kv_pair>(
             "Target cells per thread",
-            std::to_string(target_cells_per_thread)));
+            std::to_string(m_config.target_cells_per_thread)));
     dynamic_cast<configuration_category &>(*cat).add_child(
         std::make_unique<configuration_kv_pair>(
-            "Max cells per thread", std::to_string(max_cells_per_thread)));
+            "Max cells per thread",
+            std::to_string(m_config.max_cells_per_thread)));
     dynamic_cast<configuration_category &>(*cat).add_child(
         std::make_unique<configuration_kv_pair>(
             "Scratch space multiplier",
-            std::to_string(backup_size_multiplier)));
+            std::to_string(m_config.backup_size_multiplier)));
 
     return cat;
 }

--- a/examples/options/src/track_propagation.cpp
+++ b/examples/options/src/track_propagation.cpp
@@ -23,44 +23,49 @@ namespace po = boost::program_options;
 
 track_propagation::track_propagation()
     : interface("Track Propagation Options") {
+    m_search_window[0] = m_config.navigation.search_window[0];
+    m_search_window[1] = m_config.navigation.search_window[1];
 
     m_desc.add_options()("constraint-step-size-mm",
-                         po::value(&(config.stepping.step_constraint))
-                             ->default_value(std::numeric_limits<float>::max()),
+                         po::value(&(m_config.stepping.step_constraint))
+                             ->default_value(m_config.stepping.step_constraint),
                          "The constrained step size [mm]");
-    m_desc.add_options()("overstep-tolerance-um",
-                         po::value(&(config.navigation.overstep_tolerance))
-                             ->default_value(-100.f),
-                         "The overstep tolerance [um]");
-    m_desc.add_options()("min-mask-tolerance-mm",
-                         po::value(&(config.navigation.min_mask_tolerance))
-                             ->default_value(1e-5f),
-                         "The minimum mask tolerance [mm]");
+    m_desc.add_options()(
+        "overstep-tolerance-um",
+        po::value(&(m_config.navigation.overstep_tolerance))
+            ->default_value(m_config.navigation.overstep_tolerance),
+        "The overstep tolerance [um]");
+    m_desc.add_options()(
+        "min-mask-tolerance-mm",
+        po::value(&(m_config.navigation.min_mask_tolerance))
+            ->default_value(m_config.navigation.min_mask_tolerance),
+        "The minimum mask tolerance [mm]");
     m_desc.add_options()(
         "max-mask-tolerance-mm",
-        po::value(&(config.navigation.max_mask_tolerance))->default_value(1.f),
+        po::value(&(m_config.navigation.max_mask_tolerance))
+            ->default_value(m_config.navigation.max_mask_tolerance),
         "The maximum mask tolerance [mm]");
     m_desc.add_options()(
         "search-window",
         po::value(&m_search_window)->default_value(m_search_window),
         "Size of the grid surface search window");
-    m_desc.add_options()(
-        "rk-tolerance",
-        po::value(&(config.stepping.rk_error_tol))->default_value(1e-4f),
-        "The Runge-Kutta stepper tolerance");
+    m_desc.add_options()("rk-tolerance",
+                         po::value(&(m_config.stepping.rk_error_tol))
+                             ->default_value(m_config.stepping.rk_error_tol),
+                         "The Runge-Kutta stepper tolerance");
 }
 
 void track_propagation::read(const po::variables_map &) {
 
-    config.stepping.step_constraint *= detray::unit<float>::mm;
-    config.navigation.overstep_tolerance *= detray::unit<float>::um;
-    config.navigation.min_mask_tolerance *= detray::unit<float>::mm;
-    config.navigation.max_mask_tolerance *= detray::unit<float>::mm;
-    config.navigation.search_window = m_search_window;
+    m_config.stepping.step_constraint *= detray::unit<float>::mm;
+    m_config.navigation.overstep_tolerance *= detray::unit<float>::um;
+    m_config.navigation.min_mask_tolerance *= detray::unit<float>::mm;
+    m_config.navigation.max_mask_tolerance *= detray::unit<float>::mm;
+    m_config.navigation.search_window = m_search_window;
 }
 
 track_propagation::operator detray::propagation::config() const {
-    return config;
+    return m_config;
 }
 
 std::unique_ptr<configuration_printable> track_propagation::as_printable()
@@ -71,91 +76,92 @@ std::unique_ptr<configuration_printable> track_propagation::as_printable()
     dynamic_cast<configuration_category &>(*cat_nav).add_child(
         std::make_unique<configuration_kv_pair>(
             "Min mask tolerance",
-            std::to_string(config.navigation.min_mask_tolerance /
+            std::to_string(m_config.navigation.min_mask_tolerance /
                            detray::unit<float>::mm) +
                 " mm"));
     dynamic_cast<configuration_category &>(*cat_nav).add_child(
         std::make_unique<configuration_kv_pair>(
             "Max mask tolerance",
-            std::to_string(config.navigation.max_mask_tolerance /
+            std::to_string(m_config.navigation.max_mask_tolerance /
                            detray::unit<float>::mm) +
                 " mm"));
     dynamic_cast<configuration_category &>(*cat_nav).add_child(
         std::make_unique<configuration_kv_pair>(
             "Mask tolerance scalar",
-            std::to_string(config.navigation.mask_tolerance_scalor)));
+            std::to_string(m_config.navigation.mask_tolerance_scalor)));
     dynamic_cast<configuration_category &>(*cat_nav).add_child(
         std::make_unique<configuration_kv_pair>(
-            "Path tolerance", std::to_string(config.navigation.path_tolerance /
-                                             detray::unit<float>::um) +
-                                  " um"));
+            "Path tolerance",
+            std::to_string(m_config.navigation.path_tolerance /
+                           detray::unit<float>::um) +
+                " um"));
     dynamic_cast<configuration_category &>(*cat_nav).add_child(
         std::make_unique<configuration_kv_pair>(
             "Overstep tolerance",
-            std::to_string(config.navigation.overstep_tolerance /
+            std::to_string(m_config.navigation.overstep_tolerance /
                            detray::unit<float>::um) +
                 " um"));
     dynamic_cast<configuration_category &>(*cat_nav).add_child(
         std::make_unique<configuration_kv_pair>(
             "Search window",
-            std::to_string(config.navigation.search_window[0]) + " x " +
-                std::to_string(config.navigation.search_window[1])));
+            std::to_string(m_config.navigation.search_window[0]) + " x " +
+                std::to_string(m_config.navigation.search_window[1])));
 
     std::unique_ptr<configuration_printable> cat_tsp =
         std::make_unique<configuration_category>("Transport");
 
     dynamic_cast<configuration_category &>(*cat_tsp).add_child(
         std::make_unique<configuration_kv_pair>(
-            "Min step size", std::to_string(config.stepping.min_stepsize /
+            "Min step size", std::to_string(m_config.stepping.min_stepsize /
                                             detray::unit<float>::mm) +
                                  " mm"));
     dynamic_cast<configuration_category &>(*cat_tsp).add_child(
         std::make_unique<configuration_kv_pair>(
             "Runge-Kutta tolerance",
-            std::to_string(config.stepping.rk_error_tol /
+            std::to_string(m_config.stepping.rk_error_tol /
                            detray::unit<float>::mm) +
                 " mm"));
     dynamic_cast<configuration_category &>(*cat_tsp).add_child(
         std::make_unique<configuration_kv_pair>(
             "Max step updates",
-            std::to_string(config.stepping.max_rk_updates)));
+            std::to_string(m_config.stepping.max_rk_updates)));
     dynamic_cast<configuration_category &>(*cat_tsp).add_child(
         std::make_unique<configuration_kv_pair>(
             "Step size constraint",
-            std::to_string(config.stepping.step_constraint /
+            std::to_string(m_config.stepping.step_constraint /
                            detray::unit<float>::mm) +
                 " mm"));
     dynamic_cast<configuration_category &>(*cat_tsp).add_child(
         std::make_unique<configuration_kv_pair>(
-            "Path limit", std::to_string(config.stepping.path_limit /
+            "Path limit", std::to_string(m_config.stepping.path_limit /
                                          detray::unit<float>::m) +
                               " m"));
     dynamic_cast<configuration_category &>(*cat_tsp).add_child(
         std::make_unique<configuration_kv_pair>(
-            "Min step size", std::to_string(config.stepping.min_stepsize /
+            "Min step size", std::to_string(m_config.stepping.min_stepsize /
                                             detray::unit<float>::mm) +
                                  " mm"));
     dynamic_cast<configuration_category &>(*cat_tsp).add_child(
         std::make_unique<configuration_kv_pair>(
             "Enable Bethe energy loss",
-            config.stepping.use_mean_loss ? "yes" : "no"));
+            m_config.stepping.use_mean_loss ? "yes" : "no"));
     dynamic_cast<configuration_category &>(*cat_tsp).add_child(
         std::make_unique<configuration_kv_pair>(
             "Enable covariance transport",
-            config.stepping.do_covariance_transport ? "yes" : "no"));
+            m_config.stepping.do_covariance_transport ? "yes" : "no"));
 
-    if (config.stepping.do_covariance_transport) {
+    if (m_config.stepping.do_covariance_transport) {
         std::unique_ptr<configuration_printable> cat_cov =
             std::make_unique<configuration_category>("Covariance transport");
 
         dynamic_cast<configuration_category &>(*cat_cov).add_child(
             std::make_unique<configuration_kv_pair>(
                 "Enable energy loss gradient",
-                config.stepping.use_eloss_gradient ? "yes" : "no"));
+                m_config.stepping.use_eloss_gradient ? "yes" : "no"));
         dynamic_cast<configuration_category &>(*cat_cov).add_child(
             std::make_unique<configuration_kv_pair>(
                 "Enable B-field gradient",
-                config.stepping.use_field_gradient ? "yes" : "no"));
+                m_config.stepping.use_field_gradient ? "yes" : "no"));
 
         dynamic_cast<configuration_category &>(*cat_tsp).add_child(
             std::move(cat_cov));


### PR DESCRIPTION
As it stands, some of our default values for configuration parameters, e.g. those of the track finding, have defaults defined both in the configuration type as well as in the corresponding options type in the examples. This is confusing as @paradajzblond discovered today. In this commit, I remove the defaults defined in the examples code and treat the configuration type defaults as the single source of truth for default values.