### PR TITLE
Fix rocprim version to 6.1.1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -81,7 +81,7 @@ jobs:
           - platform:
               name: "ALPAKA_HIP_SYCL"
               container: ghcr.io/acts-project/ubuntu2404_rocm_oneapi:69
-              options: --preset alpaka-fp32 -Dalpaka_ACC_GPU_HIP_ENABLE=ON -DCMAKE_PREFIX_PATH=/opt/rocm/lib/cmake/ -Dalpaka_DISABLE_VENDOR_RNG=ON -DTRACCC_USE_ROOT=OFF
+              options: --preset alpaka-fp32 -Dalpaka_ACC_GPU_HIP_ENABLE=ON -DCMAKE_PREFIX_PATH=/opt/rocm/lib/cmake/ -Dalpaka_DISABLE_VENDOR_RNG=ON -DTRACCC_USE_ROOT=OFF -DTRACCC_SETUP_ROCTHRUST=ON -DTRACCC_BUILD_HIP=ON
               run_tests: false
             build: Release
           - platform:

--- a/extern/rocThrust/rocm-6.1.1.patch
+++ b/extern/rocThrust/rocm-6.1.1.patch
@@ -24,3 +24,16 @@ diff -ur rocThrust-rocm-6.1.1-orig/CMakeLists.txt rocThrust-rocm-6.1.1-fixed/CMa
  # Build options
  # Disable -Werror
  option(DISABLE_WERROR "Disable building with Werror" ON)
+diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
+index 218f6122..6394bfec 100644
+--- a/cmake/Dependencies.cmake
++++ b/cmake/Dependencies.cmake
+@@ -21,7 +21,7 @@ if(NOT rocprim_FOUND)
+   download_project(
+     PROJ                rocprim
+     GIT_REPOSITORY      https://github.com/ROCmSoftwarePlatform/rocPRIM.git
+-    GIT_TAG             develop
++    GIT_TAG             rocm-6.1.1
+     INSTALL_DIR         ${CMAKE_CURRENT_BINARY_DIR}/deps/rocprim
+     CMAKE_ARGS          -DBUILD_TEST=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=/opt/rocm
+     LOG_DOWNLOAD        TRUE


### PR DESCRIPTION
Required for https://github.com/acts-project/traccc/pull/901 and fixes the compilation error seen there:
```/bld/_deps/rocthrust-build/deps/rocprim/include/rocprim/device/detail/config_types.hpp:324:78: error: use of undeclared identifier 'hipStreamLegacy'
  324 |     if(stream == default_stream || stream == hipStreamPerThread || stream == hipStreamLegacy)
```

After investigation I opened a rocThrust bug (https://github.com/ROCm/rocThrust/issues/527) - we are picking up the tip of the develop branch for rocprim (a rocThrust dependency), which is no longer compatible with rocm-6.1.1. Fix this in the patch.

Additionally, so this can be tested, start building rocThrust and related test code in HIP Alpaka flavour.

