### PR TITLE
Fix SFINAE bug in container base type

### DIFF
--- a/core/include/traccc/edm/details/container_base.hpp
+++ b/core/include/traccc/edm/details/container_base.hpp
@@ -137,13 +137,11 @@ class container_base {
     /**
      * @brief Constructor from a pair of "view type" objects
      */
-    template <typename header_vector_tp, typename item_vector_tp,
-              typename = std::enable_if<
-                  std::is_same<header_vector_tp, header_vector>::value>,
-              typename = std::enable_if<
-                  std::is_same<item_vector_tp, item_vector>::value>>
-    TRACCC_HOST_DEVICE container_base(const header_vector_tp& hv,
-                                      const item_vector_tp& iv)
+    template <typename header_vector_tp, typename item_vector_tp>
+    requires(std::constructible_from<header_vector, const header_vector_tp&>&&
+                 std::constructible_from<item_vector, const item_vector_tp&>)
+        TRACCC_HOST_DEVICE
+        container_base(const header_vector_tp& hv, const item_vector_tp& iv)
         : m_headers(hv), m_items(iv) {
 
         assert(m_headers.size() == m_items.size());


### PR DESCRIPTION
This commit fixes a bug in the use of SFINAE in the container base type. In particuler, this issue has three layers:

1. The existing code uses the `typename = std::enable_if` anti-pattern which is discouraged in the C++ standard.
2. The code used `std::enable_if` without getting `::type` from it, meaning that a specialization failure cannot ever occur, rendering the SFINAE useless.
3. The check used about type equality is incorrect, it should rather check constructability.

This commit fixes the issues by converting the code to a C++20 requires clause and by modifying the conditions.