### PR TITLE
Implement less aggressive and configurable caching

### DIFF
--- a/examples/options/CMakeLists.txt
+++ b/examples/options/CMakeLists.txt
@@ -28,6 +28,7 @@ traccc_add_library( traccc_options options TYPE SHARED
   # source files
   "src/details/interface.cpp"
   "src/accelerator.cpp"
+  "src/allocation_caching.cpp"
   "src/clusterization.cpp"
   "src/detector.cpp"
   "src/generation.cpp"

--- a/examples/options/include/traccc/options/allocation_caching.hpp
+++ b/examples/options/include/traccc/options/allocation_caching.hpp
@@ -1,0 +1,26 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/options/details/interface.hpp"
+
+namespace traccc::opts {
+
+/// Options for memory allocation caching
+class allocation_caching
+    : public interface {
+    public:
+    std::size_t m_host_caching_threshold = 2lu << 28lu;
+    std::size_t m_device_caching_threshold = 2lu << 28lu;
+    
+    /// Constructor
+    allocation_caching();
+
+    std::unique_ptr<configuration_printable> as_printable() const override;
+};
+}  // namespace traccc::opts

--- a/examples/options/src/allocation_caching.cpp
+++ b/examples/options/src/allocation_caching.cpp
@@ -1,0 +1,50 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <string>
+#include "traccc/options/allocation_caching.hpp"
+#include "traccc/examples/utils/printable.hpp"
+
+namespace {
+std::string pretty_print_bytes(std::size_t n) {
+    if (n % (1024lu * 1024lu * 1024lu) == 0) {
+        return std::to_string(n / (1024lu * 1024lu * 1024lu)) + " GiB";
+    } else if (n % (1024lu * 1024lu) == 0) {
+        return std::to_string(n / (1024lu * 1024lu)) + " MiB";
+    } else if (n % 1024lu == 0) {
+        return std::to_string(n / 1024lu) + " KiB";
+    } else {
+        return std::to_string(n) + " B";
+    }
+}
+}
+
+namespace traccc::opts {
+
+allocation_caching::allocation_caching() : interface("Memory Allocation Options") {
+    m_desc.add_options()("host-caching-threshold",
+                         boost::program_options::value(&m_host_caching_threshold)->default_value(m_host_caching_threshold),
+                         "Threshold (in bytes) below which to cache host allocations");
+    m_desc.add_options()("device-caching-threshold",
+                         boost::program_options::value(&m_device_caching_threshold)->default_value(m_device_caching_threshold),
+                         "Threshold (in bytes) below which to cache device allocations");
+}
+
+std::unique_ptr<configuration_printable> allocation_caching::as_printable() const {
+    auto cat = std::make_unique<configuration_category>("Memory allocation options");
+
+    cat->add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Host caching threshold", pretty_print_bytes(m_host_caching_threshold)));
+    cat->add_child(
+        std::make_unique<configuration_kv_pair>(
+            "Device caching threshold", pretty_print_bytes(m_device_caching_threshold)));
+
+    return cat;
+}
+
+}  // namespace traccc::opts

--- a/examples/run/alpaka/full_chain_algorithm.hpp
+++ b/examples/run/alpaka/full_chain_algorithm.hpp
@@ -28,7 +28,6 @@
 #include <vecmem/utils/hip/copy.hpp>
 #endif
 
-#include <vecmem/memory/binary_page_memory_resource.hpp>
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/utils/copy.hpp>
 
@@ -58,7 +57,8 @@ class full_chain_algorithm
                          const unsigned short target_cells_per_partiton,
                          const seedfinder_config& finder_config,
                          const spacepoint_grid_config& grid_config,
-                         const seedfilter_config& filter_config);
+                         const seedfilter_config& filter_config,
+                         const std::size_t device_caching_threshold);
 
     /// Copy constructor
     ///
@@ -102,7 +102,8 @@ class full_chain_algorithm
     vecmem::copy m_copy;
 #endif
     /// Device caching memory resource
-    std::unique_ptr<vecmem::binary_page_memory_resource> m_cached_device_mr;
+    std::size_t m_device_caching_threshold;
+    std::unique_ptr<vecmem::memory_resource> m_cached_device_mr;
 
     /// @name Sub-algorithms used by this full-chain algorithm
     /// @{

