### PR TITLE
Add CLI options to control logging verbosity

### DIFF
--- a/examples/options/CMakeLists.txt
+++ b/examples/options/CMakeLists.txt
@@ -34,6 +34,7 @@ traccc_add_library( traccc_options options TYPE SHARED
   "src/detector.cpp"
   "src/generation.cpp"
   "src/input_data.cpp"
+  "src/logging.cpp"
   "src/magnetic_field.cpp"
   "src/output_data.cpp"
   "src/performance.cpp"

--- a/examples/options/include/traccc/options/logging.hpp
+++ b/examples/options/include/traccc/options/logging.hpp
@@ -1,0 +1,33 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <string>
+
+#include "traccc/options/details/config_provider.hpp"
+#include "traccc/options/details/interface.hpp"
+#include "traccc/utils/logging.hpp"
+
+namespace traccc::opts {
+
+/// Options for logging
+class logging : public interface,
+                public config_provider<traccc::Logging::Level> {
+    public:
+    logging();
+
+    virtual operator traccc::Logging::Level() const override;
+
+    std::unique_ptr<configuration_printable> as_printable() const override;
+
+    private:
+    int m_verbosity_incr = 0;
+    int m_verbosity_decr = 0;
+};  // class output_data
+
+}  // namespace traccc::opts

--- a/examples/options/src/logging.cpp
+++ b/examples/options/src/logging.cpp
@@ -1,0 +1,83 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "traccc/options/logging.hpp"
+
+#include <Acts/Utilities/Logger.hpp>
+
+#include "traccc/examples/utils/printable.hpp"
+
+// System include(s).
+#include <format>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+namespace {
+class verbosity_counter : public boost::program_options::typed_value<int> {
+    public:
+    verbosity_counter(int* store)
+        : boost::program_options::typed_value<int>(store) {
+        default_value(0);
+        zero_tokens();
+    }
+
+    virtual ~verbosity_counter() = default;
+
+    virtual void xparse(boost::any& store,
+                        const std::vector<std::string>&) const {
+        store = boost::any(++m_value);
+    }
+
+    private:
+    mutable int m_value{0};
+};
+}  // namespace
+
+namespace traccc::opts {
+
+logging::logging() : interface("Logging Options") {
+    m_desc.add_options()(
+        "verbose,v", new verbosity_counter(&m_verbosity_decr),
+        "Increase verbosity (can be specified multiple times)")(
+        "quiet,q", new verbosity_counter(&m_verbosity_incr),
+        "Decrease verbosity (can be specified multiple times)");
+}
+
+logging::operator traccc::Logging::Level() const {
+    int verb = m_verbosity_incr - m_verbosity_decr;
+
+    if (verb <= -2) {
+        return traccc::Logging::Level::VERBOSE;
+    } else if (verb == -1) {
+        return traccc::Logging::Level::DEBUG;
+    } else if (verb == 0) {
+        return traccc::Logging::Level::INFO;
+    } else if (verb == 1) {
+        return traccc::Logging::Level::WARNING;
+    } else if (verb == 2) {
+        return traccc::Logging::Level::ERROR;
+    } else {
+        return traccc::Logging::Level::FATAL;
+    }
+}
+
+std::unique_ptr<configuration_printable> logging::as_printable() const {
+    auto cat = std::make_unique<configuration_category>(m_description);
+
+    traccc::Logging::Level lvl(*this);
+
+    std::string verbosity_string{Acts::Logging::levelName(lvl)};
+
+    cat->add_child(std::make_unique<configuration_kv_pair>("Verbosity level",
+                                                           verbosity_string));
+
+    return cat;
+}
+
+}  // namespace traccc::opts

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -18,6 +18,7 @@
 #include "traccc/options/clusterization.hpp"
 #include "traccc/options/detector.hpp"
 #include "traccc/options/input_data.hpp"
+#include "traccc/options/logging.hpp"
 #include "traccc/options/magnetic_field.hpp"
 #include "traccc/options/program_options.hpp"
 #include "traccc/options/threading.hpp"
