### PR TITLE
Make CKF types and initializers more readable

### DIFF
--- a/core/include/traccc/finding/candidate_link.hpp
+++ b/core/include/traccc/finding/candidate_link.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/edm/measurement.hpp"
+#include "traccc/finding/candidate_tip.hpp"
 #include "traccc/utils/pair.hpp"
 
 namespace traccc {
@@ -16,12 +17,9 @@ namespace traccc {
 // A link that contains the index of corresponding measurement and the index of
 // a link from a previous step of track finding
 struct candidate_link {
+    candidate_tip::index_t previous_step_idx;
 
-    // Type of index
-    using link_index_type = traccc::pair<unsigned int, unsigned int>;
-
-    // Index of link from the previous step
-    link_index_type previous;
+    candidate_tip::index_t previous_candidate_idx;
 
     // Measurement index
     unsigned int meas_idx;

--- a/core/include/traccc/finding/candidate_tip.hpp
+++ b/core/include/traccc/finding/candidate_tip.hpp
@@ -1,0 +1,24 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc {
+
+// A track candidate tip, pointing to the last candidate on a potential track.
+// Models the beginning of a reversed singularly linked list.
+struct candidate_tip {
+    using index_t = unsigned int;
+
+    /// The step index of the candidate pointed at.
+    index_t step_idx;
+
+    /// The candidate index in the list belonging to `step_idx`.
+    index_t candidate_idx;
+};
+
+}  // namespace traccc

--- a/device/common/include/traccc/finding/device/build_tracks.hpp
+++ b/device/common/include/traccc/finding/device/build_tracks.hpp
@@ -16,6 +16,7 @@
 #include "traccc/edm/track_candidate.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/candidate_tip.hpp"
 #include "traccc/finding/finding_config.hpp"
 
 // VecMem include(s).
@@ -46,8 +47,7 @@ struct build_tracks_payload {
     /**
      * @brief View object to the vector of tips
      */
-    vecmem::data::vector_view<const typename candidate_link::link_index_type>
-        tips_view;
+    vecmem::data::vector_view<const candidate_tip> tips_view;
 
     /**
      * @brief View object to the vector of track candidates

--- a/device/common/include/traccc/finding/device/find_tracks.hpp
+++ b/device/common/include/traccc/finding/device/find_tracks.hpp
@@ -17,6 +17,7 @@
 #include "traccc/edm/measurement.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/candidate_tip.hpp"
 #include "traccc/finding/finding_config.hpp"
 
 // VecMem include(s).

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -80,11 +80,9 @@ TRACCC_DEVICE inline void find_tracks(
      * Compute the last step ID, using a sentinel value if the current step is
      * step 0.
      */
-    const candidate_link::link_index_type::first_type previous_step =
-        (payload.step == 0)
-            ? std::numeric_limits<
-                  candidate_link::link_index_type::first_type>::max()
-            : payload.step - 1;
+    const candidate_tip::index_t previous_step =
+        (payload.step == 0) ? std::numeric_limits<candidate_tip::index_t>::max()
+                            : payload.step - 1;
 
     const unsigned int in_param_id = thread_id.getGlobalThreadIdX();
 
@@ -226,21 +224,23 @@ TRACCC_DEVICE inline void find_tracks(
                 } else {
                     if (payload.step == 0) {
                         links.at(l_pos) = {
-                            {previous_step, owner_global_thread_id},
-                            meas_idx,
-                            owner_global_thread_id,
-                            0,
-                            chi2};
+                            .previous_step_idx = previous_step,
+                            .previous_candidate_idx = owner_global_thread_id,
+                            .meas_idx = meas_idx,
+                            .seed_idx = owner_global_thread_id,
+                            .n_skipped = 0,
+                            .chi2 = chi2};
                     } else {
                         const candidate_link& prev_link =
                             prev_links[owner_global_thread_id];
 
                         links.at(l_pos) = {
-                            {previous_step, owner_global_thread_id},
-                            meas_idx,
-                            prev_link.seed_idx,
-                            prev_link.n_skipped,
-                            chi2};
+                            .previous_step_idx = previous_step,
+                            .previous_candidate_idx = owner_global_thread_id,
+                            .meas_idx = meas_idx,
+                            .seed_idx = prev_link.seed_idx,
+                            .n_skipped = prev_link.n_skipped,
+                            .chi2 = chi2};
                     }
 
                     // Increase the number of candidates (or branches) per input
@@ -294,19 +294,23 @@ TRACCC_DEVICE inline void find_tracks(
             *payload.n_total_candidates = payload.n_max_candidates;
         } else {
             if (payload.step == 0) {
-                links.at(l_pos) = {{previous_step, in_param_id},
-                                   std::numeric_limits<unsigned int>::max(),
-                                   in_param_id,
-                                   1,
-                                   std::numeric_limits<traccc::scalar>::max()};
+                links.at(l_pos) = {
+                    .previous_step_idx = previous_step,
+                    .previous_candidate_idx = in_param_id,
+                    .meas_idx = std::numeric_limits<unsigned int>::max(),
+                    .seed_idx = in_param_id,
+                    .n_skipped = 1,
+                    .chi2 = std::numeric_limits<traccc::scalar>::max()};
             } else {
                 const candidate_link& prev_link = prev_links[in_param_id];
 
-                links.at(l_pos) = {{previous_step, in_param_id},
-                                   std::numeric_limits<unsigned int>::max(),
-                                   prev_link.seed_idx,
-                                   prev_link.n_skipped + 1,
-                                   std::numeric_limits<traccc::scalar>::max()};
+                links.at(l_pos) = {
+                    .previous_step_idx = previous_step,
+                    .previous_candidate_idx = in_param_id,
+                    .meas_idx = std::numeric_limits<unsigned int>::max(),
+                    .seed_idx = prev_link.seed_idx,
+                    .n_skipped = prev_link.n_skipped + 1,
+                    .chi2 = std::numeric_limits<traccc::scalar>::max()};
             }
 
             out_params.at(l_pos) = in_params.at(in_param_id);

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -54,8 +54,7 @@ TRACCC_DEVICE inline void propagate_to_next_surface(
     }
 
     // tips
-    vecmem::device_vector<typename candidate_link::link_index_type> tips(
-        payload.tips_view);
+    vecmem::device_vector<candidate_tip> tips(payload.tips_view);
 
     if (links.at(param_id).n_skipped > cfg.max_num_skipping_per_cand) {
         params_liveness[param_id] = 0u;

--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -14,6 +14,7 @@
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/candidate_tip.hpp"
 #include "traccc/finding/finding_config.hpp"
 
 // VecMem include(s).
@@ -68,8 +69,7 @@ struct propagate_to_next_surface_payload {
     /**
      * @brief View object to the vector of tips
      */
-    vecmem::data::vector_view<typename candidate_link::link_index_type>
-        tips_view;
+    vecmem::data::vector_view<candidate_tip> tips_view;
 
     /**
      * @brief View object to the vector of the number of tracks per initial

--- a/device/sycl/src/finding/find_tracks.hpp
+++ b/device/sycl/src/finding/find_tracks.hpp
@@ -188,9 +188,9 @@ track_candidate_container_types::buffer find_tracks(
         link_map;
 
     // Create a buffer of tip links
-    vecmem::data::vector_buffer<typename candidate_link::link_index_type>
-        tips_buffer{config.max_num_branches_per_seed * n_seeds, mr.main,
-                    vecmem::data::buffer_type::resizable};
+    vecmem::data::vector_buffer<candidate_tip> tips_buffer{
+        config.max_num_branches_per_seed * n_seeds, mr.main,
+        vecmem::data::buffer_type::resizable};
     copy.setup(tips_buffer)->wait();
 
     // Link size


### PR DESCRIPTION
This commit aims to improve the readability of the CKF by replacing some pairs (with their non-descriptive `.first` and `.second` accessors) with dedicated structs and by adding explicit named member initialization to some larger POD structures.