--- a/examples/run/cpu/full_chain_algorithm.cpp
+++ b/examples/run/cpu/full_chain_algorithm.cpp
@@ -18,7 +18,7 @@ full_chain_algorithm::full_chain_algorithm(
     const finding_algorithm::config_type& finding_config,
     const fitting_algorithm::config_type& fitting_config,
     const silicon_detector_description::host& det_descr,
-    detector_type* detector)
+    std::size_t /*device_caching_threshold*/, detector_type* detector)
     : m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
       m_field(detray::bfield::create_const_field<
               typename detector_type::scalar_type>(m_field_vec)),

--- a/examples/run/cpu/full_chain_algorithm.hpp
+++ b/examples/run/cpu/full_chain_algorithm.hpp
@@ -77,6 +77,7 @@ class full_chain_algorithm : public algorithm<track_state_container_types::host(
                          const finding_algorithm::config_type& finding_config,
                          const fitting_algorithm::config_type& fitting_config,
                          const silicon_detector_description::host& det_descr,
+                         std::size_t /*device_caching_threshold*/,
                          detector_type* detector = nullptr);
 
     /// Reconstruct track parameters in the entire detector

--- a/examples/run/cuda/CMakeLists.txt
+++ b/examples/run/cuda/CMakeLists.txt
@@ -34,7 +34,7 @@ add_library( traccc_examples_cuda STATIC
    "full_chain_algorithm.cpp" )
 target_link_libraries( traccc_examples_cuda
    PUBLIC CUDA::cudart vecmem::core vecmem::cuda detray::core detray::detectors
-          traccc::core traccc::device_common traccc::cuda )
+          traccc::core traccc::device_common traccc::cuda traccc::utils )
 
 traccc_add_executable( throughput_st_cuda "throughput_st.cpp"
    LINK_LIBRARIES indicators::indicators vecmem::core vecmem::cuda

--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -33,7 +33,6 @@
 
 // VecMem include(s).
 #include <vecmem/containers/vector.hpp>
-#include <vecmem/memory/binary_page_memory_resource.hpp>
 #include <vecmem/memory/cuda/device_memory_resource.hpp>
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/utils/cuda/async_copy.hpp>
@@ -97,6 +96,7 @@ class full_chain_algorithm
                          const finding_algorithm::config_type& finding_config,
                          const fitting_algorithm::config_type& fitting_config,
                          const silicon_detector_description::host& det_descr,
+                         std::size_t device_caching_threshold,
                          host_detector_type* detector);
 
     /// Copy constructor
@@ -128,7 +128,9 @@ class full_chain_algorithm
     /// Device memory resource
     vecmem::cuda::device_memory_resource m_device_mr;
     /// Device caching memory resource
-    std::unique_ptr<vecmem::binary_page_memory_resource> m_cached_device_mr;
+    std::size_t m_device_caching_threshold;
+    std::unique_ptr<vecmem::memory_resource> m_cached_device_mr;
+
     /// (Asynchronous) Memory copy object
     mutable vecmem::cuda::async_copy m_copy;
 

--- a/examples/run/sycl/CMakeLists.txt
+++ b/examples/run/sycl/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library( traccc_examples_sycl OBJECT
    "full_chain_algorithm.sycl" )
 target_link_libraries( traccc_examples_sycl
    PUBLIC vecmem::core vecmem::sycl detray::core detray::detectors
-          traccc::core traccc::device_common traccc::sycl )
+          traccc::core traccc::device_common traccc::sycl traccc::utils )
 
 traccc_add_executable( throughput_st_sycl "throughput_st.cpp"
    LINK_LIBRARIES indicators::indicators vecmem::core vecmem::sycl

--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -27,7 +27,6 @@
 #include "detray/propagator/rk_stepper.hpp"
 
 // VecMem include(s).
-#include <vecmem/memory/binary_page_memory_resource.hpp>
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/memory/sycl/device_memory_resource.hpp>
 #include <vecmem/utils/sycl/async_copy.hpp>
@@ -92,6 +91,7 @@ class full_chain_algorithm
                          const finding_algorithm::config_type& finding_config,
                          const fitting_algorithm::config_type& fitting_config,
                          const silicon_detector_description::host& det_descr,
+                         std::size_t device_caching_threshold,
                          host_detector_type* detector = nullptr);
 
     /// Copy constructor
@@ -123,7 +123,8 @@ class full_chain_algorithm
     /// Device memory resource
     vecmem::sycl::device_memory_resource m_device_mr;
     /// Device caching memory resource
