### PR TITLE
Improve memory usage in track finding postamble

### DIFF
--- a/device/common/include/traccc/finding/device/find_tracks.hpp
+++ b/device/common/include/traccc/finding/device/find_tracks.hpp
@@ -105,6 +105,11 @@ struct find_tracks_payload {
     vecmem::data::vector_view<unsigned int> tips_view;
 
     /**
+     * @brief Vector to hold the number of track states per tip
+     */
+    vecmem::data::vector_view<unsigned int> tip_lengths_view;
+
+    /**
      * @brief View object to the vector of the number of tracks per initial
      * input seed
      */

--- a/device/common/include/traccc/finding/device/impl/build_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/build_tracks.ipp
@@ -41,16 +41,9 @@ TRACCC_HOST_DEVICE inline void build_tracks(
     auto L = links.at(tip);
     const unsigned int n_meas = measurements.size();
 
-    const unsigned int n_cands = L.step + 1 - L.n_skipped;
-
-    // Resize the candidates with the exact size
-    cands_per_track.resize(n_cands);
-
     // Track summary variables
     scalar ndf_sum = 0.f;
     scalar chi2_sum = 0.f;
-
-    [[maybe_unused]] std::size_t num_inserted = 0;
 
     // Reversely iterate to fill the track candidates
     for (auto it = cands_per_track.rbegin(); it != cands_per_track.rend();
@@ -64,7 +57,6 @@ TRACCC_HOST_DEVICE inline void build_tracks(
         assert(L.meas_idx < n_meas);
 
         *it = {measurements.at(L.meas_idx)};
-        num_inserted++;
 
         // Sanity check on chi2
         assert(L.chi2 < std::numeric_limits<traccc::scalar>::max());
@@ -87,10 +79,6 @@ TRACCC_HOST_DEVICE inline void build_tracks(
     }
 
 #ifndef NDEBUG
-    // Assert that we inserted exactly as many elements as we reserved
-    // space for.
-    assert(num_inserted == cands_per_track.size());
-
     // Assert that we did not make any duplicate track states.
     for (unsigned int i = 0; i < cands_per_track.size(); ++i) {
         for (unsigned int j = 0; j < cands_per_track.size(); ++j) {

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -72,6 +72,7 @@ TRACCC_HOST_DEVICE inline void find_tracks(
     vecmem::device_vector<const unsigned int> upper_bounds(
         payload.upper_bounds_view);
     vecmem::device_vector<unsigned int> tips(payload.tips_view);
+    vecmem::device_vector<unsigned int> tip_lengths(payload.tip_lengths_view);
     vecmem::device_vector<unsigned int> n_tracks_per_seed(
         payload.n_tracks_per_seed_view);
 
@@ -276,7 +277,8 @@ TRACCC_HOST_DEVICE inline void find_tracks(
                 // a tip
                 if (last_step &&
                     n_cands >= cfg.min_track_candidates_per_track) {
-                    tips.push_back(l_pos);
+                    auto tip_pos = tips.push_back(l_pos);
+                    tip_lengths.at(tip_pos) = n_cands;
                 }
             }
         }
@@ -331,7 +333,8 @@ TRACCC_HOST_DEVICE inline void find_tracks(
                     // step being skipped, the links are empty, and the tip has
                     // nowhere to point
                     assert(payload.step > 0);
-                    tips.push_back(prev_link_idx);
+                    auto tip_pos = tips.push_back(prev_link_idx);
+                    tip_lengths.at(tip_pos) = n_cands;
                 }
             } else {
                 // Add measurement candidates to link

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -46,6 +46,7 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
 
     // tips
     vecmem::device_vector<unsigned int> tips(payload.tips_view);
+    vecmem::device_vector<unsigned int> tip_lengths(payload.tip_lengths_view);
 
     // Detector
     typename propagator_t::detector_type det(payload.det_data);
@@ -106,7 +107,8 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
         params_liveness[param_id] = 0u;
 
         if (n_cands >= cfg.min_track_candidates_per_track) {
-            tips.push_back(link_idx);
+            auto tip_pos = tips.push_back(link_idx);
+            tip_lengths.at(tip_pos) = n_cands;
         }
     }
 }

--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -74,6 +74,11 @@ struct propagate_to_next_surface_payload {
      * @brief View object to the vector of tips
      */
     vecmem::data::vector_view<unsigned int> tips_view;
+
+    /**
+     * @brief Vector to hold the number of track states per tip
+     */
+    vecmem::data::vector_view<unsigned int> tip_lengths_view;
 };
 
 /// Function for propagating the kalman-updated tracks to the next surface

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -176,6 +176,9 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
         m_cfg.max_num_branches_per_seed * n_seeds, m_mr.main,
         vecmem::data::buffer_type::resizable};
     m_copy.setup(tips_buffer)->wait();
+    vecmem::data::vector_buffer<unsigned int> tip_length_buffer{
+        m_cfg.max_num_branches_per_seed * n_seeds, m_mr.main};
+    m_copy.setup(tip_length_buffer)->wait();
 
     std::map<unsigned int, unsigned int> step_to_link_idx_map;
     step_to_link_idx_map[0] = 0;
@@ -279,6 +282,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
                     .out_params_view = updated_params_buffer,
                     .out_params_liveness_view = updated_liveness_buffer,
                     .tips_view = tips_buffer,
+                    .tip_lengths_view = tip_length_buffer,
                     .n_tracks_per_seed_view = n_tracks_per_seed_buffer});
             TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 
@@ -359,7 +363,8 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
                         .prev_links_idx = step_to_link_idx_map[step],
                         .step = step,
                         .n_in_params = n_candidates,
-                        .tips_view = tips_buffer});
+                        .tips_view = tips_buffer,
+                        .tip_lengths_view = tip_length_buffer});
                 TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 
                 m_stream.synchronize();
