### PR TITLE
Keep states ordered by quality in CKF

### DIFF
--- a/device/common/include/traccc/finding/device/find_tracks.hpp
+++ b/device/common/include/traccc/finding/device/find_tracks.hpp
@@ -23,6 +23,7 @@
 #include <vecmem/containers/data/vector_view.hpp>
 
 // System include(s).
+#include <cstdint>
 #include <utility>
 
 namespace traccc::device {
@@ -114,15 +115,38 @@ struct find_tracks_payload {
      * input seed
      */
     vecmem::data::vector_view<unsigned int> n_tracks_per_seed_view;
+
+    /**
+     * @brief View object to the temporary track parameter vector
+     */
+    bound_track_parameters_collection_types::view tmp_params_view;
+
+    /**
+     * @brief View object to the temporary link vector
+     */
+    vecmem::data::vector_view<candidate_link> tmp_links_view;
 };
 
 /// (Shared Event Data) Payload for the @c traccc::device::find_tracks function
 struct find_tracks_shared_payload {
     /**
-     * @brief Shared-memory vector with the number of measurements found per
-     * track
+     * @brief Shared-memory value indicating the final number of track
+     * parameters to write to permanent storage.
      */
-    unsigned int* shared_num_candidates;
+    unsigned int& shared_num_out_params;
+
+    /**
+     * @brief Shared-memory value indicating the offset at which the block
+     * will write its parameters.
+     */
+    unsigned int& shared_out_offset;
+
+    /**
+     * @brief Shared-memory array with mutexes for the insertionof parameters.
+     *
+     * @note Length is always exactly the block size.
+     */
+    unsigned long long int* shared_insertion_mutex;
 
     /**
      * @brief Shared-memory vector of measurement candidats with ID and

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -253,49 +253,62 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
                 links_buffer = std::move(new_links_buffer);
             }
 
-            const unsigned int prev_link_idx =
-                step == 0 ? 0 : step_to_link_idx_map[step - 1];
+            {
+                vecmem::data::vector_buffer<candidate_link> tmp_links_buffer(
+                    n_max_candidates, m_mr.main);
+                m_copy.setup(tmp_links_buffer)->ignore();
+                bound_track_parameters_collection_types::buffer
+                    tmp_params_buffer(n_max_candidates, m_mr.main);
+                m_copy.setup(tmp_params_buffer)->ignore();
 
-            assert(links_size == step_to_link_idx_map[step]);
+                const unsigned int nThreads = m_warp_size * 2;
+                const unsigned int nBlocks =
+                    (n_in_params + nThreads - 1) / nThreads;
 
-            const unsigned int nThreads = m_warp_size * 2;
-            const unsigned int nBlocks =
-                (n_in_params + nThreads - 1) / nThreads;
-            const std::size_t shared_size =
-                nThreads * sizeof(unsigned int) +
-                2 * nThreads * sizeof(std::pair<unsigned int, unsigned int>);
+                const unsigned int prev_link_idx =
+                    step == 0 ? 0 : step_to_link_idx_map[step - 1];
 
-            find_tracks<std::decay_t<detector_type>>(
-                nBlocks, nThreads, shared_size, stream, m_cfg,
-                device::find_tracks_payload<std::decay_t<detector_type>>{
-                    .det_data = det_view,
-                    .measurements_view = measurements,
-                    .in_params_view = in_params_buffer,
-                    .in_params_liveness_view = param_liveness_buffer,
-                    .n_in_params = n_in_params,
-                    .barcodes_view = barcodes_buffer,
-                    .upper_bounds_view = upper_bounds_buffer,
-                    .links_view = links_buffer,
-                    .prev_links_idx = prev_link_idx,
-                    .curr_links_idx = step_to_link_idx_map[step],
-                    .step = step,
-                    .out_params_view = updated_params_buffer,
-                    .out_params_liveness_view = updated_liveness_buffer,
-                    .tips_view = tips_buffer,
-                    .tip_lengths_view = tip_length_buffer,
-                    .n_tracks_per_seed_view = n_tracks_per_seed_buffer});
-            TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+                assert(links_size == step_to_link_idx_map[step]);
 
-            std::swap(in_params_buffer, updated_params_buffer);
-            std::swap(param_liveness_buffer, updated_liveness_buffer);
+                const std::size_t shared_size =
+                    nThreads * sizeof(unsigned int) +
+                    2 * nThreads *
+                        sizeof(std::pair<unsigned int, unsigned int>);
 
-            m_stream.synchronize();
+                find_tracks<std::decay_t<detector_type>>(
+                    nBlocks, nThreads, shared_size, stream, m_cfg,
+                    device::find_tracks_payload<std::decay_t<detector_type>>{
+                        .det_data = det_view,
+                        .measurements_view = measurements,
+                        .in_params_view = in_params_buffer,
+                        .in_params_liveness_view = param_liveness_buffer,
+                        .n_in_params = n_in_params,
+                        .barcodes_view = barcodes_buffer,
+                        .upper_bounds_view = upper_bounds_buffer,
+                        .links_view = links_buffer,
+                        .prev_links_idx = prev_link_idx,
+                        .curr_links_idx = step_to_link_idx_map[step],
+                        .step = step,
+                        .out_params_view = updated_params_buffer,
+                        .out_params_liveness_view = updated_liveness_buffer,
+                        .tips_view = tips_buffer,
+                        .tip_lengths_view = tip_length_buffer,
+                        .n_tracks_per_seed_view = n_tracks_per_seed_buffer,
+                        .tmp_params_view = tmp_params_buffer,
+                        .tmp_links_view = tmp_links_buffer});
+                TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 
-            step_to_link_idx_map[step + 1] = m_copy.get_size(links_buffer);
-            n_candidates =
-                step_to_link_idx_map[step + 1] - step_to_link_idx_map[step];
+                std::swap(in_params_buffer, updated_params_buffer);
+                std::swap(param_liveness_buffer, updated_liveness_buffer);
 
-            m_stream.synchronize();
+                m_stream.synchronize();
+
+                step_to_link_idx_map[step + 1] = m_copy.get_size(links_buffer);
+                n_candidates =
+                    step_to_link_idx_map[step + 1] - step_to_link_idx_map[step];
+
+                m_stream.synchronize();
+            }
         }
 
         // If no more CKF step is expected, the tips and links are populated,

--- a/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
@@ -23,19 +23,22 @@ namespace kernels {
 template <typename detector_t>
 __global__ void find_tracks(const finding_config cfg,
                             device::find_tracks_payload<detector_t> payload) {
+    __shared__ unsigned int shared_num_out_params;
+    __shared__ unsigned int shared_out_offset;
     __shared__ unsigned int shared_candidates_size;
-    extern __shared__ unsigned int s[];
-    unsigned int* shared_num_candidates = s;
+    extern __shared__ unsigned long long int s[];
+    unsigned long long int* shared_insertion_mutex = s;
     std::pair<unsigned int, unsigned int>* shared_candidates =
         reinterpret_cast<std::pair<unsigned int, unsigned int>*>(
-            &shared_num_candidates[blockDim.x]);
+            &shared_insertion_mutex[blockDim.x]);
 
     cuda::barrier barrier;
     details::thread_id1 thread_id;
 
     device::find_tracks<detector_t>(
         thread_id, barrier, cfg, payload,
-        {shared_num_candidates, shared_candidates, shared_candidates_size});
+        {shared_num_out_params, shared_out_offset, shared_insertion_mutex,
+         shared_candidates, shared_candidates_size});
 }
 
 }  // namespace kernels

--- a/device/sycl/src/finding/find_tracks.hpp
+++ b/device/sycl/src/finding/find_tracks.hpp
@@ -261,68 +261,88 @@ track_candidate_container_types::buffer find_tracks(
             links_buffer = std::move(new_links_buffer);
         }
 
-        // The number of threads to use per block in the track finding.
-        static const unsigned int nFindTracksThreads = 64;
+        {
+            vecmem::data::vector_buffer<candidate_link> tmp_links_buffer(
+                n_max_candidates, mr.main);
+            copy.setup(tmp_links_buffer)->ignore();
+            bound_track_parameters_collection_types::buffer tmp_params_buffer(
+                n_max_candidates, mr.main);
+            copy.setup(tmp_params_buffer)->ignore();
 
-        // Submit the kernel to the queue.
-        queue
-            .submit([&](::sycl::handler& h) {
-                // Allocate shared memory for the kernel.
-                vecmem::sycl::local_accessor<unsigned int>
-                    shared_num_candidates(nFindTracksThreads, h);
-                vecmem::sycl::local_accessor<
-                    std::pair<unsigned int, unsigned int>>
-                    shared_candidates(2 * nFindTracksThreads, h);
-                vecmem::sycl::local_accessor<unsigned int>
-                    shared_candidates_size(1, h);
+            // The number of threads to use per block in the track finding.
+            static const unsigned int nFindTracksThreads = 64;
 
-                // Launch the kernel.
-                h.parallel_for<kernels::find_tracks<kernel_t>>(
-                    calculate1DimNdRange(n_in_params, nFindTracksThreads),
-                    [config, det, measurements,
-                     in_params = vecmem::get_data(in_params_buffer),
-                     param_liveness = vecmem::get_data(param_liveness_buffer),
-                     n_in_params, barcodes = vecmem::get_data(barcodes_buffer),
-                     upper_bounds = vecmem::get_data(upper_bounds_buffer),
-                     links_view = vecmem::get_data(links_buffer),
-                     prev_links_idx =
-                         step == 0 ? 0 : step_to_link_idx_map[step - 1],
-                     curr_links_idx = step_to_link_idx_map[step], step,
-                     updated_params = vecmem::get_data(updated_params_buffer),
-                     updated_liveness =
-                         vecmem::get_data(updated_liveness_buffer),
-                     tips = vecmem::get_data(tips_buffer),
-                     tip_lengths = vecmem::get_data(tip_length_buffer),
-                     n_tracks_per_seed =
-                         vecmem::get_data(n_tracks_per_seed_buffer),
-                     shared_candidates_size, shared_num_candidates,
-                     shared_candidates](::sycl::nd_item<1> item) {
-                        // SYCL wrappers used in the algorithm.
-                        const details::barrier barrier{item};
-                        const details::thread_id thread_id{item};
+            // Submit the kernel to the queue.
+            queue
+                .submit([&](::sycl::handler& h) {
+                    // Allocate shared memory for the kernel.
+                    vecmem::sycl::local_accessor<unsigned long long int>
+                        shared_insertion_mutex(nFindTracksThreads, h);
+                    vecmem::sycl::local_accessor<
+                        std::pair<unsigned int, unsigned int>>
+                        shared_candidates(2 * nFindTracksThreads, h);
+                    vecmem::sycl::local_accessor<unsigned int>
+                        shared_candidates_size(1, h);
+                    vecmem::sycl::local_accessor<unsigned int>
+                        shared_num_out_params(1, h);
+                    vecmem::sycl::local_accessor<unsigned int>
+                        shared_out_offset(1, h);
+                    // Launch the kernel.
+                    h.parallel_for<kernels::find_tracks<kernel_t>>(
+                        calculate1DimNdRange(n_in_params, nFindTracksThreads),
+                        [config, det, measurements,
+                         in_params = vecmem::get_data(in_params_buffer),
+                         param_liveness =
+                             vecmem::get_data(param_liveness_buffer),
+                         n_in_params,
+                         barcodes = vecmem::get_data(barcodes_buffer),
+                         upper_bounds = vecmem::get_data(upper_bounds_buffer),
+                         links_view = vecmem::get_data(links_buffer),
+                         prev_links_idx =
+                             step == 0 ? 0 : step_to_link_idx_map[step - 1],
+                         curr_links_idx = step_to_link_idx_map[step], step,
+                         updated_params =
+                             vecmem::get_data(updated_params_buffer),
+                         updated_liveness =
+                             vecmem::get_data(updated_liveness_buffer),
+                         tips = vecmem::get_data(tips_buffer),
+                         tip_lengths = vecmem::get_data(tip_length_buffer),
+                         n_tracks_per_seed =
+                             vecmem::get_data(n_tracks_per_seed_buffer),
+                         tmp_params = vecmem::get_data(tmp_params_buffer),
+                         tmp_links = vecmem::get_data(tmp_links_buffer),
+                         shared_insertion_mutex, shared_candidates,
+                         shared_candidates_size, shared_num_out_params,
+                         shared_out_offset](::sycl::nd_item<1> item) {
+                            // SYCL wrappers used in the algorithm.
+                            const details::barrier barrier{item};
+                            const details::thread_id thread_id{item};
 
-                        // Call the device function to find tracks.
-                        device::find_tracks<
-                            std::decay_t<typename navigator_t::detector_type>>(
-                            thread_id, barrier, config,
-                            {det, measurements, in_params, param_liveness,
-                             n_in_params, barcodes, upper_bounds, links_view,
-                             prev_links_idx, curr_links_idx, step,
-                             updated_params, updated_liveness, tips,
-                             tip_lengths, n_tracks_per_seed},
-                            {&(shared_num_candidates[0]),
-                             &(shared_candidates[0]),
-                             shared_candidates_size[0]});
-                    });
-            })
-            .wait_and_throw();
+                            // Call the device function to find tracks.
+                            device::find_tracks<std::decay_t<
+                                typename navigator_t::detector_type>>(
+                                thread_id, barrier, config,
+                                {det, measurements, in_params, param_liveness,
+                                 n_in_params, barcodes, upper_bounds,
+                                 links_view, prev_links_idx, curr_links_idx,
+                                 step, updated_params, updated_liveness, tips,
+                                 tip_lengths, n_tracks_per_seed, tmp_params,
+                                 tmp_links},
+                                {shared_num_out_params[0], shared_out_offset[0],
+                                 &(shared_insertion_mutex[0]),
+                                 &(shared_candidates[0]),
+                                 shared_candidates_size[0]});
+                        });
+                })
+                .wait_and_throw();
 
-        std::swap(in_params_buffer, updated_params_buffer);
-        std::swap(param_liveness_buffer, updated_liveness_buffer);
+            std::swap(in_params_buffer, updated_params_buffer);
+            std::swap(param_liveness_buffer, updated_liveness_buffer);
 
-        step_to_link_idx_map[step + 1] = copy.get_size(links_buffer);
-        n_candidates =
-            step_to_link_idx_map[step + 1] - step_to_link_idx_map[step];
+            step_to_link_idx_map[step + 1] = copy.get_size(links_buffer);
+            n_candidates =
+                step_to_link_idx_map[step + 1] - step_to_link_idx_map[step];
+        }
 
         if (step == config.max_track_candidates_per_track - 1) {
             break;


### PR DESCRIPTION
This commit allows the `find_tracks` kernel in the CKF to keep the best measurements instead of keeping random ones, which will hopefully allow us to significantly reduce the branching factor of the CKF. The logic here works by employing a series of mutexes, allowing threads to lock a critical section and insert their own measurement, overwriting the previous ones.