### PR TITLE
Add debugging output to the propagation kernel

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -70,6 +70,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "src/finding/combinatorial_kalman_filter_algorithm.cpp"
   "src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.cpp"
   "src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.cpp"
+  "src/finding/details/debug_output.cpp"
   # Fitting algorithmic code
   "include/traccc/fitting/kalman_filter/gain_matrix_smoother.hpp"
   "include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp"

--- a/core/include/traccc/finding/details/debug_output.hpp
+++ b/core/include/traccc/finding/details/debug_output.hpp
@@ -1,0 +1,28 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/utils/logging.hpp"
+
+namespace traccc {
+enum class propagate_to_next_surface_exit_mode {
+    HOLE_LIMIT_REACHED,
+    BRANCH_LIMIT_REACHED,
+    MAX
+};
+
+struct propagate_to_next_surface_debug {
+    void reset();
+
+    unsigned int m_failure_count[static_cast<std::size_t>(
+        propagate_to_next_surface_exit_mode::MAX)];
+};
+
+void log_propagate_to_next_surface_debug(
+    const propagate_to_next_surface_debug& obj, const Logger& logger);
+}  // namespace traccc

--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -48,6 +48,9 @@ struct finding_config {
     /// Particle hypothesis
     detray::pdg_particle<traccc::scalar> ptc_hypothesis =
         detray::muon<traccc::scalar>();
+
+    /// Provide more verbose output for debugging; may reduce performance
+    bool verbose = false;
 };
 
 }  // namespace traccc

--- a/core/src/finding/details/debug_output.cpp
+++ b/core/src/finding/details/debug_output.cpp
@@ -1,0 +1,36 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "traccc/finding/details/debug_output.hpp"
+
+#include "traccc/utils/logging.hpp"
+
+namespace traccc {
+void propagate_to_next_surface_debug::reset() {
+    for (std::size_t i = 0;
+         i < static_cast<std::size_t>(propagate_to_next_surface_exit_mode::MAX);
+         ++i) {
+        m_failure_count[i] = 0;
+    }
+}
+
+void log_propagate_to_next_surface_debug(
+    const propagate_to_next_surface_debug& obj, const Logger& logger) {
+    if (unsigned int n = obj.m_failure_count[static_cast<std::size_t>(
+            propagate_to_next_surface_exit_mode::HOLE_LIMIT_REACHED)];
+        n > 0) {
+        TRACCC_DEBUG(n << " tracks were killed due to reaching the hole limit");
+    }
+
+    if (unsigned int n = obj.m_failure_count[static_cast<std::size_t>(
+            propagate_to_next_surface_exit_mode::BRANCH_LIMIT_REACHED)];
+        n > 0) {
+        TRACCC_DEBUG(
+            n << " tracks were killed due to reaching the branch limit");
+    }
+}
+}  // namespace traccc

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -50,6 +50,14 @@ TRACCC_DEVICE inline void propagate_to_next_surface(
 
     if (s_pos >= cfg.max_num_branches_per_seed) {
         params_liveness[param_id] = 0u;
+
+        if (payload.debug) {
+            vecmem::device_atomic_ref<unsigned int>(
+                payload.debug->m_failure_count[static_cast<std::size_t>(
+                    propagate_to_next_surface_exit_mode::BRANCH_LIMIT_REACHED)])
+                .fetch_add(1u);
+        }
+
         return;
     }
 
@@ -60,6 +68,14 @@ TRACCC_DEVICE inline void propagate_to_next_surface(
     if (links.at(param_id).n_skipped > cfg.max_num_skipping_per_cand) {
         params_liveness[param_id] = 0u;
         tips.push_back({payload.step, param_id});
+
+        if (payload.debug) {
+            vecmem::device_atomic_ref<unsigned int>(
+                payload.debug->m_failure_count[static_cast<std::size_t>(
+                    propagate_to_next_surface_exit_mode::HOLE_LIMIT_REACHED)])
+                .fetch_add(1u);
+        }
+
         return;
     }
 

--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -14,13 +14,13 @@
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/details/debug_output.hpp"
 #include "traccc/finding/finding_config.hpp"
 
 // VecMem include(s).
 #include <vecmem/containers/data/vector_view.hpp>
 
 namespace traccc::device {
-
 /// (Event Data) Payload for the @c traccc::device::propagate_to_next_surface
 /// function
 template <typename propagator_t, typename bfield_t>
@@ -76,6 +76,11 @@ struct propagate_to_next_surface_payload {
      * input seed
      */
     vecmem::data::vector_view<unsigned int> n_tracks_per_seed_view;
+
+    /**
+     * @brief Optional debug object
+     */
+    propagate_to_next_surface_debug* debug;
 };
 
 /// Function for propagating the kalman-updated tracks to the next surface

--- a/device/sycl/src/finding/find_tracks.hpp
+++ b/device/sycl/src/finding/find_tracks.hpp
@@ -398,7 +398,8 @@ track_candidate_container_types::buffer find_tracks(
                                 details::global_index(item), config,
                                 {det, field, in_params, param_liveness,
                                  param_ids, current_candidate_links, step,
-                                 n_candidates, tips, n_tracks_per_seed});
+                                 n_candidates, tips, n_tracks_per_seed,
+                                 nullptr});
                         });
                 })
                 .wait_and_throw();

--- a/examples/options/src/track_finding.cpp
+++ b/examples/options/src/track_finding.cpp
@@ -12,6 +12,7 @@
 #include "traccc/utils/particle.hpp"
 
 // System include(s).
+#include <format>
 #include <sstream>
 
 namespace traccc::opts {
@@ -63,6 +64,10 @@ track_finding::track_finding() : interface("Track Finding Options") {
     m_desc.add_options()("particle-hypothesis",
                          po::value(&m_pdg_number)->default_value(m_pdg_number),
                          "PDG number for the particle hypothesis");
+    m_desc.add_options()(
+        "finding-debug",
+        po::value(&m_config.verbose)->default_value(m_config.verbose),
+        "Extra verbose output");
 }
 
 track_finding::operator finding_config() const {
@@ -102,6 +107,8 @@ std::unique_ptr<configuration_printable> track_finding::as_printable() const {
         std::to_string(m_config.max_num_skipping_per_cand)));
     cat->add_child(std::make_unique<configuration_kv_pair>(
         "PDG number", std::to_string(m_pdg_number)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Debug output", std::format("{}", m_config.verbose)));
 
     return cat;
 }


### PR DESCRIPTION
This commit adds some optional debugging output to the propagation kernel, allowing it to output more precise statistics on why tracks were killed.