### PR TITLE
Divide default propagation options by proper units

### DIFF
--- a/examples/options/src/track_propagation.cpp
+++ b/examples/options/src/track_propagation.cpp
@@ -29,27 +29,32 @@ track_propagation::track_propagation()
 
     m_desc.add_options()("constraint-step-size-mm",
                          po::value(&(m_config.stepping.step_constraint))
-                             ->default_value(m_config.stepping.step_constraint),
+                             ->default_value(m_config.stepping.step_constraint /
+                                             detray::unit<float>::mm),
                          "The constrained step size [mm]");
     m_desc.add_options()(
         "overstep-tolerance-um",
         po::value(&(m_config.navigation.overstep_tolerance))
-            ->default_value(m_config.navigation.overstep_tolerance),
+            ->default_value(m_config.navigation.overstep_tolerance /
+                            detray::unit<float>::um),
         "The overstep tolerance [um]");
     m_desc.add_options()(
         "min-mask-tolerance-mm",
         po::value(&(m_config.navigation.min_mask_tolerance))
-            ->default_value(m_config.navigation.min_mask_tolerance),
+            ->default_value(m_config.navigation.min_mask_tolerance /
+                            detray::unit<float>::mm),
         "The minimum mask tolerance [mm]");
     m_desc.add_options()(
         "max-mask-tolerance-mm",
         po::value(&(m_config.navigation.max_mask_tolerance))
-            ->default_value(m_config.navigation.max_mask_tolerance),
+            ->default_value(m_config.navigation.max_mask_tolerance /
+                            detray::unit<float>::mm),
         "The maximum mask tolerance [mm]");
     m_desc.add_options()(
         "search-window",
         po::value(&m_search_window)->default_value(m_search_window),
         "Size of the grid surface search window");
+    // TODO: Use the unit of [mm] for rk tolerance
     m_desc.add_options()("rk-tolerance",
                          po::value(&(m_config.stepping.rk_error_tol))
                              ->default_value(m_config.stepping.rk_error_tol),


### PR DESCRIPTION
Currently overstep tolerenace is set to  -300 um (detray default) * um = -0.3 um, which makes propagation unstable

