### PR TITLE
Minor fixes to the track building kernel

### DIFF
--- a/core/include/traccc/finding/details/find_tracks.hpp
+++ b/core/include/traccc/finding/details/find_tracks.hpp
@@ -362,7 +362,7 @@ track_candidate_container_types::host find_tracks(
         unsigned int n_skipped{0u};
         while (true) {
 
-            if (L.meas_idx > n_meas) {
+            if (L.meas_idx >= n_meas) {
                 n_skipped++;
             }
 
@@ -393,7 +393,7 @@ track_candidate_container_types::host find_tracks(
         for (auto it = cands_per_track.rbegin(); it != cands_per_track.rend();
              it++) {
 
-            while (L.meas_idx > n_meas) {
+            while (L.meas_idx >= n_meas) {
                 const auto link_pos =
                     param_to_link[L.previous.first][L.previous.second];
 
@@ -401,12 +401,11 @@ track_candidate_container_types::host find_tracks(
             }
 
             // Break if the measurement is still invalid
-            if (L.meas_idx > measurements.size()) {
+            if (L.meas_idx >= measurements.size()) {
                 break;
             }
 
-            auto& cand = *it;
-            cand = measurements.at(L.meas_idx);
+            *it = measurements.at(L.meas_idx);
 
             // Break the loop if the iterator is at the first candidate and
             // fill the seed
@@ -416,13 +415,12 @@ track_candidate_container_types::host find_tracks(
 
                 // Add seed and track candidates to the output container
                 output_candidates.push_back(cand_seed, cands_per_track);
-                break;
+            } else {
+                const auto l_pos =
+                    param_to_link[L.previous.first][L.previous.second];
+
+                L = links[L.previous.first][l_pos];
             }
-
-            const auto l_pos =
-                param_to_link[L.previous.first][L.previous.second];
-
-            L = links[L.previous.first][l_pos];
         }
     }
 


### PR DESCRIPTION
This commit makes some minor fixes and improvements to the track building kernel. In particular, it:

1. Fixes an error where we were comparing measurements indices to see if they were _larger_ than the total number of measurements, but they should be check also for _equality_.
2. Fail more gracefully if we cannot find any true measurements, i.e. register the failed track as a candidate for pruning.
3. Simplify the control flow of the kernel by removing an unnecessary break statement.