### PR TITLE
Update detray to v0.92.0

### DIFF
--- a/core/include/traccc/finding/details/find_tracks.hpp
+++ b/core/include/traccc/finding/details/find_tracks.hpp
@@ -325,10 +325,6 @@ track_candidate_container_types::host find_tracks(
             s4.min_step_length = config.min_step_length_for_next_surface;
             s4.max_count = config.max_step_counts_for_next_surface;
 
-            // @TODO: Should be removed once detray is fixed to set the
-            // volume in the constructor
-            propagation._navigation.set_volume(param.surface_link().volume());
-
             // Propagate to the next surface
             propagator.propagate_sync(propagation,
                                       detray::tie(s0, s1, s2, s3, s4));

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -193,10 +193,6 @@ class kalman_fitter {
         propagation.set_particle(detail::correct_particle_hypothesis(
             m_cfg.ptc_hypothesis, seed_params));
 
-        // @TODO: Should be removed once detray is fixed to set the
-        // volume in the constructor
-        propagation._navigation.set_volume(seed_params.surface_link().volume());
-
         // Set overstep tolerance, stepper constraint and mask tolerance
         propagation._stepping
             .template set_constraint<detray::step::constraint::e_accuracy>(
@@ -276,9 +272,6 @@ class kalman_fitter {
 
             inflate_covariance(propagation._stepping.bound_params(),
                                m_cfg.covariance_inflation_factor);
-
-            propagation._navigation.set_volume(
-                last.smoothed().surface_link().volume());
 
             propagation._navigation.set_direction(
                 detray::navigation::direction::e_backward);

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -102,10 +102,6 @@ TRACCC_DEVICE inline void propagate_to_next_surface(
     s4.min_step_length = cfg.min_step_length_for_next_surface;
     s4.max_count = cfg.max_step_counts_for_next_surface;
 
-    // @TODO: Should be removed once detray is fixed to set the volume in the
-    // constructor
-    propagation._navigation.set_volume(in_par.surface_link().volume());
-
     // Propagate to the next surface
     propagator.propagate_sync(propagation, detray::tie(s0, s2, s3, s4));
 

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.90.0.tar.gz;URL_MD5;330432ab2ad697cfa4a122c81c08cf5c"
+"URL;https://github.com/acts-project/detray/archive/refs/tags/v0.92.0.tar.gz;URL_MD5;8b793e50b502d103ef24b574a7617339"
    CACHE STRING "Source for Detray, when built as part of this project" )
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
 FetchContent_Declare( Detray SYSTEM ${TRACCC_DETRAY_SOURCE} )


### PR DESCRIPTION
This PR updates detray to v0.92.0.

As the propagator state sets the volume in the constructor, we don't need to call `set_volume` anymore