### PR TITLE
Add failure propagation to Kálmán filter code

### DIFF
--- a/core/include/traccc/finding/details/find_tracks.hpp
+++ b/core/include/traccc/finding/details/find_tracks.hpp
@@ -15,6 +15,7 @@
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/finding/finding_config.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
+#include "traccc/fitting/status_codes.hpp"
 #include "traccc/sanity/contiguous_on.hpp"
 #include "traccc/utils/particle.hpp"
 #include "traccc/utils/projections.hpp"
@@ -236,12 +237,13 @@ track_candidate_container_types::host find_tracks(
                 track_state<algebra_type> trk_state(meas);
 
                 // Run the Kalman update on a copy of the track parameters
-                const bool res =
+                const kalman_fitter_status res =
                     sf.template visit_mask<gain_matrix_updater<algebra_type>>(
                         trk_state, in_param);
 
                 // The chi2 from Kalman update should be less than chi2_max
-                if (res && trk_state.filtered_chi2() < config.chi2_max) {
+                if (res == kalman_fitter_status::SUCCESS &&
+                    trk_state.filtered_chi2() < config.chi2_max) {
                     n_branches++;
 
                     links[step].push_back({{previous_step, in_param_id},

--- a/core/include/traccc/fitting/details/fit_tracks.hpp
+++ b/core/include/traccc/fitting/details/fit_tracks.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "traccc/edm/track_candidate.hpp"
 #include "traccc/edm/track_state.hpp"
+#include "traccc/fitting/status_codes.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
@@ -61,11 +62,16 @@ track_state_container_types::host fit_tracks(
         typename fitter_t::state fitter_state(vecmem::get_data(input_states));
 
         // Run the fitter.
-        fitter.fit(track_candidates.get_headers()[i], fitter_state);
+        kalman_fitter_status fit_status =
+            fitter.fit(track_candidates.get_headers()[i], fitter_state);
 
-        // Save the results into the output container.
-        result.push_back(std::move(fitter_state.m_fit_res),
-                         std::move(input_states));
+        if (fit_status == kalman_fitter_status::SUCCESS) {
+            // Save the results into the output container.
+            result.push_back(std::move(fitter_state.m_fit_res),
+                             std::move(input_states));
+        } else {
+            // TODO: Print a warning here.
+        }
     }
 
     // Return the fitted track states.

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
@@ -11,6 +11,7 @@
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/edm/track_state.hpp"
+#include "traccc/fitting/status_codes.hpp"
 
 // Detray inlcude(s)
 #include <detray/geometry/shapes/line.hpp>
@@ -43,7 +44,7 @@ struct gain_matrix_smoother {
     ///
     /// @return true if the update succeeds
     template <typename mask_group_t, typename index_t>
-    TRACCC_HOST_DEVICE inline void operator()(
+    TRACCC_HOST_DEVICE [[nodiscard]] inline kalman_fitter_status operator()(
         const mask_group_t& /*mask_group*/, const index_t& /*index*/,
         track_state<algebra_t>& cur_state,
         const track_state<algebra_t>& next_state) {
@@ -53,14 +54,16 @@ struct gain_matrix_smoother {
         const auto D = cur_state.get_measurement().meas_dim;
         assert(D == 1u || D == 2u);
         if (D == 1u) {
-            smoothe<1u, shape_type>(cur_state, next_state);
+            return smoothe<1u, shape_type>(cur_state, next_state);
         } else if (D == 2u) {
-            smoothe<2u, shape_type>(cur_state, next_state);
+            return smoothe<2u, shape_type>(cur_state, next_state);
         }
+
+        return kalman_fitter_status::ERROR_OTHER;
     }
 
     template <size_type D, typename shape_t>
-    TRACCC_HOST_DEVICE inline void smoothe(
+    TRACCC_HOST_DEVICE [[nodiscard]] inline kalman_fitter_status smoothe(
         track_state<algebra_t>& cur_state,
         const track_state<algebra_t>& next_state) const {
         const auto meas = cur_state.get_measurement();
@@ -105,6 +108,21 @@ struct gain_matrix_smoother {
         cur_state.smoothed().set_vector(smt_vec);
         cur_state.smoothed().set_covariance(smt_cov);
 
+        // Return false if track is parallel to z-axis or phi is not finite
+        const scalar theta = cur_state.smoothed().theta();
+
+        if (theta <= 0.f || theta >= constant<traccc::scalar>::pi) {
+            return kalman_fitter_status::ERROR_THETA_ZERO;
+        }
+
+        if (!std::isfinite(cur_state.smoothed().phi())) {
+            return kalman_fitter_status::ERROR_INVERSION;
+        }
+
+        if (std::abs(cur_state.smoothed().qop()) == 0.f) {
+            return kalman_fitter_status::ERROR_QOP_ZERO;
+        }
+
         // Wrap the phi in the range of [-pi, pi]
         wrap_phi(cur_state.smoothed());
 
@@ -131,7 +149,7 @@ struct gain_matrix_smoother {
 
         cur_state.smoothed_chi2() = getter::element(chi2, 0, 0);
 
-        return;
+        return kalman_fitter_status::SUCCESS;
     }
 };
 

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -12,6 +12,7 @@
 #include "traccc/edm/track_state.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
 #include "traccc/fitting/kalman_filter/two_filters_smoother.hpp"
+#include "traccc/fitting/status_codes.hpp"
 #include "traccc/utils/particle.hpp"
 
 // detray include(s).
@@ -134,7 +135,7 @@ struct kalman_actor : detray::actor {
             // Run Kalman Gain Updater
             const auto sf = navigation.get_surface();
 
-            bool res = false;
+            kalman_fitter_status res = kalman_fitter_status::SUCCESS;
 
             if (!actor_state.backward_mode) {
                 // Forward filter
@@ -153,7 +154,7 @@ struct kalman_actor : detray::actor {
             }
 
             // Abort if the Kalman update fails
-            if (!res) {
+            if (res != kalman_fitter_status::SUCCESS) {
                 propagation._heartbeat &= navigation.abort();
                 return;
             }

--- a/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
@@ -11,6 +11,7 @@
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/definitions/track_parametrization.hpp"
 #include "traccc/edm/track_state.hpp"
+#include "traccc/fitting/status_codes.hpp"
 
 namespace traccc {
 
@@ -32,7 +33,7 @@ struct two_filters_smoother {
     ///
     /// @return true if the update succeeds
     template <typename mask_group_t, typename index_t>
-    TRACCC_HOST_DEVICE inline bool operator()(
+    TRACCC_HOST_DEVICE [[nodiscard]] inline kalman_fitter_status operator()(
         const mask_group_t& /*mask_group*/, const index_t& /*index*/,
         track_state<algebra_t>& trk_state,
         bound_track_parameters& bound_params) const {
@@ -47,13 +48,13 @@ struct two_filters_smoother {
             return smoothe<2u, shape_type>(trk_state, bound_params);
         }
 
-        return false;
+        return kalman_fitter_status::ERROR_OTHER;
     }
 
     // Reference: The Optimun Linear Smoother as a Combination of Two Optimum
     // Linear Filters
     template <size_type D, typename shape_t>
-    TRACCC_HOST_DEVICE inline bool smoothe(
+    TRACCC_HOST_DEVICE [[nodiscard]] inline kalman_fitter_status smoothe(
         track_state<algebra_t>& trk_state,
         bound_track_parameters& bound_params) const {
 
@@ -150,9 +151,12 @@ struct two_filters_smoother {
 
         // Return false if track is parallel to z-axis or phi is not finite
         const scalar theta = bound_params.theta();
-        if (theta <= 0.f || theta >= constant<traccc::scalar>::pi ||
-            !std::isfinite(bound_params.phi())) {
-            return false;
+        if (theta <= 0.f || theta >= constant<traccc::scalar>::pi) {
+            return kalman_fitter_status::ERROR_THETA_ZERO;
+        }
+
+        if (!std::isfinite(bound_params.phi())) {
+            return kalman_fitter_status::ERROR_INVERSION;
         }
 
         // Update the bound track parameters
@@ -165,7 +169,7 @@ struct two_filters_smoother {
         // Wrap the phi in the range of [-pi, pi]
         wrap_phi(bound_params);
 
-        return true;
+        return kalman_fitter_status::SUCCESS;
     }
 };
 

--- a/core/include/traccc/fitting/status_codes.hpp
+++ b/core/include/traccc/fitting/status_codes.hpp
@@ -1,0 +1,20 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+namespace traccc {
+enum class kalman_fitter_status : uint32_t {
+    SUCCESS,
+    ERROR_QOP_ZERO,
+    ERROR_THETA_ZERO,
+    ERROR_INVERSION,
+    ERROR_OTHER,
+    MAX_STATUS
+};
+}  // namespace traccc

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -20,6 +20,7 @@
 
 // Project include(s).
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
+#include "traccc/fitting/status_codes.hpp"
 
 // Detray include(s)
 #include <detray/geometry/tracking_surface.hpp>
@@ -206,12 +207,13 @@ TRACCC_DEVICE inline void find_tracks(
             const detray::tracking_surface sf{det, in_par.surface_link()};
 
             // Run the Kalman update
-            const bool res = sf.template visit_mask<
+            const kalman_fitter_status res = sf.template visit_mask<
                 gain_matrix_updater<typename detector_t::algebra_type>>(
                 trk_state, in_par);
 
             // The chi2 from Kalman update should be less than chi2_max
-            if (res && trk_state.filtered_chi2() < cfg.chi2_max) {
+            if (res == kalman_fitter_status::SUCCESS &&
+                trk_state.filtered_chi2() < cfg.chi2_max) {
                 // Add measurement candidates to link
                 const unsigned int l_pos = num_total_candidates.fetch_add(1);
 

--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "traccc/fitting/status_codes.hpp"
+
 namespace traccc::device {
 
 template <typename fitter_t>
@@ -53,7 +55,10 @@ TRACCC_HOST_DEVICE inline void fit(
     typename fitter_t::state fitter_state(track_states_per_track);
 
     // Run fitting
-    fitter.fit(seed_param, fitter_state);
+    kalman_fitter_status fit_status = fitter.fit(seed_param, fitter_state);
+
+    // TODO: Process fit failures more elegantly
+    assert(fit_status == kalman_fitter_status::SUCCESS);
 
     // Get the final fitting information
     track_states.at(param_id).header = fitter_state.m_fit_res;

--- a/tests/cpu/test_kalman_fitter_wire_chamber.cpp
+++ b/tests/cpu/test_kalman_fitter_wire_chamber.cpp
@@ -147,7 +147,8 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
 
         // Iterator over tracks
         const std::size_t n_tracks = track_states.size();
-        ASSERT_EQ(n_tracks, n_truth_tracks);
+        ASSERT_GE(static_cast<float>(n_tracks),
+                  static_cast<float>(n_truth_tracks) * 0.95);
 
         for (std::size_t i_trk = 0; i_trk < n_tracks; i_trk++) {
 
@@ -180,7 +181,7 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
     scalar success_rate = static_cast<scalar>(n_success) /
                           static_cast<scalar>(n_truth_tracks * n_events);
 
-    ASSERT_GE(success_rate, 0.99f);
+    ASSERT_GE(success_rate, 0.95f);
     ASSERT_LE(success_rate, 1.00f);
 }
 


### PR DESCRIPTION
This commit enables our Kálmán filter code to fail, e.g. it allows the smoothers and updaters to return a success value, and that success value is returned to the outside algorithm. This allows us to elegantly handle edge cases like those described in #858, as well as cases where tracks propagate exactly along the z-axis. Some of this code taken from #781, thanks @beomki-yeo.