### PR TITLE
Update detray external to v0.94.0

### DIFF
--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.93.0.tar.gz;URL_MD5;c01cc864316b65bc8c88639b709e9816"
+   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.94.0.tar.gz;URL_MD5;b9f6c8f0fa5c6df22df1ebe1aff2ab4a"
    CACHE STRING "Source for Detray, when built as part of this project" )
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
 FetchContent_Declare( Detray SYSTEM ${TRACCC_DETRAY_SOURCE} )

--- a/tests/common/tests/kalman_fitting_momentum_resolution_test.cpp
+++ b/tests/common/tests/kalman_fitting_momentum_resolution_test.cpp
@@ -133,7 +133,7 @@ void KalmanFittingMomentumResolutionTests::SetUp() {
 
     const auto p = std::get<3>(GetParam());
     const detray::detail::helix<traccc::default_algebra> hlx(
-        {0, 0, 0}, 0, {1, 0, 0}, -1.f / p, &bfield);
+        {0, 0, 0}, 0, {1, 0, 0}, -1.f / p, bfield);
 
     constexpr scalar rect_half_length = 500.f;
     constexpr detray::mask<detray::rectangle2D, traccc::default_algebra>

--- a/tests/cpu/test_track_params_estimation.cpp
+++ b/tests/cpu/test_track_params_estimation.cpp
@@ -44,7 +44,7 @@ TEST(track_params_estimation, helix_negative_charge) {
 
     // Make a helix
     detray::detail::helix<traccc::default_algebra> hlx(
-        pos, time, vector::normalize(mom), q / vector::norm(mom), &B);
+        pos, time, vector::normalize(mom), q / vector::norm(mom), B);
 
     // Make three spacepoints with the helix
     measurement_collection_types::host measurements(&host_mr);
@@ -86,7 +86,7 @@ TEST(track_params_estimation, helix_positive_charge) {
 
     // Make a helix
     detray::detail::helix<traccc::default_algebra> hlx(
-        pos, time, vector::normalize(mom), q / vector::norm(mom), &B);
+        pos, time, vector::normalize(mom), q / vector::norm(mom), B);
 
     // Make three spacepoints with the helix
     measurement_collection_types::host measurements(&host_mr);


### PR DESCRIPTION
Some benchmark number will be added later

EDIT: There is a slight performance improvement

### ODD 

#### This PR

```
12:37:40    CudaSeqExample                INFO      ==> Statistics ... 
12:37:40    CudaSeqExample                INFO      - read    3790687 cells
12:37:40    CudaSeqExample                INFO      - created (cpu)  0 measurements     
12:37:40    CudaSeqExample                INFO      - created (cuda)  1042450 measurements     
12:37:40    CudaSeqExample                INFO      - created (cpu)  0 spacepoints     
12:37:40    CudaSeqExample                INFO      - created (cuda) 823334 spacepoints     
12:37:40    CudaSeqExample                INFO      - created  (cpu) 0 seeds
12:37:40    CudaSeqExample                INFO      - created (cuda) 368854 seeds
12:37:40    CudaSeqExample                INFO      - found (cpu)    0 tracks
12:37:40    CudaSeqExample                INFO      - found (cuda)   918911 tracks
12:37:40    CudaSeqExample                INFO      - fitted (cpu)   0 tracks
12:37:40    CudaSeqExample                INFO      - fitted (cuda)  918911 tracks
12:37:40    CudaSeqExample                INFO      ==>Elapsed times...            File reading  (cpu)  7935 ms
12:37:40    CudaSeqExample                INFO               Clusterization (cuda)  32 ms
12:37:40    CudaSeqExample                INFO         Spacepoint formation (cuda)  4 ms
12:37:40    CudaSeqExample                INFO                      Seeding (cuda)  378 ms
12:37:40    CudaSeqExample                INFO                 Track params (cuda)  4 ms
12:37:40    CudaSeqExample                INFO                Track finding (cuda)  2894 ms
12:37:40    CudaSeqExample                INFO                Track fitting (cuda)  4088 ms
12:37:40    CudaSeqExample                INFO                           Wall time  15410 ms
```

#### main 476f725

```
11:53:15    CudaSeqExample                INFO      ==> Statistics ... 
11:53:15    CudaSeqExample                INFO      - read    3790687 cells
11:53:15    CudaSeqExample                INFO      - created (cpu)  0 measurements     
11:53:15    CudaSeqExample                INFO      - created (cuda)  1042450 measurements     
11:53:15    CudaSeqExample                INFO      - created (cpu)  0 spacepoints     
11:53:15    CudaSeqExample                INFO      - created (cuda) 823334 spacepoints     
11:53:15    CudaSeqExample                INFO      - created  (cpu) 0 seeds
11:53:15    CudaSeqExample                INFO      - created (cuda) 368854 seeds
11:53:15    CudaSeqExample                INFO      - found (cpu)    0 tracks
11:53:15    CudaSeqExample                INFO      - found (cuda)   918924 tracks
11:53:15    CudaSeqExample                INFO      - fitted (cpu)   0 tracks
11:53:15    CudaSeqExample                INFO      - fitted (cuda)  918924 tracks
11:53:15    CudaSeqExample                INFO      ==>Elapsed times...            File reading  (cpu)  7917 ms
11:53:15    CudaSeqExample                INFO               Clusterization (cuda)  33 ms
11:53:15    CudaSeqExample                INFO         Spacepoint formation (cuda)  4 ms
11:53:15    CudaSeqExample                INFO                      Seeding (cuda)  378 ms
11:53:15    CudaSeqExample                INFO                 Track params (cuda)  4 ms
11:53:15    CudaSeqExample                INFO                Track finding (cuda)  2935 ms
11:53:15    CudaSeqExample                INFO                Track fitting (cuda)  4157 ms
11:53:15    CudaSeqExample                INFO                           Wall time  15474 ms
```

### Continuous benchmark with toy detector

#### This PR

```
Detector check: OK
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
ToyDetectorBenchmark/CUDA/real_time 6926930398 ns   6926525294 ns            1 event_throughput_Hz=14.4364/s
```

#### main 476f725

```
Detector check: OK
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
ToyDetectorBenchmark/CUDA/real_time 6952780753 ns   6952405253 ns            1 event_throughput_Hz=14.3827/s
```