### PR TITLE
Remove dependency on dfelibs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,20 +296,6 @@ if( TRACCC_SETUP_COVFIE )
    endif()
 endif()
 
-# Set up dfelibs.
-option( TRACCC_SETUP_DFELIBS
-   "Set up the dfelibs target(s) explicitly" TRUE )
-option( TRACCC_USE_SYSTEM_DFELIBS
-   "Pick up an existing installation of dfelibs from the build environment"
-   ${TRACCC_USE_SYSTEM_LIBS} )
-if( TRACCC_SETUP_DFELIBS )
-   if( TRACCC_USE_SYSTEM_DFELIBS )
-      find_package( dfelibs REQUIRED )
-   else()
-      add_subdirectory( extern/dfelibs )
-   endif()
-endif()
-
 # Set up Detray.
 option( TRACCC_SETUP_DETRAY
    "Set up the Detray target(s) explicitly" TRUE )

--- a/README.md
+++ b/README.md
@@ -242,7 +242,6 @@ cmake --build build/
 | TRACCC_BUILD_TESTING  | Build the (unit) tests of traccc |
 | TRACCC_BUILD_EXAMPLES  | Build the examples of traccc |
 | TRACCC_USE_SYSTEM_VECMEM | Pick up an existing installation of VecMem from the build environment |
-| TRACCC_USE_SYSTEM_DFELIBS | Pick up an existing installation of dfelibs from the build environment |
 | TRACCC_USE_SYSTEM_DETRAY | Pick up an existing installation of Detray from the build environment |
 | TRACCC_USE_SYSTEM_ACTS | Pick up an existing installation of Acts from the build environment |
 | TRACCC_USE_SYSTEM_GOOGLETEST | Pick up an existing installation of GoogleTest from the build environment |

--- a/cmake/traccc-config.cmake.in
+++ b/cmake/traccc-config.cmake.in
@@ -28,7 +28,6 @@ list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}" )
 # Find all packages that traccc needs to function.
 include( CMakeFindDependencyMacro )
 find_dependency( Thrust )
-find_dependency( dfelibs )
 if( TRACCC_BUILD_ALPAKA )
    find_dependency( alpaka )
 endif()

