### PR TITLE
Fix the CKF bugs that break the continuous benchmark

### DIFF
--- a/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
+++ b/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
@@ -155,8 +155,9 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
 
     void apply_propagation_config(detray::propagation::config& cfg) const {
         // Configure the propagation for the toy detector
+        // @NOTE: currently Non-{0,0} search windows cause an error during CKF
         // cfg.navigation.search_window = {3, 3};
-        cfg.navigation.overstep_tolerance = -300.f * traccc::unit<float>::um;
+        cfg.navigation.overstep_tolerance = -1000.f * traccc::unit<float>::um;
         cfg.navigation.min_mask_tolerance = 1e-5f * traccc::unit<float>::mm;
         cfg.navigation.max_mask_tolerance = 3.f * traccc::unit<float>::mm;
         cfg.navigation.mask_tolerance_scalor = 0.05f;

--- a/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
+++ b/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
@@ -125,6 +125,7 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
 
         // Same propagation configuration for sim and reco
         apply_propagation_config(sim.get_config().propagation);
+        sim.get_config().propagation.navigation.search_window = {3, 3};
         // Set constrained step size to 1 mm
         sim.get_config().propagation.stepping.step_constraint =
             1.f * traccc::unit<float>::mm;

--- a/core/include/traccc/finding/details/find_tracks.hpp
+++ b/core/include/traccc/finding/details/find_tracks.hpp
@@ -57,6 +57,11 @@ track_candidate_container_types::host find_tracks(
     const bound_track_parameters_collection_types::const_view& seeds_view,
     const finding_config& config) {
 
+    assert(config.min_step_length_for_next_surface >
+               math::fabs(config.propagation.navigation.overstep_tolerance) &&
+           "Min step length for the next surface should be higher than the "
+           "overstep tolerance");
+
     /*****************************************************************
      * Types used by the track finding
      *****************************************************************/

--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -35,7 +35,7 @@ struct finding_config {
     /// Minimum step length that track should make to reach the next surface. It
     /// should be set higher than the overstep tolerance not to make it stay on
     /// the same surface
-    float min_step_length_for_next_surface = 0.5f * traccc::unit<float>::mm;
+    float min_step_length_for_next_surface = 1.2f * traccc::unit<float>::mm;
     /// Maximum step counts that track can make to reach the next surface
     unsigned int max_step_counts_for_next_surface = 100;
 

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -73,6 +73,11 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
     const typename measurement_collection_types::view& measurements,
     const bound_track_parameters_collection_types::buffer& seeds_buffer) const {
 
+    assert(m_cfg.min_step_length_for_next_surface >
+               math::fabs(m_cfg.propagation.navigation.overstep_tolerance) &&
+           "Min step length for the next surface should be higher than the "
+           "overstep tolerance");
+
     // Get a convenience variable for the stream that we'll be using.
     cudaStream_t stream = details::get_stream(m_stream);
 

--- a/device/sycl/src/finding/find_tracks.hpp
+++ b/device/sycl/src/finding/find_tracks.hpp
@@ -100,6 +100,11 @@ track_candidate_container_types::buffer find_tracks(
     const finding_config& config, const memory_resource& mr, vecmem::copy& copy,
     ::sycl::queue& queue) {
 
+    assert(m_cfg.min_step_length_for_next_surface >
+               math::fabs(m_cfg.propagation.navigation.overstep_tolerance) &&
+           "Min step length for the next surface should be higher than the "
+           "overstep tolerance");
+
     assert(is_contiguous_on<measurement_collection_types::const_device>(
         measurement_module_projection(), mr.main, copy, queue, measurements));
 

--- a/io/src/csv/read_spacepoints.cpp
+++ b/io/src/csv/read_spacepoints.cpp
@@ -26,7 +26,7 @@ void read_spacepoints(edm::spacepoint_collection::host& spacepoints,
                       const traccc::default_detector::host* detector) {
 
     // Read all measurements.
-    static constexpr bool sort_measurements = false;
+    static constexpr bool sort_measurements = true;
     read_measurements(measurements, meas_filename, detector, sort_measurements);
 
     // Measurement hit id reader


### PR DESCRIPTION
Current benchmark is stuck in the CKF due to a bug that measurements are not sorted in `read_spacepoints`
This PR also asserts `config.min_step_length_for_next_surface > math::fabs(config.propagation.navigation.overstep_tolerance` which potentially break the CKF.

The CKF is still stuck with `cfg.navigation.search_window = {3, 3};` so let us keep {0, 0} for the CKF
The simulation now uses {3, 3} though