### PR TITLE
ref: Measure wall time in multithreaded benchmark and reduce number of events

### DIFF
--- a/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
+++ b/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
@@ -19,11 +19,7 @@
 
 // Detray include(s).
 #include <detray/detectors/bfield.hpp>
-#include <detray/io/frontend/detector_reader.hpp>
 #include <detray/io/frontend/detector_writer.hpp>
-#include <detray/navigation/navigator.hpp>
-#include <detray/propagator/propagator.hpp>
-#include <detray/propagator/rk_stepper.hpp>
 #include <detray/test/utils/detectors/build_toy_detector.hpp>
 #include <detray/test/utils/simulation/event_generator/track_generators.hpp>
 #include <detray/tracks/ray.hpp>
@@ -42,8 +38,11 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
     // VecMem memory resource(s)
     vecmem::host_memory_resource host_mr;
 
-    static const int n_events = 100u;
-    static const int n_tracks = 5000u;
+    // TODO: This causes a segmentation fault
+    // static const int n_events = 100u;
+    // static const int n_tracks = 5000u;
+    static const int n_events = 50u;
+    static const int n_tracks = 10000u;
 
     std::vector<traccc::spacepoint_collection_types::host> spacepoints;
     std::vector<traccc::measurement_collection_types::host> measurements;

--- a/benchmarks/cpu/toy_detector_cpu.cpp
+++ b/benchmarks/cpu/toy_detector_cpu.cpp
@@ -24,12 +24,8 @@
 #include "benchmarks/toy_detector_benchmark.hpp"
 
 // Detray include(s).
-#include <detray/core/detector.hpp>
 #include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
-#include <detray/navigation/navigator.hpp>
-#include <detray/propagator/propagator.hpp>
-#include <detray/propagator/rk_stepper.hpp>
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -37,7 +33,7 @@
 // Google benchmark include(s).
 #include <benchmark/benchmark.h>
 
-BENCHMARK_F(ToyDetectorBenchmark, CPU)(benchmark::State& state) {
+BENCHMARK_DEFINE_F(ToyDetectorBenchmark, CPU)(benchmark::State& state) {
 
     // Type declarations
     using host_detector_type = traccc::default_detector::host;
@@ -88,3 +84,5 @@ BENCHMARK_F(ToyDetectorBenchmark, CPU)(benchmark::State& state) {
     state.counters["event_throughput_Hz"] = benchmark::Counter(
         static_cast<double>(n_events), benchmark::Counter::kIsRate);
 }
+
+BENCHMARK_REGISTER_F(ToyDetectorBenchmark, CPU)->UseRealTime();

--- a/benchmarks/cuda/toy_detector_cuda.cpp
+++ b/benchmarks/cuda/toy_detector_cuda.cpp
@@ -22,11 +22,9 @@
 #include "benchmarks/toy_detector_benchmark.hpp"
 
 // Detray include(s).
-#include <detray/core/detector.hpp>
 #include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
-#include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 
 // VecMem include(s).
@@ -39,7 +37,7 @@
 // Google benchmark include(s).
 #include <benchmark/benchmark.h>
 
-BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
+BENCHMARK_DEFINE_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
 
     // Type declarations
     using rk_stepper_type = detray::rk_stepper<
@@ -163,3 +161,5 @@ BENCHMARK_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
     state.counters["event_throughput_Hz"] = benchmark::Counter(
         static_cast<double>(n_events), benchmark::Counter::kIsRate);
 }
+
+BENCHMARK_REGISTER_F(ToyDetectorBenchmark, CUDA)->UseRealTime();


### PR DESCRIPTION
To get an accurate result in a multithreaded benchmark, measure the wall clock time.
Until we find out, why the benchmark produces a segmentation fault, I have reduced the number of events, so that it at least runs. At the same time, I also increased the number of tracks per event to simulate higher pileup