### PR TITLE
Track Parameter CSV Writing, main branch (2025.02.10.)

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2024 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -61,6 +61,8 @@ traccc_add_library( traccc_io io TYPE SHARED
   "src/csv/read_cells.cpp"
   "src/csv/write_cells.hpp"
   "src/csv/write_cells.cpp"
+  "src/csv/write_track_parameters.hpp"
+  "src/csv/write_track_parameters.cpp"
   "src/csv/read_spacepoints.hpp"
   "src/csv/read_spacepoints.cpp"
   "src/csv/make_measurement_reader.cpp"

--- a/io/include/traccc/io/write.hpp
+++ b/io/include/traccc/io/write.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,6 +12,7 @@
 #include "traccc/edm/silicon_cell_collection.hpp"
 #include "traccc/edm/spacepoint.hpp"
 #include "traccc/edm/track_candidate.hpp"
+#include "traccc/edm/track_parameters.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/silicon_detector_description.hpp"
 #include "traccc/io/data_format.hpp"
@@ -72,6 +73,17 @@ void write(std::size_t event, std::string_view directory,
 void write(std::size_t event, std::string_view directory,
            traccc::data_format format, seed_collection_types::const_view seeds,
            spacepoint_collection_types::const_view spacepoints);
+
+/// Function for track parameter writing
+///
+/// @param event is the event index
+/// @param directory is the directory for the output seed file
+/// @param format is the data format (obj only right now) of output file
+/// @param track_params is the track parameter collection to write
+///
+void write(std::size_t event, std::string_view directory,
+           traccc::data_format format,
+           bound_track_parameters_collection_types::const_view track_params);
 
 /// Function for track candidate writing
 ///

--- a/io/src/csv/write_track_parameters.cpp
+++ b/io/src/csv/write_track_parameters.cpp
@@ -1,0 +1,47 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "write_track_parameters.hpp"
+
+// System include(s).
+#include <format>
+#include <fstream>
+#include <stdexcept>
+
+namespace traccc::io::csv {
+
+void write_track_parameters(
+    std::string_view filename,
+    bound_track_parameters_collection_types::const_view track_params_view) {
+
+    // Open the file for writing.
+    std::ofstream ofile(filename.data());
+    if (!ofile.is_open()) {
+        throw std::runtime_error(
+            std::format("Could not open file \"{}\"", filename));
+    }
+
+    // Create device objects.
+    const bound_track_parameters_collection_types::const_device track_params(
+        track_params_view);
+
+    // Write the header.
+    ofile << "surface_link,local0,local1,phi,theta,time,qop\n";
+
+    // Write out each track parameter.
+    for (const traccc::bound_track_parameters& track : track_params) {
+
+        // Write the track parameter info to the file.
+        ofile << track.surface_link().value() << ","
+              << track.bound_local().at(0) << "," << track.bound_local().at(1)
+              << "," << track.phi() << "," << track.theta() << ","
+              << track.time() << "," << track.qop() << '\n';
+    }
+}
+
+}  // namespace traccc::io::csv

--- a/io/src/csv/write_track_parameters.hpp
+++ b/io/src/csv/write_track_parameters.hpp
@@ -1,0 +1,27 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/edm/track_parameters.hpp"
+
+// System include(s).
+#include <string_view>
+
+namespace traccc::io::csv {
+
+/// Function for track parameter writing to CSV files
+///
+/// @param filename The name of the file to write the data to
+/// @param track_params Track parameters to write
+///
+void write_track_parameters(
+    std::string_view filename,
+    bound_track_parameters_collection_types::const_view track_params);
+
+}  // namespace traccc::io::csv

--- a/io/src/write.cpp
+++ b/io/src/write.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,6 +9,7 @@
 #include "traccc/io/write.hpp"
 
 #include "csv/write_cells.hpp"
+#include "csv/write_track_parameters.hpp"
 #include "json/write_digitization_config.hpp"
 #include "obj/write_seeds.hpp"
 #include "obj/write_spacepoints.hpp"
@@ -70,6 +71,24 @@ void write(std::size_t event, std::string_view directory,
                                        event, "-spacepoints.obj")))
                                       .native()),
                 spacepoints);
+            break;
+        default:
+            throw std::invalid_argument("Unsupported data format");
+    }
+}
+
+void write(std::size_t event, std::string_view directory,
+           traccc::data_format format,
+           bound_track_parameters_collection_types::const_view track_params) {
+
+    switch (format) {
+        case data_format::csv:
+            csv::write_track_parameters(
+                get_absolute_path((std::filesystem::path(directory) /
+                                   std::filesystem::path(get_event_filename(
+                                       event, "-trackparams.csv")))
+                                      .native()),
+                track_params);
             break;
         default:
             throw std::invalid_argument("Unsupported data format");


### PR DESCRIPTION
While debugging the issue fixed in #848, I wrote this code for dumping the properties of reconstructed bound track parameters.

While `detray::bound_track_parameters` has a print operator itself (which I'm very much on board with, and could've technically used for this debugging as well...), I thought this code may still be good to preserve. It could come in handy in some future debugging sessions as well. 🤔