### PR TITLE
VecMem 1.14.0, main branch (2025.02.21.)

### DIFF
--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2024 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.13.0.tar.gz;URL_MD5;02fe327552c21779f501c224b8c95e87"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.14.0.tar.gz;URL_MD5;4f91ff58af080d4bc6e2d74fa3051ede"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem SYSTEM ${TRACCC_VECMEM_SOURCE} )

--- a/io/src/csv/read_cells.cpp
+++ b/io/src/csv/read_cells.cpp
@@ -152,20 +152,10 @@ void read_cells(edm::silicon_cell_collection::host& cells,
             ddIndex = it->second;
         }
 
-        // Helper lambda for setting up SoA cells.
-        auto assign = [ddIndex](auto soa_cell, const cell& iocell) {
-            soa_cell.channel0() = iocell.channel0;
-            soa_cell.channel1() = iocell.channel1;
-            soa_cell.activation() = iocell.value;
-            soa_cell.time() = iocell.timestamp;
-            soa_cell.module_index() = ddIndex;
-        };
-
         // Add the cells to the output.
         for (auto& cell : cellz) {
-            const std::size_t cellIndex = cells.size();
-            cells.resize(cellIndex + 1);
-            assign(cells.at(cellIndex), cell);
+            cells.push_back({cell.channel0, cell.channel1, cell.value,
+                             cell.timestamp, ddIndex});
         }
     }
 }

--- a/tests/cpu/seq_single_module.cpp
+++ b/tests/cpu/seq_single_module.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,12 +29,15 @@ TEST(algorithms, seq_single_module) {
 
     /// Following [DOI: 10.1109/DASIP48288.2019.9049184]
     traccc::edm::silicon_cell_collection::host cells{resource};
-    cells.resize(9);
-    cells.channel0() = {1, 8, 10, 9, 10, 12, 3, 11, 4};
-    cells.channel1() = {0, 4, 4, 5, 5, 12, 13, 13, 14};
-    cells.activation() = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f};
-    cells.time() = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    cells.module_index() = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+    cells.push_back({1, 0, 1.f, 0.f, 0});
+    cells.push_back({8, 4, 2.f, 0.f, 0});
+    cells.push_back({10, 4, 3.f, 0.f, 0});
+    cells.push_back({9, 5, 4.f, 0.f, 0});
+    cells.push_back({10, 5, 5.f, 0.f, 0});
+    cells.push_back({12, 12, 6.f, 0.f, 0});
+    cells.push_back({3, 13, 7.f, 0.f, 0});
+    cells.push_back({11, 13, 8.f, 0.f, 0});
+    cells.push_back({4, 14, 9.f, 0.f, 0});
     traccc::silicon_detector_description::host dd{resource};
     dd.resize(1);
 


### PR DESCRIPTION
Update to [vecmem-1.14.0](https://github.com/acts-project/vecmem/releases/tag/v1.14.0). Which brings in a number of updates, but most importantly the ability to use `vecmem::edm::host::push_back(...)` and `vecmem::edm::device::push_back(...)` to add elements to (resizable) SoA containers.

I modified a couple of places in the code where this makes the code a little more readable with the existing SoA containers. But didn't go through absolutely everything.

Most importantly, this will help make #878 be a little more readable in the test code.