### PR TITLE
Logging Tweaks, main branch (2025.02.27.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2024 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -44,6 +44,8 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/utils/memory_resource.hpp"
   "include/traccc/utils/seed_generator.hpp"
   "include/traccc/utils/subspace.hpp"
+  "include/traccc/utils/logging.hpp"
+  "src/utils/logging.cpp"
   # Clusterization algorithmic code.
   "include/traccc/clusterization/details/sparse_ccl.hpp"
   "include/traccc/clusterization/impl/sparse_ccl.ipp"

--- a/core/include/traccc/utils/logging.hpp
+++ b/core/include/traccc/utils/logging.hpp
@@ -1,28 +1,41 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
+// Acts include(s).
 #include <Acts/Utilities/Logger.hpp>
 
 namespace traccc {
+
+/// Use the @c Acts::Logging namespace.
 namespace Logging = ::Acts::Logging;
 
+/// Use the @c Acts::Logger type.
 using Logger = ::Acts::Logger;
 
-inline std::unique_ptr<const Logger> getDefaultLogger(
-    const std::string& name, const Logging::Level& lvl,
-    std::ostream* log_stream = &std::cout) {
-    return ::Acts::getDefaultLogger(name, lvl, log_stream);
-}
+/// Construct a logger with default settings for this project
+///
+/// @param name the name of the log writer
+/// @param lvl the log level
+/// @param log_stream the stream to write the log to
+///
+/// @return a unique pointer to the logger
+///
+std::unique_ptr<const Logger> getDefaultLogger(
+    const std::string& name, const Logging::Level& lvl = Logging::INFO,
+    std::ostream* log_stream = &std::cout);
 
-inline const Logger& getDummyLogger() {
-    return ::Acts::getDummyLogger();
-}
+/// Construct a dummy logger that does nothing
+///
+/// @return a reference to the dummy logger
+///
+const Logger& getDummyLogger();
+
 }  // namespace traccc
 
 #define TRACCC_LOCAL_LOGGER(x) ACTS_LOCAL_LOGGER(x)

--- a/core/src/utils/logging.cpp
+++ b/core/src/utils/logging.cpp
@@ -1,0 +1,66 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "traccc/utils/logging.hpp"
+
+// System include(s).
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+namespace {
+
+/// Decorator to split the output into separate lines
+class split_output_decorator final : public traccc::Logging::OutputDecorator {
+
+    public:
+    explicit split_output_decorator(
+        std::unique_ptr<traccc::Logging::OutputPrintPolicy> print_policy)
+        : traccc::Logging::OutputDecorator(std::move(print_policy)) {}
+
+    void flush(const traccc::Logging::Level& lvl,
+               const std::string& input) override {
+
+        // Split the message into separate lines.
+        std::istringstream iss(input);
+        for (std::string line; std::getline(iss, line);) {
+            m_wrappee->flush(lvl, line);
+        }
+    }
+
+    std::unique_ptr<OutputPrintPolicy> clone(
+        const std::string& name) const override {
+        return std::make_unique<split_output_decorator>(m_wrappee->clone(name));
+    }
+};
+
+}  // namespace
+
+namespace traccc {
+
+std::unique_ptr<const Logger> getDefaultLogger(const std::string& name,
+                                               const Logging::Level& lvl,
+                                               std::ostream* log_stream) {
+
+    return std::make_unique<const Logger>(
+        std::make_unique<::split_output_decorator>(
+            std::make_unique<Logging::LevelOutputDecorator>(
+                std::make_unique<Logging::NamedOutputDecorator>(
+                    std::make_unique<Logging::TimedOutputDecorator>(
+                        std::make_unique<Logging::DefaultPrintPolicy>(
+                            log_stream)),
+                    name, 30))),
+        std::make_unique<Logging::DefaultFilterPolicy>(lvl));
+}
+
+const Logger& getDummyLogger() {
+    return ::Acts::getDummyLogger();
+}
+
+}  // namespace traccc

--- a/examples/options/src/program_options.cpp
+++ b/examples/options/src/program_options.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -57,7 +57,7 @@ program_options::program_options(
     }
 
     // Tell the user what's happening.
-    TRACCC_INFO("Running " << description);
+    TRACCC_INFO("\nRunning " << description);
 
     configuration_list cl;
 
@@ -65,9 +65,7 @@ program_options::program_options(
         cl.add_child(opt.get().as_printable());
     }
 
-    cl.print();
-
-    std::cout << std::endl;
+    TRACCC_INFO("\n" << cl.print() << "\n");
 }
 
 }  // namespace traccc::opts

