### PR TITLE
ref: update detray to v0.88.1

### DIFF
--- a/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
+++ b/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
@@ -21,12 +21,12 @@
 #include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/io/frontend/detector_writer.hpp>
-#include <detray/navigation/detail/ray.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 #include <detray/test/utils/detectors/build_toy_detector.hpp>
 #include <detray/test/utils/simulation/event_generator/track_generators.hpp>
+#include <detray/tracks/ray.hpp>
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/core/include/traccc/definitions/primitives.hpp
+++ b/core/include/traccc/definitions/primitives.hpp
@@ -19,6 +19,9 @@
 #include "traccc/plugins/algebra/vecmem_definitions.hpp"
 #endif
 
+// Detray include(s)
+#include <detray/definitions/algebra.hpp>
+
 // System include(s)
 #include <cstdint>
 

--- a/core/include/traccc/finding/details/find_tracks.hpp
+++ b/core/include/traccc/finding/details/find_tracks.hpp
@@ -20,11 +20,7 @@
 #include "traccc/utils/projections.hpp"
 
 // Detray include(s).
-#include <detray/propagator/actor_chain.hpp>
-#include <detray/propagator/actors/aborters.hpp>
-#include <detray/propagator/actors/parameter_resetter.hpp>
-#include <detray/propagator/actors/parameter_transporter.hpp>
-#include <detray/propagator/actors/pointwise_material_interactor.hpp>
+#include <detray/propagator/actors.hpp>
 #include <detray/propagator/propagator.hpp>
 
 // System include(s).
@@ -71,7 +67,7 @@ track_candidate_container_types::host find_tracks(
     using interactor_type = detray::pointwise_material_interactor<algebra_type>;
 
     using actor_type = detray::actor_chain<
-        detray::tuple, detray::pathlimit_aborter<scalar_type>, transporter_type,
+        detray::pathlimit_aborter<scalar_type>, transporter_type,
         interaction_register<interactor_type>, interactor_type, ckf_aborter>;
 
     using propagator_type =

--- a/core/include/traccc/fitting/details/fit_tracks.hpp
+++ b/core/include/traccc/fitting/details/fit_tracks.hpp
@@ -58,15 +58,14 @@ track_state_container_types::host fit_tracks(
         }
 
         // Make a fitter state
-        typename fitter_t::state fitter_state(std::move(input_states));
+        typename fitter_t::state fitter_state(vecmem::get_data(input_states));
 
         // Run the fitter.
         fitter.fit(track_candidates.get_headers()[i], fitter_state);
 
         // Save the results into the output container.
-        result.push_back(
-            std::move(fitter_state.m_fit_res),
-            std::move(fitter_state.m_fit_actor_state.m_track_states));
+        result.push_back(std::move(fitter_state.m_fit_res),
+                         std::move(input_states));
     }
 
     // Return the fitted track states.

--- a/core/include/traccc/seeding/detail/spacepoint_grid.hpp
+++ b/core/include/traccc/seeding/detail/spacepoint_grid.hpp
@@ -12,7 +12,7 @@
 #include "traccc/edm/spacepoint.hpp"
 
 // detray core
-#include <detray/definitions/detail/indexing.hpp>
+#include <detray/definitions/indexing.hpp>
 #include <detray/grids/axis.hpp>
 #include <detray/grids/grid2.hpp>
 #include <detray/grids/populator.hpp>

--- a/core/include/traccc/utils/seed_generator.hpp
+++ b/core/include/traccc/utils/seed_generator.hpp
@@ -13,12 +13,7 @@
 // detray include(s).
 #include <detray/geometry/barcode.hpp>
 #include <detray/geometry/tracking_surface.hpp>
-#include <detray/propagator/actor_chain.hpp>
-#include <detray/propagator/actors/aborters.hpp>
-#include <detray/propagator/actors/parameter_resetter.hpp>
-#include <detray/propagator/actors/parameter_transporter.hpp>
-#include <detray/propagator/actors/pointwise_material_interactor.hpp>
-#include <detray/propagator/base_actor.hpp>
+#include <detray/propagator/actors.hpp>
 #include <detray/propagator/propagator.hpp>
 
 // System include(s).
