### PR TITLE
Alpaka: Add Fitting + Finding Code

### DIFF
--- a/device/alpaka/CMakeLists.txt
+++ b/device/alpaka/CMakeLists.txt
@@ -25,6 +25,8 @@ endif()
 
 traccc_add_alpaka_library( traccc_alpaka alpaka TYPE SHARED
   # Utility definitions.
+  "include/traccc/alpaka/utils/get_device_info.hpp"
+  "include/traccc/alpaka/utils/get_vecmem_resource.hpp"
   "include/traccc/alpaka/utils/make_prefix_sum_buff.hpp"
   "src/utils/make_prefix_sum_buff.cpp"
   "src/utils/get_device_info.cpp"

--- a/device/alpaka/CMakeLists.txt
+++ b/device/alpaka/CMakeLists.txt
@@ -44,6 +44,16 @@ traccc_add_alpaka_library( traccc_alpaka alpaka TYPE SHARED
   "src/seeding/seeding_algorithm.cpp"
   "include/traccc/alpaka/seeding/track_params_estimation.hpp"
   "src/seeding/track_params_estimation.cpp"
+  # Finding
+  "include/traccc/alpaka/finding/finding_algorithm.hpp"
+  "src/finding/finding_algorithm.cpp"
+  "src/finding/kernels/make_barcode_sequence.hpp"
+  "src/finding/kernels/apply_interaction.hpp"
+  "src/finding/kernels/fill_sort_keys.hpp"
+  "src/finding/kernels/prune_tracks.hpp"
+  "src/finding/kernels/build_tracks.hpp"
+  "src/finding/kernels/find_tracks.hpp"
+  "src/finding/kernels/propagate_to_next_surface.hpp"
 )
 # Set up Thrust specifically for the traccc::alpaka library.
 if(alpaka_ACC_GPU_CUDA_ENABLE)

--- a/device/alpaka/CMakeLists.txt
+++ b/device/alpaka/CMakeLists.txt
@@ -54,7 +54,11 @@ traccc_add_alpaka_library( traccc_alpaka alpaka TYPE SHARED
   "src/finding/kernels/build_tracks.hpp"
   "src/finding/kernels/find_tracks.hpp"
   "src/finding/kernels/propagate_to_next_surface.hpp"
+  # Fitting
+  "include/traccc/alpaka/fitting/fitting_algorithm.hpp"
+  "src/fitting/fitting_algorithm.cpp"
 )
+
 # Set up Thrust specifically for the traccc::alpaka library.
 if(alpaka_ACC_GPU_CUDA_ENABLE)
 thrust_create_target( traccc::cuda_thrust

--- a/device/alpaka/include/traccc/alpaka/finding/finding_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/finding/finding_algorithm.hpp
@@ -1,0 +1,103 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/track_candidate.hpp"
+#include "traccc/finding/actors/ckf_aborter.hpp"
+#include "traccc/finding/actors/interaction_register.hpp"
+#include "traccc/finding/finding_config.hpp"
+#include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/memory_resource.hpp"
+#include "traccc/utils/messaging.hpp"
+
+// detray include(s).
+#include <detray/propagator/actors.hpp>
+#include <detray/propagator/propagator.hpp>
+
+// VecMem include(s).
+#include <vecmem/utils/copy.hpp>
+
+namespace traccc::alpaka {
+
+/// Track Finding algorithm for a set of tracks
+template <typename stepper_t, typename navigator_t>
+class finding_algorithm
+    : public algorithm<track_candidate_container_types::buffer(
+          const typename navigator_t::detector_type::view_type&,
+          const typename stepper_t::magnetic_field_type&,
+          const typename measurement_collection_types::view&,
+          const bound_track_parameters_collection_types::buffer&)>,
+      public messaging {
+
+    /// Detector type
+    using detector_type = typename navigator_t::detector_type;
+
+    /// algebra type
+    using algebra_type = typename detector_type::algebra_type;
+
+    /// scalar type
+    using scalar_type = detray::dscalar<algebra_type>;
+
+    /// Field type
+    using bfield_type = typename stepper_t::magnetic_field_type;
+
+    /// Actor types
+    using interactor = detray::pointwise_material_interactor<algebra_type>;
+
+    /// Actor chain for propagate to the next surface and its propagator type
+    using actor_type =
+        detray::actor_chain<detray::pathlimit_aborter<scalar_type>,
+                            detray::parameter_transporter<algebra_type>,
+                            interaction_register<interactor>, interactor,
+                            ckf_aborter>;
+
+    using propagator_type =
+        detray::propagator<stepper_t, navigator_t, actor_type>;
+
+    public:
+    /// Configuration type
+    using config_type = finding_config;
+
+    /// Constructor for the finding algorithm
+    ///
+    /// @param cfg  Configuration object
+    /// @param mr   The memory resource to use
+    /// @param copy Copy object
+    /// @param str  Cuda stream object
+    finding_algorithm(
+        const config_type& cfg, const traccc::memory_resource& mr,
+        vecmem::copy& copy,
+        std::unique_ptr<const Logger> logger = getDummyLogger().clone());
+
+    /// Get config object (const access)
+    const finding_config& get_config() const { return m_cfg; }
+
+    /// Run the algorithm
+    ///
+    /// @param det_view  Detector view object
+    /// @param seeds     Input seeds
+    track_candidate_container_types::buffer operator()(
+        const typename detector_type::view_type& det_view,
+        const bfield_type& field_view,
+        const typename measurement_collection_types::view& measurements,
+        const bound_track_parameters_collection_types::buffer& seeds)
+        const override;
+
+    private:
+    /// Config object
+    config_type m_cfg;
+    /// Memory resource used by the algorithm
+    traccc::memory_resource m_mr;
+    /// The copy object to use
+    vecmem::copy& m_copy;
+};
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/include/traccc/alpaka/fitting/fitting_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/fitting/fitting_algorithm.hpp
@@ -1,0 +1,66 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/edm/track_candidate.hpp"
+#include "traccc/edm/track_state.hpp"
+#include "traccc/fitting/fitting_config.hpp"
+#include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/memory_resource.hpp"
+#include "traccc/utils/messaging.hpp"
+
+// VecMem include(s).
+#include <vecmem/utils/copy.hpp>
+
+// traccc library include(s).
+#include "traccc/utils/memory_resource.hpp"
+
+namespace traccc::alpaka {
+
+/// Fitting algorithm for a set of tracks
+template <typename fitter_t>
+class fitting_algorithm
+    : public algorithm<track_state_container_types::buffer(
+          const typename fitter_t::detector_type::view_type&,
+          const typename fitter_t::bfield_type&,
+          const typename track_candidate_container_types::const_view&)>,
+      public messaging {
+
+    public:
+    using algebra_type = typename fitter_t::algebra_type;
+    /// Configuration type
+    using config_type = typename fitter_t::config_type;
+
+    /// Constructor for the fitting algorithm
+    ///
+    /// @param cfg  Configuration object
+    /// @param mr   The memory resource to use
+    /// @param copy Copy object
+    fitting_algorithm(
+        const config_type& cfg, const traccc::memory_resource& mr,
+        vecmem::copy& copy,
+        std::unique_ptr<const Logger> logger = getDummyLogger().clone());
+
+    /// Run the algorithm
+    track_state_container_types::buffer operator()(
+        const typename fitter_t::detector_type::view_type& det_view,
+        const typename fitter_t::bfield_type& field_view,
+        const typename track_candidate_container_types::const_view&
+            track_candidates_view) const override;
+
+    private:
+    /// Config object
+    config_type m_cfg;
+    /// Memory resource used by the algorithm
+    traccc::memory_resource m_mr;
+    /// The copy object to use
+    vecmem::copy& m_copy;
+};
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/include/traccc/alpaka/seeding/track_params_estimation.hpp
+++ b/device/alpaka/include/traccc/alpaka/seeding/track_params_estimation.hpp
@@ -66,7 +66,7 @@ struct track_params_estimation
     /// Memory resource used by the algorithm
     traccc::memory_resource m_mr;
     /// Copy object used by the algorithm
-    ::vecmem::copy& m_copy;
+    vecmem::copy& m_copy;
 };
 
 }  // namespace traccc::alpaka

--- a/device/alpaka/include/traccc/alpaka/utils/get_vecmem_resource.hpp
+++ b/device/alpaka/include/traccc/alpaka/utils/get_vecmem_resource.hpp
@@ -1,7 +1,7 @@
 /**
  * traccc library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -58,49 +58,49 @@ class copy;
 }  // namespace sycl
 }  // namespace vecmem
 
-namespace traccc::alpaka::vecmem {
+namespace traccc::alpaka::vecmem_resources {
 // For all CPU accelerators (except SYCL), just use host
 template <typename T>
 struct host_device_types {
-    using device_memory_resource = ::vecmem::host_memory_resource;
-    using host_memory_resource = ::vecmem::host_memory_resource;
-    using managed_memory_resource = ::vecmem::host_memory_resource;
-    using device_copy = ::vecmem::copy;
+    using device_memory_resource = vecmem::host_memory_resource;
+    using host_memory_resource = vecmem::host_memory_resource;
+    using managed_memory_resource = vecmem::host_memory_resource;
+    using device_copy = vecmem::copy;
 };
 template <>
 struct host_device_types<::alpaka::TagGpuCudaRt> {
-    using device_memory_resource = ::vecmem::cuda::device_memory_resource;
-    using host_memory_resource = ::vecmem::cuda::host_memory_resource;
-    using managed_memory_resource = ::vecmem::cuda::managed_memory_resource;
-    using device_copy = ::vecmem::cuda::copy;
+    using device_memory_resource = vecmem::cuda::device_memory_resource;
+    using host_memory_resource = vecmem::cuda::host_memory_resource;
+    using managed_memory_resource = vecmem::cuda::managed_memory_resource;
+    using device_copy = vecmem::cuda::copy;
 };
 template <>
 struct host_device_types<::alpaka::TagGpuHipRt> {
-    using device_memory_resource = ::vecmem::hip::device_memory_resource;
-    using host_memory_resource = ::vecmem::hip::host_memory_resource;
-    using managed_memory_resource = ::vecmem::hip::managed_memory_resource;
-    using device_copy = ::vecmem::hip::copy;
+    using device_memory_resource = vecmem::hip::device_memory_resource;
+    using host_memory_resource = vecmem::hip::host_memory_resource;
+    using managed_memory_resource = vecmem::hip::managed_memory_resource;
+    using device_copy = vecmem::hip::copy;
 };
 template <>
 struct host_device_types<::alpaka::TagCpuSycl> {
-    using device_memory_resource = ::vecmem::sycl::device_memory_resource;
-    using host_memory_resource = ::vecmem::sycl::host_memory_resource;
-    using managed_memory_resource = ::vecmem::sycl::shared_memory_resource;
-    using device_copy = ::vecmem::sycl::copy;
+    using device_memory_resource = vecmem::sycl::device_memory_resource;
+    using host_memory_resource = vecmem::sycl::host_memory_resource;
+    using managed_memory_resource = vecmem::sycl::shared_memory_resource;
+    using device_copy = vecmem::sycl::copy;
 };
 template <>
 struct host_device_types<::alpaka::TagFpgaSyclIntel> {
-    using device_memory_resource = ::vecmem::sycl::device_memory_resource;
-    using host_memory_resource = ::vecmem::sycl::host_memory_resource;
-    using managed_memory_resource = ::vecmem::sycl::shared_memory_resource;
-    using device_copy = ::vecmem::sycl::copy;
+    using device_memory_resource = vecmem::sycl::device_memory_resource;
+    using host_memory_resource = vecmem::sycl::host_memory_resource;
+    using managed_memory_resource = vecmem::sycl::shared_memory_resource;
+    using device_copy = vecmem::sycl::copy;
 };
 template <>
 struct host_device_types<::alpaka::TagGpuSyclIntel> {
-    using device_memory_resource = ::vecmem::sycl::device_memory_resource;
-    using host_memory_resource = ::vecmem::sycl::host_memory_resource;
-    using managed_memory_resource = ::vecmem::sycl::shared_memory_resource;
-    using device_copy = ::vecmem::sycl::copy;
+    using device_memory_resource = vecmem::sycl::device_memory_resource;
+    using host_memory_resource = vecmem::sycl::host_memory_resource;
+    using managed_memory_resource = vecmem::sycl::shared_memory_resource;
+    using device_copy = vecmem::sycl::copy;
 };
 
 using device_memory_resource =
@@ -111,4 +111,4 @@ using managed_memory_resource =
     typename host_device_types<AccTag>::managed_memory_resource;
 using device_copy = typename host_device_types<AccTag>::device_copy;
 
-}  // namespace traccc::alpaka::vecmem
+}  // namespace traccc::alpaka::vecmem_resources

--- a/device/alpaka/src/clusterization/clusterization_algorithm.cpp
+++ b/device/alpaka/src/clusterization/clusterization_algorithm.cpp
@@ -15,6 +15,8 @@
 // Project include(s)
 #include "traccc/clusterization/clustering_config.hpp"
 #include "traccc/clusterization/device/ccl_kernel.hpp"
+#include "traccc/utils/projections.hpp"
+#include "traccc/utils/relations.hpp"
 
 // System include(s).
 #include <algorithm>
@@ -36,7 +38,7 @@ struct CCLKernel {
         measurement_collection_types::view measurements_view,
         vecmem::data::vector_view<unsigned int> cell_links) const {
 
-        details::thread_id1 thread_id(acc);
+        details::thread_id1 thread_id(&acc);
 
         auto& partition_start =
             ::alpaka::declareSharedVar<std::size_t, __COUNTER__>(acc);
@@ -81,7 +83,13 @@ clusterization_algorithm::clusterization_algorithm(
       m_gf_backup(m_config.backup_size(), m_mr.main),
       m_adjc_backup(m_config.backup_size(), m_mr.main),
       m_adjv_backup(m_config.backup_size() * 8, m_mr.main),
-      m_backup_mutex(vecmem::make_unique_alloc<unsigned int>(m_mr.main)) {}
+      m_backup_mutex(vecmem::make_unique_alloc<unsigned int>(m_mr.main)) {
+
+    m_copy.get().setup(m_f_backup)->wait();
+    m_copy.get().setup(m_gf_backup)->wait();
+    m_copy.get().setup(m_adjc_backup)->wait();
+    m_copy.get().setup(m_adjv_backup)->wait();
+}
 
 clusterization_algorithm::output_type clusterization_algorithm::operator()(
     const edm::silicon_cell_collection::const_view& cells,

--- a/device/alpaka/src/finding/finding_algorithm.cpp
+++ b/device/alpaka/src/finding/finding_algorithm.cpp
@@ -1,0 +1,483 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/alpaka/finding/finding_algorithm.hpp"
+
+#include "../utils/barrier.hpp"
+#include "../utils/thread_id.hpp"
+#include "../utils/utils.hpp"
+#include "./kernels/apply_interaction.hpp"
+#include "./kernels/build_tracks.hpp"
+#include "./kernels/fill_sort_keys.hpp"
+#include "./kernels/find_tracks.hpp"
+#include "./kernels/make_barcode_sequence.hpp"
+#include "./kernels/propagate_to_next_surface.hpp"
+#include "./kernels/prune_tracks.hpp"
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/device/sort_key.hpp"
+#include "traccc/finding/candidate_link.hpp"
+#include "traccc/geometry/detector.hpp"
+#include "traccc/utils/projections.hpp"
+
+// detray include(s).
+#include <detray/detectors/bfield.hpp>
+#include <detray/navigation/navigator.hpp>
+#include <detray/propagator/rk_stepper.hpp>
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_buffer.hpp>
+#include <vecmem/containers/data/vector_view.hpp>
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/containers/jagged_device_vector.hpp>
+#include <vecmem/containers/vector.hpp>
+#include <vecmem/memory/unique_ptr.hpp>
+
+// Thrust include(s).
+#include <thrust/copy.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/scan.h>
+#include <thrust/sort.h>
+#include <thrust/unique.h>
+
+// System include(s).
+#include <cassert>
+#include <vector>
+
+namespace traccc::alpaka {
+
+template <typename stepper_t, typename navigator_t>
+finding_algorithm<stepper_t, navigator_t>::finding_algorithm(
+    const config_type& cfg, const traccc::memory_resource& mr,
+    vecmem::copy& copy, std::unique_ptr<const Logger> logger)
+    : messaging(std::move(logger)), m_cfg(cfg), m_mr(mr), m_copy(copy) {}
+
+template <typename stepper_t, typename navigator_t>
+track_candidate_container_types::buffer
+finding_algorithm<stepper_t, navigator_t>::operator()(
+    const typename detector_type::view_type& det_view,
+    const bfield_type& field_view,
+    const typename measurement_collection_types::view& measurements,
+    const bound_track_parameters_collection_types::buffer& seeds_buffer) const {
+
+    // Setup alpaka
+    auto devHost = ::alpaka::getDevByIdx(::alpaka::Platform<Host>{}, 0u);
+    auto devAcc = ::alpaka::getDevByIdx(::alpaka::Platform<Acc>{}, 0u);
+    auto queue = Queue{devAcc};
+    Idx threadsPerBlock = getWarpSize<Acc>() * 2;
+
+    // Copy setup
+    m_copy.setup(seeds_buffer)->ignore();
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+    auto thrustExecPolicy = thrust::device;
+#else
+    auto thrustExecPolicy = thrust::host;
+#endif
+
+    /*****************************************************************
+     * Measurement Operations
+     *****************************************************************/
+
+    unsigned int n_modules;
+    measurement_collection_types::const_view::size_type n_measurements =
+        m_copy.get_size(measurements);
+
+    // Get copy of barcode uniques
+    measurement_collection_types::buffer uniques_buffer{n_measurements,
+                                                        m_mr.main};
+    m_copy.setup(uniques_buffer)->ignore();
+
+    {
+        measurement_collection_types::device uniques(uniques_buffer);
+
+        measurement* uniques_end =
+            thrust::unique_copy(thrustExecPolicy, measurements.ptr(),
+                                measurements.ptr() + n_measurements,
+                                uniques.begin(), measurement_equal_comp());
+        n_modules = static_cast<unsigned int>(uniques_end - uniques.begin());
+    }
+
+    // Get upper bounds of unique elements
+    vecmem::data::vector_buffer<unsigned int> upper_bounds_buffer{n_modules,
+                                                                  m_mr.main};
+    m_copy.setup(upper_bounds_buffer)->ignore();
+
+    {
+        vecmem::device_vector<unsigned int> upper_bounds(upper_bounds_buffer);
+
+        measurement_collection_types::device uniques(uniques_buffer);
+
+        thrust::upper_bound(thrustExecPolicy, measurements.ptr(),
+                            measurements.ptr() + n_measurements,
+                            uniques.begin(), uniques.begin() + n_modules,
+                            upper_bounds.begin(), measurement_sort_comp());
+    }
+
+    /*****************************************************************
+     * Kernel1: Create barcode sequence
+     *****************************************************************/
+
+    vecmem::data::vector_buffer<detray::geometry::barcode> barcodes_buffer{
+        n_modules, m_mr.main};
+    m_copy.setup(barcodes_buffer)->ignore();
+
+    {
+        Idx blocksPerGrid =
+            (barcodes_buffer.size() + threadsPerBlock - 1) / threadsPerBlock;
+        auto workDiv = makeWorkDiv<Acc>(blocksPerGrid, threadsPerBlock);
+
+        ::alpaka::exec<Acc>(queue, workDiv, MakeBarcodeSequenceKernel{},
+                            device::make_barcode_sequence_payload{
+                                vecmem::get_data(uniques_buffer),
+                                vecmem::get_data(barcodes_buffer)});
+        ::alpaka::wait(queue);
+    }
+
+    const unsigned int n_seeds = m_copy.get_size(seeds_buffer);
+
+    // Prepare input parameters with seeds
+    bound_track_parameters_collection_types::buffer in_params_buffer(n_seeds,
+                                                                     m_mr.main);
+    m_copy.setup(in_params_buffer)->ignore();
+    m_copy(vecmem::get_data(seeds_buffer), vecmem::get_data(in_params_buffer))
+        ->ignore();
+    vecmem::data::vector_buffer<unsigned int> param_liveness_buffer(n_seeds,
+                                                                    m_mr.main);
+    m_copy.setup(param_liveness_buffer)->ignore();
+    m_copy.memset(param_liveness_buffer, 1)->ignore();
+
+    // Number of tracks per seed
+    vecmem::data::vector_buffer<unsigned int> n_tracks_per_seed_buffer(
+        n_seeds, m_mr.main);
+    m_copy.setup(n_tracks_per_seed_buffer)->ignore();
+
+    // Create a map for links
+    std::map<unsigned int, vecmem::data::vector_buffer<candidate_link>>
+        link_map;
+
+    // Create a buffer of tip links
+    vecmem::data::vector_buffer<typename candidate_link::link_index_type>
+        tips_buffer{m_cfg.max_num_branches_per_seed * n_seeds, m_mr.main,
+                    vecmem::data::buffer_type::resizable};
+    m_copy.setup(tips_buffer)->wait();
+
+    // Link size
+    std::vector<std::size_t> n_candidates_per_step;
+    n_candidates_per_step.reserve(m_cfg.max_track_candidates_per_track);
+
+    unsigned int n_in_params = n_seeds;
+
+    for (unsigned int step = 0;
+         step < m_cfg.max_track_candidates_per_track && n_in_params > 0;
+         step++) {
+
+        /*****************************************************************
+         * Kernel2: Apply material interaction
+         ****************************************************************/
+
+        {
+            Idx blocksPerGrid =
+                (n_in_params + threadsPerBlock - 1) / threadsPerBlock;
+            auto workDiv = makeWorkDiv<Acc>(blocksPerGrid, threadsPerBlock);
+
+            ::alpaka::exec<Acc>(
+                queue, workDiv,
+                ApplyInteractionKernel<std::decay_t<detector_type>>{}, m_cfg,
+                device::apply_interaction_payload<std::decay_t<detector_type>>{
+                    det_view, n_in_params, vecmem::get_data(in_params_buffer),
+                    vecmem::get_data(param_liveness_buffer)});
+            ::alpaka::wait(queue);
+        }
+
+        /*****************************************************************
+         * Kernel3: Count the number of measurements per parameter
+         ****************************************************************/
+
+        auto bufHost_n_candidates =
+            ::alpaka::allocBuf<unsigned int, Idx>(devHost, 1u);
+        unsigned int* n_candidates =
+            ::alpaka::getPtrNative(bufHost_n_candidates);
+        ::alpaka::memset(queue, bufHost_n_candidates, 0);
+        ::alpaka::wait(queue);
+
+        {
+            // Previous step
+            const unsigned int prev_step = (step == 0 ? 0 : step - 1);
+
+            // Buffer for kalman-updated parameters spawned by the measurement
+            // candidates
+            const unsigned int n_max_candidates =
+                n_in_params * m_cfg.max_num_branches_per_surface;
+
+            bound_track_parameters_collection_types::buffer
+                updated_params_buffer(
+                    n_in_params * m_cfg.max_num_branches_per_surface,
+                    m_mr.main);
+            m_copy.setup(updated_params_buffer)->ignore();
+
+            vecmem::data::vector_buffer<unsigned int> updated_liveness_buffer(
+                n_in_params * m_cfg.max_num_branches_per_surface, m_mr.main);
+            m_copy.setup(updated_liveness_buffer)->ignore();
+
+            // Create the link map
+            link_map[step] = {n_in_params * m_cfg.max_num_branches_per_surface,
+                              m_mr.main};
+            m_copy.setup(link_map[step])->ignore();
+
+            Idx blocksPerGrid =
+                (n_in_params + threadsPerBlock - 1) / threadsPerBlock;
+            auto workDiv = makeWorkDiv<Acc>(blocksPerGrid, threadsPerBlock);
+
+            auto bufAcc_n_candidates =
+                ::alpaka::allocBuf<unsigned int, Idx>(devAcc, 1u);
+            ::alpaka::memset(queue, bufAcc_n_candidates, 0);
+            ::alpaka::wait(queue);
+
+            ::alpaka::exec<Acc>(
+                queue, workDiv, FindTracksKernel<std::decay_t<detector_type>>{},
+                m_cfg,
+                device::find_tracks_payload<std::decay_t<detector_type>>{
+                    det_view, measurements, vecmem::get_data(in_params_buffer),
+                    vecmem::get_data(param_liveness_buffer), n_in_params,
+                    vecmem::get_data(barcodes_buffer),
+                    vecmem::get_data(upper_bounds_buffer),
+                    vecmem::get_data(link_map[prev_step]), step,
+                    n_max_candidates, vecmem::get_data(updated_params_buffer),
+                    vecmem::get_data(updated_liveness_buffer),
+                    vecmem::get_data(link_map[step]),
+                    ::alpaka::getPtrNative(bufAcc_n_candidates)});
+            ::alpaka::wait(queue);
+
+            std::swap(in_params_buffer, updated_params_buffer);
+            std::swap(param_liveness_buffer, updated_liveness_buffer);
+
+            ::alpaka::memcpy(queue, bufHost_n_candidates, bufAcc_n_candidates);
+            ::alpaka::wait(queue);
+        }
+
+        if (*n_candidates > 0) {
+            /*****************************************************************
+             * Kernel4: Get key and value for parameter sorting
+             *****************************************************************/
+
+            vecmem::data::vector_buffer<unsigned int> param_ids_buffer(
+                *n_candidates, m_mr.main);
+            m_copy.setup(param_ids_buffer)->ignore();
+
+            {
+                vecmem::data::vector_buffer<device::sort_key> keys_buffer(
+                    *n_candidates, m_mr.main);
+                m_copy.setup(keys_buffer)->ignore();
+
+                Idx blocksPerGrid =
+                    (*n_candidates + threadsPerBlock - 1) / threadsPerBlock;
+                auto workDiv = makeWorkDiv<Acc>(blocksPerGrid, threadsPerBlock);
+
+                ::alpaka::exec<Acc>(queue, workDiv, FillSortKeysKernel{},
+                                    device::fill_sort_keys_payload{
+                                        vecmem::get_data(in_params_buffer),
+                                        vecmem::get_data(keys_buffer),
+                                        vecmem::get_data(param_ids_buffer)});
+                ::alpaka::wait(queue);
+
+                // Sort the key and values
+                vecmem::device_vector<device::sort_key> keys_device(
+                    keys_buffer);
+                vecmem::device_vector<unsigned int> param_ids_device(
+                    param_ids_buffer);
+                thrust::sort_by_key(thrustExecPolicy, keys_device.begin(),
+                                    keys_device.end(),
+                                    param_ids_device.begin());
+            }
+
+            /*****************************************************************
+             * Kernel5: Propagate to the next surface
+             *****************************************************************/
+
+            {
+                // Reset the number of tracks per seed
+                m_copy.memset(n_tracks_per_seed_buffer, 0)->ignore();
+
+                Idx blocksPerGrid =
+                    (*n_candidates + threadsPerBlock - 1) / threadsPerBlock;
+                auto workDiv = makeWorkDiv<Acc>(blocksPerGrid, threadsPerBlock);
+
+                ::alpaka::exec<Acc>(
+                    queue, workDiv,
+                    PropagateToNextSurfaceKernel<std::decay_t<propagator_type>,
+                                                 std::decay_t<bfield_type>>{},
+                    m_cfg,
+                    device::propagate_to_next_surface_payload<
+                        std::decay_t<propagator_type>,
+                        std::decay_t<bfield_type>>{
+                        det_view, field_view,
+                        vecmem::get_data(in_params_buffer),
+                        vecmem::get_data(param_liveness_buffer),
+                        vecmem::get_data(param_ids_buffer),
+                        vecmem::get_data(link_map[step]), step, *n_candidates,
+                        vecmem::get_data(tips_buffer),
+                        vecmem::get_data(n_tracks_per_seed_buffer)});
+                ::alpaka::wait(queue);
+            }
+        }
+
+        // Fill the candidate size vector
+        n_candidates_per_step.push_back(*n_candidates);
+
+        n_in_params = *n_candidates;
+    }
+
+    // Create link buffer
+    vecmem::data::jagged_vector_buffer<candidate_link> links_buffer(
+        n_candidates_per_step, m_mr.main, m_mr.host);
+    m_copy.setup(links_buffer)->ignore();
+
+    // Copy link map to link buffer
+    const auto n_steps = n_candidates_per_step.size();
+    for (unsigned int it = 0; it < n_steps; it++) {
+
+        vecmem::device_vector<candidate_link> in(link_map[it]);
+        vecmem::device_vector<candidate_link> out(
+            *(links_buffer.host_ptr() + it));
+
+        thrust::copy(thrustExecPolicy, in.begin(),
+                     in.begin() + n_candidates_per_step[it], out.begin());
+    }
+
+    /*****************************************************************
+     * Kernel6: Build tracks
+     *****************************************************************/
+
+    // Get the number of tips
+    auto n_tips_total = m_copy.get_size(tips_buffer);
+
+    // Create track candidate buffer
+    track_candidate_container_types::buffer track_candidates_buffer{
+        {n_tips_total, m_mr.main},
+        {std::vector<std::size_t>(n_tips_total,
+                                  m_cfg.max_track_candidates_per_track),
+         m_mr.main, m_mr.host, vecmem::data::buffer_type::resizable}};
+
+    m_copy.setup(track_candidates_buffer.headers)->ignore();
+    m_copy.setup(track_candidates_buffer.items)->ignore();
+
+    // Create buffer for valid indices
+    vecmem::data::vector_buffer<unsigned int> valid_indices_buffer(n_tips_total,
+                                                                   m_mr.main);
+
+    // Count the number of valid tracks
+    auto bufHost_n_valid_tracks =
+        ::alpaka::allocBuf<unsigned int, Idx>(devHost, 1u);
+    unsigned int* n_valid_tracks =
+        ::alpaka::getPtrNative(bufHost_n_valid_tracks);
+    ::alpaka::memset(queue, bufHost_n_valid_tracks, 0);
+    ::alpaka::wait(queue);
+
+    // @Note: nBlocks can be zero in case there is no tip. This happens when
+    // chi2_max config is set tightly and no tips are found
+    if (n_tips_total > 0) {
+        auto n_valid_tracks_device =
+            ::alpaka::allocBuf<unsigned int, Idx>(devAcc, 1u);
+        ::alpaka::memset(queue, n_valid_tracks_device, 0);
+
+        Idx blocksPerGrid =
+            (n_tips_total + threadsPerBlock - 1) / threadsPerBlock;
+        auto workDiv = makeWorkDiv<Acc>(blocksPerGrid, threadsPerBlock);
+
+        track_candidate_container_types::view track_candidates_view(
+            track_candidates_buffer);
+
+        ::alpaka::exec<Acc>(
+            queue, workDiv, BuildTracksKernel{}, m_cfg,
+            device::build_tracks_payload{
+                measurements, vecmem::get_data(seeds_buffer),
+                vecmem::get_data(links_buffer), vecmem::get_data(tips_buffer),
+                track_candidates_view, vecmem::get_data(valid_indices_buffer),
+                ::alpaka::getPtrNative(n_valid_tracks_device)});
+        ::alpaka::wait(queue);
+
+        // Global counter object: Device -> Host
+        ::alpaka::memcpy(queue, bufHost_n_valid_tracks, n_valid_tracks_device);
+        ::alpaka::wait(queue);
+    }
+
+    // Create pruned candidate buffer
+    track_candidate_container_types::buffer prune_candidates_buffer{
+        {*n_valid_tracks, m_mr.main},
+        {std::vector<std::size_t>(*n_valid_tracks,
+                                  m_cfg.max_track_candidates_per_track),
+         m_mr.main, m_mr.host, vecmem::data::buffer_type::resizable}};
+
+    m_copy.setup(prune_candidates_buffer.headers)->ignore();
+    m_copy.setup(prune_candidates_buffer.items)->ignore();
+
+    if (*n_valid_tracks > 0) {
+        Idx blocksPerGrid =
+            (*n_valid_tracks + threadsPerBlock - 1) / threadsPerBlock;
+        auto workDiv = makeWorkDiv<Acc>(blocksPerGrid, threadsPerBlock);
+
+        track_candidate_container_types::const_view track_candidates_view(
+            track_candidates_buffer);
+
+        track_candidate_container_types::view prune_candidates_view(
+            prune_candidates_buffer);
+
+        ::alpaka::exec<Acc>(
+            queue, workDiv, PruneTracksKernel{},
+            device::prune_tracks_payload{track_candidates_view,
+                                         vecmem::get_data(valid_indices_buffer),
+                                         prune_candidates_view});
+        ::alpaka::wait(queue);
+    }
+
+    return prune_candidates_buffer;
+}
+
+// Explicit template instantiation
+using default_detector_type = traccc::default_detector::device;
+using default_stepper_type = detray::rk_stepper<
+    covfie::field<detray::bfield::const_bknd_t<
+        default_detector_type::scalar_type>>::view_t,
+    default_detector_type::algebra_type,
+    detray::constrained_step<default_detector_type::scalar_type>>;
+using default_navigator_type = detray::navigator<const default_detector_type>;
+template class finding_algorithm<default_stepper_type, default_navigator_type>;
+
+}  // namespace traccc::alpaka
+
+// Add an Alpaka trait that the measurement_collection_types::const_device type
+// is trivially copyable
+namespace alpaka {
+
+template <>
+struct IsKernelArgumentTriviallyCopyable<
+    traccc::measurement_collection_types::const_device> : std::true_type {};
+
+}  // namespace alpaka
+
+// Also need to add an Alpaka trait for the dynamic shared memory
+namespace alpaka::trait {
+
+template <typename TAcc, typename detector_t>
+struct BlockSharedMemDynSizeBytes<traccc::alpaka::FindTracksKernel<detector_t>,
+                                  TAcc> {
+    template <typename TVec, typename... TArgs>
+    ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
+        traccc::alpaka::FindTracksKernel<detector_t> const& /* kernel */,
+        TVec const& blockThreadExtent, TVec const& /* threadElemExtent */,
+        TArgs const&... /* args */
+        ) -> std::size_t {
+        return static_cast<std::size_t>(blockThreadExtent.prod()) *
+               sizeof(unsigned int) * 2 *
+               sizeof(std::pair<unsigned int, unsigned int>);
+    }
+};
+
+}  // namespace alpaka::trait