--- a/examples/utils/include/traccc/examples/utils/printable.hpp
+++ b/examples/utils/include/traccc/examples/utils/printable.hpp
@@ -1,25 +1,28 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-#include <iostream>
+// System include(s).
+#include <iosfwd>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace traccc {
 class configuration_printable {
     public:
-    virtual void print() const;
+    virtual std::string print() const;
 
-    virtual void print_impl(std::string self_prefix, std::string child_prefix,
-                            std::size_t prefix_len,
-                            std::size_t max_key_width) const = 0;
+    virtual void print_impl(const std::string& self_prefix,
+                            const std::string& child_prefix,
+                            std::size_t prefix_len, std::size_t max_key_width,
+                            std::ostream& out) const = 0;
 
     virtual std::size_t get_max_key_width_impl() const = 0;
 
@@ -28,17 +31,18 @@ class configuration_printable {
 
 class configuration_category final : public configuration_printable {
     public:
-    explicit configuration_category(std::string n);
+    explicit configuration_category(std::string_view n);
 
-    void add_child(std::unique_ptr<configuration_printable>&& elem);
+    void add_child(std::unique_ptr<configuration_printable> elem);
 
-    void print_impl(std::string self_prefix, std::string child_prefix,
-                    std::size_t prefix_len,
-                    std::size_t max_key_width) const final;
+    void print_impl(const std::string& self_prefix,
+                    const std::string& child_prefix, std::size_t prefix_len,
+                    std::size_t max_key_width,
+                    std::ostream& out) const override;
 
-    std::size_t get_max_key_width_impl() const final;
+    std::size_t get_max_key_width_impl() const override;
 
-    ~configuration_category() final;
+    ~configuration_category() override;
 
     private:
     std::string name;
@@ -49,15 +53,16 @@ class configuration_list final : public configuration_printable {
     public:
     configuration_list();
 
-    void add_child(std::unique_ptr<configuration_printable>&& elem);
+    void add_child(std::unique_ptr<configuration_printable> elem);
 
-    void print_impl(std::string self_prefix, std::string child_prefix,
-                    std::size_t prefix_len,
-                    std::size_t max_key_width) const final;
+    void print_impl(const std::string& self_prefix,
+                    const std::string& child_prefix, std::size_t prefix_len,
+                    std::size_t max_key_width,
+                    std::ostream& out) const override;
 
-    std::size_t get_max_key_width_impl() const final;
+    std::size_t get_max_key_width_impl() const override;
 
-    ~configuration_list() final;
+    ~configuration_list() override;
 
     private:
     std::vector<std::unique_ptr<configuration_printable>> elements;
@@ -65,15 +70,15 @@ class configuration_list final : public configuration_printable {
 
 class configuration_kv_pair final : public configuration_printable {
     public:
-    configuration_kv_pair(std::string k, std::string v);
+    configuration_kv_pair(std::string_view k, std::string_view v);
 
-    void print_impl(std::string self_prefix, std::string,
-                    std::size_t prefix_len,
-                    std::size_t max_key_width) const final;
+    void print_impl(const std::string& self_prefix, const std::string&,
+                    std::size_t prefix_len, std::size_t max_key_width,
+                    std::ostream& out) const override;
 
-    std::size_t get_max_key_width_impl() const final;
+    std::size_t get_max_key_width_impl() const override;
 
-    ~configuration_kv_pair() final;
+    ~configuration_kv_pair() override;
 
     private:
     std::string key;


### PR DESCRIPTION
Since we're anyway having a heated debate about logging in #897 already, let me throw some oil on that fire with this PR.

I'm basically reviving some ideas from #837 in this one. So that the configuration of the applications would get printed in a (to me...) nice way, using the logging infrastructure. Going from the current:

```
[bash][Legolas]:traccc > ./out/build/cuda-native-fp32/bin/traccc_seq_example
15:00:28    TracccExampl   INFO      Running Full Tracking Chain on the Host
Detector Options:
├ Detector file:                   geometries/odd/odd-detray_geometry_detray.json
├ Material file:                   geometries/odd/odd-detray_material_detray.json
├ Surface grid file:               geometries/odd/odd-detray_surface_grids_detray.json
├ Use detray detector:             true
└ Digitization file:               geometries/odd/odd-digi-geometric-config.json
Input Data Options:
├ Use ACTS geometry source:        true
...
```

To:

```
[bash][Legolas]:traccc > ./out/build/cuda-native-fp32/bin/traccc_seq_example
14:56:50    TracccExampleSeqCpuOptions    INFO      Running Full Tracking Chain on the Host
14:56:50    TracccExampleSeqCpuOptions    INFO      
14:56:50    TracccExampleSeqCpuOptions    INFO      Detector Options:
14:56:50    TracccExampleSeqCpuOptions    INFO      ├ Detector file:                   geometries/odd/odd-detray_geometry_detray.json
14:56:50    TracccExampleSeqCpuOptions    INFO      ├ Material file:                   geometries/odd/odd-detray_material_detray.json
14:56:50    TracccExampleSeqCpuOptions    INFO      ├ Surface grid file:               geometries/odd/odd-detray_surface_grids_detray.json
14:56:50    TracccExampleSeqCpuOptions    INFO      ├ Use detray detector:             true
14:56:50    TracccExampleSeqCpuOptions    INFO      └ Digitization file:               geometries/odd/odd-digi-geometric-config.json
14:56:50    TracccExampleSeqCpuOptions    INFO      Input Data Options:
14:56:50    TracccExampleSeqCpuOptions    INFO      ├ Use ACTS geometry source:        true
...
```

The one new trick I have in this PR compared to #837 is the `split_output_decorator` class. That would allow us to pass multi-line strings to the logger, and have them appear in a (to me) pleasing fashion.

We will still need to update a number of places in the code to make everything end up in the loggers, but I think `split_output_decorator` will help us with a number of other places as well. (For instance with how Detray prints messages of its own.)