@@ -76,8 +71,10 @@ struct seed_generator {
 
         for (std::size_t i = 0; i < e_bound_size; i++) {
 
-            bound_param[i] = std::normal_distribution<scalar>(
-                bound_param[i], m_stddevs[i])(m_generator);
+            if (m_stddevs[i] != scalar{0}) {
+                bound_param[i] = std::normal_distribution<scalar>(
+                    bound_param[i], m_stddevs[i])(m_generator);
+            }
 
             getter::element(bound_param.covariance(), i, i) =
                 m_stddevs[i] * m_stddevs[i];

--- a/core/src/seeding/spacepoint_binning.cpp
+++ b/core/src/seeding/spacepoint_binning.cpp
@@ -8,7 +8,7 @@
 // Library include(s).
 #include "traccc/seeding/spacepoint_binning.hpp"
 
-#include <detray/definitions/detail/indexing.hpp>
+#include <detray/definitions/indexing.hpp>
 
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/seeding/spacepoint_binning_helper.hpp"

--- a/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
@@ -19,11 +19,7 @@
 #include "traccc/utils/memory_resource.hpp"
 
 // detray include(s).
-#include <detray/propagator/actor_chain.hpp>
-#include <detray/propagator/actors/aborters.hpp>
-#include <detray/propagator/actors/parameter_resetter.hpp>
-#include <detray/propagator/actors/parameter_transporter.hpp>
-#include <detray/propagator/actors/pointwise_material_interactor.hpp>
+#include <detray/propagator/actors.hpp>
 #include <detray/propagator/propagator.hpp>
 
 // VecMem include(s).
@@ -57,10 +53,11 @@ class finding_algorithm
     using interactor = detray::pointwise_material_interactor<algebra_type>;
 
     /// Actor chain for propagate to the next surface and its propagator type
-    using actor_type = detray::actor_chain<
-        detray::dtuple, detray::pathlimit_aborter<scalar_type>,
-        detray::parameter_transporter<algebra_type>,
-        interaction_register<interactor>, interactor, ckf_aborter>;
+    using actor_type =
+        detray::actor_chain<detray::pathlimit_aborter<scalar_type>,
+                            detray::parameter_transporter<algebra_type>,
+                            interaction_register<interactor>, interactor,
+                            ckf_aborter>;
 
     using propagator_type =
         detray::propagator<stepper_t, navigator_t, actor_type>;

--- a/device/cuda/src/finding/kernels/specializations/types.hpp
+++ b/device/cuda/src/finding/kernels/specializations/types.hpp
@@ -15,11 +15,7 @@
 
 // Detray include(s)
 #include <detray/detectors/bfield.hpp>
-#include <detray/propagator/actor_chain.hpp>
-#include <detray/propagator/actors/aborters.hpp>
-#include <detray/propagator/actors/parameter_resetter.hpp>
-#include <detray/propagator/actors/parameter_transporter.hpp>
-#include <detray/propagator/actors/pointwise_material_interactor.hpp>
+#include <detray/propagator/actors.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 

--- a/device/sycl/src/finding/find_tracks.hpp
+++ b/device/sycl/src/finding/find_tracks.hpp
@@ -32,11 +32,7 @@
 #include "traccc/utils/projections.hpp"
 
 // Detray include(s).
-#include <detray/propagator/actor_chain.hpp>
-#include <detray/propagator/actors/aborters.hpp>
-#include <detray/propagator/actors/parameter_resetter.hpp>
-#include <detray/propagator/actors/parameter_transporter.hpp>
-#include <detray/propagator/actors/pointwise_material_interactor.hpp>
+#include <detray/propagator/actors.hpp>
 #include <detray/propagator/propagator.hpp>
 
 // VecMem include(s).
@@ -370,8 +366,7 @@ track_candidate_container_types::buffer find_tracks(
             using interactor_type =
                 detray::pointwise_material_interactor<algebra_type>;
             using actor_type =
-                detray::actor_chain<detray::dtuple,
-                                    detray::pathlimit_aborter<scalar_type>,
+                detray::actor_chain<detray::pathlimit_aborter<scalar_type>,
                                     detray::parameter_transporter<algebra_type>,
                                     interaction_register<interactor_type>,
                                     interactor_type, ckf_aborter>;

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -24,9 +24,9 @@
 #include <detray/geometry/shapes/rectangle2D.hpp>
 #include <detray/io/frontend/detector_writer.hpp>
 #include <detray/materials/material.hpp>
-#include <detray/navigation/detail/ray.hpp>
 #include <detray/test/utils/detectors/build_telescope_detector.hpp>
 #include <detray/test/utils/simulation/event_generator/track_generators.hpp>
+#include <detray/tracks/ray.hpp>
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -13,13 +13,13 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.87.0.tar.gz;URL_MD5;0e30107edebfd41fbb3fc1974f665ea9"
+"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.88.1.tar.gz;URL_MD5;b4c1d2f4323d5e34d8964c6454c34983"
    CACHE STRING "Source for Detray, when built as part of this project" )
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
 FetchContent_Declare( Detray SYSTEM ${TRACCC_DETRAY_SOURCE} )
 
 # Options used in the build of Detray.
-set( DETRAY_CUSTOM_SCALARTYPE "float" CACHE STRING
+set( DETRAY_CUSTOM_SCALARTYPE "${TRACCC_CUSTOM_SCALARTYPE}" CACHE STRING
    "Scalar type to use in the Detray code" )
 
 set( DETRAY_BUILD_UNITTESTS FALSE CACHE BOOL
@@ -48,8 +48,6 @@ set( DETRAY_SETUP_GOOGLETEST FALSE CACHE BOOL
    "Do not set up GoogleTest as part of Detray" )
 set( DETRAY_SETUP_BENCHMARK FALSE CACHE BOOL
    "Do not set up Google Benchmark as part of Detray" )
-set( DETRAY_SETUP_THRUST FALSE CACHE BOOL
-   "Do not set up Thrust as part of Detray" )
 set( DETRAY_SETUP_COVFIE FALSE CACHE BOOL
    "Do not set up covfie as part of Detray" )
 

--- a/plugins/algebra/array/include/traccc/plugins/algebra/array_definitions.hpp
+++ b/plugins/algebra/array/include/traccc/plugins/algebra/array_definitions.hpp
@@ -9,10 +9,7 @@
 #pragma once
 
 // Detray include(s).
-#include <detray/definitions/detail/algebra.hpp>
-
-// Algebra Plugins include(s).
-#include <algebra/array_cmath.hpp>
+#include <detray/plugins/algebra/array_definitions.hpp>
 
 // VecMem include(s).
 #include <vecmem/containers/jagged_vector.hpp>

--- a/simulation/include/traccc/simulation/measurement_smearer.hpp
+++ b/simulation/include/traccc/simulation/measurement_smearer.hpp
@@ -45,9 +45,12 @@ struct measurement_smearer {
     std::mt19937_64 generator{rd()};
 
     std::array<scalar_type, 2> get_offset() {
-        return {
-            std::normal_distribution<scalar_type>(0.f, stddev[0])(generator),
-            std::normal_distribution<scalar_type>(0.f, stddev[1])(generator)};
+        auto generate_offset = [&gen = generator](const scalar_type sigma) {
+            return sigma == scalar_type{0}
+                       ? 0.f
+                       : std::normal_distribution<scalar_type>(0.f, sigma)(gen);
+        };
+        return {generate_offset(stddev[0]), generate_offset(stddev[1])};
     }
 
     template <typename mask_t>

--- a/simulation/include/traccc/simulation/simulator.hpp
+++ b/simulation/include/traccc/simulation/simulator.hpp
@@ -46,8 +46,7 @@ struct simulator {
     using bfield_type = bfield_t;
 
     using actor_chain_type =
-        detray::actor_chain<detray::dtuple,
-                            detray::parameter_transporter<algebra_type>,
+        detray::actor_chain<detray::parameter_transporter<algebra_type>,
                             detray::random_scatterer<algebra_type>,
                             detray::parameter_resetter<algebra_type>, writer_t>;
 

--- a/tests/common/tests/kalman_fitting_momentum_resolution_test.hpp
+++ b/tests/common/tests/kalman_fitting_momentum_resolution_test.hpp
@@ -14,8 +14,8 @@
 #include <detray/geometry/mask.hpp>
 #include <detray/geometry/shapes/rectangle2D.hpp>
 #include <detray/io/frontend/detector_writer.hpp>
-#include <detray/navigation/detail/ray.hpp>
 #include <detray/test/utils/detectors/build_telescope_detector.hpp>
+#include <detray/tracks/ray.hpp>
 
 namespace traccc {
 

--- a/tests/common/tests/kalman_fitting_telescope_test.hpp
+++ b/tests/common/tests/kalman_fitting_telescope_test.hpp
@@ -14,8 +14,8 @@
 #include <detray/geometry/mask.hpp>
 #include <detray/geometry/shapes/rectangle2D.hpp>
 #include <detray/io/frontend/detector_writer.hpp>
-#include <detray/navigation/detail/ray.hpp>
 #include <detray/test/utils/detectors/build_telescope_detector.hpp>
+#include <detray/tracks/ray.hpp>
 
 namespace traccc {
 

--- a/tests/cpu/test_spacepoint_formation.cpp
+++ b/tests/cpu/test_spacepoint_formation.cpp
@@ -12,8 +12,8 @@
 
 // Detray include(s).
 #include <detray/geometry/shapes/rectangle2D.hpp>
-#include <detray/navigation/detail/ray.hpp>
 #include <detray/test/utils/detectors/build_telescope_detector.hpp>
+#include <detray/tracks/ray.hpp>
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/tests/cpu/test_track_params_estimation.cpp
+++ b/tests/cpu/test_track_params_estimation.cpp
@@ -12,7 +12,7 @@
 #include "traccc/seeding/track_params_estimation.hpp"
 
 // Detray include(s).
-#include <detray/navigation/detail/helix.hpp>
+#include <detray/tracks/helix.hpp>
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/tests/cuda/test_spacepoint_formation.cpp
+++ b/tests/cuda/test_spacepoint_formation.cpp
@@ -12,8 +12,8 @@
 #include "traccc/geometry/detector.hpp"
 
 // Detray include(s).
-#include <detray/navigation/detail/ray.hpp>
 #include <detray/test/utils/detectors/build_telescope_detector.hpp>
+#include <detray/tracks/ray.hpp>
 
 // VecMem include(s).
 #include <vecmem/memory/cuda/device_memory_resource.hpp>

--- a/tests/sycl/test_spacepoint_formation.sycl
+++ b/tests/sycl/test_spacepoint_formation.sycl
@@ -13,8 +13,8 @@
 // Detray include(s).
 #include <detray/geometry/mask.hpp>
 #include <detray/geometry/shapes/rectangle2D.hpp>
-#include <detray/navigation/detail/ray.hpp>
 #include <detray/test/utils/detectors/build_telescope_detector.hpp>
+#include <detray/tracks/ray.hpp>
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>


### PR DESCRIPTION
Update to the new detray version. I also made sure that the traccc custom scalar type is handed through to detray, so that it will be built in double precision when required. Apart from that, I removed a detray thrust related cmake variable, which doesn't exist anymore.
The Kalman Fit actor state was switched to use the non-owning `vecmem::device_vector` type always, since it just needs a view on the track states returned from the CKF and the detray detector no longer provides a host/device vector type publicly.