### PR TITLE
Set particle hypothesis in Kálmán fitter

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -253,6 +253,12 @@ class kalman_fitter {
 
             typename backward_propagator_type::state propagation(
                 last.smoothed(), m_field, m_detector);
+            propagation.set_particle(detail::correct_particle_hypothesis(
+                m_cfg.ptc_hypothesis, last.smoothed()));
+
+            assert(std::signbit(
+                       propagation._stepping.particle_hypothesis().charge()) ==
+                   std::signbit(propagation._stepping.bound_params().qop()));
 
             inflate_covariance(propagation._stepping.bound_params(),
                                m_cfg.covariance_inflation_factor);


### PR DESCRIPTION
Currently, we are not actually setting the particle hypothesis in the Kálmán fitter, which I find leads to some assertions about the sign of the $\frac{q}{p}$ value not being equal to the sign of $q$. This commit enforces the particle hypothesis in the fitter and adds an additional assert to ensure that the operation was successful.