### PR TITLE
Fix dangerous usage of `std::forward`

### DIFF
--- a/core/include/traccc/edm/details/host_container.hpp
+++ b/core/include/traccc/edm/details/host_container.hpp
@@ -138,11 +138,8 @@ class host_container : public container_base<header_t, item_t, vecmem::vector,
      */
     template <typename h_prime, typename v_prime>
     TRACCC_HOST void push_back(h_prime&& new_header, v_prime&& new_items) {
-        this->m_headers.push_back(
-            std::forward<typename base_type::header_type>(new_header));
-        this->m_items.push_back(
-            std::forward<typename base_type::item_vector::value_type>(
-                new_items));
+        this->m_headers.push_back(std::forward<h_prime>(new_header));
+        this->m_items.push_back(std::forward<v_prime>(new_items));
     }
 
     /**

--- a/performance/src/efficiency/nseed_performance_writer.cpp
+++ b/performance/src/efficiency/nseed_performance_writer.cpp
@@ -16,8 +16,8 @@ nseed_performance_writer::nseed_performance_writer(
     const std::string& prefix, std::unique_ptr<track_filter>&& filter,
     std::unique_ptr<track_matcher>&& matcher)
     : _prefix(prefix),
-      _filter(std::forward<std::unique_ptr<track_filter>>(filter)),
-      _matcher(std::forward<std::unique_ptr<track_matcher>>(matcher)) {}
+      _filter(std::move(filter)),
+      _matcher(std::move(matcher)) {}
 
 void nseed_performance_writer::initialize() {
     output_seed_file.open(_prefix + "seeds.csv");


### PR DESCRIPTION
While debugging the CI failures in #859, I found out that the problem was not with my code, but rather that there is a critical failure with the use of `std::forward` in `host_container.cpp`, which causes objects passed to `push_back` as l-value references to be inadvertently converted to r-value references. This commit fixes the bug in `host_container.hpp`. The `nseed_performance_writer.cpp` contained a much less serious mistake which I also fixed.