### PR TITLE
Sort truth track measurements by time

### DIFF
--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -40,6 +40,9 @@ struct measurement {
     /// Geometry ID
     detray::geometry::barcode surface_link;
 
+    /// The time of the measurement
+    scalar time = 0.f;
+
     // Unique measurement ID
     std::size_t measurement_id = 0;
 

--- a/io/src/csv/make_measurement_edm.cpp
+++ b/io/src/csv/make_measurement_edm.cpp
@@ -45,6 +45,8 @@ traccc::measurement make_measurement_edm(
         }
     }
 
+    meas.time = csv_meas.time;
+
     meas.subs.set_indices(indices);
     if (acts_to_detray_id) {
         meas.surface_link = detray::geometry::barcode{


### PR DESCRIPTION
Currently, our truth track measurements are unsorted, and this appears to cause some problems with tracking, i.e. with seeds that start way too far from the interaction point. This commit sorts measurements in our truth data by the timing information in the measurement and, if that is not available, the timing information in the hit data.

This has the effect that we find more tracks, of course, as it gets rid of some bogus seeds:

### Before

```
Number of fitted tracks: 4227 (host), 4226 (device)
  Matching rate(s):
    - 67.4% at 0.01% uncertainty
    - 92.5716% at 0.1% uncertainty
    - 96.3568% at 1% uncertainty
    - 97.2321% at 5% uncertainty
```

### After

```
Number of fitted tracks: 4421 (host), 4420 (device)
  Matching rate(s):
    - 69.3734% at 0.01% uncertainty
    - 92.3773% at 0.1% uncertainty
    - 95.7928% at 1% uncertainty
    - 96.9916% at 5% uncertainty
```
