### PR TITLE
Add Spack environment specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,25 @@ and toolchains that are currently known to work (last updated 2022/01/24):
 - [CMake](https://cmake.org/)
 - (Optional) [ROOT](https://root.cern/): RIO, Hist, Tree
 
+### Dependency management with Spack
+
+The [Spack](https://spack.io/) project provides a particularly easy way to
+install the dependencies that you need to use traccc. In order to use Spack to
+manage your dependencies, simply create a new Spack environment using the
+provided environment file:
+
+```sh
+spack env create traccc spack.yaml
+spack -e traccc concretize -f
+spack -e traccc install
+spack env activate traccc
+```
+
+This way, Spack will automatically download and install all dependencies
+necessary to use traccc with the CUDA, SYCL, Kokkos, and Alpaka programming
+models. When using Spack to manage your dependencies, make sure to compile
+traccc with the `-DTRACCC_USE_SYSTEM_LIBS=ON` flag.
+
 ## Getting started
 
 ### Clone the repository

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,0 +1,33 @@
+# traccc library, part of the ACTS project (R&D line)
+#
+# (c) 2025 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+spack:
+  specs:
+    # Build tools
+    - "cmake@3.26:"
+    - "intel-oneapi-compilers@2024.2.0"
+    - "cuda@12.5"
+    - "gcc@13"
+    # HEP dependencies
+    - "acts@38.2.0 +json"
+    - "detray@0.87"
+    - "covfie@0.10.0 +cuda"
+    - "vecmem@1.13.0%oneapi@2024.2.0 +cuda+sycl"
+    - "acts-algebra-plugins@0.26.2"
+    - "root cxxstd=20"
+    # General dependencies
+    - "intel-oneapi-tbb@2021.12.0"
+    - "kokkos"
+    - "alpaka"
+    - "boost@1.85.0: +log+program_options"
+    - "indicators"
+    - "benchmark ~performance_counters"
+    # SYCL dependencies
+    - "intel-oneapi-dpl"
+    # Examples and test dependencies
+    - "googletest@1.14:"
+  view: true
+  concretizer:
+    unify: true


### PR DESCRIPTION
This commit adds a YAML-based Spack environment specification which allows users to more easily install traccc's dependencies.