### PR TITLE
Fix bug in seed selection in track finder

### DIFF
--- a/core/include/traccc/finding/details/find_tracks.hpp
+++ b/core/include/traccc/finding/details/find_tracks.hpp
@@ -417,7 +417,7 @@ track_candidate_container_types::host find_tracks(
             // fill the seed
             if (it == cands_per_track.rend() - 1) {
 
-                auto cand_seed = seeds.at(L.previous.second);
+                auto cand_seed = seeds.at(L.seed_idx);
 
                 // Add seed and track candidates to the output container
                 output_candidates.push_back(

--- a/device/common/include/traccc/finding/device/impl/build_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/build_tracks.ipp
@@ -88,7 +88,7 @@ TRACCC_DEVICE inline void build_tracks(const global_index_t globalIndex,
         // Break the loop if the iterator is at the first candidate and fill the
         // seed and track quality
         if (it == cands_per_track.rend() - 1) {
-            seed = seeds.at(L.previous.second);
+            seed = seeds.at(L.seed_idx);
             trk_quality.ndf = ndf_sum - 5.f;
             trk_quality.chi2 = chi2_sum;
             trk_quality.n_holes = L.n_skipped;


### PR DESCRIPTION
PRs #911 and #915 inadvertently introduced a new bug in the track finding where tracks on which the first measurement is a hole would potentially cause an out-of-bounds access in the seed array. This commit fixes this bug by always using the seed ID which is already encoded in the candidate link.