### PR TITLE
Allow event data reader to work on Geant4 data

### DIFF
--- a/examples/options/CMakeLists.txt
+++ b/examples/options/CMakeLists.txt
@@ -44,6 +44,7 @@ traccc_add_library( traccc_options options TYPE SHARED
   "src/track_propagation.cpp"
   "src/track_resolution.cpp"
   "src/track_seeding.cpp"
+  "src/truth_finding.cpp"
   )
 target_link_libraries( traccc_options
    PUBLIC

--- a/examples/options/include/traccc/options/truth_finding.hpp
+++ b/examples/options/include/traccc/options/truth_finding.hpp
@@ -1,0 +1,25 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/definitions/common.hpp"
+#include "traccc/options/details/interface.hpp"
+
+namespace traccc::opts {
+class truth_finding : public interface {
+
+    public:
+    float m_min_pt = 0.5f * unit<float>::GeV;
+
+    truth_finding();
+
+    void read(const boost::program_options::variables_map &) override;
+
+    std::unique_ptr<configuration_printable> as_printable() const override;
+};
+}  // namespace traccc::opts

--- a/examples/options/src/truth_finding.cpp
+++ b/examples/options/src/truth_finding.cpp
@@ -1,0 +1,36 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "traccc/options/truth_finding.hpp"
+
+#include <format>
+
+#include "traccc/definitions/common.hpp"
+#include "traccc/examples/utils/printable.hpp"
+
+namespace traccc::opts {
+
+truth_finding::truth_finding() : interface("Truth Track Finding Options") {
+    m_desc.add_options()(
+        "truth-finding-min-pt",
+        boost::program_options::value(&m_min_pt)->default_value(m_min_pt),
+        "Candidate particule pT cut [GeV]");
+}
+
+void truth_finding::read(const boost::program_options::variables_map &) {
+    m_min_pt *= unit<float>::GeV;
+}
+
+std::unique_ptr<configuration_printable> truth_finding::as_printable() const {
+    auto cat = std::make_unique<configuration_category>(m_description);
+
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Minimum pT", std::format("{} GeV", m_min_pt / unit<float>::GeV)));
+
+    return cat;
+}
+}  // namespace traccc::opts

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -23,6 +23,7 @@
 #include "traccc/options/track_finding.hpp"
 #include "traccc/options/track_fitting.hpp"
 #include "traccc/options/track_propagation.hpp"
+#include "traccc/options/truth_finding.hpp"
 #include "traccc/resolution/fitting_performance_writer.hpp"
 #include "traccc/utils/seed_generator.hpp"
 
@@ -53,6 +54,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
             const traccc::opts::input_data& input_opts,
             const traccc::opts::detector& detector_opts,
             const traccc::opts::performance& performance_opts,
+            const traccc::opts::truth_finding& truth_finding_opts,
             std::unique_ptr<const traccc::Logger> ilogger) {
     TRACCC_LOCAL_LOGGER(std::move(ilogger));
 
@@ -128,7 +130,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
                                     input_opts.format, false);
 
         traccc::track_candidate_container_types::host truth_track_candidates =
-            evt_data.generate_truth_candidates(sg, host_mr);
+            evt_data.generate_truth_candidates(sg, host_mr,
+                                               truth_finding_opts.m_min_pt);
 
         // Prepare truth seeds
         traccc::bound_track_parameters_collection_types::host seeds(&host_mr);
@@ -198,15 +201,17 @@ int main(int argc, char* argv[]) {
     traccc::opts::track_propagation propagation_opts;
     traccc::opts::track_fitting fitting_opts;
     traccc::opts::performance performance_opts;
+    traccc::opts::truth_finding truth_finding_config;
     traccc::opts::program_options program_opts{
         "Truth Track Finding on the Host",
         {detector_opts, input_opts, finding_opts, propagation_opts,
-         fitting_opts, performance_opts},
+         fitting_opts, performance_opts, truth_finding_config},
         argc,
         argv,
         logger->cloneWithSuffix("Options")};
 
     // Run the application.
     return seq_run(finding_opts, propagation_opts, fitting_opts, input_opts,
-                   detector_opts, performance_opts, logger->clone());
+                   detector_opts, performance_opts, truth_finding_config,
+                   logger->clone());
 }

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -30,6 +30,7 @@
 #include "traccc/options/track_finding.hpp"
 #include "traccc/options/track_fitting.hpp"
 #include "traccc/options/track_propagation.hpp"
+#include "traccc/options/truth_finding.hpp"
 #include "traccc/performance/collection_comparator.hpp"
 #include "traccc/performance/container_comparator.hpp"
 #include "traccc/performance/timer.hpp"
@@ -64,6 +65,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
             const traccc::opts::detector& detector_opts,
             const traccc::opts::performance& performance_opts,
             const traccc::opts::accelerator& accelerator_opts,
+            const traccc::opts::truth_finding& truth_finding_opts,
             std::unique_ptr<const traccc::Logger> ilogger) {
     TRACCC_LOCAL_LOGGER(std::move(ilogger));
 
@@ -183,7 +185,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
                                     input_opts.format, false);
 
         traccc::track_candidate_container_types::host truth_track_candidates =
-            evt_data.generate_truth_candidates(sg, host_mr);
+            evt_data.generate_truth_candidates(sg, host_mr,
+                                               truth_finding_opts.m_min_pt);
 
         // Prepare truth seeds
         traccc::bound_track_parameters_collection_types::host seeds(mr.host);
@@ -356,10 +359,12 @@ int main(int argc, char* argv[]) {
     traccc::opts::track_fitting fitting_opts;
     traccc::opts::performance performance_opts;
     traccc::opts::accelerator accelerator_opts;
+    traccc::opts::truth_finding truth_finding_config;
     traccc::opts::program_options program_opts{
         "Truth Track Finding Using CUDA",
         {detector_opts, input_opts, finding_opts, propagation_opts,
-         fitting_opts, performance_opts, accelerator_opts},
+         fitting_opts, performance_opts, accelerator_opts,
+         truth_finding_config},
         argc,
         argv,
         logger->cloneWithSuffix("Options")};
@@ -367,5 +372,5 @@ int main(int argc, char* argv[]) {
     // Run the application.
     return seq_run(finding_opts, propagation_opts, fitting_opts, input_opts,
                    detector_opts, performance_opts, accelerator_opts,
-                   logger->clone());
+                   truth_finding_config, logger->clone());
 }

--- a/performance/include/traccc/utils/event_data.hpp
+++ b/performance/include/traccc/utils/event_data.hpp
@@ -80,7 +80,8 @@ struct event_data {
     /// @param[in] resource vecmem memory resource
     ///
     track_candidate_container_types::host generate_truth_candidates(
-        seed_generator<detector_type>& sg, vecmem::memory_resource& resource);
+        seed_generator<detector_type>& sg, vecmem::memory_resource& resource,
+        float pt_cut = 0.f);
 
     // Measurement map
     std::map<measurement_id, measurement> m_measurement_map;


### PR DESCRIPTION
Currently, the event data reader for performance-related examples (e.g. the truth seeding) fails on Geant4 data as it is possible for Geant4 to generate multiple measurements in the exact same place. This previously caused an exception, but we can downgrade this to simply merge the measurements. This will allow the truth examples to work on Geant4 data.