### PR TITLE
Add a distance-based cut to select measurements close to the track

### DIFF
--- a/core/include/traccc/finding/details/find_tracks.hpp
+++ b/core/include/traccc/finding/details/find_tracks.hpp
@@ -237,22 +237,27 @@ track_candidate_container_types::host find_tracks(
 
                 const auto& meas = measurements[item_id];
 
-                track_state<algebra_type> trk_state(meas);
+                const scalar dist =
+                    vector::norm(meas.local - in_param.bound_local());
 
-                // Run the Kalman update on a copy of the track parameters
-                const bool res =
-                    sf.template visit_mask<gain_matrix_updater<algebra_type>>(
-                        trk_state, in_param);
+                if (dist < config.dist_max) {
 
-                // The chi2 from Kalman update should be less than chi2_max
-                if (res && trk_state.filtered_chi2() < config.chi2_max) {
-                    n_branches++;
+                    track_state<algebra_type> trk_state(meas);
 
-                    links[step].push_back({{previous_step, in_param_id},
-                                           item_id,
-                                           orig_param_id,
-                                           skip_counter});
-                    updated_params.push_back(trk_state.filtered());
+                    // Run the Kalman update on a copy of the track parameters
+                    const bool res = sf.template visit_mask<
+                        gain_matrix_updater<algebra_type>>(trk_state, in_param);
+
+                    // The chi2 from Kalman update should be less than chi2_max
+                    if (res && trk_state.filtered_chi2() < config.chi2_max) {
+                        n_branches++;
+
+                        links[step].push_back({{previous_step, in_param_id},
+                                               item_id,
+                                               orig_param_id,
+                                               skip_counter});
+                        updated_params.push_back(trk_state.filtered());
+                    }
                 }
             }
 

--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -39,6 +39,9 @@ struct finding_config {
     /// Maximum step counts that track can make to reach the next surface
     unsigned int max_step_counts_for_next_surface = 100;
 
+    /// Maximum distance that is allowed for branching
+    float dist_max = 10 * detray::unit<float>::mm;
+
     /// Maximum Chi-square that is allowed for branching
     float chi2_max = 10.f;
 

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -199,49 +199,55 @@ TRACCC_DEVICE inline void find_tracks(
 
             const auto& meas = measurements.at(meas_idx);
 
-            track_state<typename detector_t::algebra_type> trk_state(meas);
-            const detray::tracking_surface sf{det, in_par.surface_link()};
+            const scalar dist = vector::norm(meas.local - in_par.bound_local());
 
-            // Run the Kalman update
-            const bool res = sf.template visit_mask<
-                gain_matrix_updater<typename detector_t::algebra_type>>(
-                trk_state, in_par);
+            if (dist < cfg.dist_max) {
 
-            // The chi2 from Kalman update should be less than chi2_max
-            if (res && trk_state.filtered_chi2() < cfg.chi2_max) {
-                // Add measurement candidates to link
-                const unsigned int l_pos = num_total_candidates.fetch_add(1);
+                track_state<typename detector_t::algebra_type> trk_state(meas);
+                const detray::tracking_surface sf{det, in_par.surface_link()};
 
-                if (l_pos >= payload.n_max_candidates) {
-                    *payload.n_total_candidates = payload.n_max_candidates;
-                } else {
-                    if (payload.step == 0) {
-                        links.at(l_pos) = {
-                            {previous_step, owner_global_thread_id},
-                            meas_idx,
-                            owner_global_thread_id,
-                            0};
+                // Run the Kalman update
+                const bool res = sf.template visit_mask<
+                    gain_matrix_updater<typename detector_t::algebra_type>>(
+                    trk_state, in_par);
+
+                // The chi2 from Kalman update should be less than chi2_max
+                if (res && trk_state.filtered_chi2() < cfg.chi2_max) {
+                    // Add measurement candidates to link
+                    const unsigned int l_pos =
+                        num_total_candidates.fetch_add(1);
+
+                    if (l_pos >= payload.n_max_candidates) {
+                        *payload.n_total_candidates = payload.n_max_candidates;
                     } else {
-                        const candidate_link& prev_link =
-                            prev_links[owner_global_thread_id];
+                        if (payload.step == 0) {
+                            links.at(l_pos) = {
+                                {previous_step, owner_global_thread_id},
+                                meas_idx,
+                                owner_global_thread_id,
+                                0};
+                        } else {
+                            const candidate_link& prev_link =
+                                prev_links[owner_global_thread_id];
 
-                        links.at(l_pos) = {
-                            {previous_step, owner_global_thread_id},
-                            meas_idx,
-                            prev_link.seed_idx,
-                            prev_link.n_skipped};
+                            links.at(l_pos) = {
+                                {previous_step, owner_global_thread_id},
+                                meas_idx,
+                                prev_link.seed_idx,
+                                prev_link.n_skipped};
+                        }
+
+                        // Increase the number of candidates (or branches) per
+                        // input parameter
+                        vecmem::device_atomic_ref<
+                            unsigned int, vecmem::device_address_space::local>(
+                            shared_payload
+                                .shared_num_candidates[owner_local_thread_id])
+                            .fetch_add(1u);
+
+                        out_params.at(l_pos) = trk_state.filtered();
+                        out_params_liveness.at(l_pos) = 1u;
                     }
-
-                    // Increase the number of candidates (or branches) per input
-                    // parameter
-                    vecmem::device_atomic_ref<
-                        unsigned int, vecmem::device_address_space::local>(
-                        shared_payload
-                            .shared_num_candidates[owner_local_thread_id])
-                        .fetch_add(1u);
-
-                    out_params.at(l_pos) = trk_state.filtered();
-                    out_params_liveness.at(l_pos) = 1u;
                 }
             }
         }

--- a/examples/options/src/track_finding.cpp
+++ b/examples/options/src/track_finding.cpp
@@ -52,6 +52,10 @@ track_finding::track_finding() : interface("Track Finding Options") {
             ->default_value(m_config.max_step_counts_for_next_surface),
         "Maximum step counts that track can make to reach the next surface");
     m_desc.add_options()(
+        "dist-max",
+        po::value(&m_config.dist_max)->default_value(m_config.dist_max),
+        "Maximum distance that measurements can be included in the track");
+    m_desc.add_options()(
         "chi2-max",
         po::value(&m_config.chi2_max)->default_value(m_config.chi2_max),
         "Maximum Chi suqare that measurements can be included in the track");
@@ -101,6 +105,8 @@ std::unique_ptr<configuration_printable> track_finding::as_printable() const {
     cat->add_child(std::make_unique<configuration_kv_pair>(
         "Max step count to next surface",
         std::to_string(m_config.max_step_counts_for_next_surface)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Max distance", std::to_string(m_config.dist_max)));
     cat->add_child(std::make_unique<configuration_kv_pair>(
         "Max Chi2", std::to_string(m_config.chi2_max)));
     cat->add_child(std::make_unique<configuration_kv_pair>(


### PR DESCRIPTION
This PR adds a CKF finding option for a given distance-based cut value: If the distance between track and measurement is smaller than the cut value, the measurement is passed and Kalman updater is applied.

With this PR, **the CKF can be more input covariance agnostic,** which means that we can finally go with #846.

Command used:
```
byeo@hermes:/mnt/nvme0n1/byeo/projects/traccc/traccc_build_FP32$     ./bin/traccc_seq_example_cuda \
    --digitization-file=geometries/odd/odd-digi-geometric-config.json \
    --detector-file=geometries/odd/odd-detray_geometry_detray.json \
    --material-file=geometries/odd/odd-detray_material_detray.json \
    --grid-file=geometries/odd/odd-detray_surface_grids_detray.json \
    --use-detray-detector=true \
    --use-acts-geom-source=true \
    --input-directory=odd/odd-simulations-20240509/geant4_ttbar_mu200/ \
    --input-events=1 \
    --compare-with-cpu
```

Output from this PR with the default cut value (10 mm) 
```

==> Statistics ... 
- read    438151 cells
- created (cpu)  117907 measurements     
- created (cuda)  117907 measurements     
- created (cpu)  92892 spacepoints     
- created (cuda) 92892 spacepoints     
- created  (cpu) 42372 seeds
- created (cuda) 42372 seeds
- found (cpu)    70942 tracks
- found (cuda)   71096 tracks
- fitted (cpu)   70942 tracks
- fitted (cuda)  71096 tracks
==>Elapsed times...
           File reading  (cpu)  917 ms
         Clusterization (cuda)  141 ms
         Clusterization  (cpu)  28 ms
   Spacepoint formation (cuda)  1 ms
   Spacepoint formation  (cpu)  4 ms
                Seeding (cuda)  44 ms
                Seeding  (cpu)  6353 ms
           Track params (cuda)  0 ms
           Track params  (cpu)  13 ms
          Track finding (cuda)  326 ms
           Track finding (cpu)  8150 ms
          Track fitting (cuda)  393 ms
           Track fitting (cpu)  9147 ms
                     Wall time  25525 ms
```

Output from the main branch
```
==> Statistics ... 
- read    438151 cells
- created (cpu)  117907 measurements     
- created (cuda)  117907 measurements     
- created (cpu)  92892 spacepoints     
- created (cuda) 92892 spacepoints     
- created  (cpu) 42372 seeds
- created (cuda) 42372 seeds
- found (cpu)    133042 tracks
- found (cuda)   135006 tracks
- fitted (cpu)   133042 tracks
- fitted (cuda)  135006 tracks
==>Elapsed times...
           File reading  (cpu)  923 ms
         Clusterization (cuda)  16 ms
         Clusterization  (cpu)  31 ms
   Spacepoint formation (cuda)  1 ms
   Spacepoint formation  (cpu)  5 ms
                Seeding (cuda)  43 ms
                Seeding  (cpu)  6327 ms
           Track params (cuda)  0 ms
           Track params  (cpu)  15 ms
          Track finding (cuda)  478 ms
           Track finding (cpu)  18282 ms
          Track fitting (cuda)  857 ms
           Track fitting (cpu)  17201 ms
                     Wall time  44189 ms
```

The cut value decrease the number of tracks a lot. I will also post the tendency of the tracking efficiency as a function of distance cut value once the analysis is done