--- a/extern/dfelibs/README.md
+++ b/extern/dfelibs/README.md
@@ -1,4 +1,0 @@
-# Build Recipe for dfelibs
-
-This directory holds a simple build recipe for the
-[dfelibs](https://github.com/msmk0/dfelibs) project.

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -85,7 +85,7 @@ traccc_add_library( traccc_io io TYPE SHARED
   "src/obj/write_tracks.cpp"
   )
 target_link_libraries( traccc_io
-  PUBLIC vecmem::core traccc::core Acts::Core dfelibs::dfelibs
+  PUBLIC vecmem::core traccc::core Acts::Core
   PRIVATE detray::core detray::io Acts::PluginJson )
 target_compile_definitions( traccc_io
   PRIVATE TRACCC_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/data" )

--- a/io/include/traccc/io/csv/cell.hpp
+++ b/io/include/traccc/io/csv/cell.hpp
@@ -7,8 +7,7 @@
 
 #pragma once
 
-// DFE include(s).
-#include <dfe/dfe_namedtuple.hpp>
+#include "traccc/io/csv/dfe.hpp"
 
 // System include(s).
 #include <cstdint>

--- a/io/include/traccc/io/csv/dfe.hpp
+++ b/io/include/traccc/io/csv/dfe.hpp
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2015,2018-2020 Moritz Kiehn
+
+#pragma once
+
+#include <Acts/Utilities/Concepts.hpp>
+#include <Acts/Utilities/Helpers.hpp>
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <fstream>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#define DFE_NAMEDTUPLE(name, ...)                                           \
+    using Tuple = decltype(::std::make_tuple(__VA_ARGS__));                 \
+    static ::std::array<::std::string, ::std::tuple_size<Tuple>::value>     \
+    names() {                                                               \
+        return ::traccc::io::dfe::unstringify<                              \
+            ::std::tuple_size<Tuple>::value>((#__VA_ARGS__));               \
+    }                                                                       \
+    template <typename... U>                                                \
+    name& operator=(const ::std::tuple<U...>& other) {                      \
+        ::std::tie(__VA_ARGS__) = other;                                    \
+        return *this;                                                       \
+    }                                                                       \
+    template <typename... U>                                                \
+    name& operator=(::std::tuple<U...>&& other) {                           \
+        ::std::tie(__VA_ARGS__) = ::std::forward<std::tuple<U...>>(other);  \
+        return *this;                                                       \
+    }                                                                       \
+    operator Tuple() const {                                                \
+        return ::std::make_tuple(__VA_ARGS__);                              \
+    }                                                                       \
+    Tuple tuple() const {                                                   \
+        return ::std::make_tuple(__VA_ARGS__);                              \
+    }                                                                       \
+    template <std::size_t I>                                                \
+    constexpr ::std::tuple_element_t<I, Tuple>& get() {                     \
+        return ::std::get<I>(std::tie(__VA_ARGS__));                        \
+    }                                                                       \
+    template <::std::size_t I>                                              \
+    constexpr const ::std::tuple_element_t<I, Tuple>& get() const {         \
+        return ::std::get<I>(std::tie(__VA_ARGS__));                        \
+    }                                                                       \
+    template <::std::size_t I>                                              \
+    friend constexpr ::std::tuple_element_t<I, Tuple>& get(name& nt) {      \
+        return nt.template get<I>();                                        \
+    }                                                                       \
+    template <::std::size_t I>                                              \
+    friend constexpr const ::std::tuple_element_t<I, Tuple>& get(           \
+        const name& nt) {                                                   \
+        return nt.template get<I>();                                        \
+    }                                                                       \
+    friend inline ::std::ostream& operator<<(::std::ostream& os,            \
+                                             const name& nt) {              \
+        return ::traccc::io::dfe::print_tuple(                              \
+            os, nt.names(), nt.tuple(),                                     \
+            ::std::make_index_sequence<::std::tuple_size<Tuple>::value>{}); \
+    }
+
+namespace traccc::io {
+namespace dfe {
+
+template <std::size_t N>
+constexpr std::array<std::string, N> unstringify(const char* str) {
+    assert(str && "Input string must be non-null");
+
+    std::array<std::string, N> out;
+
+    for (std::size_t idx = 0; idx < N; ++idx) {
+        while ((*str != '\0') && (*str == ' ')) {
+            ++str;
+        }
+        const char* sep = str;
+        while ((*sep != '\0') && (*sep != ',')) {
+            ++sep;
+        }
+        out[idx].assign(str, static_cast<std::size_t>(sep - str));
+        if (*sep == '\0') {
+            break;
+        }
+        str = ++sep;
+    }
+    return out;
+}
+
+template <typename Names, typename Values, std::size_t... I>
+inline std::ostream& print_tuple(std::ostream& os, const Names& n,
+                                 const Values& v,
+                                 std::index_sequence<I...> /*seq*/) {
+    using std::get;
+    using Vacuum = int[];
+    (void)Vacuum{
+        (os << ((0 < I) ? " " : "") << get<I>(n) << "=" << get<I>(v), 0)...};
+    return os;
+}
+
+template <char Delimiter>
+class DsvWriter {
+    public:
+    DsvWriter() = delete;
+    DsvWriter(const DsvWriter&) = delete;
+    DsvWriter(DsvWriter&&) = default;
+    ~DsvWriter() = default;
+    DsvWriter& operator=(const DsvWriter&) = delete;
+    DsvWriter& operator=(DsvWriter&&) = default;
+
+    DsvWriter(const std::vector<std::string>& columns, const std::string& path,
+              int precision = std::numeric_limits<double>::max_digits10);
+
+    template <typename Arg0, typename... Args>
+    void append(Arg0&& arg0, Args&&... args);
+
+    private:
+    std::ofstream m_file;
+    std::size_t m_num_columns;
+
+    template <typename T>
+    unsigned write(T&& x, std::ostream& os);
+
+    template <typename T, typename Allocator>
+    static unsigned write(const std::vector<T, Allocator>& xs,
+                          std::ostream& os);
+};
+
+template <char Delimiter>
+class DsvReader {
+    public:
+    DsvReader() = delete;
+    DsvReader(const DsvReader&) = delete;
+    DsvReader(DsvReader&&) = default;
+    ~DsvReader() = default;
+    DsvReader& operator=(const DsvReader&) = delete;
+    DsvReader& operator=(DsvReader&&) = default;
+
+    explicit DsvReader(const std::string& path);
+
+    bool read(std::vector<std::string>& columns);
+
+    std::size_t num_lines() const { return m_num_lines; }
+
+    private:
+    std::ifstream m_file;
+    std::string m_line;
+    std::size_t m_num_lines = 0;
+};
+
+template <char Delimiter, typename NamedTuple>
+class NamedTupleDsvWriter {
+    public:
+    NamedTupleDsvWriter() = delete;
+    NamedTupleDsvWriter(const NamedTupleDsvWriter&) = delete;
+    NamedTupleDsvWriter(NamedTupleDsvWriter&&) = default;
+    ~NamedTupleDsvWriter() = default;
+    NamedTupleDsvWriter& operator=(const NamedTupleDsvWriter&) = delete;
+    NamedTupleDsvWriter& operator=(NamedTupleDsvWriter&&) = default;
+
+    NamedTupleDsvWriter(
+        const std::string& path,
+        int precision = std::numeric_limits<double>::max_digits10)
+        : m_writer(colum_names(), path, precision) {}
+
+    void append(const NamedTuple& record) {
+        append_impl(record,
+                    std::make_index_sequence<
+                        std::tuple_size_v<typename NamedTuple::Tuple>>{});
+    }
+
+    private:
+    DsvWriter<Delimiter> m_writer;
+
+    static std::vector<std::string> colum_names() {
+        const auto& from_record = NamedTuple::names();
+        return {from_record.begin(), from_record.end()};
+    }
+    template <std::size_t... I>
+    void append_impl(const NamedTuple& values,
+                     std::index_sequence<I...> /*seq*/) {
+        using std::get;
+        m_writer.append(get<I>(values)...);
+    }
+};
+
+template <typename T>
+static void parse(const std::string& str, T& value) {
+    std::istringstream is(str);
+    is >> value;
+}
+
+template <char Delimiter, typename NamedTuple>
+class NamedTupleDsvReader {
+    public:
+    NamedTupleDsvReader() = delete;
+    NamedTupleDsvReader(const NamedTupleDsvReader&) = delete;
+    NamedTupleDsvReader(NamedTupleDsvReader&&) = default;
+    ~NamedTupleDsvReader() = default;
+    NamedTupleDsvReader& operator=(const NamedTupleDsvReader&) = delete;
+    NamedTupleDsvReader& operator=(NamedTupleDsvReader&&) = default;
+
+    NamedTupleDsvReader(const std::string& path,
+                        const std::vector<std::string>& optional_columns = {},
+                        bool verify_header = true);
+    bool read(NamedTuple& record);
+
+    template <typename T>
+    bool read(NamedTuple& record, std::vector<T>& extra);
+
+    std::size_t num_extra_columns() const { return m_extra_columns.size(); }
+    std::size_t num_records() const { return m_reader.num_lines() - 1u; }
+
+    private:
+    using Tuple = typename NamedTuple::Tuple;
+
+    DsvReader<Delimiter> m_reader;
+    std::vector<std::string> m_columns;
+    std::size_t m_num_columns = SIZE_MAX;
+    std::array<std::size_t, std::tuple_size<Tuple>::value> m_tuple_column_map;
+    std::vector<std::size_t> m_extra_columns;
+
+    void use_default_columns();
+    void parse_header(const std::vector<std::string>& optional_columns);
+    template <std::size_t... I>
+    void parse_record(NamedTuple& record,
+                      std::index_sequence<I...> /*seq*/) const {
+        using Vacuum = int[];
+        (void)Vacuum{(parse_element<I>(record), 0)...};
+    }
+    template <std::size_t I>
+    void parse_element(NamedTuple& record) const {
+        using std::get;
+        if (m_tuple_column_map[I] != SIZE_MAX) {
+            parse(m_columns[m_tuple_column_map[I]], get<I>(record));
+        }
+    }
+};
+
+template <char Delimiter>
+inline DsvWriter<Delimiter>::DsvWriter(const std::vector<std::string>& columns,
+                                       const std::string& path, int precision)
+    : m_file(path,
+             std::ios_base::binary | std::ios_base::out | std::ios_base::trunc),
+      m_num_columns(columns.size()) {
+    if (!m_file.is_open() || m_file.fail()) {
+        throw std::runtime_error("Could not open file '" + path + "'");
+    }
+    m_file.precision(precision);
+    if (m_num_columns == 0) {
+        throw std::invalid_argument("No columns were specified");
+    }
+    append(columns);
+}
+
+template <char Delimiter>
+template <typename Arg0, typename... Args>
+inline void DsvWriter<Delimiter>::append(Arg0&& arg0, Args&&... args) {
+    std::stringstream line;
+    unsigned written_columns[] = {
+        write(std::forward<Arg0>(arg0), line),
+        (line << Delimiter, write(std::forward<Args>(args), line))...,
+    };
+    line << '\n';
+    unsigned total_columns = 0;
+    for (auto nc : written_columns) {
+        total_columns += nc;
+    }
+    if (total_columns < m_num_columns) {
+        throw std::invalid_argument("Not enough columns");
+    }
+    if (m_num_columns < total_columns) {
+        throw std::invalid_argument("Too many columns");
+    }
+    m_file << line.rdbuf();
+    if (!m_file.good()) {
+        throw std::runtime_error("Could not write data to file");
+    }
+}
+
+template <char Delimiter>
+template <typename T>
+inline unsigned DsvWriter<Delimiter>::write(T&& x, std::ostream& os) {
+    os << x;
+    return 1u;
+}
+
+template <char Delimiter>
+template <typename T, typename Allocator>
+inline unsigned DsvWriter<Delimiter>::write(const std::vector<T, Allocator>& xs,
+                                            std::ostream& os) {
+    unsigned n = 0;
+    for (const auto& x : xs) {
+        if (0 < n) {
+            os << Delimiter;
+        }
+        os << x;
+        n += 1;
+    }
+    return n;
+}
+
+template <char Delimiter>
+inline DsvReader<Delimiter>::DsvReader(const std::string& path)
+    : m_file(path, std::ios_base::binary | std::ios_base::in) {
+    if (!m_file.is_open() || m_file.fail()) {
+        throw std::runtime_error("Could not open file '" + path + "'");
+    }
+}
+
+template <char Delimiter>
+inline bool DsvReader<Delimiter>::read(std::vector<std::string>& columns) {
+    std::getline(m_file, m_line);
+    if (m_file.eof()) {
+        return false;
+    }
+    if (m_file.fail()) {
+        throw std::runtime_error(std::string("Could not read line ") +
+                                 std::to_string(m_num_lines));
+    }
+    m_num_lines += 1;
+
+    columns.clear();
+    for (std::string::size_type pos = 0; pos < m_line.size();) {
+        auto del = m_line.find_first_of(Delimiter, pos);
+        if (del == std::string::npos) {
+            columns.emplace_back(m_line, pos);
+            break;
+        } else {
+            columns.emplace_back(m_line, pos, del - pos);
+            pos = del + 1;
+        }
+    }
+    return true;
+}
+
+template <char Delimiter, typename NamedTuple>
+inline NamedTupleDsvReader<Delimiter, NamedTuple>::NamedTupleDsvReader(
+    const std::string& path, const std::vector<std::string>& optional_columns,
+    bool verify_header)
+    : m_reader(path) {
+    if ((!optional_columns.empty()) && (!verify_header)) {
+        throw std::runtime_error(
+            "Optional columns can not be used without header verification");
+    }
+    if (!m_reader.read(m_columns)) {
+        throw std::runtime_error("Could not read header from '" + path + "'");
+    }
+    if (verify_header) {
+        parse_header(optional_columns);
+    } else {
+        use_default_columns();
+    }
+}
+
+template <char Delimiter, typename NamedTuple>
+inline bool NamedTupleDsvReader<Delimiter, NamedTuple>::read(
+    NamedTuple& record) {
+    if (!m_reader.read(m_columns)) {
+        return false;
+    }
+    if (m_columns.size() < m_num_columns) {
+        throw std::runtime_error("Too few columns in line " +
+                                 std::to_string(m_reader.num_lines()));
+    }
+    if (m_num_columns < m_columns.size()) {
+        throw std::runtime_error("Too many columns in line " +
+                                 std::to_string(m_reader.num_lines()));
+    }
+    parse_record(record, std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+    return true;
+}
+
+template <char Delimiter, typename NamedTuple>
+template <typename T>
+inline bool NamedTupleDsvReader<Delimiter, NamedTuple>::read(
+    NamedTuple& record, std::vector<T>& extra) {
+    if (!read(record)) {
+        return false;
+    }
+    extra.resize(m_extra_columns.size());
+    for (std::size_t i = 0; i < m_extra_columns.size(); ++i) {
+        parse(m_columns[m_extra_columns[i]], extra[i]);
+    }
+    return true;
+}
+
+template <char Delimiter, typename NamedTuple>
+inline void NamedTupleDsvReader<Delimiter, NamedTuple>::use_default_columns() {
+    m_num_columns = std::tuple_size_v<Tuple>;
+    for (std::size_t i = 0; i < m_tuple_column_map.size(); ++i) {
+        m_tuple_column_map[i] = i;
+    }
+    m_extra_columns.clear();
+}
+
+template <char Delimiter, typename NamedTuple>
+inline void NamedTupleDsvReader<Delimiter, NamedTuple>::parse_header(
+    const std::vector<std::string>& optional_columns) {
+    const auto& names = NamedTuple::names();
+
+    m_num_columns = m_columns.size();
+
+    for (const auto& name : names) {
+        if (::Acts::rangeContainsValue(optional_columns, name)) {
+            continue;
+        }
+        if (!::Acts::rangeContainsValue(m_columns, name)) {
+            throw std::runtime_error("Missing header column '" + name + "'");
+        }
+    }
+
+    m_tuple_column_map.fill(SIZE_MAX);
+
+    m_extra_columns.clear();
+    for (std::size_t i = 0; i < m_columns.size(); ++i) {
+        auto it = std::ranges::find(names, m_columns[i]);
+        if (it != names.end()) {
+            m_tuple_column_map[static_cast<std::size_t>(
+                std::distance(names.begin(), it))] = i;
+        } else {
+            m_extra_columns.push_back(i);
+        }
+    }
+}
+
+using CsvWriter = dfe::DsvWriter<','>;
+
+using TsvWriter = dfe::DsvWriter<'\t'>;
+
+template <typename T>
+using NamedTupleCsvWriter = dfe::NamedTupleDsvWriter<',', T>;
+
+template <typename T>
+using NamedTupleCsvReader = dfe::NamedTupleDsvReader<',', T>;
+
+template <typename T>
+using NamedTupleTsvWriter = dfe::NamedTupleDsvWriter<'\t', T>;
+
+template <typename T>
+using NamedTupleTsvReader = dfe::NamedTupleDsvReader<'\t', T>;
+}  // namespace dfe
+}  // namespace traccc::io

--- a/io/include/traccc/io/csv/hit.hpp
+++ b/io/include/traccc/io/csv/hit.hpp
@@ -7,8 +7,7 @@
 
 #pragma once
 
-// DFE include(s).
-#include <dfe/dfe_namedtuple.hpp>
+#include "traccc/io/csv/dfe.hpp"
 
 // System include(s).
 #include <cstdint>

--- a/io/include/traccc/io/csv/make_cell_reader.hpp
+++ b/io/include/traccc/io/csv/make_cell_reader.hpp
@@ -9,9 +9,7 @@
 
 // Local include(s).
 #include "traccc/io/csv/cell.hpp"
-
-// DFE include(s).
-#include <dfe/dfe_io_dsv.hpp>
+#include "traccc/io/csv/dfe.hpp"
 
 // System include(s).
 #include <string_view>

--- a/io/include/traccc/io/csv/make_hit_reader.hpp
+++ b/io/include/traccc/io/csv/make_hit_reader.hpp
@@ -8,10 +8,8 @@
 #pragma once
 
 // Local include(s).
+#include "traccc/io/csv/dfe.hpp"
 #include "traccc/io/csv/hit.hpp"
-
-// DFE include(s).
-#include <dfe/dfe_io_dsv.hpp>
 
 // System include(s).
 #include <string_view>

--- a/io/include/traccc/io/csv/make_measurement_hit_id_reader.hpp
+++ b/io/include/traccc/io/csv/make_measurement_hit_id_reader.hpp
@@ -8,10 +8,8 @@
 #pragma once
 
 // Local include(s).
+#include "traccc/io/csv/dfe.hpp"
 #include "traccc/io/csv/measurement_hit_id.hpp"
-
-// DFE include(s).
-#include <dfe/dfe_io_dsv.hpp>
 
 // System include(s).
 #include <string_view>

--- a/io/include/traccc/io/csv/make_measurement_reader.hpp
+++ b/io/include/traccc/io/csv/make_measurement_reader.hpp
@@ -8,10 +8,8 @@
 #pragma once
 
 // Local include(s).
+#include "traccc/io/csv/dfe.hpp"
 #include "traccc/io/csv/measurement.hpp"
-
-// DFE include(s).
-#include <dfe/dfe_io_dsv.hpp>
 
 // System include(s).
 #include <string_view>

--- a/io/include/traccc/io/csv/make_particle_reader.hpp
+++ b/io/include/traccc/io/csv/make_particle_reader.hpp
@@ -8,10 +8,8 @@
 #pragma once
 
 // Local include(s).
+#include "traccc/io/csv/dfe.hpp"
 #include "traccc/io/csv/particle.hpp"
-
-// DFE include(s).
-#include <dfe/dfe_io_dsv.hpp>
 
 // System include(s).
 #include <string_view>

--- a/io/include/traccc/io/csv/make_surface_reader.hpp
+++ b/io/include/traccc/io/csv/make_surface_reader.hpp
@@ -8,10 +8,8 @@
 #pragma once
 
 // Local include(s).
+#include "traccc/io/csv/dfe.hpp"
 #include "traccc/io/csv/surface.hpp"
-
-// DFE include(s).
-#include <dfe/dfe_io_dsv.hpp>
 
 // System include(s).
 #include <string_view>

--- a/io/include/traccc/io/csv/measurement.hpp
+++ b/io/include/traccc/io/csv/measurement.hpp
@@ -7,8 +7,7 @@
 
 #pragma once
 
-// DFE include(s).
-#include <dfe/dfe_namedtuple.hpp>
+#include "traccc/io/csv/dfe.hpp"
 
 // System include(s).
 #include <cstdint>

--- a/io/include/traccc/io/csv/measurement_hit_id.hpp
+++ b/io/include/traccc/io/csv/measurement_hit_id.hpp
@@ -7,8 +7,7 @@
 
 #pragma once
 
-// DFE include(s).
-#include <dfe/dfe_namedtuple.hpp>
+#include "traccc/io/csv/dfe.hpp"
 
 // System include(s).
 #include <cstdint>

--- a/io/include/traccc/io/csv/particle.hpp
+++ b/io/include/traccc/io/csv/particle.hpp
@@ -7,8 +7,7 @@
 
 #pragma once
 
-// DFE include(s).
-#include <dfe/dfe_namedtuple.hpp>
+#include "traccc/io/csv/dfe.hpp"
 
 // System include(s).
 #include <cstdint>

--- a/io/include/traccc/io/csv/surface.hpp
+++ b/io/include/traccc/io/csv/surface.hpp
@@ -7,8 +7,7 @@
 
 #pragma once
 
-// DFE include(s).
-#include <dfe/dfe_namedtuple.hpp>
+#include "traccc/io/csv/dfe.hpp"
 
 // System include(s).
 #include <cstdint>

--- a/io/src/csv/read_surfaces.cpp
+++ b/io/src/csv/read_surfaces.cpp
@@ -1,0 +1,34 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "read_surfaces.hpp"
+
+#include "traccc/io/csv/dfe.hpp"
+#include "traccc/io/csv/make_surface_reader.hpp"
+
+namespace traccc::io::csv {
+
+std::map<geometry_id, transform3> read_surfaces(std::string_view filename) {
+
+    // Construct the surface reader object.
+    auto reader = make_surface_reader(filename);
+
+    // Fill an std::map with entries from the file.
+    std::map<geometry_id, transform3> result;
+    surface surf;
+    while (reader.read(surf)) {
+        result.insert(
+            {surf.geometry_id,
+             transform3{vector3{surf.cx, surf.cy, surf.cz},
+                        vector3{surf.rot_xw, surf.rot_yw, surf.rot_zw},
+                        vector3{surf.rot_xu, surf.rot_yu, surf.rot_zu}}});
+    }
+    return result;
+}
+
+}  // namespace traccc::io::csv

--- a/simulation/CMakeLists.txt
+++ b/simulation/CMakeLists.txt
@@ -13,4 +13,4 @@ traccc_add_library( traccc_simulation simulation TYPE INTERFACE
   "include/traccc/simulation/smearing_writer.hpp" )
 target_link_libraries( traccc_simulation
   INTERFACE traccc::core traccc::io detray::core detray::io
-            detray::test_common detray::test_utils dfelibs::dfelibs )
+            detray::test_common detray::test_utils )

--- a/simulation/include/traccc/simulation/smearing_writer.hpp
+++ b/simulation/include/traccc/simulation/smearing_writer.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/edm/track_parameters.hpp"
+#include "traccc/io/csv/dfe.hpp"
 #include "traccc/io/csv/hit.hpp"
 #include "traccc/io/csv/measurement.hpp"
 #include "traccc/io/csv/measurement_hit_id.hpp"
@@ -23,10 +24,6 @@
 #include <detray/propagator/base_actor.hpp>
 #include <detray/utils/concepts.hpp>
 
-// DFE include(s).
-#include <dfe/dfe_io_dsv.hpp>
-#include <dfe/dfe_namedtuple.hpp>
-
 // System include(s).
 #include <filesystem>
 #include <string>
@@ -40,10 +37,11 @@ struct smearing_writer : detray::base_actor {
     using scalar_type = detray::dscalar<algebra_type>;
 
     using measurement_hit_id_writer =
-        dfe::NamedTupleCsvWriter<io::csv::measurement_hit_id>;
-    using measurement_writer = dfe::NamedTupleCsvWriter<io::csv::measurement>;
-    using hit_writer = dfe::NamedTupleCsvWriter<io::csv::hit>;
-    using particle_writer = dfe::NamedTupleCsvWriter<io::csv::particle>;
+        io::dfe::NamedTupleCsvWriter<io::csv::measurement_hit_id>;
+    using measurement_writer =
+        io::dfe::NamedTupleCsvWriter<io::csv::measurement>;
+    using hit_writer = io::dfe::NamedTupleCsvWriter<io::csv::hit>;
+    using particle_writer = io::dfe::NamedTupleCsvWriter<io::csv::particle>;
 
     struct config {
         smearer_t smearer;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library( traccc_tests_common STATIC
 target_include_directories( traccc_tests_common
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common )
 target_link_libraries( traccc_tests_common
-    PUBLIC dfelibs::dfelibs GTest::gtest Acts::Core vecmem::core
+    PUBLIC GTest::gtest Acts::Core vecmem::core
            detray::core detray::io detray::test_common covfie::core traccc::core traccc::io traccc_simulation)
 
 # Use ROOT in traccc_tests_common, if requested.

--- a/tests/common/tests/cca_test.hpp
+++ b/tests/common/tests/cca_test.hpp
@@ -14,6 +14,7 @@
 #include "traccc/edm/silicon_cell_collection.hpp"
 #include "traccc/edm/silicon_cluster_collection.hpp"
 #include "traccc/geometry/detector_design_description.hpp"
+#include "traccc/io/csv/dfe.hpp"
 #include "traccc/io/csv/make_cell_reader.hpp"
 #include "traccc/io/read_cells.hpp"
 
@@ -26,10 +27,6 @@
 
 // GTest include(s).
 #include <gtest/gtest.h>
-
-// DFE include(s).
-#include <dfe/dfe_io_dsv.hpp>
-#include <dfe/dfe_namedtuple.hpp>
 
 // System include(s).
 #include <functional>
@@ -85,7 +82,8 @@ class ConnectedComponentAnalysisTests
                        channel0, channel1, variance0, variance1);
     };
 
-    using cca_truth_hit_reader = dfe::NamedTupleCsvReader<cca_truth_hit>;
+    using cca_truth_hit_reader =
+        ::traccc::io::dfe::NamedTupleCsvReader<cca_truth_hit>;
 
     inline static std::string get_test_name(
         const testing::TestParamInfo<ParamType> &info) {


### PR DESCRIPTION
The ACTS project is deprecating its fork of dfelibs, which we use only for CSV reading. Thus, this commit removes our dependency on dfelibs and simply places the relevant code into the traccc repository.