### PR TITLE
Add pre-commit hook to check for detray units

### DIFF
--- a/.github/check_taboos.sh
+++ b/.github/check_taboos.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if ! [ -x "$(command -v rg)" ]; then
+   GREP="grep -R"
+else
+   GREP="rg -j 1 --no-heading -N"
+fi
+
+INPUT="$@"
+
+INPUT_EX_THIS_FILE=${INPUT[@]/".github/check_taboos.sh"}
+
+UNIT_CONSTANT_EXCUDE_FILE="core/include/traccc/definitions/common.hpp"
+INPUT_EX_UNIT_CONSTANT=${INPUT_EX_THIS_FILE[@]/$UNIT_CONSTANT_EXCUDE_FILE}
+
+${GREP} "detray::unit" ${INPUT_EX_UNIT_CONSTANT[@]} ; test $? -eq 1 || exit 1
+${GREP} "detray::constant" ${INPUT_EX_UNIT_CONSTANT[@]} ; test $? -eq 1 || exit 1
+
+TRACK_PARAMS_EXCLUDE_FILE="core/include/traccc/edm/track_parameters.hpp"
+INPUT_EX_TRACK_PARAMS=${INPUT_EX_THIS_FILE[@]/$TRACK_PARAMS_EXCLUDE_FILE}
+
+${GREP} "detray::free_track_parameters" ${INPUT_EX_TRACK_PARAMS[@]} ; test $? -eq 1 || exit 1
+${GREP} "detray::bound_track_parameters" ${INPUT_EX_TRACK_PARAMS[@]} ; test $? -eq 1 || exit 1
+${GREP} "detray::bound_vector" ${INPUT_EX_TRACK_PARAMS[@]} ; test $? -eq 1 || exit 1
+${GREP} "detray::bound_matrix" ${INPUT_EX_TRACK_PARAMS[@]} ; test $? -eq 1 || exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,10 @@ repos:
         name: Check includes with quotes
         language: system
         entry: .github/check_quote_includes.sh
+
+  - repo: local
+    hooks:
+      - id: check_taboos
+        name: Check taboo code patterns
+        language: system
+        entry: .github/check_taboos.sh


### PR DESCRIPTION
This commit adds a little pre-commit hook (inspired by #866 and #876) that ensures that we don't re-introduce uses of the `detray::unit` and `detray::constant` namespaces. Can be extended in the future to hold more patterns if desired.

Depends on #876.