### PR TITLE
Improve assertions in Kálmán filter and fitter

### DIFF
--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -57,8 +57,9 @@ TRACCC_HOST_DEVICE inline void fit(
     // Run fitting
     kalman_fitter_status fit_status = fitter.fit(seed_param, fitter_state);
 
-    // TODO: Process fit failures more elegantly
-    assert(fit_status == kalman_fitter_status::SUCCESS);
+    if (fitter_state.m_fit_res.fit_outcome == fitter_outcome::SUCCESS) {
+        assert(fit_status == kalman_fitter_status::SUCCESS);
+    }
 
     // Get the final fitting information
     track_states.at(param_id).header = fitter_state.m_fit_res;


### PR DESCRIPTION
This commit makes some improvements to the assertions in the Kálmán filter and fitter. Namely, it asserts that the number of measurements added in the track building kernel is the correct number, and it asserts that none of the measurements are duplicated. In the fitting kernel, the assertion on the fitting status is loosened.