### PR TITLE
Git Ignore Update, main branch (2025.02.10.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# TRACCC library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2025 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
 # Prerequisites
 *.d
 
@@ -31,5 +37,6 @@
 *.out
 *.app
 
-# VSCode build output.
+# Build system related files.
+CMakeUserPresets.json
 out/


### PR DESCRIPTION
This is a bit specific to me I guess, but I recently started using a local `CMakeUserPresets.json` file with the following contents:

```json
{
   "version" : 3,
   "configurePresets": [
      {
         "name" : "cuda-native-fp32",
         "displayName" : "CUDA Native FP32 Code Development",
         "inherits": ["cuda-fp32"],
         "cacheVariables": {
            "CMAKE_CUDA_ARCHITECTURES" : "native"
         }
      },
      {
         "name" : "cuda-native-fp64",
         "displayName" : "CUDA Native FP64 Code Development",
         "inherits": ["cuda-fp64"],
         "cacheVariables": {
            "CMAKE_CUDA_ARCHITECTURES" : "native"
         }
      }
   ]
}
```

Just to make it more convenient to build "native" binaries (in VSCode). But generally, ignoring `CMakeUserPresets.json` is something that well behaved projects should do. 😉