### PR TITLE
Fix the bug in getting the first smoother state

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -218,7 +218,15 @@ class kalman_fitter {
         // Since the smoothed track parameter of the last surface can be
         // considered to be the filtered one, we can reversly iterate the
         // algorithm to obtain the smoothed parameter of other surfaces
-        auto& last = track_states.back();
+        for (auto it = track_states.rbegin(); it != track_states.rend(); ++it) {
+            if (!(*it).is_hole) {
+                fitter_state.m_fit_actor_state.m_it_rev = it;
+                break;
+            }
+            // TODO: Return false because there is no valid track state
+            // return false;
+        }
+        auto& last = *fitter_state.m_fit_actor_state.m_it_rev;
         last.smoothed().set_parameter_vector(last.filtered());
         last.smoothed().set_covariance(last.filtered().covariance());
         last.smoothed_chi2() = last.filtered_chi2();


### PR DESCRIPTION
A little bit critial bug.. when the measurement of the last track state is not found during the forward filtering

After merging #862, we will need to `return false` in `smoothe` if all track states are holes.