### PR TITLE
Determine succesfully fitted tracks

### DIFF
--- a/core/include/traccc/edm/track_state.hpp
+++ b/core/include/traccc/edm/track_state.hpp
@@ -20,10 +20,21 @@
 
 namespace traccc {
 
+enum class fitter_outcome : uint32_t {
+    UNKNOWN,
+    SUCCESS,
+    FAILURE_NON_POSITIVE_NDF,
+    FAILURE_NOT_ALL_SMOOTHED,
+    MAX_OUTCOME
+};
+
 /// Fitting result per track
 template <typename algebra_t>
 struct fitting_result {
     using scalar_type = detray::dscalar<algebra_t>;
+
+    /// Fitting outcome
+    fitter_outcome fit_outcome = fitter_outcome::UNKNOWN;
 
     /// Fitted track parameter
     traccc::bound_track_parameters<algebra_t> fit_params;
@@ -191,6 +202,7 @@ struct track_state {
 
     public:
     bool is_hole{true};
+    bool is_smoothed{false};
 
     private:
     detray::geometry::barcode m_surface_link;
@@ -212,5 +224,20 @@ using track_state_collection_types =
 using track_state_container_types =
     container_types<fitting_result<default_algebra>,
                     track_state<default_algebra>>;
+
+inline std::size_t count_fitted_tracks(
+    const track_state_container_types::host& track_states) {
+
+    const std::size_t n_tracks = track_states.size();
+    std::size_t n_fitted_tracks = 0u;
+
+    for (std::size_t i = 0; i < n_tracks; i++) {
+        if (track_states.at(i).header.fit_outcome == fitter_outcome::SUCCESS) {
+            n_fitted_tracks++;
+        }
+    }
+
+    return n_fitted_tracks;
+}
 
 }  // namespace traccc

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp
@@ -148,6 +148,7 @@ struct gain_matrix_smoother {
             matrix::transpose(residual) * matrix::inverse(R) * residual;
 
         cur_state.smoothed_chi2() = getter::element(chi2, 0, 0);
+        cur_state.is_smoothed = true;
 
         return kalman_fitter_status::SUCCESS;
     }

--- a/core/include/traccc/fitting/kalman_filter/statistics_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/statistics_updater.hpp
@@ -41,13 +41,15 @@ struct statistics_updater {
             // Track quality
             auto& trk_quality = fit_res.trk_quality;
 
-            // NDoF = NDoF + number of coordinates per measurement
-            trk_quality.ndf += static_cast<scalar_type>(D);
-
-            // total_chi2 = total_chi2 + chi2
             if (use_backward_filter) {
-                trk_quality.chi2 += trk_state.backward_chi2();
+                if (trk_state.is_smoothed) {
+                    // NDoF = NDoF + number of coordinates per measurement
+                    trk_quality.ndf += static_cast<scalar_type>(D);
+                    trk_quality.chi2 += trk_state.backward_chi2();
+                }
             } else {
+                // NDoF = NDoF + number of coordinates per measurement
+                trk_quality.ndf += static_cast<scalar_type>(D);
                 trk_quality.chi2 += trk_state.filtered_chi2();
             }
         }

--- a/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
@@ -169,6 +169,7 @@ struct two_filters_smoother {
         // Wrap the phi in the range of [-pi, pi]
         wrap_phi(bound_params);
 
+        trk_state.is_smoothed = true;
         return kalman_fitter_status::SUCCESS;
     }
 };

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -151,8 +151,9 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
         auto track_states =
             host_fitting(detector, field, traccc::get_data(track_candidates));
 
-        std::cout << "Number of fitted tracks: " << track_states.size()
-                  << std::endl;
+        std::cout << "Number of fitted tracks: ( "
+                  << count_fitted_tracks(track_states) << " / "
+                  << track_states.size() << " ) " << std::endl;
 
         const std::size_t n_fitted_tracks = track_states.size();
 

--- a/examples/run/cpu/truth_fitting_example.cpp
+++ b/examples/run/cpu/truth_fitting_example.cpp
@@ -130,8 +130,9 @@ int main(int argc, char* argv[]) {
         auto track_states = host_fitting(
             host_det, field, traccc::get_data(truth_track_candidates));
 
-        std::cout << "Number of fitted tracks: " << track_states.size()
-                  << std::endl;
+        std::cout << "Number of fitted tracks: ( "
+                  << count_fitted_tracks(track_states) << " / "
+                  << track_states.size() << " ) " << std::endl;
 
         const decltype(track_states)::size_type n_fitted_tracks =
             track_states.size();


### PR DESCRIPTION
Now depends on #881

-------------------------------------------------
This PR adds a boolean variable in `fitting_result` to determine whether the fitting was successful. This should be harmonized with #862 as well

Success conditions:
1. NDF >0
2. All non-hole track states should be smoothed (i.e. In case of two-filters smoother, forward and backward filter need to pass the same modules.)

The second condition will be much easier to be met once we implement the direct navigator.

Some plots about fitting efficiency will follow soon...


----------------------------------------------

Here is the plot of fitting efficiency (Number of successfully fitted track / Total number of tracks) as a function of mask tolerance. 

Fitting efficiency drops a lot for momentum < 10 GeV/c, which is expected due to the larger material effect + unstable navigation.

- Firx overstep tolerance = default value (-300 um)

<img src="https://github.com/user-attachments/assets/bc61c0dd-5ca3-4bb6-8ce0-88df3a2716ae" width="500" height="400" />


- Fixed mask tolerance

<img src="https://github.com/user-attachments/assets/63f86aee-2c37-43f9-8487-7a74e10e4f7a" width="500" height="400" />

Following is the script used:

<details>

<summary>Script</summary>

```sh
#!/bin/bash
n_ptc=2000
mom_array=(1 2 5 10 100)
tol_array=(0 1 2 3 4)

for mom in "${mom_array[@]}"
do

    command_simulate="
    ./bin/traccc_simulate \
    --detector-file=geometries/odd/odd-detray_geometry_detray.json \
    --material-file=geometries/odd/odd-detray_material_detray.json \
    --grid-file=geometries/odd/odd-detray_surface_grids_detray.json \
    --output-directory=odd/simplified_${n_ptc}muon_${mom}GeV/ \
    --gen-events=1 \
    --gen-nparticles=${n_ptc} \
    --gen-mom-gev=${mom}:${mom} \
    --gen-eta=-1:1 \
    --rk-tolerance=1e-8
    "

    ${command_simulate}

    for tol in "${tol_array[@]}"
    do

        echo "Mom setup: ${mom}, Tol setup: ${tol}"

        command_truth_fit="
        ./bin/traccc_truth_fitting_example \
        --detector-file=geometries/odd/odd-detray_geometry_detray.json \
        --material-file=geometries/odd/odd-detray_material_detray.json \
        --grid-file=geometries/odd/odd-detray_surface_grids_detray.json \
        --use-detray-detector=true \
        --use-acts-geom-source=false \
        --input-directory=odd/simplified_${n_ptc}muon_${mom}GeV/ \
        --input-events=1 \
        --min-mask-tolerance=${tol} \
        --max-mask-tolerance=${tol} \
        --check-performance 
        "

        ${command_truth_fit}

        mv performance_track_fitting.root performance_track_fitting_${mom}_${tol}.root
    done
done
```

</details>


@niermann999 advised that mask tolerances of the first figure should not be touched. I also think the mask tolerance won't be even an issue once we implement the direct navigator. However, the current default overstep tolerance of (-300 um) may be too small for small momentum particle. It would be nice to make it larger or adaptive for different values of momentum.

 