--- a/device/alpaka/src/finding/kernels/apply_interaction.hpp
+++ b/device/alpaka/src/finding/kernels/apply_interaction.hpp
@@ -1,0 +1,30 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/edm/track_parameters.hpp"
+#include "traccc/finding/device/apply_interaction.hpp"
+#include "traccc/geometry/detector.hpp"
+
+namespace traccc::alpaka {
+
+template <typename detector_t>
+struct ApplyInteractionKernel {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc, const finding_config& cfg,
+        device::apply_interaction_payload<detector_t> payload) const {
+
+        int globalThreadIdx =
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
+
+        device::apply_interaction<detector_t>(globalThreadIdx, cfg, payload);
+    }
+};
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/src/finding/kernels/build_tracks.hpp
+++ b/device/alpaka/src/finding/kernels/build_tracks.hpp
@@ -1,0 +1,32 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "../../utils/utils.hpp"
+#include "traccc/edm/measurement.hpp"
+#include "traccc/edm/track_candidate.hpp"
+#include "traccc/edm/track_parameters.hpp"
+#include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/device/build_tracks.hpp"
+#include "traccc/finding/finding_config.hpp"
+
+namespace traccc::alpaka {
+
+struct BuildTracksKernel {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, const finding_config cfg,
+                                  device::build_tracks_payload payload) const {
+
+        int globalThreadIdx =
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
+
+        device::build_tracks(globalThreadIdx, cfg, payload);
+    }
+};
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/src/finding/kernels/fill_sort_keys.hpp
+++ b/device/alpaka/src/finding/kernels/fill_sort_keys.hpp
@@ -1,0 +1,28 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "../../utils/utils.hpp"
+#include "traccc/edm/track_parameters.hpp"
+#include "traccc/finding/device/fill_sort_keys.hpp"
+
+namespace traccc::alpaka {
+
+struct FillSortKeysKernel {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc, device::fill_sort_keys_payload payload) const {
+
+        int globalThreadIdx =
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
+
+        device::fill_sort_keys(globalThreadIdx, payload);
+    }
+};
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/src/finding/kernels/find_tracks.hpp
+++ b/device/alpaka/src/finding/kernels/find_tracks.hpp
@@ -1,0 +1,44 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "../../utils/barrier.hpp"
+#include "../../utils/thread_id.hpp"
+#include "traccc/edm/track_parameters.hpp"
+#include "traccc/finding/device/find_tracks.hpp"
+#include "traccc/geometry/detector.hpp"
+
+namespace traccc::alpaka {
+
+template <typename detector_t>
+struct FindTracksKernel {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc, const finding_config& cfg,
+        device::find_tracks_payload<detector_t> payload) const {
+
+        auto& shared_candidates_size =
+            ::alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+        unsigned int* const s = ::alpaka::getDynSharedMem<unsigned int>(acc);
+        unsigned int* shared_num_candidates = s;
+
+        alpaka::barrier<TAcc> barrier(&acc);
+        details::thread_id1 thread_id(&acc);
+
+        int blockDimX = thread_id.getBlockDimX();
+        std::pair<unsigned int, unsigned int>* shared_candidates =
+            reinterpret_cast<std::pair<unsigned int, unsigned int>*>(
+                &shared_num_candidates[blockDimX]);
+
+        device::find_tracks<detector_t>(
+            thread_id, barrier, cfg, payload,
+            {shared_num_candidates, shared_candidates, shared_candidates_size});
+    }
+};
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/src/finding/kernels/make_barcode_sequence.hpp
+++ b/device/alpaka/src/finding/kernels/make_barcode_sequence.hpp
@@ -1,0 +1,27 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "../../utils/utils.hpp"
+#include "traccc/edm/measurement.hpp"
+#include "traccc/finding/device/make_barcode_sequence.hpp"
+
+namespace traccc::alpaka {
+
+struct MakeBarcodeSequenceKernel {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc, device::make_barcode_sequence_payload payload) const {
+
+        int globalThreadIdx =
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
+        device::make_barcode_sequence(globalThreadIdx, payload);
+    }
+};
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/src/finding/kernels/propagate_to_next_surface.hpp
+++ b/device/alpaka/src/finding/kernels/propagate_to_next_surface.hpp
@@ -1,0 +1,32 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/finding/device/propagate_to_next_surface.hpp"
+#include "traccc/finding/finding_config.hpp"
+#include "traccc/geometry/detector.hpp"
+
+namespace traccc::alpaka {
+
+template <typename propagator_t, typename bfield_t>
+struct PropagateToNextSurfaceKernel {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc, const finding_config cfg,
+        device::propagate_to_next_surface_payload<propagator_t, bfield_t>
+            payload) const {
+
+        int globalThreadIdx =
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
+
+        device::propagate_to_next_surface<propagator_t, bfield_t>(
+            globalThreadIdx, cfg, payload);
+    }
+};
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/src/finding/kernels/prune_tracks.hpp
+++ b/device/alpaka/src/finding/kernels/prune_tracks.hpp
@@ -1,0 +1,28 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "../../utils/utils.hpp"
+#include "traccc/edm/track_parameters.hpp"
+#include "traccc/finding/device/prune_tracks.hpp"
+
+namespace traccc::alpaka {
+
+struct PruneTracksKernel {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+                                  device::prune_tracks_payload payload) const {
+
+        int globalThreadIdx =
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
+
+        device::prune_tracks(globalThreadIdx, payload);
+    }
+};
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/src/fitting/fitting_algorithm.cpp
+++ b/device/alpaka/src/fitting/fitting_algorithm.cpp
@@ -1,0 +1,159 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/alpaka/fitting/fitting_algorithm.hpp"
+
+#include "../utils/utils.hpp"
+#include "traccc/fitting/device/fill_sort_keys.hpp"
+#include "traccc/fitting/device/fit.hpp"
+#include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+#include "traccc/geometry/detector.hpp"
+
+// detray include(s).
+#include <detray/detectors/bfield.hpp>
+#include <detray/propagator/rk_stepper.hpp>
+
+// Thrust include(s).
+#include <thrust/sort.h>
+
+// System include(s).
+#include <memory_resource>
+#include <vector>
+
+namespace traccc::alpaka {
+
+struct FillSortKeysKernel {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        track_candidate_container_types::const_view track_candidates_view,
+        vecmem::data::vector_view<device::sort_key> keys_view,
+        vecmem::data::vector_view<unsigned int> ids_view) const {
+
+        int globalThreadIdx =
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
+
+        device::fill_sort_keys(globalThreadIdx, track_candidates_view,
+                               keys_view, ids_view);
+    }
+};
+
+template <typename fitter_t, typename detector_view_t>
+struct FitTrackKernel {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc, detector_view_t det_data,
+        const typename fitter_t::bfield_type field_data,
+        const typename fitter_t::config_type cfg,
+        track_candidate_container_types::const_view track_candidates_view,
+        vecmem::data::vector_view<const unsigned int> param_ids_view,
+        track_state_container_types::view track_states_view) const {
+
+        int globalThreadIdx =
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
+
+        device::fit<fitter_t>(globalThreadIdx, det_data, field_data, cfg,
+                              track_candidates_view, param_ids_view,
+                              track_states_view);
+    }
+};
+
+template <typename fitter_t>
+fitting_algorithm<fitter_t>::fitting_algorithm(
+    const config_type& cfg, const traccc::memory_resource& mr,
+    vecmem::copy& copy, std::unique_ptr<const Logger> logger)
+    : messaging(std::move(logger)), m_cfg(cfg), m_mr(mr), m_copy(copy) {}
+
+template <typename fitter_t>
+track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
+    const typename fitter_t::detector_type::view_type& det_view,
+    const typename fitter_t::bfield_type& field_view,
+    const typename track_candidate_container_types::const_view&
+        track_candidates_view) const {
+
+    // Setup alpaka
+    auto devHost = ::alpaka::getDevByIdx(::alpaka::Platform<Host>{}, 0u);
+    auto devAcc = ::alpaka::getDevByIdx(::alpaka::Platform<Acc>{}, 0u);
+    auto queue = Queue{devAcc};
+    Idx threadsPerBlock = getWarpSize<Acc>() * 2;
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+    auto thrustExecPolicy = thrust::device;
+#else
+    auto thrustExecPolicy = thrust::host;
+#endif
+
+    // Number of tracks
+    const track_candidate_container_types::const_device::header_vector::
+        size_type n_tracks = m_copy.get_size(track_candidates_view.headers);
+
+    // Get the sizes of the track candidates in each track
+    const std::vector<track_candidate_container_types::const_device::
+                          item_vector::value_type::size_type>
+        candidate_sizes = m_copy.get_sizes(track_candidates_view.items);
+
+    track_state_container_types::buffer track_states_buffer{
+        {n_tracks, m_mr.main},
+        {candidate_sizes, m_mr.main, m_mr.host,
+         vecmem::data::buffer_type::resizable}};
+    track_state_container_types::view track_states_view(track_states_buffer);
+
+    m_copy.setup(track_states_buffer.headers)->ignore();
+    m_copy.setup(track_states_buffer.items)->ignore();
+
+    // Calculate the number of threads and thread blocks to run the track
+    // fitting
+    if (n_tracks > 0) {
+        const Idx blocksPerGrid =
+            (n_tracks + threadsPerBlock - 1) / threadsPerBlock;
+        auto workDiv = makeWorkDiv<Acc>(blocksPerGrid, threadsPerBlock);
+
+        vecmem::data::vector_buffer<device::sort_key> keys_buffer(n_tracks,
+                                                                  m_mr.main);
+        vecmem::data::vector_buffer<unsigned int> param_ids_buffer(n_tracks,
+                                                                   m_mr.main);
+
+        // Get key and value for sorting
+        ::alpaka::exec<Acc>(
+            queue, workDiv, FillSortKeysKernel{}, track_candidates_view,
+            vecmem::get_data(keys_buffer), vecmem::get_data(param_ids_buffer));
+        ::alpaka::wait(queue);
+
+        // Sort the key to get the sorted parameter ids
+        vecmem::device_vector<device::sort_key> keys_device(keys_buffer);
+        vecmem::device_vector<unsigned int> param_ids_device(param_ids_buffer);
+
+        thrust::sort_by_key(thrustExecPolicy, keys_device.begin(),
+                            keys_device.end(), param_ids_device.begin());
+
+        // Run the track fitting
+        ::alpaka::exec<Acc>(
+            queue, workDiv,
+            FitTrackKernel<fitter_t,
+                           typename fitter_t::detector_type::view_type>{},
+            det_view, field_view, m_cfg, track_candidates_view,
+            vecmem::get_data(param_ids_buffer), track_states_view);
+        ::alpaka::wait(queue);
+    }
+
+    return track_states_buffer;
+}
+
+// Explicit template instantiation
+using default_detector_type = traccc::default_detector::device;
+using default_stepper_type = detray::rk_stepper<
+    covfie::field<detray::bfield::const_bknd_t<
+        default_detector_type::scalar_type>>::view_t,
+    default_detector_type::algebra_type,
+    detray::constrained_step<default_detector_type::scalar_type>>;
+using default_navigator_type = detray::navigator<const default_detector_type>;
+using default_fitter_type =
+    kalman_fitter<default_stepper_type, default_navigator_type>;
+template class fitting_algorithm<default_fitter_type>;
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/src/seeding/seed_finding.cpp
+++ b/device/alpaka/src/seeding/seed_finding.cpp
@@ -210,7 +210,9 @@ edm::seed_collection::buffer seed_finding::operator()(
     auto queue = Queue{devAcc};
     auto const deviceProperties = ::alpaka::getAccDevProps<Acc>(devAcc);
     auto maxThreads = deviceProperties.m_blockThreadExtentMax[0];
-    auto threadsPerBlock = maxThreads;
+    Idx threadsPerBlock = getWarpSize<Acc>() * 2 < maxThreads
+                              ? getWarpSize<Acc>() * 2
+                              : maxThreads;
 
     // Get the sizes from the grid view
     auto grid_sizes = m_copy.get_sizes(g2_view._data_view);
@@ -226,15 +228,13 @@ edm::seed_collection::buffer seed_finding::operator()(
 
     // Set up the doublet counter buffer.
     device::doublet_counter_collection_types::buffer doublet_counter_buffer = {
-        m_copy.get_size(sp_grid_prefix_sum_buff), m_mr.main,
-        vecmem::data::buffer_type::resizable};
+        num_spacepoints, m_mr.main, vecmem::data::buffer_type::resizable};
     m_copy.setup(doublet_counter_buffer)->ignore();
 
     // Calculate the number of threads and thread blocks to run the doublet
     // counting kernel for.
-    auto blocksPerGrid =
-        (sp_grid_prefix_sum_buff.size() + threadsPerBlock - 1) /
-        threadsPerBlock;
+    Idx blocksPerGrid =
+        (num_spacepoints + threadsPerBlock - 1) / threadsPerBlock;
     auto workDiv = makeWorkDiv<Acc>(blocksPerGrid, threadsPerBlock);
 
     // Counter for the total number of doublets and triplets
@@ -248,6 +248,7 @@ edm::seed_collection::buffer seed_finding::operator()(
     auto bufAcc_counter =
         ::alpaka::allocBuf<device::seeding_global_counter, Idx>(devAcc, 1u);
     ::alpaka::memcpy(queue, bufAcc_counter, bufHost_counter);
+    ::alpaka::wait(queue);
 
     // Count the number of doublets that we need to produce.
     ::alpaka::exec<Acc>(queue, workDiv, kernels::CountDoublets{},
@@ -259,6 +260,7 @@ edm::seed_collection::buffer seed_finding::operator()(
 
     // Get the summary values per bin.
     ::alpaka::memcpy(queue, bufHost_counter, bufAcc_counter);
+    ::alpaka::wait(queue);
 
     if (pBufHost_counter->m_nMidBot == 0 || pBufHost_counter->m_nMidTop == 0) {
         return {0, m_mr.main};
@@ -328,6 +330,7 @@ edm::seed_collection::buffer seed_finding::operator()(
     ::alpaka::wait(queue);
 
     ::alpaka::memcpy(queue, bufHost_counter, bufAcc_counter);
+    ::alpaka::wait(queue);
 
     if (pBufHost_counter->m_nTriplets == 0) {
         return {0, m_mr.main};

--- a/device/alpaka/src/seeding/spacepoint_binning.cpp
+++ b/device/alpaka/src/seeding/spacepoint_binning.cpp
@@ -90,11 +90,8 @@ traccc::details::spacepoint_grid_types::buffer spacepoint_binning::operator()(
         grid_capacities_buff;
 
     // Now define the Alpaka Work division
-    auto const deviceProperties = ::alpaka::getAccDevProps<Acc>(devAcc);
-    auto const maxThreadsPerBlock = deviceProperties.m_blockThreadExtentMax[0];
-    auto const threadsPerBlock = maxThreadsPerBlock;
-    auto const blocksPerGrid =
-        (sp_size + threadsPerBlock - 1) / threadsPerBlock;
+    const Idx threadsPerBlock = getWarpSize<Acc>() * 8;
+    const Idx blocksPerGrid = (sp_size + threadsPerBlock - 1) / threadsPerBlock;
     auto workDiv = makeWorkDiv<Acc>(blocksPerGrid, threadsPerBlock);
 
     ::alpaka::exec<Acc>(queue, workDiv, kernels::CountGridCapacity{}, m_config,

--- a/device/alpaka/src/seeding/track_params_estimation.cpp
+++ b/device/alpaka/src/seeding/track_params_estimation.cpp
@@ -59,10 +59,9 @@ track_params_estimation::output_type track_params_estimation::operator()(
 
     auto devAcc = ::alpaka::getDevByIdx(::alpaka::Platform<Acc>{}, 0u);
     auto queue = Queue{devAcc};
-    auto const deviceProperties = ::alpaka::getAccDevProps<Acc>(devAcc);
-    auto const threadsPerBlock = deviceProperties.m_blockThreadExtentMax[0];
+    const Idx threadsPerBlock = getWarpSize<Acc>() * 2;
 
-    auto blocksPerGrid = (seeds_size + threadsPerBlock - 1) / threadsPerBlock;
+    Idx blocksPerGrid = (seeds_size + threadsPerBlock - 1) / threadsPerBlock;
     auto workDiv = makeWorkDiv<Acc>(blocksPerGrid, threadsPerBlock);
 
     // Run the kernel

--- a/device/alpaka/src/utils/thread_id.hpp
+++ b/device/alpaka/src/utils/thread_id.hpp
@@ -21,45 +21,46 @@
 namespace traccc::alpaka::details {
 
 /// An Alpaka thread identifier type
-template <typename Acc>
+template <typename TAcc>
 struct thread_id1 {
-    TRACCC_HOST_DEVICE explicit thread_id1(const Acc& acc) : m_acc(acc) {}
+    ALPAKA_FN_INLINE ALPAKA_FN_ACC explicit thread_id1(const TAcc* acc)
+        : m_acc(acc) {}
 
-    unsigned int inline TRACCC_HOST_DEVICE getLocalThreadId() const {
+    unsigned int inline ALPAKA_FN_ACC getLocalThreadId() const {
         return static_cast<unsigned int>(
-            ::alpaka::getIdx<::alpaka::Block, ::alpaka::Threads>(m_acc)[0u]);
+            ::alpaka::getIdx<::alpaka::Block, ::alpaka::Threads>(*m_acc)[0u]);
     }
 
-    unsigned int inline TRACCC_HOST_DEVICE getLocalThreadIdX() const {
+    unsigned int inline ALPAKA_FN_ACC getLocalThreadIdX() const {
         return getLocalThreadId();
     }
 
-    unsigned int inline TRACCC_HOST_DEVICE getGlobalThreadId() const {
+    unsigned int inline ALPAKA_FN_ACC getGlobalThreadId() const {
         return getLocalThreadId() + getBlockIdX() * getBlockDimX();
     }
 
-    unsigned int inline TRACCC_HOST_DEVICE getGlobalThreadIdX() const {
+    unsigned int inline ALPAKA_FN_ACC getGlobalThreadIdX() const {
         return getLocalThreadId() + getBlockIdX() * getBlockDimX();
     }
 
-    unsigned int inline TRACCC_HOST_DEVICE getBlockIdX() const {
+    unsigned int inline ALPAKA_FN_ACC getBlockIdX() const {
         return static_cast<unsigned int>(
-            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Blocks>(m_acc)[0u]);
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Blocks>(*m_acc)[0u]);
     }
 
-    unsigned int inline TRACCC_HOST_DEVICE getBlockDimX() const {
+    unsigned int inline ALPAKA_FN_ACC getBlockDimX() const {
         return static_cast<unsigned int>(
             ::alpaka::getWorkDiv<::alpaka::Block, ::alpaka::Threads>(
-                m_acc)[0u]);
+                *m_acc)[0u]);
     }
 
-    unsigned int inline TRACCC_HOST_DEVICE getGridDimX() const {
+    unsigned int inline ALPAKA_FN_ACC getGridDimX() const {
         return static_cast<unsigned int>(
-            ::alpaka::getWorkDiv<::alpaka::Grid, ::alpaka::Blocks>(m_acc)[0u]);
+            ::alpaka::getWorkDiv<::alpaka::Grid, ::alpaka::Blocks>(*m_acc)[0u]);
     }
 
     private:
-    const Acc& m_acc;
+    const TAcc* m_acc;
 };
 
 /// Verify that @c traccc::alpaka::details::thread_id1 fulfills the

--- a/device/common/include/traccc/finding/device/apply_interaction.hpp
+++ b/device/common/include/traccc/finding/device/apply_interaction.hpp
@@ -53,7 +53,7 @@ struct apply_interaction_payload {
 /// @param[inout] payload      The function call payload
 ///
 template <typename detector_t>
-TRACCC_DEVICE inline void apply_interaction(
+TRACCC_HOST_DEVICE inline void apply_interaction(
     global_index_t globalIndex, const finding_config& cfg,
     const apply_interaction_payload<detector_t>& payload);
 

--- a/device/common/include/traccc/finding/device/build_tracks.hpp
+++ b/device/common/include/traccc/finding/device/build_tracks.hpp
@@ -75,9 +75,9 @@ struct build_tracks_payload {
 /// @param[in] cfg                    Track finding config object
 /// @param[inout] payload      The function call payload
 ///
-TRACCC_DEVICE inline void build_tracks(global_index_t globalIndex,
-                                       const finding_config& cfg,
-                                       const build_tracks_payload& payload);
+TRACCC_HOST_DEVICE inline void build_tracks(
+    global_index_t globalIndex, const finding_config& cfg,
+    const build_tracks_payload& payload);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/finding/device/find_tracks.hpp
+++ b/device/common/include/traccc/finding/device/find_tracks.hpp
@@ -141,7 +141,7 @@ struct find_tracks_shared_payload {
 ///
 template <typename detector_t, concepts::thread_id1 thread_id_t,
           concepts::barrier barrier_t>
-TRACCC_DEVICE inline void find_tracks(
+TRACCC_HOST_DEVICE inline void find_tracks(
     const thread_id_t& thread_id, const barrier_t& barrier,
     const finding_config& cfg, const find_tracks_payload<detector_t>& payload,
     const find_tracks_shared_payload& shared_payload);

--- a/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
+++ b/device/common/include/traccc/finding/device/impl/apply_interaction.ipp
@@ -17,7 +17,7 @@
 namespace traccc::device {
 
 template <typename detector_t>
-TRACCC_DEVICE inline void apply_interaction(
+TRACCC_HOST_DEVICE inline void apply_interaction(
     const global_index_t globalIndex, const finding_config& cfg,
     const apply_interaction_payload<detector_t>& payload) {
 

--- a/device/common/include/traccc/finding/device/impl/build_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/build_tracks.ipp
@@ -9,9 +9,9 @@
 
 namespace traccc::device {
 
-TRACCC_DEVICE inline void build_tracks(const global_index_t globalIndex,
-                                       const finding_config& cfg,
-                                       const build_tracks_payload& payload) {
+TRACCC_HOST_DEVICE inline void build_tracks(
+    const global_index_t globalIndex, const finding_config& cfg,
+    const build_tracks_payload& payload) {
 
     const measurement_collection_types::const_device measurements(
         payload.measurements_view);

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -33,7 +33,7 @@ namespace traccc::device {
 
 template <typename detector_t, concepts::thread_id1 thread_id_t,
           concepts::barrier barrier_t>
-TRACCC_DEVICE inline void find_tracks(
+TRACCC_HOST_DEVICE inline void find_tracks(
     const thread_id_t& thread_id, const barrier_t& barrier,
     const finding_config& cfg, const find_tracks_payload<detector_t>& payload,
     const find_tracks_shared_payload& shared_payload) {

--- a/device/common/include/traccc/finding/device/impl/make_barcode_sequence.ipp
+++ b/device/common/include/traccc/finding/device/impl/make_barcode_sequence.ipp
@@ -9,7 +9,7 @@
 
 namespace traccc::device {
 
-TRACCC_DEVICE inline void make_barcode_sequence(
+TRACCC_HOST_DEVICE inline void make_barcode_sequence(
     const global_index_t globalIndex,
     const make_barcode_sequence_payload& payload) {
 

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -17,7 +17,7 @@
 namespace traccc::device {
 
 template <typename propagator_t, typename bfield_t>
-TRACCC_DEVICE inline void propagate_to_next_surface(
+TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     const global_index_t globalIndex, const finding_config& cfg,
     const propagate_to_next_surface_payload<propagator_t, bfield_t>& payload) {
 

--- a/device/common/include/traccc/finding/device/impl/prune_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/prune_tracks.ipp
@@ -9,8 +9,8 @@
 
 namespace traccc::device {
 
-TRACCC_DEVICE inline void prune_tracks(const global_index_t globalIndex,
-                                       const prune_tracks_payload& payload) {
+TRACCC_HOST_DEVICE inline void prune_tracks(
+    const global_index_t globalIndex, const prune_tracks_payload& payload) {
 
     const track_candidate_container_types::const_device track_candidates(
         payload.track_candidates_view);

--- a/device/common/include/traccc/finding/device/make_barcode_sequence.hpp
+++ b/device/common/include/traccc/finding/device/make_barcode_sequence.hpp
@@ -41,7 +41,7 @@ struct make_barcode_sequence_payload {
 /// @param[in] globalIndex   The index of the current thread
 /// @param[inout] payload      The function call payload
 ///
-TRACCC_DEVICE inline void make_barcode_sequence(
+TRACCC_HOST_DEVICE inline void make_barcode_sequence(
     global_index_t globalIndex, const make_barcode_sequence_payload& payload);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -90,7 +90,7 @@ struct propagate_to_next_surface_payload {
 /// @param[inout] payload      The function call payload
 ///
 template <typename propagator_t, typename bfield_t>
-TRACCC_DEVICE inline void propagate_to_next_surface(
+TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     global_index_t globalIndex, const finding_config& cfg,
     const propagate_to_next_surface_payload<propagator_t, bfield_t>& payload);
 

--- a/device/common/include/traccc/finding/device/prune_tracks.hpp
+++ b/device/common/include/traccc/finding/device/prune_tracks.hpp
@@ -42,8 +42,8 @@ struct prune_tracks_payload {
 /// @param[in] globalIndex         The index of the current thread
 /// @param[inout] payload      The function call payload
 ///
-TRACCC_DEVICE inline void prune_tracks(global_index_t globalIndex,
-                                       const prune_tracks_payload& payload);
+TRACCC_HOST_DEVICE inline void prune_tracks(
+    global_index_t globalIndex, const prune_tracks_payload& payload);
 
 }  // namespace traccc::device
 

--- a/examples/run/alpaka/CMakeLists.txt
+++ b/examples/run/alpaka/CMakeLists.txt
@@ -1,15 +1,13 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2023 CERN for the benefit of the ACTS project
+# (c) 2023-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
-set(EXTRA_LIBS)
+# Project include(s).
+include( traccc-alpaka-functions )
 
-set(TRACCC_ALPAKA_EXAMPLE_SOURCES
-    seq_example_alpaka.cpp
-    seeding_example_alpaka.cpp
-)
+set(EXTRA_LIBS)
 
 include(traccc-alpaka-functions)
 traccc_enable_language_alpaka()
@@ -26,8 +24,25 @@ endif()
 set(LIBRARIES vecmem::core traccc::io traccc::performance
     traccc::core traccc::device_common traccc::alpaka alpaka::alpaka
     traccc::options ${EXTRA_LIBS})
+set(DETRAY detray::io detray::detectors)
 
 traccc_add_executable( seq_example_alpaka "seq_example_alpaka.cpp"
-    LINK_LIBRARIES ${LIBRARIES} )
+    LINK_LIBRARIES ${LIBRARIES} ${DETRAY} )
 traccc_add_executable( seeding_example_alpaka "seeding_example_alpaka.cpp"
     LINK_LIBRARIES ${LIBRARIES} )
+
+#
+# Set up the "throughput applications".
+#
+add_library( traccc_examples_alpaka STATIC
+   "full_chain_algorithm.hpp"
+   "full_chain_algorithm.cpp" )
+target_link_libraries( traccc_examples_alpaka
+   PUBLIC alpaka::alpaka vecmem::core detray::core detray::detectors
+   traccc::core traccc::device_common traccc::alpaka ${EXTRA_LIBS})
+
+traccc_add_executable( throughput_st_alpaka "throughput_st.cpp"
+   LINK_LIBRARIES indicators::indicators ${LIBRARIES} ${DETRAY} traccc_examples_alpaka )
+
+traccc_add_executable( throughput_mt_alpaka "throughput_mt.cpp"
+   LINK_LIBRARIES TBB::tbb indicators::indicators ${LIBRARIES} ${DETRAY} traccc_examples_alpaka )

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -1,16 +1,12 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 // Local include(s).
 #include "full_chain_algorithm.hpp"
-
-// Alpaka include(s).
-#include <alpaka/alpaka.hpp>
-#include <alpaka/example/ExampleDefaultAcc.hpp>
 
 // System include(s).
 #include <iostream>
@@ -20,43 +16,72 @@ namespace traccc::alpaka {
 
 full_chain_algorithm::full_chain_algorithm(
     vecmem::memory_resource& host_mr,
-    const unsigned short target_cells_per_partition,
+    const clustering_config& clustering_config,
     const seedfinder_config& finder_config,
     const spacepoint_grid_config& grid_config,
-    const seedfilter_config& filter_config)
-    : m_host_mr(host_mr),
+    const seedfilter_config& filter_config,
+    const finding_algorithm::config_type& finding_config,
+    const fitting_algorithm::config_type& fitting_config,
+    const silicon_detector_description::host& det_descr,
+    host_detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
+    : messaging(std::move(logger->clone())),
+      m_host_mr(host_mr),
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
       m_device_mr(),
 #else
       m_device_mr(host_mr),
 #endif
+      m_copy(),
       m_cached_device_mr(
-          std::make_unique<vecmem::binary_page_memory_resource>(m_device_mr)),
-      m_target_cells_per_partition(target_cells_per_partition),
+          std::make_unique<::vecmem::binary_page_memory_resource>(m_device_mr)),
+      m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
+      m_field(
+          detray::bfield::create_const_field<host_detector_type::scalar_type>(
+              m_field_vec)),
+      m_det_descr(det_descr),
+      m_device_det_descr(
+          static_cast<silicon_detector_description::buffer::size_type>(
+              m_det_descr.get().size()),
+          m_device_mr),
+      m_detector(detector),
       m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                       m_target_cells_per_partition),
-      m_measurement_sorting(m_copy),
+                       clustering_config),
+      m_measurement_sorting(m_copy, logger->cloneWithSuffix("MeasSortingAlg")),
       m_spacepoint_formation(memory_resource{*m_cached_device_mr, &m_host_mr},
-                             m_copy),
+                             m_copy, logger->cloneWithSuffix("SpFormationAlg")),
       m_seeding(finder_config, grid_config, filter_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy),
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                logger->cloneWithSuffix("SeedingAlg")),
       m_track_parameter_estimation(
-          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy),
+          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+          logger->cloneWithSuffix("TrackParamEstAlg")),
+      m_finding(finding_config,
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                logger->cloneWithSuffix("TrackFindingAlg")),
+      m_fitting(fitting_config,
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                logger->cloneWithSuffix("TrackFittingAlg")),
+      m_clustering_config(clustering_config),
       m_finder_config(finder_config),
       m_grid_config(grid_config),
-      m_filter_config(filter_config) {
+      m_filter_config(filter_config),
+      m_finding_config(finding_config),
+      m_fitting_config(fitting_config) {
 
-    // Tell the user what device is being used.
-    using Acc = ::alpaka::ExampleDefaultAcc<::alpaka::DimInt<1>, uint32_t>;
-    int device = 0;
-    auto devAcc = ::alpaka::getDevByIdx(::alpaka::Platform<Acc>{}, 0u);
-    auto const props = ::alpaka::getAccDevProps<Acc>(devAcc);
-    std::cout << "Using Alpaka device: " << ::alpaka::getName(devAcc)
-              << " [id: " << device << "] " << std::endl;
+    traccc::alpaka::get_device_info();
+
+    // Copy the detector (description) to the device.
+    m_copy(::vecmem::get_data(m_det_descr.get()), m_device_det_descr)->ignore();
+    if (m_detector != nullptr) {
+        m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
+                                               m_device_mr, m_copy);
+        m_device_detector_view = detray::get_data(m_device_detector);
+    }
 }
 
 full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
-    : m_host_mr(parent.m_host_mr),
+    : messaging(parent.logger().clone()),
+      m_host_mr(parent.m_host_mr),
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
       m_device_mr(),
 #else
@@ -64,53 +89,101 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
 #endif
       m_copy(),
       m_cached_device_mr(
-          std::make_unique<vecmem::binary_page_memory_resource>(m_device_mr)),
-      m_target_cells_per_partition(parent.m_target_cells_per_partition),
+          std::make_unique<::vecmem::binary_page_memory_resource>(m_device_mr)),
+      m_field_vec(parent.m_field_vec),
+      m_field(parent.m_field),
+      m_det_descr(parent.m_det_descr),
+      m_device_det_descr(
+          static_cast<silicon_detector_description::buffer::size_type>(
+              m_det_descr.get().size()),
+          m_device_mr),
+      m_detector(parent.m_detector),
       m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                       m_target_cells_per_partition),
-      m_measurement_sorting(m_copy),
+                       parent.m_clustering_config),
+      m_measurement_sorting(m_copy,
+                            parent.logger().cloneWithSuffix("MeasSortingAlg")),
       m_spacepoint_formation(memory_resource{*m_cached_device_mr, &m_host_mr},
-                             m_copy),
+                             m_copy,
+                             parent.logger().cloneWithSuffix("SpFormationAlg")),
       m_seeding(parent.m_finder_config, parent.m_grid_config,
                 parent.m_filter_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy),
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                parent.logger().cloneWithSuffix("SeedingAlg")),
       m_track_parameter_estimation(
-          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy),
+          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+          parent.logger().cloneWithSuffix("TrackParamEstAlg")),
+      m_finding(parent.m_finding_config,
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                parent.logger().cloneWithSuffix("TrackFindingAlg")),
+      m_fitting(parent.m_fitting_config,
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                parent.logger().cloneWithSuffix("TrackFittingAlg")),
+      m_clustering_config(parent.m_clustering_config),
       m_finder_config(parent.m_finder_config),
       m_grid_config(parent.m_grid_config),
-      m_filter_config(parent.m_filter_config) {
+      m_filter_config(parent.m_filter_config),
+      m_finding_config(parent.m_finding_config),
+      m_fitting_config(parent.m_fitting_config) {
+
+    // Copy the detector (description) to the device.
+    m_copy(::vecmem::get_data(m_det_descr.get()), m_device_det_descr)->ignore();
+    if (m_detector != nullptr) {
+        m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
+                                               m_device_mr, m_copy);
+        m_device_detector_view = detray::get_data(m_device_detector);
+    }
 }
 
 full_chain_algorithm::~full_chain_algorithm() = default;
 
 full_chain_algorithm::output_type full_chain_algorithm::operator()(
-    const cell_collection_types::host& cells,
-    const cell_module_collection_types::host& modules) const {
+    const edm::silicon_cell_collection::host& cells) const {
 
     // Create device copy of input collections
-    cell_collection_types::buffer cells_buffer(cells.size(),
-                                               *m_cached_device_mr);
-    m_copy(vecmem::get_data(cells), cells_buffer)->ignore();
-    cell_module_collection_types::buffer modules_buffer(modules.size(),
-                                                        *m_cached_device_mr);
-    m_copy(vecmem::get_data(modules), modules_buffer)->ignore();
+    edm::silicon_cell_collection::buffer cells_buffer(
+        static_cast<unsigned int>(cells.size()), *m_cached_device_mr);
+    m_copy(::vecmem::get_data(cells), cells_buffer)->ignore();
 
-    // Run the clusterization
+    // Run the clusterization.
     const clusterization_algorithm::output_type measurements =
-        m_clusterization(cells_buffer, modules_buffer);
-    const spacepoint_formation_algorithm::output_type spacepoints =
-        m_spacepoint_formation(m_measurement_sorting(measurements),
-                               modules_buffer);
-    const track_params_estimation::output_type track_params =
-        m_track_parameter_estimation(spacepoints, m_seeding(spacepoints),
-                                     {0.f, 0.f, m_finder_config.bFieldInZ});
+        m_clusterization(cells_buffer, m_device_det_descr);
+    m_measurement_sorting(measurements);
 
-    // Get the final data back to the host.
-    bound_track_parameters_collection_types::host result(&m_host_mr);
-    m_copy(track_params, result)->wait();
+    // If we have a Detray detector, run the track finding and fitting.
+    if (m_detector != nullptr) {
 
-    // Return the host container.
-    return result;
+        // Run the seed-finding.
+        const spacepoint_formation_algorithm::output_type spacepoints =
+            m_spacepoint_formation(m_device_detector_view, measurements);
+        const track_params_estimation::output_type track_params =
+            m_track_parameter_estimation(measurements, spacepoints,
+                                         m_seeding(spacepoints), m_field_vec);
+
+        // Run the track finding.
+        const finding_algorithm::output_type track_candidates = m_finding(
+            m_device_detector_view, m_field, measurements, track_params);
+
+        // Run the track fitting.
+        const fitting_algorithm::output_type track_states =
+            m_fitting(m_device_detector_view, m_field, track_candidates);
+
+        // Copy a limited amount of result data back to the host.
+        output_type result{&m_host_mr};
+        m_copy(track_states.headers, result)->wait();
+        return result;
+
+    }
+    // If not, copy the track parameters back to the host, and return a dummy
+    // object.
+    else {
+
+        // Copy the measurements back to the host.
+        measurement_collection_types::host measurements_host(&m_host_mr);
+        m_copy(measurements, measurements_host)->wait();
+
+        // Return an empty object.
+        return {};
+    }
 }
 
 }  // namespace traccc::alpaka

--- a/examples/run/alpaka/full_chain_algorithm.hpp
+++ b/examples/run/alpaka/full_chain_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,28 +10,32 @@
 // Project include(s).
 #include "traccc/alpaka/clusterization/clusterization_algorithm.hpp"
 #include "traccc/alpaka/clusterization/measurement_sorting_algorithm.hpp"
-#include "traccc/alpaka/clusterization/spacepoint_formation_algorithm.hpp"
+#include "traccc/alpaka/finding/finding_algorithm.hpp"
+#include "traccc/alpaka/fitting/fitting_algorithm.hpp"
 #include "traccc/alpaka/seeding/seeding_algorithm.hpp"
+#include "traccc/alpaka/seeding/spacepoint_formation_algorithm.hpp"
 #include "traccc/alpaka/seeding/track_params_estimation.hpp"
-#include "traccc/device/container_h2d_copy_alg.hpp"
-#include "traccc/edm/cell.hpp"
+#include "traccc/alpaka/utils/get_device_info.hpp"
+#include "traccc/alpaka/utils/get_vecmem_resource.hpp"
+#include "traccc/clusterization/clustering_config.hpp"
+#include "traccc/edm/silicon_cell_collection.hpp"
+#include "traccc/edm/track_state.hpp"
+#include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+#include "traccc/geometry/detector.hpp"
+#include "traccc/geometry/silicon_detector_description.hpp"
 #include "traccc/utils/algorithm.hpp"
 #include "traccc/utils/messaging.hpp"
 
+// Detray include(s).
+#include <detray/core/detector.hpp>
+#include <detray/detectors/bfield.hpp>
+#include <detray/navigation/navigator.hpp>
+#include <detray/propagator/propagator.hpp>
+#include <detray/propagator/rk_stepper.hpp>
+
 // VecMem include(s).
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-#include <vecmem/memory/cuda/device_memory_resource.hpp>
-#include <vecmem/utils/cuda/copy.hpp>
-#endif
-
-#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-#include <vecmem/memory/hip/device_memory_resource.hpp>
-#include <vecmem/utils/hip/copy.hpp>
-#endif
-
+#include <vecmem/containers/vector.hpp>
 #include <vecmem/memory/binary_page_memory_resource.hpp>
-#include <vecmem/memory/memory_resource.hpp>
-#include <vecmem/utils/copy.hpp>
 
 // System include(s).
 #include <memory>
@@ -43,24 +47,58 @@ namespace traccc::alpaka {
 /// At least as much as is implemented in the project at any given moment.
 ///
 class full_chain_algorithm
-    : public algorithm<bound_track_parameters_collection_types::host(
-          const cell_collection_types::host&,
-          const cell_module_collection_types::host&)>,
+    : public algorithm<vecmem::vector<fitting_result<default_algebra>>(
+          const edm::silicon_cell_collection::host&)>,
       public messaging {
 
     public:
+    /// @name Type declaration(s)
+    /// @{
+
+    /// (Host) Detector type used during track finding and fitting
+    using host_detector_type = traccc::default_detector::host;
+    /// (Device) Detector type used during track finding and fitting
+    using device_detector_type = traccc::default_detector::device;
+
+    using scalar_type = device_detector_type::scalar_type;
+
+    /// Stepper type used by the track finding and fitting algorithms
+    using stepper_type =
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
+                           device_detector_type::algebra_type,
+                           detray::constrained_step<scalar_type>>;
+    /// Navigator type used by the track finding and fitting algorithms
+    using navigator_type = detray::navigator<const device_detector_type>;
+    /// Spacepoint formation algorithm type
+    using spacepoint_formation_algorithm =
+        traccc::alpaka::spacepoint_formation_algorithm<
+            traccc::default_detector::device>;
+    /// Clustering algorithm type
+    using clustering_algorithm = traccc::alpaka::clusterization_algorithm;
+    /// Track finding algorithm type
+    using finding_algorithm =
+        traccc::alpaka::finding_algorithm<stepper_type, navigator_type>;
+    /// Track fitting algorithm type
+    using fitting_algorithm = traccc::alpaka::fitting_algorithm<
+        traccc::kalman_fitter<stepper_type, navigator_type>>;
+
+    /// @}
+
     /// Algorithm constructor
     ///
     /// @param mr The memory resource to use for the intermediate and result
     ///           objects
-    /// @param target_cells_per_partition The average number of cells in each
-    /// partition.
     ///
     full_chain_algorithm(vecmem::memory_resource& host_mr,
-                         const unsigned short target_cells_per_partiton,
+                         const clustering_config& clustering_config,
                          const seedfinder_config& finder_config,
                          const spacepoint_grid_config& grid_config,
-                         const seedfilter_config& filter_config);
+                         const seedfilter_config& filter_config,
+                         const finding_algorithm::config_type& finding_config,
+                         const fitting_algorithm::config_type& fitting_config,
+                         const silicon_detector_description::host& det_descr,
+                         host_detector_type* detector,
+                         std::unique_ptr<const traccc::Logger> logger);
 
     /// Copy constructor
     ///
@@ -81,37 +119,38 @@ class full_chain_algorithm
     /// @return The track parameters reconstructed
     ///
     output_type operator()(
-        const cell_collection_types::host& cells,
-        const cell_module_collection_types::host& modules) const override;
+        const edm::silicon_cell_collection::host& cells) const override;
 
     private:
     /// Host memory resource
-    vecmem::memory_resource& m_host_mr;
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+    ::vecmem::memory_resource& m_host_mr;
     /// Device memory resource
-    vecmem::cuda::device_memory_resource m_device_mr;
+    traccc::alpaka::vecmem_resources::device_memory_resource m_device_mr;
     /// Memory copy object
-    vecmem::cuda::copy m_copy;
-#elif ALPAKA_ACC_GPU_HIP_ENABLED
-    /// Device memory resource
-    vecmem::hip::device_memory_resource m_device_mr;
-    /// Memory copy object
-    vecmem::hip::copy m_copy;
-#else
-    /// Device memory resource
-    vecmem::memory_resource& m_device_mr;
-    /// Memory copy object
-    vecmem::copy m_copy;
-#endif
+    traccc::alpaka::vecmem_resources::device_copy m_copy;
     /// Device caching memory resource
-    std::unique_ptr<vecmem::binary_page_memory_resource> m_cached_device_mr;
+    std::unique_ptr<::vecmem::binary_page_memory_resource> m_cached_device_mr;
+
+    /// Constant B field for the (seed) track parameter estimation
+    traccc::vector3 m_field_vec;
+    /// Constant B field for the track finding and fitting
+    detray::bfield::const_field_t<traccc::scalar> m_field;
+
+    /// Detector description
+    std::reference_wrapper<const silicon_detector_description::host>
+        m_det_descr;
+    /// Detector description buffer
+    silicon_detector_description::buffer m_device_det_descr;
+    /// Host detector
+    host_detector_type* m_detector;
+    /// Buffer holding the detector's payload on the device
+    host_detector_type::buffer_type m_device_detector;
+    /// View of the detector's payload on the device
+    host_detector_type::view_type m_device_detector_view;
 
     /// @name Sub-algorithms used by this full-chain algorithm
     /// @{
 
-    /// The average number of cells in each partition.
-    /// Adapt to different GPUs' capabilities.
-    unsigned short m_target_cells_per_partition;
     /// Clusterization algorithm
     clusterization_algorithm m_clusterization;
     /// Measurement sorting algorithm
@@ -123,10 +162,29 @@ class full_chain_algorithm
     /// Track parameter estimation algorithm
     track_params_estimation m_track_parameter_estimation;
 
-    /// Configs
+    /// Track finding algorithm
+    finding_algorithm m_finding;
+    /// Track fitting algorithm
+    fitting_algorithm m_fitting;
+
+    /// @}
+
+    /// @name Algorithm configurations
+    /// @{
+
+    /// Configuration for clustering
+    clustering_config m_clustering_config;
+    /// Configuration for the seed finding
     seedfinder_config m_finder_config;
+    /// Configuration for the spacepoint grid formation
     spacepoint_grid_config m_grid_config;
+    /// Configuration for the seed filtering
     seedfilter_config m_filter_config;
+
+    /// Configuration for the track finding
+    finding_algorithm::config_type m_finding_config;
+    /// Configuration for the track fitting
+    fitting_algorithm::config_type m_fitting_config;
 
     /// @}
 

--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -6,9 +6,11 @@
  */
 
 // Project include(s).
+#include "traccc/alpaka/finding/finding_algorithm.hpp"
+#include "traccc/alpaka/fitting/fitting_algorithm.hpp"
 #include "traccc/alpaka/seeding/seeding_algorithm.hpp"
 #include "traccc/alpaka/seeding/track_params_estimation.hpp"
-#include "traccc/alpaka/utils/vecmem_types.hpp"
+#include "traccc/alpaka/utils/get_vecmem_resource.hpp"
 #include "traccc/definitions/common.hpp"
 #include "traccc/device/container_d2h_copy_alg.hpp"
 #include "traccc/device/container_h2d_copy_alg.hpp"
@@ -16,8 +18,12 @@
 #include "traccc/efficiency/nseed_performance_writer.hpp"
 #include "traccc/efficiency/seeding_performance_writer.hpp"
 #include "traccc/efficiency/track_filter.hpp"
+#include "traccc/finding/combinatorial_kalman_filter_algorithm.hpp"
+#include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+#include "traccc/fitting/kalman_fitting_algorithm.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/io/read_detector.hpp"
+#include "traccc/io/read_detector_description.hpp"
 #include "traccc/io/read_measurements.hpp"
 #include "traccc/io/read_spacepoints.hpp"
 #include "traccc/io/utils.hpp"
@@ -38,7 +44,6 @@
 #include "traccc/seeding/track_params_estimation.hpp"
 
 // Detray include(s).
-#include <detray/core/detector.hpp>
 #include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
@@ -58,9 +63,9 @@
 using namespace traccc;
 
 int seq_run(const traccc::opts::track_seeding& seeding_opts,
-            const traccc::opts::track_finding& /*finding_opts*/,
-            const traccc::opts::track_propagation& /*propagation_opts*/,
-            const traccc::opts::track_fitting& /*fitting_opts*/,
+            const traccc::opts::track_finding& finding_opts,
+            const traccc::opts::track_propagation& propagation_opts,
+            const traccc::opts::track_fitting& fitting_opts,
             const traccc::opts::input_data& input_opts,
             const traccc::opts::detector& detector_opts,
             const traccc::opts::performance& performance_opts,
@@ -68,25 +73,41 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             [[maybe_unused]] std::unique_ptr<const traccc::Logger> ilogger) {
     TRACCC_LOCAL_LOGGER(std::move(ilogger));
 
+    /// Type declarations
+    using scalar_t = traccc::default_detector::host::scalar_type;
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_t>>;
+    using rk_stepper_type =
+        detray::rk_stepper<b_field_t::view_t,
+                           traccc::default_detector::host::algebra_type,
+                           detray::constrained_step<scalar_t>>;
+    using device_navigator_type =
+        detray::navigator<const traccc::default_detector::device>;
+    using device_fitter_type =
+        traccc::kalman_fitter<rk_stepper_type, device_navigator_type>;
+
 #ifdef ALPAKA_ACC_SYCL_ENABLED
     ::sycl::queue q;
     vecmem::sycl::queue_wrapper qw{&q};
-    traccc::alpaka::vecmem::device_copy copy(qw);
-    traccc::alpaka::vecmem::host_memory_resource host_mr(qw);
-    traccc::alpaka::vecmem::device_memory_resource device_mr(qw);
-    traccc::alpaka::vecmem::managed_memory_resource mng_mr(qw);
+    traccc::alpaka::vecmem_resources::device_copy copy(qw);
+    traccc::alpaka::vecmem_resources::host_memory_resource host_mr(qw);
+    traccc::alpaka::vecmem_resources::device_memory_resource device_mr(qw);
+    traccc::alpaka::vecmem_resources::managed_memory_resource mng_mr(qw);
     traccc::memory_resource mr{device_mr, &host_mr};
 #else
-    traccc::alpaka::vecmem::device_copy copy;
-    traccc::alpaka::vecmem::host_memory_resource host_mr;
-    traccc::alpaka::vecmem::device_memory_resource device_mr;
-    traccc::alpaka::vecmem::managed_memory_resource mng_mr;
+    traccc::alpaka::vecmem_resources::device_copy copy;
+    traccc::alpaka::vecmem_resources::host_memory_resource host_mr;
+    traccc::alpaka::vecmem_resources::device_memory_resource device_mr;
+    traccc::alpaka::vecmem_resources::managed_memory_resource mng_mr;
     traccc::memory_resource mr{device_mr, &host_mr};
 #endif
 
     // Performance writer
     traccc::seeding_performance_writer sd_performance_writer(
         traccc::seeding_performance_writer::config{});
+    traccc::finding_performance_writer find_performance_writer(
+        traccc::finding_performance_writer::config{});
+    traccc::fitting_performance_writer fit_performance_writer(
+        traccc::fitting_performance_writer::config{});
 
     traccc::nseed_performance_writer nsd_performance_writer(
         "nseed_performance_",
@@ -102,17 +123,37 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     uint64_t n_spacepoints = 0;
     uint64_t n_seeds = 0;
     uint64_t n_seeds_alpaka = 0;
+    uint64_t n_found_tracks = 0;
+    uint64_t n_found_tracks_alpaka = 0;
+    uint64_t n_fitted_tracks = 0;
+    uint64_t n_fitted_tracks_alpaka = 0;
 
     /*****************************
      * Build a geometry
      *****************************/
 
+    // B field value and its type
+    // @TODO: Set B field as argument
+    const traccc::vector3 B{0, 0, 2 * traccc::unit<traccc::scalar>::T};
+    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
+
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host host_det{mng_mr};
-    assert(detector_opts.use_detray_detector == true);
     traccc::io::read_detector(host_det, mng_mr, detector_opts.detector_file,
                               detector_opts.material_file,
                               detector_opts.grid_file);
+
+    // Detector view object
+    traccc::default_detector::view det_view = detray::get_data(host_det);
+
+    // Copy objects
+    traccc::device::container_d2h_copy_alg<
+        traccc::track_candidate_container_types>
+        track_candidate_d2h{mr, copy,
+                            logger().clone("TrackCandidateD2HCopyAlg")};
+
+    traccc::device::container_d2h_copy_alg<traccc::track_state_container_types>
+        track_state_d2h{mr, copy, logger().clone("TrackStateD2HCopyAlg")};
 
     // Seeding algorithms
     traccc::host::seeding_algorithm sa(
@@ -132,6 +173,26 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     traccc::alpaka::track_params_estimation tp_alpaka{
         mr, copy, logger().clone("AlpakaTrackParEstAlg")};
 
+    // Propagation configuration
+    detray::propagation::config propagation_config(propagation_opts);
+
+    // Finding algorithm configuration
+    traccc::finding_config cfg(finding_opts);
+    cfg.propagation = propagation_config;
+
+    // Finding algorithm object
+    traccc::host::combinatorial_kalman_filter_algorithm host_finding(cfg);
+    traccc::alpaka::finding_algorithm<rk_stepper_type, device_navigator_type>
+        device_finding(cfg, mr, copy);
+
+    // Fitting algorithm object
+    traccc::fitting_config fit_cfg(fitting_opts);
+    fit_cfg.propagation = propagation_config;
+
+    traccc::host::kalman_fitting_algorithm host_fitting(fit_cfg, host_mr);
+    traccc::alpaka::fitting_algorithm<device_fitter_type> device_fitting(
+        fit_cfg, mr, copy);
+
     traccc::performance::timing_info elapsedTimes;
 
     // Loop over events
@@ -142,7 +203,6 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         traccc::edm::spacepoint_collection::host spacepoints_per_event{host_mr};
         traccc::measurement_collection_types::host measurements_per_event{
             &host_mr};
-
         traccc::host::seeding_algorithm::output_type seeds{host_mr};
         traccc::host::track_params_estimation::output_type params;
         traccc::track_candidate_container_types::host track_candidates;
@@ -151,6 +211,13 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         traccc::edm::seed_collection::buffer seeds_alpaka_buffer;
         traccc::bound_track_parameters_collection_types::buffer
             params_alpaka_buffer(0, *mr.host);
+
+        traccc::track_candidate_container_types::buffer
+            track_candidates_alpaka_buffer{{{}, *(mr.host)},
+                                           {{}, *(mr.host), mr.host}};
+
+        traccc::track_state_container_types::buffer track_states_alpaka_buffer{
+            {{}, *(mr.host)}, {{}, *(mr.host), mr.host}};
 
         {  // Start measuring wall time
             traccc::performance::timer wall_t("Wall time", elapsedTimes);
@@ -176,7 +243,6 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
             // Alpaka
 
-            // TODO: Check this (and all other copies) are intelligent.
             // Copy the spacepoint data to the device.
             traccc::edm::spacepoint_collection::buffer
                 spacepoints_alpaka_buffer(
@@ -185,6 +251,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             copy(vecmem::get_data(spacepoints_per_event),
                  spacepoints_alpaka_buffer)
                 ->wait();
+
             traccc::measurement_collection_types::buffer
                 measurements_alpaka_buffer(
                     static_cast<unsigned int>(measurements_per_event.size()),
@@ -232,6 +299,45 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                             {0.f, 0.f, seeding_opts.seedfinder.bFieldInZ});
             }  // stop measuring track params cpu timer
 
+            /*------------------------
+               Track Finding with CKF
+              ------------------------*/
+
+            {
+                traccc::performance::timer t("Track finding with CKF (alpaka)",
+                                             elapsedTimes);
+                track_candidates_alpaka_buffer =
+                    device_finding(det_view, field, measurements_alpaka_buffer,
+                                   params_alpaka_buffer);
+            }
+
+            if (accelerator_opts.compare_with_cpu) {
+                traccc::performance::timer t("Track finding with CKF (cpu)",
+                                             elapsedTimes);
+                track_candidates = host_finding(
+                    host_det, field, vecmem::get_data(measurements_per_event),
+                    vecmem::get_data(params));
+            }
+
+            /*------------------------
+               Track Fitting with KF
+              ------------------------*/
+
+            {
+                traccc::performance::timer t("Track fitting with KF (alpaka)",
+                                             elapsedTimes);
+
+                track_states_alpaka_buffer = device_fitting(
+                    det_view, field, track_candidates_alpaka_buffer);
+            }
+
+            if (accelerator_opts.compare_with_cpu) {
+                traccc::performance::timer t("Track fitting with KF (cpu)",
+                                             elapsedTimes);
+                track_states = host_fitting(host_det, field,
+                                            traccc::get_data(track_candidates));
+            }
+
         }  // Stop measuring wall time
 
         /*----------------------------------
@@ -244,6 +350,14 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             &host_mr};
         copy(seeds_alpaka_buffer, seeds_alpaka)->wait();
         copy(params_alpaka_buffer, params_alpaka)->wait();
+
+        // Copy track candidates from device to host
+        traccc::track_candidate_container_types::host track_candidates_alpaka =
+            track_candidate_d2h(track_candidates_alpaka_buffer);
+
+        // Copy track states from device to host
+        traccc::track_state_container_types::host track_states_alpaka =
+            track_state_d2h(track_states_alpaka_buffer);
 
         if (accelerator_opts.compare_with_cpu) {
             // Show which event we are currently presenting the results for.
@@ -264,6 +378,26 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                 compare_track_parameters{"track parameters"};
             compare_track_parameters(vecmem::get_data(params),
                                      vecmem::get_data(params_alpaka));
+
+            // Compare the track candidates made on the host and on the
+            // device
+            unsigned int n_matches = 0;
+            for (unsigned int i = 0; i < track_candidates.size(); i++) {
+                auto iso = traccc::details::is_same_object(
+                    track_candidates.at(i).items);
+
+                for (unsigned int j = 0; j < track_candidates_alpaka.size();
+                     j++) {
+                    if (iso(track_candidates_alpaka.at(j).items)) {
+                        n_matches++;
+                        break;
+                    }
+                }
+            }
+            std::cout << "Track candidate matching Rate: "
+                      << float(n_matches) /
+                             static_cast<float>(track_candidates.size())
+                      << std::endl;
         }
 
         /*----------------
@@ -273,6 +407,10 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         n_spacepoints += spacepoints_per_event.size();
         n_seeds_alpaka += seeds_alpaka.size();
         n_seeds += seeds.size();
+        n_found_tracks_alpaka += track_candidates_alpaka.size();
+        n_found_tracks += track_candidates.size();
+        n_fitted_tracks_alpaka += track_states_alpaka.size();
+        n_fitted_tracks += track_states.size();
 
         /*------------
           Writer
@@ -294,7 +432,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     if (performance_opts.run) {
         sd_performance_writer.finalize();
         nsd_performance_writer.finalize();
-
+        find_performance_writer.finalize();
+        fit_performance_writer.finalize();
         std::cout << nsd_performance_writer.generate_report_str();
     }
 
@@ -303,6 +442,14 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     std::cout << "- created  (cpu)  " << n_seeds << " seeds" << std::endl;
     std::cout << "- created (alpaka)  " << n_seeds_alpaka << " seeds"
               << std::endl;
+    std::cout << "- created  (cpu) " << n_found_tracks << " found tracks"
+              << std::endl;
+    std::cout << "- created (alpaka) " << n_found_tracks_alpaka
+              << " found tracks" << std::endl;
+    std::cout << "- created  (cpu) " << n_fitted_tracks << " fitted tracks"
+              << std::endl;
+    std::cout << "- created (alpaka) " << n_fitted_tracks_alpaka
+              << " fitted tracks" << std::endl;
     std::cout << "==>Elapsed times...\n" << elapsedTimes << std::endl;
 
     return 0;

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -8,17 +8,18 @@
 // Project include(s).
 #include "traccc/alpaka/clusterization/clusterization_algorithm.hpp"
 #include "traccc/alpaka/clusterization/measurement_sorting_algorithm.hpp"
+#include "traccc/alpaka/finding/finding_algorithm.hpp"
+#include "traccc/alpaka/fitting/fitting_algorithm.hpp"
 #include "traccc/alpaka/seeding/seeding_algorithm.hpp"
 #include "traccc/alpaka/seeding/spacepoint_formation_algorithm.hpp"
 #include "traccc/alpaka/seeding/track_params_estimation.hpp"
-#include "traccc/alpaka/utils/vecmem_types.hpp"
-#ifdef ALPAKA_ACC_SYCL_ENABLED
-#include <sycl/sycl.hpp>
-#include <vecmem/utils/sycl/queue_wrapper.hpp>
-#endif
-
+#include "traccc/alpaka/utils/get_vecmem_resource.hpp"
 #include "traccc/clusterization/clusterization_algorithm.hpp"
+#include "traccc/device/container_d2h_copy_alg.hpp"
 #include "traccc/efficiency/seeding_performance_writer.hpp"
+#include "traccc/finding/combinatorial_kalman_filter_algorithm.hpp"
+#include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+#include "traccc/fitting/kalman_fitting_algorithm.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_detector.hpp"
@@ -30,13 +31,24 @@
 #include "traccc/options/input_data.hpp"
 #include "traccc/options/performance.hpp"
 #include "traccc/options/program_options.hpp"
+#include "traccc/options/track_finding.hpp"
+#include "traccc/options/track_fitting.hpp"
+#include "traccc/options/track_propagation.hpp"
 #include "traccc/options/track_seeding.hpp"
 #include "traccc/performance/collection_comparator.hpp"
+#include "traccc/performance/container_comparator.hpp"
 #include "traccc/performance/soa_comparator.hpp"
 #include "traccc/performance/timer.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
+
+// Detray include(s).
+#include <detray/detectors/bfield.hpp>
+#include <detray/io/frontend/detector_reader.hpp>
+#include <detray/navigation/navigator.hpp>
+#include <detray/propagator/propagator.hpp>
+#include <detray/propagator/rk_stepper.hpp>
 
 // System include(s).
 #include <exception>
@@ -44,40 +56,29 @@
 #include <iostream>
 #include <memory>
 
-namespace po = boost::program_options;
-
 int seq_run(const traccc::opts::detector& detector_opts,
             const traccc::opts::input_data& input_opts,
             const traccc::opts::clusterization& clusterization_opts,
             const traccc::opts::track_seeding& seeding_opts,
+            const traccc::opts::track_finding& finding_opts,
+            const traccc::opts::track_propagation& propagation_opts,
+            const traccc::opts::track_fitting& fitting_opts,
             const traccc::opts::performance& performance_opts,
             const traccc::opts::accelerator& accelerator_opts,
             std::unique_ptr<const traccc::Logger> ilogger) {
     TRACCC_LOCAL_LOGGER(std::move(ilogger));
 
-    // Output stats
-    uint64_t n_cells = 0;
-    uint64_t n_measurements = 0;
-    uint64_t n_spacepoints = 0;
-    uint64_t n_spacepoints_alpaka = 0;
-    uint64_t n_seeds = 0;
-    uint64_t n_seeds_alpaka = 0;
-
-    // Constant B field for the track finding and fitting
-    const traccc::vector3 field_vec = {0.f, 0.f,
-                                       seeding_opts.seedfinder.bFieldInZ};
-
     // Memory resources used by the application.
 #ifdef ALPAKA_ACC_SYCL_ENABLED
     ::sycl::queue q;
     vecmem::sycl::queue_wrapper qw{&q};
-    traccc::alpaka::vecmem::device_copy copy(qw);
-    traccc::alpaka::vecmem::host_memory_resource host_mr(qw);
-    traccc::alpaka::vecmem::device_memory_resource device_mr(qw);
+    traccc::alpaka::vecmem_resources::device_copy copy(qw);
+    traccc::alpaka::vecmem_resources::host_memory_resource host_mr(qw);
+    traccc::alpaka::vecmem_resources::device_memory_resource device_mr(qw);
 #else
-    traccc::alpaka::vecmem::device_copy copy;
-    traccc::alpaka::vecmem::host_memory_resource host_mr;
-    traccc::alpaka::vecmem::device_memory_resource device_mr;
+    traccc::alpaka::vecmem_resources::device_copy copy;
+    traccc::alpaka::vecmem_resources::host_memory_resource host_mr;
+    traccc::alpaka::vecmem_resources::device_memory_resource device_mr;
 #endif
     traccc::memory_resource mr{device_mr, &host_mr};
 
@@ -93,7 +94,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
     traccc::silicon_detector_description::buffer device_det_descr{
         static_cast<traccc::silicon_detector_description::buffer::size_type>(
             host_det_descr.size()),
-        mr.main};
+        device_mr};
+    copy.setup(device_det_descr)->wait();
     copy(host_det_descr_data, device_det_descr)->wait();
 
     // Construct a Detray detector object, if supported by the configuration.
@@ -104,16 +106,60 @@ int seq_run(const traccc::opts::detector& detector_opts,
         traccc::io::read_detector(
             host_detector, host_mr, detector_opts.detector_file,
             detector_opts.material_file, detector_opts.grid_file);
-        device_detector = detray::get_buffer(host_detector, mr.main, copy);
+        device_detector = detray::get_buffer(host_detector, device_mr, copy);
         device_detector_view = detray::get_data(device_detector);
     }
 
+    // Output stats
+    uint64_t n_cells = 0;
+    uint64_t n_measurements = 0;
+    uint64_t n_measurements_alpaka = 0;
+    uint64_t n_spacepoints = 0;
+    uint64_t n_spacepoints_alpaka = 0;
+    uint64_t n_seeds = 0;
+    uint64_t n_seeds_alpaka = 0;
+    uint64_t n_found_tracks = 0;
+    uint64_t n_found_tracks_alpaka = 0;
+    uint64_t n_fitted_tracks = 0;
+    uint64_t n_fitted_tracks_alpaka = 0;
+
     // Type definitions
+    using scalar_type = traccc::default_detector::host::scalar_type;
     using host_spacepoint_formation_algorithm =
         traccc::host::silicon_pixel_spacepoint_formation_algorithm;
     using device_spacepoint_formation_algorithm =
         traccc::alpaka::spacepoint_formation_algorithm<
             traccc::default_detector::device>;
+    using stepper_type =
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
+                           traccc::default_detector::host::algebra_type,
+                           detray::constrained_step<scalar_type>>;
+    using device_navigator_type =
+        detray::navigator<const traccc::default_detector::device>;
+
+    using host_finding_algorithm =
+        traccc::host::combinatorial_kalman_filter_algorithm;
+    using device_finding_algorithm =
+        traccc::alpaka::finding_algorithm<stepper_type, device_navigator_type>;
+
+    using host_fitting_algorithm = traccc::host::kalman_fitting_algorithm;
+    using device_fitting_algorithm = traccc::alpaka::fitting_algorithm<
+        traccc::kalman_fitter<stepper_type, device_navigator_type>>;
+
+    // Algorithm configuration(s).
+    detray::propagation::config propagation_config(propagation_opts);
+
+    traccc::finding_config finding_cfg(finding_opts);
+    finding_cfg.propagation = propagation_config;
+
+    traccc::fitting_config fitting_cfg(fitting_opts);
+    fitting_cfg.propagation = propagation_config;
+
+    // Constant B field for the track finding and fitting
+    const traccc::vector3 field_vec = {0.f, 0.f,
+                                       seeding_opts.seedfinder.bFieldInZ};
+    const detray::bfield::const_field_t<traccc::scalar> field =
+        detray::bfield::create_const_field<traccc::scalar>(field_vec);
 
     traccc::host::clusterization_algorithm ca(
         host_mr, logger().clone("HostClusteringAlg"));
@@ -124,6 +170,10 @@ int seq_run(const traccc::opts::detector& detector_opts,
         seeding_opts.seedfilter, host_mr, logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
+    host_finding_algorithm finding_alg(finding_cfg,
+                                       logger().clone("HostFindingAlg"));
+    host_fitting_algorithm fitting_alg(fitting_cfg, host_mr,
+                                       logger().clone("HostFittingAlg"));
 
     traccc::alpaka::clusterization_algorithm ca_alpaka(
         mr, copy, clusterization_opts, logger().clone("AlpakaClusteringAlg"));
@@ -136,6 +186,17 @@ int seq_run(const traccc::opts::detector& detector_opts,
         seeding_opts.seedfilter, mr, copy, logger().clone("AlpakaSeedingAlg"));
     traccc::alpaka::track_params_estimation tp_alpaka(
         mr, copy, logger().clone("AlpakaTrackParEstAlg"));
+    device_finding_algorithm finding_alg_alpaka(
+        finding_cfg, mr, copy, logger().clone("AlpakaFindingAlg"));
+    device_fitting_algorithm fitting_alg_alpaka(
+        fitting_cfg, mr, copy, logger().clone("AlpakaFittingAlg"));
+
+    traccc::device::container_d2h_copy_alg<
+        traccc::track_candidate_container_types>
+        copy_track_candidates(mr, copy,
+                              logger().clone("TrackCandidateD2HCopyAlg"));
+    traccc::device::container_d2h_copy_alg<traccc::track_state_container_types>
+        copy_track_states(mr, copy, logger().clone("TrackStateD2HCopyAlg"));
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
@@ -154,6 +215,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
             host_mr};
         traccc::host::seeding_algorithm::output_type seeds{host_mr};
         traccc::host::track_params_estimation::output_type params{&host_mr};
+        host_finding_algorithm::output_type track_candidates;
+        host_fitting_algorithm::output_type track_states;
 
         // Instantiate alpaka containers/collections
         traccc::measurement_collection_types::buffer measurements_alpaka_buffer(
@@ -162,6 +225,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
         traccc::edm::seed_collection::buffer seeds_alpaka_buffer;
         traccc::bound_track_parameters_collection_types::buffer
             params_alpaka_buffer(0, *mr.host);
+        traccc::track_candidate_container_types::buffer track_candidates_buffer;
+        traccc::track_state_container_types::buffer track_states_buffer;
 
         {
             traccc::performance::timer wall_t("Wall time", elapsedTimes);
@@ -184,6 +249,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
             // Create device copy of input collections
             traccc::edm::silicon_cell_collection::buffer cells_buffer(
                 static_cast<unsigned int>(cells_per_event.size()), mr.main);
+            copy.setup(cells_buffer)->wait();
             copy(vecmem::get_data(cells_per_event), cells_buffer)->wait();
 
             // Alpaka
@@ -204,6 +270,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
                     ca(vecmem::get_data(cells_per_event), host_det_descr_data);
             }  // stop measuring clusterization cpu timer
 
+            // Perform seeding, track finding and fitting only when using a
+            // Detray geometry.
             if (detector_opts.use_detray_detector) {
 
                 // Alpaka
@@ -212,7 +280,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
                         "Spacepoint formation (alpaka)", elapsedTimes);
                     spacepoints_alpaka_buffer = sf_alpaka(
                         device_detector_view, measurements_alpaka_buffer);
-                }  // stop measuring spacepoint formation cuda timer
+                }  // stop measuring spacepoint formation alpaka timer
 
                 // CPU
                 if (accelerator_opts.compare_with_cpu) {
@@ -254,6 +322,42 @@ int seq_run(const traccc::opts::detector& detector_opts,
                                 vecmem::get_data(spacepoints_per_event),
                                 vecmem::get_data(seeds), field_vec);
                 }  // stop measuring track params cpu timer
+
+                // Alpaka
+                {
+                    traccc::performance::timer timer{"Track finding (alpaka)",
+                                                     elapsedTimes};
+                    track_candidates_buffer = finding_alg_alpaka(
+                        device_detector_view, field, measurements_alpaka_buffer,
+                        params_alpaka_buffer);
+                }
+
+                // CPU
+                if (accelerator_opts.compare_with_cpu) {
+                    traccc::performance::timer timer{"Track finding (cpu)",
+                                                     elapsedTimes};
+                    track_candidates =
+                        finding_alg(host_detector, field,
+                                    vecmem::get_data(measurements_per_event),
+                                    vecmem::get_data(params));
+                }
+
+                // Alpaka
+                {
+                    traccc::performance::timer timer{"Track fitting (alpaka)",
+                                                     elapsedTimes};
+                    track_states_buffer = fitting_alg_alpaka(
+                        device_detector_view, field, track_candidates_buffer);
+                }
+
+                // CPU
+                if (accelerator_opts.compare_with_cpu) {
+                    traccc::performance::timer timer{"Track fitting (cpu)",
+                                                     elapsedTimes};
+                    track_states =
+                        fitting_alg(host_detector, field,
+                                    traccc::get_data(track_candidates));
+                }
             }
         }  // Stop measuring wall time
 
@@ -261,20 +365,33 @@ int seq_run(const traccc::opts::detector& detector_opts,
           compare cpu and alpaka result
           ----------------------------------*/
 
+        traccc::measurement_collection_types::host
+            measurements_per_event_alpaka;
         traccc::edm::spacepoint_collection::host spacepoints_per_event_alpaka{
             host_mr};
         traccc::edm::seed_collection::host seeds_alpaka{host_mr};
         traccc::bound_track_parameters_collection_types::host params_alpaka{
             &host_mr};
 
+        copy(measurements_alpaka_buffer, measurements_per_event_alpaka)->wait();
         copy(spacepoints_alpaka_buffer, spacepoints_per_event_alpaka)->wait();
         copy(seeds_alpaka_buffer, seeds_alpaka)->wait();
         copy(params_alpaka_buffer, params_alpaka)->wait();
+        auto track_candidates_alpaka =
+            copy_track_candidates(track_candidates_buffer);
+        auto track_states_alpaka = copy_track_states(track_states_buffer);
 
         if (accelerator_opts.compare_with_cpu) {
 
             // Show which event we are currently presenting the results for.
-            std::cout << "===>>> Event " << event << " <<<===" << std::endl;
+            TRACCC_INFO("===>>> Event " << event << " <<<===");
+
+            // Compare the measurements made on the host and on the device.
+            traccc::collection_comparator<traccc::measurement>
+                compare_measurements{"measurements"};
+            compare_measurements(
+                vecmem::get_data(measurements_per_event),
+                vecmem::get_data(measurements_per_event_alpaka));
 
             // Compare the spacepoints made on the host and on the device.
             traccc::soa_comparator<traccc::edm::spacepoint_collection>
@@ -297,14 +414,55 @@ int seq_run(const traccc::opts::detector& detector_opts,
                 compare_track_parameters{"track parameters"};
             compare_track_parameters(vecmem::get_data(params),
                                      vecmem::get_data(params_alpaka));
-        }
 
+            // Compare tracks found on the host and on the device.
+            traccc::collection_comparator<
+                traccc::track_candidate_container_types::host::header_type>
+                compare_track_candidates{"track candidates (header)"};
+            compare_track_candidates(
+                vecmem::get_data(track_candidates.get_headers()),
+                vecmem::get_data(track_candidates_alpaka.get_headers()));
+
+            unsigned int n_matches = 0;
+            for (unsigned int i = 0; i < track_candidates.size(); i++) {
+                auto iso = traccc::details::is_same_object(
+                    track_candidates.at(i).items);
+
+                for (unsigned int j = 0; j < track_candidates_alpaka.size();
+                     j++) {
+                    if (iso(track_candidates_alpaka.at(j).items)) {
+                        n_matches++;
+                        break;
+                    }
+                }
+            }
+
+            std::cout << "  Track candidates (item) matching rate: "
+                      << 100. * static_cast<double>(n_matches) /
+                             static_cast<double>(
+                                 std::max(track_candidates.size(),
+                                          track_candidates_alpaka.size()))
+                      << "%" << std::endl;
+
+            // Compare tracks fitted on the host and on the device.
+            traccc::collection_comparator<
+                traccc::track_state_container_types::host::header_type>
+                compare_track_states{"track states"};
+            compare_track_states(
+                vecmem::get_data(track_states.get_headers()),
+                vecmem::get_data(track_states_alpaka.get_headers()));
+        }
         /// Statistics
         n_measurements += measurements_per_event.size();
         n_spacepoints += spacepoints_per_event.size();
         n_seeds += seeds.size();
+        n_measurements_alpaka += measurements_per_event_alpaka.size();
         n_spacepoints_alpaka += spacepoints_per_event_alpaka.size();
         n_seeds_alpaka += seeds_alpaka.size();
+        n_found_tracks += track_candidates.size();
+        n_found_tracks_alpaka += track_candidates_alpaka.size();
+        n_fitted_tracks += track_states.size();
+        n_fitted_tracks_alpaka += track_states_alpaka.size();
 
         if (performance_opts.run) {
 
@@ -324,19 +482,22 @@ int seq_run(const traccc::opts::detector& detector_opts,
         sd_performance_writer.finalize();
     }
 
-    std::cout << "==> Statistics ... " << std::endl;
-    std::cout << "- read    " << n_cells << " cells" << std::endl;
-    std::cout << "- created (cpu)  " << n_measurements << " measurements     "
-              << std::endl;
-    std::cout << "- created (cpu)  " << n_spacepoints << " spacepoints     "
-              << std::endl;
-    std::cout << "- created (alpaka) " << n_spacepoints_alpaka
-              << " spacepoints     " << std::endl;
+    TRACCC_INFO("==> Statistics ... ");
+    TRACCC_INFO("- read    " << n_cells << " cells");
+    TRACCC_INFO("- created (cpu)  " << n_measurements << " measurements     ");
+    TRACCC_INFO("- created (alpaka)  " << n_measurements_alpaka
+                                       << " measurements     ");
+    TRACCC_INFO("- created (cpu)  " << n_spacepoints << " spacepoints     ");
+    TRACCC_INFO("- created (alpaka) " << n_spacepoints_alpaka
+                                      << " spacepoints     ");
 
-    std::cout << "- created  (cpu) " << n_seeds << " seeds" << std::endl;
-    std::cout << "- created (alpaka) " << n_seeds_alpaka << " seeds"
-              << std::endl;
-    std::cout << "==>Elapsed times...\n" << elapsedTimes << std::endl;
+    TRACCC_INFO("- created  (cpu) " << n_seeds << " seeds");
+    TRACCC_INFO("- created (alpaka) " << n_seeds_alpaka << " seeds");
+    TRACCC_INFO("- found (cpu)    " << n_found_tracks << " tracks");
+    TRACCC_INFO("- found (alpaka)   " << n_found_tracks_alpaka << " tracks");
+    TRACCC_INFO("- fitted (cpu)   " << n_fitted_tracks << " tracks");
+    TRACCC_INFO("- fitted (alpaka)  " << n_fitted_tracks_alpaka << " tracks");
+    TRACCC_INFO("==>Elapsed times... " << elapsedTimes);
 
     return 0;
 }
@@ -352,17 +513,22 @@ int main(int argc, char* argv[]) {
     traccc::opts::input_data input_opts;
     traccc::opts::clusterization clusterization_opts;
     traccc::opts::track_seeding seeding_opts;
+    traccc::opts::track_finding finding_opts;
+    traccc::opts::track_propagation propagation_opts;
+    traccc::opts::track_fitting fitting_opts;
     traccc::opts::performance performance_opts;
     traccc::opts::accelerator accelerator_opts;
     traccc::opts::program_options program_opts{
         "Full Tracking Chain Using Alpaka",
         {detector_opts, input_opts, clusterization_opts, seeding_opts,
-         performance_opts, accelerator_opts},
+         finding_opts, propagation_opts, performance_opts, fitting_opts,
+         accelerator_opts},
         argc,
         argv,
         logger->cloneWithSuffix("Options")};
 
     // Run the application.
     return seq_run(detector_opts, input_opts, clusterization_opts, seeding_opts,
+                   finding_opts, propagation_opts, fitting_opts,
                    performance_opts, accelerator_opts, logger->clone());
 }

--- a/examples/run/alpaka/throughput_mt.cpp
+++ b/examples/run/alpaka/throughput_mt.cpp
@@ -1,36 +1,24 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
+// Project include(s).
+#include "traccc/alpaka/utils/get_vecmem_resource.hpp"
+
 // Local include(s).
 #include "../common/throughput_mt.hpp"
-
 #include "full_chain_algorithm.hpp"
-
-// VecMem include(s).
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-#include <vecmem/memory/cuda/host_memory_resource.hpp>
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-#include <vecmem/memory/hip/host_memory_resource.hpp>
-#else
-#include <vecmem/memory/host_memory_resource.hpp>
-#endif
 
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
     static const bool use_host_caching = true;
-    return traccc::throughput_mt<traccc::alpaka::full_chain_algorithm,
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                                 vecmem::cuda::host_memory_resource
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-                                 vecmem::hip::host_memory_resource
-#else
-                                 vecmem::host_memory_resource
-#endif
-                                 >("Multi-threaded Alpaka GPU throughput tests",
-                                   argc, argv, use_host_caching);
+    return traccc::throughput_mt<
+        traccc::alpaka::full_chain_algorithm,
+        traccc::alpaka::vecmem_resources::host_memory_resource>(
+        "Multi-threaded Alpaka GPU throughput tests", argc, argv,
+        use_host_caching);
 }

--- a/examples/run/alpaka/throughput_st.cpp
+++ b/examples/run/alpaka/throughput_st.cpp
@@ -1,37 +1,24 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
+// Project include(s).
+#include "traccc/alpaka/utils/get_vecmem_resource.hpp"
+
 // Local include(s).
 #include "../common/throughput_st.hpp"
-
 #include "full_chain_algorithm.hpp"
-
-// VecMem include(s).
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-#include <vecmem/memory/cuda/host_memory_resource.hpp>
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-#include <vecmem/memory/hip/host_memory_resource.hpp>
-#else
-#include <vecmem/memory/host_memory_resource.hpp>
-#endif
 
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
     static const bool use_host_caching = true;
-    return traccc::throughput_st<traccc::alpaka::full_chain_algorithm,
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                                 vecmem::cuda::host_memory_resource
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-                                 vecmem::hip::host_memory_resource
-#else
-                                 vecmem::host_memory_resource
-#endif
-                                 >(
+    return traccc::throughput_st<
+        traccc::alpaka::full_chain_algorithm,
+        traccc::alpaka::vecmem_resources::host_memory_resource>(
         "Single-threaded Alpaka GPU throughput tests", argc, argv,
         use_host_caching);
 }

--- a/tests/alpaka/alpaka_basic.cpp
+++ b/tests/alpaka/alpaka_basic.cpp
@@ -1,7 +1,7 @@
 /**
  * TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,12 +15,7 @@
 #include <vecmem/memory/host_memory_resource.hpp>
 #include <vecmem/utils/copy.hpp>
 
-#include "traccc/alpaka/utils/vecmem_types.hpp"
-
-#ifdef ALPAKA_ACC_SYCL_ENABLED
-#include <sycl/sycl.hpp>
-#include <vecmem/utils/sycl/queue_wrapper.hpp>
-#endif
+#include "traccc/alpaka/utils/get_vecmem_resource.hpp"
 
 // GoogleTest include(s).
 #include <gtest/gtest.h>
@@ -139,13 +134,13 @@ GTEST_TEST(AlpakaBasic, VecMemOp) {
 #ifdef ALPAKA_ACC_SYCL_ENABLED
     ::sycl::queue q;
     vecmem::sycl::queue_wrapper qw{&q};
-    traccc::alpaka::vecmem::device_copy vm_copy(qw);
+    traccc::alpaka::vecmem_resources::device_copy vm_copy(qw);
 #else
-    traccc::alpaka::vecmem::device_copy vm_copy;
+    traccc::alpaka::vecmem_resources::device_copy vm_copy;
 #endif
 
-    traccc::alpaka::vecmem::host_memory_resource host_mr;
-    traccc::alpaka::vecmem::device_memory_resource device_mr;
+    traccc::alpaka::vecmem_resources::host_memory_resource host_mr;
+    traccc::alpaka::vecmem_resources::device_memory_resource device_mr;
 
     vecmem::vector<float> host_vector{n, &host_mr};
 

--- a/tests/alpaka/test_cca.cpp
+++ b/tests/alpaka/test_cca.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,9 +15,11 @@
 #include <vecmem/utils/sycl/queue_wrapper.hpp>
 #endif
 
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+
 #include "tests/cca_test.hpp"
 #include "traccc/alpaka/clusterization/clusterization_algorithm.hpp"
-#include "traccc/alpaka/utils/vecmem_types.hpp"
+#include "traccc/alpaka/utils/get_vecmem_resource.hpp"
 #include "traccc/geometry/silicon_detector_description.hpp"
 
 namespace {
@@ -32,13 +34,13 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
 #ifdef ALPAKA_ACC_SYCL_ENABLED
         ::sycl::queue q;
         vecmem::sycl::queue_wrapper qw{&q};
-        traccc::alpaka::vecmem::host_memory_resource host_mr(qw);
-        traccc::alpaka::vecmem::device_copy copy(qw);
-        traccc::alpaka::vecmem::device_memory_resource device_mr;
+        traccc::alpaka::vecmem_resources::host_memory_resource host_mr(qw);
+        traccc::alpaka::vecmem_resources::device_copy copy(qw);
+        traccc::alpaka::vecmem_resources::device_memory_resource device_mr;
 #else
-        traccc::alpaka::vecmem::host_memory_resource host_mr;
-        traccc::alpaka::vecmem::device_copy copy;
-        traccc::alpaka::vecmem::device_memory_resource device_mr;
+        traccc::alpaka::vecmem_resources::host_memory_resource host_mr;
+        traccc::alpaka::vecmem_resources::device_copy copy;
+        traccc::alpaka::vecmem_resources::device_memory_resource device_mr;
 #endif
 
         traccc::alpaka::clusterization_algorithm cc({device_mr}, copy, cfg);


### PR DESCRIPTION
After far too much time, I've managed to get some time away from other work to get this into a functional and (mostly) tidy state.

This PR has:
 - Track finding + fitting for Alpaka
 - Updates to some of the existing code to bring it closer in parity to the CUDA versions
 - Updates and new example code to use said finding + fitting

This is a fairly large PR, so if required, I can split it up further (I imagine the easiest way to do that would be at the very least split up the library code vs the example code, but other suggestions welcome).

I'll stick a few comments on this draft PR for bits I know need further input, so any help there is much appreciated.

This "functions" now, but I'm still hitting a few issues, though it is also probably / possibly the same issue:
  - The seeding examples don't show exact matches all the time. Running over the 5 events from the `odd/geant4_1muon_10GeV` file, I see 48% / 60% / 78% / 46% and 100% agreement with the CPU based version...so something is going wrong, but not all the time, killing the performance.
  - The single-threaded throughput example seems to die after 1 event with a memory error, which it didn't do previously (since I had performance numbers etc out).
  - The multi-threaded throughput example isn't working, but I've also not had any chance to really do a deeper look into the interactions between TBB + Alpaka, so that one is less known at the moment.

I don't think they should be blockers though, the code is a lot more functional and nearer feature parity vs the existing code, so it would be good to get it in (when suitably reviewed, maintainable etcetc of course). Right now, when I do manage to get half a day or day to work on this, I inevitably end up spending it catching up on recent refactors or improvements, so having the code in-repo should help with that.

This branch has some very artificial commits that I made at the very end to group things into logical chunks (vs the absolute mess of commits that happened really: https://github.com/CrossR/traccc/tree/CrossR/alpaka_fitting). I've no idea how the rest of you feel about that, but figured it was better than a behemoth number of commits coming in (and still slightly better than just a single squash commit). I don't mind re-doing that if useful / better.