### PR TITLE
Seed Parameter Estimation Fix, main branch (2025.02.10.)

### DIFF
--- a/core/include/traccc/seeding/track_params_estimation_helper.hpp
+++ b/core/include/traccc/seeding/track_params_estimation_helper.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -43,7 +43,7 @@ inline TRACCC_HOST_DEVICE bound_vector
 seed_to_bound_vector(const spacepoint_collection_t& sp_collection,
                      const seed& seed, const vector3& bfield) {
 
-    bound_vector params;
+    bound_vector params = matrix::zero<bound_vector>();
 
     const auto& spB =
         sp_collection.at(static_cast<unsigned int>(seed.spB_link));


### PR DESCRIPTION
This is a follow-up about the issue discussed (amongst other places) in #842. That in `RelWithDebInfo` mode we would see the following output from `traccc_seq_example_cuda`:

```
[bash][Celeborn]:out > ./build/cuda-fp64/bin/traccc_seq_example_cuda --compare-with-cpu

Running Full Tracking Chain Using CUDA

Detector Options:
├ Detector file:                   geometries/odd/odd-detray_geometry_detray.json
├ Material file:                   geometries/odd/odd-detray_material_detray.json
├ Surface grid file:               geometries/odd/odd-detray_surface_grids_detray.json
├ Use detray detector:             true
└ Digitization file:               geometries/odd/odd-digi-geometric-config.json
...
WARNING: @traccc::io::csv::read_cells: 28 duplicate cells found in /home/krasznaa/ATLAS/projects/traccc/traccc/data/odd/geant4_10muon_10GeV/event000000000-cells.csv
===>>> Event 0 <<<===
Number of measurements: 631 (host), 631 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of spacepoints: 451 (host), 451 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of seeds: 181 (host), 181 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of track parameters: 181 (host), 181 (device)
  Matching rate(s):
    - 0% at 0.01% uncertainty
    - 0% at 0.1% uncertainty
    - 0% at 1% uncertainty
    - 0% at 5% uncertainty
Number of track candidates (header): 183 (host), 183 (device)
  Matching rate(s):
    - 0% at 0.01% uncertainty
    - 0% at 0.1% uncertainty
    - 0% at 1% uncertainty
    - 0% at 5% uncertainty
  Track candidates (item) matching rate: 100%
Number of track states: 183 (host), 183 (device)
  Matching rate(s):
    - 98.9071% at 0.01% uncertainty
    - 98.9071% at 0.1% uncertainty
    - 98.9071% at 1% uncertainty
    - 98.9071% at 5% uncertainty
...
```

(Note that in these examples I built the code with FP64 precision, to make the point even more strongly.)

With this small update, this changes to:

```
[bash][Celeborn]:out > ./build/cuda-fp64/bin/traccc_seq_example_cuda --compare-with-cpu

Running Full Tracking Chain Using CUDA

Detector Options:
├ Detector file:                   geometries/odd/odd-detray_geometry_detray.json
├ Material file:                   geometries/odd/odd-detray_material_detray.json
├ Surface grid file:               geometries/odd/odd-detray_surface_grids_detray.json
├ Use detray detector:             true
└ Digitization file:               geometries/odd/odd-digi-geometric-config.json
...
WARNING: @traccc::io::csv::read_cells: 28 duplicate cells found in /home/krasznaa/ATLAS/projects/traccc/traccc/data/odd/geant4_10muon_10GeV/event000000000-cells.csv
===>>> Event 0 <<<===
Number of measurements: 631 (host), 631 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of spacepoints: 451 (host), 451 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of seeds: 181 (host), 181 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of track parameters: 181 (host), 181 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of track candidates (header): 183 (host), 183 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
  Track candidates (item) matching rate: 100%
Number of track states: 183 (host), 183 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
...
```

Though without backward filtering, the agreement is indeed not perfect. So that part is still as we discussed earlier. 🤔

```
[bash][Celeborn]:out > ./build/cuda-fp64/bin/traccc_seq_example_cuda --compare-with-cpu --fit-use-backward-filter=false

Running Full Tracking Chain Using CUDA

Detector Options:
├ Detector file:                   geometries/odd/odd-detray_geometry_detray.json
├ Material file:                   geometries/odd/odd-detray_material_detray.json
├ Surface grid file:               geometries/odd/odd-detray_surface_grids_detray.json
├ Use detray detector:             true
└ Digitization file:               geometries/odd/odd-digi-geometric-config.json
...
WARNING: @traccc::io::csv::read_cells: 28 duplicate cells found in /home/krasznaa/ATLAS/projects/traccc/traccc/data/odd/geant4_10muon_10GeV/event000000000-cells.csv
===>>> Event 0 <<<===
Number of measurements: 631 (host), 631 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of spacepoints: 451 (host), 451 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of seeds: 181 (host), 181 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of track parameters: 181 (host), 181 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of track candidates (header): 183 (host), 183 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
  Track candidates (item) matching rate: 100%
Number of track states: 183 (host), 183 (device)
  Matching rate(s):
    - 80.3279% at 0.01% uncertainty
    - 83.6066% at 0.1% uncertainty
    - 84.153% at 1% uncertainty
    - 84.153% at 5% uncertainty
...
```

It took me a little while to realize that we're **not** actually using `detray::bound_parameters_vector` in that part of the code, but just the underlying algebra-plugins "vector type" directly. So the `params` variable was in an undefined state over there. Leading to its time property ending up being undefined. (As it's not set to anything explicitly by either the host or the device code.) And this undefined time value made its way all the way down to the final fitted tracks. Leading to an imperfect (though not 0%) agreement even there. 🤔