@@ -65,9 +66,8 @@ namespace traccc {
 template <typename FULL_CHAIN_ALG>
 int throughput_mt(std::string_view description, int argc, char* argv[]) {
 
-    std::unique_ptr<const traccc::Logger> ilogger = traccc::getDefaultLogger(
+    std::unique_ptr<const traccc::Logger> prelogger = traccc::getDefaultLogger(
         "ThroughputExample", traccc::Logging::Level::INFO);
-    TRACCC_LOCAL_LOGGER(std::move(ilogger));
 
     // Program options.
     opts::detector detector_opts;
@@ -80,14 +80,18 @@ int throughput_mt(std::string_view description, int argc, char* argv[]) {
     opts::track_fitting fitting_opts;
     opts::throughput throughput_opts;
     opts::threading threading_opts;
+    opts::logging logging_opts;
     opts::program_options program_opts{
         description,
         {detector_opts, bfield_opts, input_opts, clusterization_opts,
          seeding_opts, finding_opts, propagation_opts, fitting_opts,
-         throughput_opts, threading_opts},
+         throughput_opts, threading_opts, logging_opts},
         argc,
         argv,
-        logger().cloneWithSuffix("Options")};
+        prelogger->cloneWithSuffix("Options")};
+
+    TRACCC_LOCAL_LOGGER(
+        prelogger->clone(std::nullopt, traccc::Logging::Level(logging_opts)));
 
     // Set up the timing info holder.
     performance::timing_info times;

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -18,6 +18,7 @@
 #include "traccc/options/clusterization.hpp"
 #include "traccc/options/detector.hpp"
 #include "traccc/options/input_data.hpp"
+#include "traccc/options/logging.hpp"
 #include "traccc/options/magnetic_field.hpp"
 #include "traccc/options/program_options.hpp"
 #include "traccc/options/throughput.hpp"
@@ -55,7 +56,7 @@ namespace traccc {
 template <typename FULL_CHAIN_ALG>
 int throughput_st(std::string_view description, int argc, char* argv[]) {
 
-    std::unique_ptr<const traccc::Logger> logger = traccc::getDefaultLogger(
+    std::unique_ptr<const traccc::Logger> prelogger = traccc::getDefaultLogger(
         "ThroughputExample", traccc::Logging::Level::INFO);
 
     // Program options.
@@ -68,14 +69,18 @@ int throughput_st(std::string_view description, int argc, char* argv[]) {
     opts::track_propagation propagation_opts;
     opts::track_fitting fitting_opts;
     opts::throughput throughput_opts;
+    opts::logging logging_opts;
     opts::program_options program_opts{
         description,
         {detector_opts, bfield_opts, input_opts, clusterization_opts,
          seeding_opts, finding_opts, propagation_opts, fitting_opts,
-         throughput_opts},
+         throughput_opts, logging_opts},
         argc,
         argv,
-        logger->cloneWithSuffix("Options")};
+        prelogger->cloneWithSuffix("Options")};
+
+    TRACCC_LOCAL_LOGGER(
+        prelogger->clone(std::nullopt, traccc::Logging::Level(logging_opts)));
 
     // Set up the timing info holder.
     performance::timing_info times;
@@ -109,7 +114,7 @@ int throughput_st(std::string_view description, int argc, char* argv[]) {
             input.emplace_back(host_mr);
             static constexpr bool DEDUPLICATE = true;
             io::read_cells(input.back(), i, input_opts.directory,
-                           logger->clone(), &det_descr, input_opts.format,
+                           logger().clone(), &det_descr, input_opts.format,
                            DEDUPLICATE, input_opts.use_acts_geom_source);
         }
     }
@@ -136,7 +141,7 @@ int throughput_st(std::string_view description, int argc, char* argv[]) {
     std::unique_ptr<FULL_CHAIN_ALG> alg = std::make_unique<FULL_CHAIN_ALG>(
         host_mr, clustering_cfg, seedfinder_config, spacepoint_grid_config,
         seedfilter_config, finding_cfg, fitting_cfg, det_descr, field,
-        &detector, logger->clone("FullChainAlg"));
+        &detector, logger().clone("FullChainAlg"));
 
     // Seed the random number generator.
     if (throughput_opts.random_seed == 0) {


### PR DESCRIPTION
This commit adds the `-v` and `-q` flag that control verbosity, respectively making the code more verbose or more quiet. Also adds these options to the throughput examples.