### PR TITLE
Check for `std::format` support in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,25 @@ option( TRACCC_USE_SYSTEM_LIBS "Use system libraries be default" FALSE )
 option( TRACCC_USE_SPACK_LIBS "Use pack libraries by default" FALSE )
 option( TRACCC_USE_ROOT "Use ROOT in the build (if needed)" TRUE )
 
+# Check for some compiler features
+if(TRACCC_BUILD_EXAMPLES)
+   message(STATUS "Checking for `std::format` support")
+   file( WRITE
+   "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/compile_test_format.cpp"
+   "#include <format>\n"
+   "int main() {\n"
+   "std::format(\"Hello {}\\n\", \"world\");\n"
+   "return 0; }\n" )
+   try_compile( TRACCCC_INTERNAL_STD_FORMAT_WORKS SOURCES
+   "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/compile_test_format.cpp")
+
+   if (NOT TRACCCC_INTERNAL_STD_FORMAT_WORKS)
+      message(FATAL_ERROR "Examples are enabled, but `std::format` is not supported by the C++ compiler; upgrade to gcc 13 or clang 14 or higher.")
+   endif()
+
+   unset(TRACCCC_INTERNAL_STD_FORMAT_WORKS)
+endif()
+
 # Check CUDA and SYCL C++ standards
 if(${TRACCC_BUILD_CUDA} AND ${CMAKE_CUDA_STANDARD} LESS 20)
    message(SEND_ERROR "CMAKE_CUDA_STANDARD=${CMAKE_CUDA_STANDARD}, but traccc requires C++>=20")


### PR DESCRIPTION
Today I tried building traccc with g++12 which broke as #845 introduced a dependency on `std::format` which is not universally available. In order to provide earlier and more readable errors, this commit adds a configuration-time check to ensure that the C++ compiler supports `std::format`.