@@ -384,12 +389,16 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
     // Get the number of tips
     auto n_tips_total = m_copy.get_size(tips_buffer);
 
+    std::vector<unsigned int> tips_length_host;
+
+    if (n_tips_total > 0) {
+        m_copy(tip_length_buffer, tips_length_host)->wait();
+        tips_length_host.resize(n_tips_total);
+    }
+
     // Create track candidate buffer
     track_candidate_container_types::buffer track_candidates_buffer{
-        {n_tips_total, m_mr.main},
-        {std::vector<std::size_t>(n_tips_total,
-                                  m_cfg.max_track_candidates_per_track),
-         m_mr.main, m_mr.host, vecmem::data::buffer_type::resizable}};
+        {n_tips_total, m_mr.main}, {tips_length_host, m_mr.main, m_mr.host}};
 
     m_copy.setup(track_candidates_buffer.headers)->ignore();
     m_copy.setup(track_candidates_buffer.items)->ignore();


### PR DESCRIPTION
The code which turns the tips of our track finding into actual tracks uses an excessive amount of memory, as it massively overallocates. Indeed, it allocates memory as though all tips have the maximum number of track states, which is unrealistic. This commit makes it so that the number of valid track states is counted instead, making the allocation more precise. In my measurements, this more than halves the memory usage of traccc on $\langle\mu\rangle = 200$ ttbar events in the ODD.

### Before:

![6fee5ca3](https://github.com/user-attachments/assets/45915974-cf70-4da2-95e7-43afc2e5483c)

```
Reconstructed track parameters: 884796
Time totals:
                  File reading  5202 ms
              Event processing  4388 ms
Throughput:
              Event processing  438.829 ms/event, 2.27879 events/s
```

### After:

![a91e94d0](https://github.com/user-attachments/assets/ee323394-a0d9-4f6b-a7b7-85918b12b364)


```
Reconstructed track parameters: 884784
Time totals:
                  File reading  5128 ms
              Event processing  4352 ms
Throughput:
              Event processing  435.297 ms/event, 2.29728 events/s
```

Note: The SYCL changes are best-effort but I haven't tested them.