### PR TITLE
Accelerate and update commit benchmarking script

### DIFF
--- a/extras/commit_benchmark/plot.py
+++ b/extras/commit_benchmark/plot.py
@@ -55,7 +55,7 @@ def main():
 
     sorted_valid_kernels = sorted(list(valid_kernels))
 
-    f, a = matplotlib.pyplot.subplots(1, 1, figsize=(8, 8))
+    f, a = matplotlib.pyplot.subplots(1, 1, figsize=(max(6, 4 + 0.1 * len(commits)), 8))
 
     xrange = list(range(len(commits)))
 


### PR DESCRIPTION
This commit updates the commit benchmarking code with the following new properties:

1. The benchmark now respects the changes to boolean flags introduced in 380fc78.
2. The benchmark now properly uses Spack libraries as introduced in 069cc80.
3. The benchmark now uses a much smaller set of metrics to speed up data collection.
4. The plotting script now adapts the plot size to the number of commits.

All in all, these changes make the script run much faster and make it compatible with more recent versions of traccc.