-    mutable vecmem::binary_page_memory_resource m_cached_device_mr;
+    std::size_t m_device_caching_threshold;
+    std::unique_ptr<vecmem::memory_resource> m_cached_device_mr;
     /// Memory copy object
     mutable vecmem::sycl::async_copy m_copy;
 

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "full_chain_algorithm.hpp"
+#include "traccc/examples/utils/caching_memory_resource.hpp"
 
 // SYCL include(s).
 #include <sycl/sycl.hpp>
@@ -57,12 +58,14 @@ full_chain_algorithm::full_chain_algorithm(
     const finding_algorithm::config_type& finding_config,
     const fitting_algorithm::config_type&,
     const silicon_detector_description::host& det_descr,
-    host_detector_type* detector)
+    std::size_t device_caching_threshold, host_detector_type* detector)
     : m_data(std::make_unique<details::full_chain_algorithm_data>(
           ::handle_async_error)),
       m_host_mr(host_mr),
       m_device_mr{&(m_data->m_queue)},
-      m_cached_device_mr{m_device_mr},
+      m_device_caching_threshold(device_caching_threshold),
+      m_cached_device_mr{traccc::make_caching_memory_resource(
+          m_device_mr, m_device_caching_threshold)},
       m_copy{&(m_data->m_queue)},
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
       m_field{
@@ -75,24 +78,24 @@ full_chain_algorithm::full_chain_algorithm(
           m_device_mr},
       m_detector(detector),
       m_device_detector{},
-      m_clusterization{memory_resource{m_cached_device_mr, &(m_host_mr.get())},
+      m_clusterization{memory_resource{*m_cached_device_mr, &(m_host_mr.get())},
                        m_copy, m_data->m_queue_wrapper, clustering_config},
       m_measurement_sorting(m_copy, m_data->m_queue_wrapper),
       m_spacepoint_formation{
-          memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
+          memory_resource{*m_cached_device_mr, &(m_host_mr.get())}, m_copy,
           m_data->m_queue_wrapper},
       m_seeding{finder_config,
                 grid_config,
                 filter_config,
-                memory_resource{m_cached_device_mr, &(m_host_mr.get())},
+                memory_resource{*m_cached_device_mr, &(m_host_mr.get())},
                 m_copy,
                 m_data->m_queue_wrapper},
       m_track_parameter_estimation{
-          memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
+          memory_resource{*m_cached_device_mr, &(m_host_mr.get())}, m_copy,
           m_data->m_queue_wrapper},
       m_finding{finding_config,
-                memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-                m_data->m_queue_wrapper},
+                memory_resource{*m_cached_device_mr, &(m_host_mr.get())},
+                m_copy, m_data->m_queue_wrapper},
       m_clustering_config(clustering_config),
       m_finder_config(finder_config),
       m_grid_config(grid_config),
@@ -119,7 +122,9 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
           ::handle_async_error)),
       m_host_mr(parent.m_host_mr),
       m_device_mr{&(m_data->m_queue)},
-      m_cached_device_mr{m_device_mr},
+      m_device_caching_threshold(parent.m_device_caching_threshold),
+      m_cached_device_mr{traccc::make_caching_memory_resource(
+          m_device_mr, m_device_caching_threshold)},
       m_copy{&(m_data->m_queue)},
       m_field_vec{parent.m_field_vec},
       m_field{parent.m_field},
@@ -130,25 +135,25 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
           m_device_mr},
       m_detector(parent.m_detector),
       m_device_detector{},
-      m_clusterization{memory_resource{m_cached_device_mr, &(m_host_mr.get())},
+      m_clusterization{memory_resource{*m_cached_device_mr, &(m_host_mr.get())},
                        m_copy, m_data->m_queue_wrapper,
                        parent.m_clustering_config},
       m_measurement_sorting(m_copy, m_data->m_queue_wrapper),
       m_spacepoint_formation{
-          memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
+          memory_resource{*m_cached_device_mr, &(m_host_mr.get())}, m_copy,
           m_data->m_queue_wrapper},
       m_seeding{parent.m_finder_config,
                 parent.m_grid_config,
                 parent.m_filter_config,
-                memory_resource{m_cached_device_mr, &(m_host_mr.get())},
+                memory_resource{*m_cached_device_mr, &(m_host_mr.get())},
                 m_copy,
                 m_data->m_queue_wrapper},
       m_track_parameter_estimation{
-          memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
+          memory_resource{*m_cached_device_mr, &(m_host_mr.get())}, m_copy,
           m_data->m_queue_wrapper},
       m_finding{parent.m_finding_config,
-                memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-                m_data->m_queue_wrapper},
+                memory_resource{*m_cached_device_mr, &(m_host_mr.get())},
+                m_copy, m_data->m_queue_wrapper},
       m_clustering_config(parent.m_clustering_config),
       m_finder_config(parent.m_finder_config),
       m_grid_config(parent.m_grid_config),
@@ -171,7 +176,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
 
     // Create device copy of input collections
     edm::silicon_cell_collection::buffer cells_buffer{
-        static_cast<unsigned int>(cells.size()), m_cached_device_mr};
+        static_cast<unsigned int>(cells.size()), *m_cached_device_mr};
     m_copy(vecmem::get_data(cells), cells_buffer)->wait();
 
     // Execute the algorithms.

--- a/examples/utils/CMakeLists.txt
+++ b/examples/utils/CMakeLists.txt
@@ -6,4 +6,7 @@
 
 traccc_add_library( traccc_utils utils TYPE SHARED
   "src/printable.cpp"
+  "src/caching_memory_resource.cpp"
 )
+
+target_link_libraries(traccc_utils PUBLIC vecmem::core)

--- a/examples/utils/include/traccc/examples/utils/caching_memory_resource.hpp
+++ b/examples/utils/include/traccc/examples/utils/caching_memory_resource.hpp
@@ -1,0 +1,31 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <vecmem/memory/binary_page_memory_resource.hpp>
+#include <vecmem/memory/memory_resource.hpp>
+
+namespace traccc {
+class caching_memory_resource final : public vecmem::memory_resource {
+    public:
+    caching_memory_resource(vecmem::memory_resource& base_mr,
+                            std::size_t threshold);
+
+    void* do_allocate(std::size_t bytes, std::size_t alignment) final;
+    void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) final;
+    bool do_is_equal(const vecmem::memory_resource& other) const noexcept final;
+
+    private:
+    vecmem::memory_resource& m_base_mr;
+    std::unique_ptr<vecmem::binary_page_memory_resource> m_caching_mr;
+    std::size_t m_threshold;
+};
+
+std::unique_ptr<vecmem::memory_resource> make_caching_memory_resource(
+    vecmem::memory_resource& base_mr, std::size_t threshold);
+}  // namespace traccc

--- a/examples/utils/src/caching_memory_resource.cpp
+++ b/examples/utils/src/caching_memory_resource.cpp
@@ -1,0 +1,47 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "traccc/examples/utils/caching_memory_resource.hpp"
+
+#include <vecmem/memory/binary_page_memory_resource.hpp>
+
+namespace traccc {
+caching_memory_resource::caching_memory_resource(
+    vecmem::memory_resource& base_mr, std::size_t threshold)
+    : m_base_mr(base_mr),
+      m_caching_mr(
+          std::make_unique<vecmem::binary_page_memory_resource>(m_base_mr)),
+      m_threshold(threshold) {}
+
+void* caching_memory_resource::do_allocate(std::size_t bytes,
+                                           std::size_t alignment) {
+    if (bytes >= m_threshold) {
+        return m_base_mr.allocate(bytes, alignment);
+    } else {
+        return m_caching_mr->allocate(bytes, alignment);
+    }
+}
+
+void caching_memory_resource::do_deallocate(void* p, std::size_t bytes,
+                                            std::size_t alignment) {
+    if (bytes >= m_threshold) {
+        return m_base_mr.deallocate(p, bytes, alignment);
+    } else {
+        return m_caching_mr->deallocate(p, bytes, alignment);
+    }
+}
+
+bool caching_memory_resource::do_is_equal(
+    const vecmem::memory_resource& other) const noexcept {
+    return (this == &other);
+}
+
+std::unique_ptr<vecmem::memory_resource> make_caching_memory_resource(
+    vecmem::memory_resource& base_mr, std::size_t threshold) {
+    return std::make_unique<caching_memory_resource>(base_mr, threshold);
+}
+}  // namespace traccc


### PR DESCRIPTION
This commit relaxes our caching a little bit by implementing a custom caching algorithm which caches only small allocations. This prevents us from allocating massive amounts of memory only to never free them. Also generalizes the way we currently handle caching memory resource handling in order to make it more flexible. The caching threshold is taken as a command line parameter. This should help with the memory issues when processing ITk data seen by @paradajzblond.