### PR TITLE
Alpaka: Fitting Examples (PR 3 of 3)

### DIFF
--- a/device/alpaka/src/finding/finding_algorithm.cpp
+++ b/device/alpaka/src/finding/finding_algorithm.cpp
@@ -68,6 +68,11 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
     const typename measurement_collection_types::view& measurements,
     const bound_track_parameters_collection_types::buffer& seeds_buffer) const {
 
+    assert(m_cfg.min_step_length_for_next_surface >
+               math::fabs(m_cfg.propagation.navigation.overstep_tolerance) &&
+           "Min step length for the next surface should be higher than the "
+           "overstep tolerance");
+
     // Setup alpaka
     auto devHost = ::alpaka::getDevByIdx(::alpaka::Platform<Host>{}, 0u);
     auto devAcc = ::alpaka::getDevByIdx(::alpaka::Platform<Acc>{}, 0u);

--- a/examples/run/alpaka/CMakeLists.txt
+++ b/examples/run/alpaka/CMakeLists.txt
@@ -30,3 +30,19 @@ traccc_add_executable( seq_example_alpaka "seq_example_alpaka.cpp"
     LINK_LIBRARIES ${LIBRARIES} ${DETRAY} )
 traccc_add_executable( seeding_example_alpaka "seeding_example_alpaka.cpp"
     LINK_LIBRARIES ${LIBRARIES} )
+
+#
+# Set up the "throughput applications".
+#
+add_library( traccc_examples_alpaka STATIC
+   "full_chain_algorithm.hpp"
+   "full_chain_algorithm.cpp" )
+target_link_libraries( traccc_examples_alpaka
+   PUBLIC alpaka::alpaka vecmem::core detray::core detray::detectors
+   traccc::core traccc::device_common traccc::alpaka ${EXTRA_LIBS})
+
+traccc_add_executable( throughput_st_alpaka "throughput_st.cpp"
+   LINK_LIBRARIES indicators::indicators ${LIBRARIES} ${DETRAY} traccc_examples_alpaka )
+
+traccc_add_executable( throughput_mt_alpaka "throughput_mt.cpp"
+   LINK_LIBRARIES TBB::tbb indicators::indicators ${LIBRARIES} ${DETRAY} traccc_examples_alpaka )

--- a/examples/run/alpaka/CMakeLists.txt
+++ b/examples/run/alpaka/CMakeLists.txt
@@ -1,15 +1,13 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2023 CERN for the benefit of the ACTS project
+# (c) 2023-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
-set(EXTRA_LIBS)
+# Project include(s).
+include( traccc-alpaka-functions )
 
-set(TRACCC_ALPAKA_EXAMPLE_SOURCES
-    seq_example_alpaka.cpp
-    seeding_example_alpaka.cpp
-)
+set(EXTRA_LIBS)
 
 include(traccc-alpaka-functions)
 traccc_enable_language_alpaka()
@@ -26,8 +24,9 @@ endif()
 set(LIBRARIES vecmem::core traccc::io traccc::performance
     traccc::core traccc::device_common traccc::alpaka alpaka::alpaka
     traccc::options ${EXTRA_LIBS})
+set(DETRAY detray::io detray::detectors)
 
 traccc_add_executable( seq_example_alpaka "seq_example_alpaka.cpp"
-    LINK_LIBRARIES ${LIBRARIES} )
+    LINK_LIBRARIES ${LIBRARIES} ${DETRAY} )
 traccc_add_executable( seeding_example_alpaka "seeding_example_alpaka.cpp"
     LINK_LIBRARIES ${LIBRARIES} )

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -1,16 +1,12 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 // Local include(s).
 #include "full_chain_algorithm.hpp"
-
-// Alpaka include(s).
-#include <alpaka/alpaka.hpp>
-#include <alpaka/example/ExampleDefaultAcc.hpp>
 
 // System include(s).
 #include <iostream>
@@ -20,97 +16,180 @@ namespace traccc::alpaka {
 
 full_chain_algorithm::full_chain_algorithm(
     vecmem::memory_resource& host_mr,
-    const unsigned short target_cells_per_partition,
+    const clustering_config& clustering_config,
     const seedfinder_config& finder_config,
     const spacepoint_grid_config& grid_config,
-    const seedfilter_config& filter_config)
-    : m_host_mr(host_mr),
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-      m_device_mr(),
+    const seedfilter_config& filter_config,
+    const finding_algorithm::config_type& finding_config,
+    const fitting_algorithm::config_type& fitting_config,
+    const silicon_detector_description::host& det_descr,
+    host_detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
+    : messaging(logger->clone()),
+      m_host_mr(host_mr),
+#if defined(ALPAKA_ACC_SYCL_ENABLED)
+      m_queue(::sycl::queue()),
+      m_queue_wrapper(&m_queue),
+      m_device_mr(m_queue_wrapper),
+      m_copy(m_queue_wrapper),
 #else
-      m_device_mr(host_mr),
+      m_device_mr(),
+      m_copy(),
 #endif
       m_cached_device_mr(
-          std::make_unique<vecmem::binary_page_memory_resource>(m_device_mr)),
-      m_target_cells_per_partition(target_cells_per_partition),
+          std::make_unique<::vecmem::binary_page_memory_resource>(m_device_mr)),
+      m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
+      m_field(
+          detray::bfield::create_const_field<host_detector_type::scalar_type>(
+              m_field_vec)),
+      m_det_descr(det_descr),
+      m_device_det_descr(
+          static_cast<silicon_detector_description::buffer::size_type>(
+              m_det_descr.get().size()),
+          m_device_mr),
+      m_detector(detector),
       m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                       m_target_cells_per_partition),
-      m_measurement_sorting(m_copy),
+                       clustering_config),
+      m_measurement_sorting(m_copy, logger->cloneWithSuffix("MeasSortingAlg")),
       m_spacepoint_formation(memory_resource{*m_cached_device_mr, &m_host_mr},
-                             m_copy),
+                             m_copy, logger->cloneWithSuffix("SpFormationAlg")),
       m_seeding(finder_config, grid_config, filter_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy),
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                logger->cloneWithSuffix("SeedingAlg")),
       m_track_parameter_estimation(
-          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy),
+          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+          logger->cloneWithSuffix("TrackParamEstAlg")),
+      m_finding(finding_config,
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                logger->cloneWithSuffix("TrackFindingAlg")),
+      m_fitting(fitting_config,
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                logger->cloneWithSuffix("TrackFittingAlg")),
+      m_clustering_config(clustering_config),
       m_finder_config(finder_config),
       m_grid_config(grid_config),
-      m_filter_config(filter_config) {
+      m_filter_config(filter_config),
+      m_finding_config(finding_config),
+      m_fitting_config(fitting_config) {
 
-    // Tell the user what device is being used.
-    using Acc = ::alpaka::ExampleDefaultAcc<::alpaka::DimInt<1>, uint32_t>;
-    int device = 0;
-    auto devAcc = ::alpaka::getDevByIdx(::alpaka::Platform<Acc>{}, 0u);
-    auto const props = ::alpaka::getAccDevProps<Acc>(devAcc);
-    std::cout << "Using Alpaka device: " << ::alpaka::getName(devAcc)
-              << " [id: " << device << "] " << std::endl;
+    traccc::alpaka::get_device_info();
+
+    // Copy the detector (description) to the device.
+    m_copy(::vecmem::get_data(m_det_descr.get()), m_device_det_descr)->ignore();
+    if (m_detector != nullptr) {
+        m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
+                                               m_device_mr, m_copy);
+        m_device_detector_view = detray::get_data(m_device_detector);
+    }
 }
 
 full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
-    : m_host_mr(parent.m_host_mr),
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-      m_device_mr(),
+    : messaging(parent.logger().clone()),
+      m_host_mr(parent.m_host_mr),
+#if defined(ALPAKA_ACC_SYCL_ENABLED)
+      m_queue(parent.m_queue),
+      m_queue_wrapper(&m_queue),
+      m_device_mr(m_queue_wrapper),
+      m_copy(m_queue_wrapper),
 #else
-      m_device_mr(parent.m_host_mr),
-#endif
+      m_device_mr(),
       m_copy(),
+#endif
       m_cached_device_mr(
-          std::make_unique<vecmem::binary_page_memory_resource>(m_device_mr)),
-      m_target_cells_per_partition(parent.m_target_cells_per_partition),
+          std::make_unique<::vecmem::binary_page_memory_resource>(m_device_mr)),
+      m_field_vec(parent.m_field_vec),
+      m_field(parent.m_field),
+      m_det_descr(parent.m_det_descr),
+      m_device_det_descr(
+          static_cast<silicon_detector_description::buffer::size_type>(
+              m_det_descr.get().size()),
+          m_device_mr),
+      m_detector(parent.m_detector),
       m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                       m_target_cells_per_partition),
-      m_measurement_sorting(m_copy),
+                       parent.m_clustering_config),
+      m_measurement_sorting(m_copy,
+                            parent.logger().cloneWithSuffix("MeasSortingAlg")),
       m_spacepoint_formation(memory_resource{*m_cached_device_mr, &m_host_mr},
-                             m_copy),
+                             m_copy,
+                             parent.logger().cloneWithSuffix("SpFormationAlg")),
       m_seeding(parent.m_finder_config, parent.m_grid_config,
                 parent.m_filter_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy),
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                parent.logger().cloneWithSuffix("SeedingAlg")),
       m_track_parameter_estimation(
-          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy),
+          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+          parent.logger().cloneWithSuffix("TrackParamEstAlg")),
+      m_finding(parent.m_finding_config,
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                parent.logger().cloneWithSuffix("TrackFindingAlg")),
+      m_fitting(parent.m_fitting_config,
+                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
+                parent.logger().cloneWithSuffix("TrackFittingAlg")),
+      m_clustering_config(parent.m_clustering_config),
       m_finder_config(parent.m_finder_config),
       m_grid_config(parent.m_grid_config),
-      m_filter_config(parent.m_filter_config) {
+      m_filter_config(parent.m_filter_config),
+      m_finding_config(parent.m_finding_config),
+      m_fitting_config(parent.m_fitting_config) {
+
+    // Copy the detector (description) to the device.
+    m_copy(::vecmem::get_data(m_det_descr.get()), m_device_det_descr)->ignore();
+    if (m_detector != nullptr) {
+        m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
+                                               m_device_mr, m_copy);
+        m_device_detector_view = detray::get_data(m_device_detector);
+    }
 }
 
 full_chain_algorithm::~full_chain_algorithm() = default;
 
 full_chain_algorithm::output_type full_chain_algorithm::operator()(
-    const cell_collection_types::host& cells,
-    const cell_module_collection_types::host& modules) const {
+    const edm::silicon_cell_collection::host& cells) const {
 
     // Create device copy of input collections
-    cell_collection_types::buffer cells_buffer(cells.size(),
-                                               *m_cached_device_mr);
-    m_copy(vecmem::get_data(cells), cells_buffer)->ignore();
-    cell_module_collection_types::buffer modules_buffer(modules.size(),
-                                                        *m_cached_device_mr);
-    m_copy(vecmem::get_data(modules), modules_buffer)->ignore();
+    edm::silicon_cell_collection::buffer cells_buffer(
+        static_cast<unsigned int>(cells.size()), *m_cached_device_mr);
+    m_copy(::vecmem::get_data(cells), cells_buffer)->ignore();
 
-    // Run the clusterization
+    // Run the clusterization.
     const clusterization_algorithm::output_type measurements =
-        m_clusterization(cells_buffer, modules_buffer);
-    const spacepoint_formation_algorithm::output_type spacepoints =
-        m_spacepoint_formation(m_measurement_sorting(measurements),
-                               modules_buffer);
-    const track_params_estimation::output_type track_params =
-        m_track_parameter_estimation(spacepoints, m_seeding(spacepoints),
-                                     {0.f, 0.f, m_finder_config.bFieldInZ});
+        m_clusterization(cells_buffer, m_device_det_descr);
+    m_measurement_sorting(measurements);
 
-    // Get the final data back to the host.
-    bound_track_parameters_collection_types::host result(&m_host_mr);
-    m_copy(track_params, result)->wait();
+    // If we have a Detray detector, run the track finding and fitting.
+    if (m_detector != nullptr) {
 
-    // Return the host container.
-    return result;
+        // Run the seed-finding.
+        const spacepoint_formation_algorithm::output_type spacepoints =
+            m_spacepoint_formation(m_device_detector_view, measurements);
+        const track_params_estimation::output_type track_params =
+            m_track_parameter_estimation(measurements, spacepoints,
+                                         m_seeding(spacepoints), m_field_vec);
+
+        // Run the track finding.
+        const finding_algorithm::output_type track_candidates = m_finding(
+            m_device_detector_view, m_field, measurements, track_params);
+
+        // Run the track fitting.
+        const fitting_algorithm::output_type track_states =
+            m_fitting(m_device_detector_view, m_field, track_candidates);
+
+        // Copy a limited amount of result data back to the host.
+        output_type result{&m_host_mr};
+        m_copy(track_states.headers, result)->wait();
+        return result;
+
+    }
+    // If not, copy the track parameters back to the host, and return a dummy
+    // object.
+    else {
+
+        // Copy the measurements back to the host.
+        measurement_collection_types::host measurements_host(&m_host_mr);
+        m_copy(measurements, measurements_host)->wait();
+
+        // Return an empty object.
+        return {};
+    }
 }
 
 }  // namespace traccc::alpaka

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -71,7 +71,7 @@ full_chain_algorithm::full_chain_algorithm(
       m_finding_config(finding_config),
       m_fitting_config(fitting_config) {
 
-    traccc::alpaka::get_device_info();
+    std::cout << traccc::alpaka::get_device_info() << std::endl;
 
     // Copy the detector (description) to the device.
     m_copy(::vecmem::get_data(m_det_descr.get()), m_device_det_descr)->ignore();

--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -6,6 +6,8 @@
  */
 
 // Project include(s).
+#include "traccc/alpaka/finding/finding_algorithm.hpp"
+#include "traccc/alpaka/fitting/fitting_algorithm.hpp"
 #include "traccc/alpaka/seeding/seeding_algorithm.hpp"
 #include "traccc/alpaka/seeding/track_params_estimation.hpp"
 #include "traccc/alpaka/utils/get_vecmem_resource.hpp"
@@ -16,8 +18,12 @@
 #include "traccc/efficiency/nseed_performance_writer.hpp"
 #include "traccc/efficiency/seeding_performance_writer.hpp"
 #include "traccc/efficiency/track_filter.hpp"
+#include "traccc/finding/combinatorial_kalman_filter_algorithm.hpp"
+#include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+#include "traccc/fitting/kalman_fitting_algorithm.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/io/read_detector.hpp"
+#include "traccc/io/read_detector_description.hpp"
 #include "traccc/io/read_measurements.hpp"
 #include "traccc/io/read_spacepoints.hpp"
 #include "traccc/io/utils.hpp"
@@ -38,7 +44,6 @@
 #include "traccc/seeding/track_params_estimation.hpp"
 
 // Detray include(s).
-#include <detray/core/detector.hpp>
 #include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
@@ -58,15 +63,27 @@
 using namespace traccc;
 
 int seq_run(const traccc::opts::track_seeding& seeding_opts,
-            const traccc::opts::track_finding& /*finding_opts*/,
-            const traccc::opts::track_propagation& /*propagation_opts*/,
-            const traccc::opts::track_fitting& /*fitting_opts*/,
+            const traccc::opts::track_finding& finding_opts,
+            const traccc::opts::track_propagation& propagation_opts,
+            const traccc::opts::track_fitting& fitting_opts,
             const traccc::opts::input_data& input_opts,
             const traccc::opts::detector& detector_opts,
             const traccc::opts::performance& performance_opts,
             const traccc::opts::accelerator& accelerator_opts,
             [[maybe_unused]] std::unique_ptr<const traccc::Logger> ilogger) {
     TRACCC_LOCAL_LOGGER(std::move(ilogger));
+
+    /// Type declarations
+    using scalar_t = traccc::default_detector::host::scalar_type;
+    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_t>>;
+    using rk_stepper_type =
+        detray::rk_stepper<b_field_t::view_t,
+                           traccc::default_detector::host::algebra_type,
+                           detray::constrained_step<scalar_t>>;
+    using device_navigator_type =
+        detray::navigator<const traccc::default_detector::device>;
+    using device_fitter_type =
+        traccc::kalman_fitter<rk_stepper_type, device_navigator_type>;
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED
     ::sycl::queue q;
@@ -87,6 +104,10 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     // Performance writer
     traccc::seeding_performance_writer sd_performance_writer(
         traccc::seeding_performance_writer::config{});
+    traccc::finding_performance_writer find_performance_writer(
+        traccc::finding_performance_writer::config{});
+    traccc::fitting_performance_writer fit_performance_writer(
+        traccc::fitting_performance_writer::config{});
 
     traccc::nseed_performance_writer nsd_performance_writer(
         "nseed_performance_",
@@ -102,17 +123,37 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     uint64_t n_spacepoints = 0;
     uint64_t n_seeds = 0;
     uint64_t n_seeds_alpaka = 0;
+    uint64_t n_found_tracks = 0;
+    uint64_t n_found_tracks_alpaka = 0;
+    uint64_t n_fitted_tracks = 0;
+    uint64_t n_fitted_tracks_alpaka = 0;
 
     /*****************************
      * Build a geometry
      *****************************/
 
+    // B field value and its type
+    // @TODO: Set B field as argument
+    const traccc::vector3 B{0, 0, 2 * traccc::unit<traccc::scalar>::T};
+    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
+
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host host_det{mng_mr};
-    assert(detector_opts.use_detray_detector == true);
     traccc::io::read_detector(host_det, mng_mr, detector_opts.detector_file,
                               detector_opts.material_file,
                               detector_opts.grid_file);
+
+    // Detector view object
+    traccc::default_detector::view det_view = detray::get_data(host_det);
+
+    // Copy objects
+    traccc::device::container_d2h_copy_alg<
+        traccc::track_candidate_container_types>
+        track_candidate_d2h{mr, copy,
+                            logger().clone("TrackCandidateD2HCopyAlg")};
+
+    traccc::device::container_d2h_copy_alg<traccc::track_state_container_types>
+        track_state_d2h{mr, copy, logger().clone("TrackStateD2HCopyAlg")};
 
     // Seeding algorithms
     traccc::host::seeding_algorithm sa(
@@ -132,6 +173,26 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     traccc::alpaka::track_params_estimation tp_alpaka{
         mr, copy, logger().clone("AlpakaTrackParEstAlg")};
 
+    // Propagation configuration
+    detray::propagation::config propagation_config(propagation_opts);
+
+    // Finding algorithm configuration
+    traccc::finding_config cfg(finding_opts);
+    cfg.propagation = propagation_config;
+
+    // Finding algorithm object
+    traccc::host::combinatorial_kalman_filter_algorithm host_finding(cfg);
+    traccc::alpaka::finding_algorithm<rk_stepper_type, device_navigator_type>
+        device_finding(cfg, mr, copy);
+
+    // Fitting algorithm object
+    traccc::fitting_config fit_cfg(fitting_opts);
+    fit_cfg.propagation = propagation_config;
+
+    traccc::host::kalman_fitting_algorithm host_fitting(fit_cfg, host_mr);
+    traccc::alpaka::fitting_algorithm<device_fitter_type> device_fitting(
+        fit_cfg, mr, copy);
+
     traccc::performance::timing_info elapsedTimes;
 
     // Loop over events
@@ -142,7 +203,6 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         traccc::edm::spacepoint_collection::host spacepoints_per_event{host_mr};
         traccc::measurement_collection_types::host measurements_per_event{
             &host_mr};
-
         traccc::host::seeding_algorithm::output_type seeds{host_mr};
         traccc::host::track_params_estimation::output_type params;
         traccc::track_candidate_container_types::host track_candidates;
@@ -151,6 +211,13 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         traccc::edm::seed_collection::buffer seeds_alpaka_buffer;
         traccc::bound_track_parameters_collection_types::buffer
             params_alpaka_buffer(0, *mr.host);
+
+        traccc::track_candidate_container_types::buffer
+            track_candidates_alpaka_buffer{{{}, *(mr.host)},
+                                           {{}, *(mr.host), mr.host}};
+
+        traccc::track_state_container_types::buffer track_states_alpaka_buffer{
+            {{}, *(mr.host)}, {{}, *(mr.host), mr.host}};
 
         {  // Start measuring wall time
             traccc::performance::timer wall_t("Wall time", elapsedTimes);
@@ -176,7 +243,6 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
             // Alpaka
 
-            // TODO: Check this (and all other copies) are intelligent.
             // Copy the spacepoint data to the device.
             traccc::edm::spacepoint_collection::buffer
                 spacepoints_alpaka_buffer(
@@ -185,6 +251,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             copy(vecmem::get_data(spacepoints_per_event),
                  spacepoints_alpaka_buffer)
                 ->wait();
+
             traccc::measurement_collection_types::buffer
                 measurements_alpaka_buffer(
                     static_cast<unsigned int>(measurements_per_event.size()),
@@ -232,6 +299,45 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                             {0.f, 0.f, seeding_opts.seedfinder.bFieldInZ});
             }  // stop measuring track params cpu timer
 
+            /*------------------------
+               Track Finding with CKF
+              ------------------------*/
+
+            {
+                traccc::performance::timer t("Track finding with CKF (alpaka)",
+                                             elapsedTimes);
+                track_candidates_alpaka_buffer =
+                    device_finding(det_view, field, measurements_alpaka_buffer,
+                                   params_alpaka_buffer);
+            }
+
+            if (accelerator_opts.compare_with_cpu) {
+                traccc::performance::timer t("Track finding with CKF (cpu)",
+                                             elapsedTimes);
+                track_candidates = host_finding(
+                    host_det, field, vecmem::get_data(measurements_per_event),
+                    vecmem::get_data(params));
+            }
+
+            /*------------------------
+               Track Fitting with KF
+              ------------------------*/
+
+            {
+                traccc::performance::timer t("Track fitting with KF (alpaka)",
+                                             elapsedTimes);
+
+                track_states_alpaka_buffer = device_fitting(
+                    det_view, field, track_candidates_alpaka_buffer);
+            }
+
+            if (accelerator_opts.compare_with_cpu) {
+                traccc::performance::timer t("Track fitting with KF (cpu)",
+                                             elapsedTimes);
+                track_states = host_fitting(host_det, field,
+                                            traccc::get_data(track_candidates));
+            }
+
         }  // Stop measuring wall time
 
         /*----------------------------------
@@ -244,6 +350,14 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             &host_mr};
         copy(seeds_alpaka_buffer, seeds_alpaka)->wait();
         copy(params_alpaka_buffer, params_alpaka)->wait();
+
+        // Copy track candidates from device to host
+        traccc::track_candidate_container_types::host track_candidates_alpaka =
+            track_candidate_d2h(track_candidates_alpaka_buffer);
+
+        // Copy track states from device to host
+        traccc::track_state_container_types::host track_states_alpaka =
+            track_state_d2h(track_states_alpaka_buffer);
 
         if (accelerator_opts.compare_with_cpu) {
             // Show which event we are currently presenting the results for.
@@ -264,6 +378,26 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                 compare_track_parameters{"track parameters"};
             compare_track_parameters(vecmem::get_data(params),
                                      vecmem::get_data(params_alpaka));
+
+            // Compare the track candidates made on the host and on the
+            // device
+            unsigned int n_matches = 0;
+            for (unsigned int i = 0; i < track_candidates.size(); i++) {
+                auto iso = traccc::details::is_same_object(
+                    track_candidates.at(i).items);
+
+                for (unsigned int j = 0; j < track_candidates_alpaka.size();
+                     j++) {
+                    if (iso(track_candidates_alpaka.at(j).items)) {
+                        n_matches++;
+                        break;
+                    }
+                }
+            }
+            std::cout << "Track candidate matching Rate: "
+                      << float(n_matches) /
+                             static_cast<float>(track_candidates.size())
+                      << std::endl;
         }
 
         /*----------------
@@ -273,6 +407,10 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         n_spacepoints += spacepoints_per_event.size();
         n_seeds_alpaka += seeds_alpaka.size();
         n_seeds += seeds.size();
+        n_found_tracks_alpaka += track_candidates_alpaka.size();
+        n_found_tracks += track_candidates.size();
+        n_fitted_tracks_alpaka += track_states_alpaka.size();
+        n_fitted_tracks += track_states.size();
 
         /*------------
           Writer
@@ -294,7 +432,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     if (performance_opts.run) {
         sd_performance_writer.finalize();
         nsd_performance_writer.finalize();
-
+        find_performance_writer.finalize();
+        fit_performance_writer.finalize();
         std::cout << nsd_performance_writer.generate_report_str();
     }
 
@@ -303,6 +442,14 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     std::cout << "- created  (cpu)  " << n_seeds << " seeds" << std::endl;
     std::cout << "- created (alpaka)  " << n_seeds_alpaka << " seeds"
               << std::endl;
+    std::cout << "- created  (cpu) " << n_found_tracks << " found tracks"
+              << std::endl;
+    std::cout << "- created (alpaka) " << n_found_tracks_alpaka
+              << " found tracks" << std::endl;
+    std::cout << "- created  (cpu) " << n_fitted_tracks << " fitted tracks"
+              << std::endl;
+    std::cout << "- created (alpaka) " << n_fitted_tracks_alpaka
+              << " fitted tracks" << std::endl;
     std::cout << "==>Elapsed times...\n" << elapsedTimes << std::endl;
 
     return 0;

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -8,12 +8,18 @@
 // Project include(s).
 #include "traccc/alpaka/clusterization/clusterization_algorithm.hpp"
 #include "traccc/alpaka/clusterization/measurement_sorting_algorithm.hpp"
+#include "traccc/alpaka/finding/finding_algorithm.hpp"
+#include "traccc/alpaka/fitting/fitting_algorithm.hpp"
 #include "traccc/alpaka/seeding/seeding_algorithm.hpp"
 #include "traccc/alpaka/seeding/spacepoint_formation_algorithm.hpp"
 #include "traccc/alpaka/seeding/track_params_estimation.hpp"
 #include "traccc/alpaka/utils/get_vecmem_resource.hpp"
 #include "traccc/clusterization/clusterization_algorithm.hpp"
+#include "traccc/device/container_d2h_copy_alg.hpp"
 #include "traccc/efficiency/seeding_performance_writer.hpp"
+#include "traccc/finding/combinatorial_kalman_filter_algorithm.hpp"
+#include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+#include "traccc/fitting/kalman_fitting_algorithm.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/io/read_cells.hpp"
 #include "traccc/io/read_detector.hpp"
@@ -25,13 +31,24 @@
 #include "traccc/options/input_data.hpp"
 #include "traccc/options/performance.hpp"
 #include "traccc/options/program_options.hpp"
+#include "traccc/options/track_finding.hpp"
+#include "traccc/options/track_fitting.hpp"
+#include "traccc/options/track_propagation.hpp"
 #include "traccc/options/track_seeding.hpp"
 #include "traccc/performance/collection_comparator.hpp"
+#include "traccc/performance/container_comparator.hpp"
 #include "traccc/performance/soa_comparator.hpp"
 #include "traccc/performance/timer.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
+
+// Detray include(s).
+#include <detray/detectors/bfield.hpp>
+#include <detray/io/frontend/detector_reader.hpp>
+#include <detray/navigation/navigator.hpp>
+#include <detray/propagator/propagator.hpp>
+#include <detray/propagator/rk_stepper.hpp>
 
 // System include(s).
 #include <exception>
@@ -39,28 +56,17 @@
 #include <iostream>
 #include <memory>
 
-namespace po = boost::program_options;
-
 int seq_run(const traccc::opts::detector& detector_opts,
             const traccc::opts::input_data& input_opts,
             const traccc::opts::clusterization& clusterization_opts,
             const traccc::opts::track_seeding& seeding_opts,
+            const traccc::opts::track_finding& finding_opts,
+            const traccc::opts::track_propagation& propagation_opts,
+            const traccc::opts::track_fitting& fitting_opts,
             const traccc::opts::performance& performance_opts,
             const traccc::opts::accelerator& accelerator_opts,
             std::unique_ptr<const traccc::Logger> ilogger) {
     TRACCC_LOCAL_LOGGER(std::move(ilogger));
-
-    // Output stats
-    uint64_t n_cells = 0;
-    uint64_t n_measurements = 0;
-    uint64_t n_spacepoints = 0;
-    uint64_t n_spacepoints_alpaka = 0;
-    uint64_t n_seeds = 0;
-    uint64_t n_seeds_alpaka = 0;
-
-    // Constant B field for the track finding and fitting
-    const traccc::vector3 field_vec = {0.f, 0.f,
-                                       seeding_opts.seedfinder.bFieldInZ};
 
     // Memory resources used by the application.
 #ifdef ALPAKA_ACC_SYCL_ENABLED
@@ -88,7 +94,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
     traccc::silicon_detector_description::buffer device_det_descr{
         static_cast<traccc::silicon_detector_description::buffer::size_type>(
             host_det_descr.size()),
-        mr.main};
+        device_mr};
+    copy.setup(device_det_descr)->wait();
     copy(host_det_descr_data, device_det_descr)->wait();
 
     // Construct a Detray detector object, if supported by the configuration.
@@ -99,16 +106,60 @@ int seq_run(const traccc::opts::detector& detector_opts,
         traccc::io::read_detector(
             host_detector, host_mr, detector_opts.detector_file,
             detector_opts.material_file, detector_opts.grid_file);
-        device_detector = detray::get_buffer(host_detector, mr.main, copy);
+        device_detector = detray::get_buffer(host_detector, device_mr, copy);
         device_detector_view = detray::get_data(device_detector);
     }
 
+    // Output stats
+    uint64_t n_cells = 0;
+    uint64_t n_measurements = 0;
+    uint64_t n_measurements_alpaka = 0;
+    uint64_t n_spacepoints = 0;
+    uint64_t n_spacepoints_alpaka = 0;
+    uint64_t n_seeds = 0;
+    uint64_t n_seeds_alpaka = 0;
+    uint64_t n_found_tracks = 0;
+    uint64_t n_found_tracks_alpaka = 0;
+    uint64_t n_fitted_tracks = 0;
+    uint64_t n_fitted_tracks_alpaka = 0;
+
     // Type definitions
+    using scalar_type = traccc::default_detector::host::scalar_type;
     using host_spacepoint_formation_algorithm =
         traccc::host::silicon_pixel_spacepoint_formation_algorithm;
     using device_spacepoint_formation_algorithm =
         traccc::alpaka::spacepoint_formation_algorithm<
             traccc::default_detector::device>;
+    using stepper_type =
+        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
+                           traccc::default_detector::host::algebra_type,
+                           detray::constrained_step<scalar_type>>;
+    using device_navigator_type =
+        detray::navigator<const traccc::default_detector::device>;
+
+    using host_finding_algorithm =
+        traccc::host::combinatorial_kalman_filter_algorithm;
+    using device_finding_algorithm =
+        traccc::alpaka::finding_algorithm<stepper_type, device_navigator_type>;
+
+    using host_fitting_algorithm = traccc::host::kalman_fitting_algorithm;
+    using device_fitting_algorithm = traccc::alpaka::fitting_algorithm<
+        traccc::kalman_fitter<stepper_type, device_navigator_type>>;
+
+    // Algorithm configuration(s).
+    detray::propagation::config propagation_config(propagation_opts);
+
+    traccc::finding_config finding_cfg(finding_opts);
+    finding_cfg.propagation = propagation_config;
+
+    traccc::fitting_config fitting_cfg(fitting_opts);
+    fitting_cfg.propagation = propagation_config;
+
+    // Constant B field for the track finding and fitting
+    const traccc::vector3 field_vec = {0.f, 0.f,
+                                       seeding_opts.seedfinder.bFieldInZ};
+    const detray::bfield::const_field_t<traccc::scalar> field =
+        detray::bfield::create_const_field<traccc::scalar>(field_vec);
 
     traccc::host::clusterization_algorithm ca(
         host_mr, logger().clone("HostClusteringAlg"));
@@ -119,6 +170,10 @@ int seq_run(const traccc::opts::detector& detector_opts,
         seeding_opts.seedfilter, host_mr, logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
+    host_finding_algorithm finding_alg(finding_cfg,
+                                       logger().clone("HostFindingAlg"));
+    host_fitting_algorithm fitting_alg(fitting_cfg, host_mr,
+                                       logger().clone("HostFittingAlg"));
 
     traccc::alpaka::clusterization_algorithm ca_alpaka(
         mr, copy, clusterization_opts, logger().clone("AlpakaClusteringAlg"));
@@ -131,6 +186,17 @@ int seq_run(const traccc::opts::detector& detector_opts,
         seeding_opts.seedfilter, mr, copy, logger().clone("AlpakaSeedingAlg"));
     traccc::alpaka::track_params_estimation tp_alpaka(
         mr, copy, logger().clone("AlpakaTrackParEstAlg"));
+    device_finding_algorithm finding_alg_alpaka(
+        finding_cfg, mr, copy, logger().clone("AlpakaFindingAlg"));
+    device_fitting_algorithm fitting_alg_alpaka(
+        fitting_cfg, mr, copy, logger().clone("AlpakaFittingAlg"));
+
+    traccc::device::container_d2h_copy_alg<
+        traccc::track_candidate_container_types>
+        copy_track_candidates(mr, copy,
+                              logger().clone("TrackCandidateD2HCopyAlg"));
+    traccc::device::container_d2h_copy_alg<traccc::track_state_container_types>
+        copy_track_states(mr, copy, logger().clone("TrackStateD2HCopyAlg"));
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
@@ -149,6 +215,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
             host_mr};
         traccc::host::seeding_algorithm::output_type seeds{host_mr};
         traccc::host::track_params_estimation::output_type params{&host_mr};
+        host_finding_algorithm::output_type track_candidates;
+        host_fitting_algorithm::output_type track_states;
 
         // Instantiate alpaka containers/collections
         traccc::measurement_collection_types::buffer measurements_alpaka_buffer(
@@ -157,6 +225,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
         traccc::edm::seed_collection::buffer seeds_alpaka_buffer;
         traccc::bound_track_parameters_collection_types::buffer
             params_alpaka_buffer(0, *mr.host);
+        traccc::track_candidate_container_types::buffer track_candidates_buffer;
+        traccc::track_state_container_types::buffer track_states_buffer;
 
         {
             traccc::performance::timer wall_t("Wall time", elapsedTimes);
@@ -179,6 +249,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
             // Create device copy of input collections
             traccc::edm::silicon_cell_collection::buffer cells_buffer(
                 static_cast<unsigned int>(cells_per_event.size()), mr.main);
+            copy.setup(cells_buffer)->wait();
             copy(vecmem::get_data(cells_per_event), cells_buffer)->wait();
 
             // Alpaka
@@ -199,6 +270,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
                     ca(vecmem::get_data(cells_per_event), host_det_descr_data);
             }  // stop measuring clusterization cpu timer
 
+            // Perform seeding, track finding and fitting only when using a
+            // Detray geometry.
             if (detector_opts.use_detray_detector) {
 
                 // Alpaka
@@ -207,7 +280,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
                         "Spacepoint formation (alpaka)", elapsedTimes);
                     spacepoints_alpaka_buffer = sf_alpaka(
                         device_detector_view, measurements_alpaka_buffer);
-                }  // stop measuring spacepoint formation cuda timer
+                }  // stop measuring spacepoint formation alpaka timer
 
                 // CPU
                 if (accelerator_opts.compare_with_cpu) {
@@ -249,6 +322,42 @@ int seq_run(const traccc::opts::detector& detector_opts,
                                 vecmem::get_data(spacepoints_per_event),
                                 vecmem::get_data(seeds), field_vec);
                 }  // stop measuring track params cpu timer
+
+                // Alpaka
+                {
+                    traccc::performance::timer timer{"Track finding (alpaka)",
+                                                     elapsedTimes};
+                    track_candidates_buffer = finding_alg_alpaka(
+                        device_detector_view, field, measurements_alpaka_buffer,
+                        params_alpaka_buffer);
+                }
+
+                // CPU
+                if (accelerator_opts.compare_with_cpu) {
+                    traccc::performance::timer timer{"Track finding (cpu)",
+                                                     elapsedTimes};
+                    track_candidates =
+                        finding_alg(host_detector, field,
+                                    vecmem::get_data(measurements_per_event),
+                                    vecmem::get_data(params));
+                }
+
+                // Alpaka
+                {
+                    traccc::performance::timer timer{"Track fitting (alpaka)",
+                                                     elapsedTimes};
+                    track_states_buffer = fitting_alg_alpaka(
+                        device_detector_view, field, track_candidates_buffer);
+                }
+
+                // CPU
+                if (accelerator_opts.compare_with_cpu) {
+                    traccc::performance::timer timer{"Track fitting (cpu)",
+                                                     elapsedTimes};
+                    track_states =
+                        fitting_alg(host_detector, field,
+                                    traccc::get_data(track_candidates));
+                }
             }
         }  // Stop measuring wall time
 
@@ -256,20 +365,33 @@ int seq_run(const traccc::opts::detector& detector_opts,
           compare cpu and alpaka result
           ----------------------------------*/
 
+        traccc::measurement_collection_types::host
+            measurements_per_event_alpaka;
         traccc::edm::spacepoint_collection::host spacepoints_per_event_alpaka{
             host_mr};
         traccc::edm::seed_collection::host seeds_alpaka{host_mr};
         traccc::bound_track_parameters_collection_types::host params_alpaka{
             &host_mr};
 
+        copy(measurements_alpaka_buffer, measurements_per_event_alpaka)->wait();
         copy(spacepoints_alpaka_buffer, spacepoints_per_event_alpaka)->wait();
         copy(seeds_alpaka_buffer, seeds_alpaka)->wait();
         copy(params_alpaka_buffer, params_alpaka)->wait();
+        auto track_candidates_alpaka =
+            copy_track_candidates(track_candidates_buffer);
+        auto track_states_alpaka = copy_track_states(track_states_buffer);
 
         if (accelerator_opts.compare_with_cpu) {
 
             // Show which event we are currently presenting the results for.
-            std::cout << "===>>> Event " << event << " <<<===" << std::endl;
+            TRACCC_INFO("===>>> Event " << event << " <<<===");
+
+            // Compare the measurements made on the host and on the device.
+            traccc::collection_comparator<traccc::measurement>
+                compare_measurements{"measurements"};
+            compare_measurements(
+                vecmem::get_data(measurements_per_event),
+                vecmem::get_data(measurements_per_event_alpaka));
 
             // Compare the spacepoints made on the host and on the device.
             traccc::soa_comparator<traccc::edm::spacepoint_collection>
@@ -292,14 +414,55 @@ int seq_run(const traccc::opts::detector& detector_opts,
                 compare_track_parameters{"track parameters"};
             compare_track_parameters(vecmem::get_data(params),
                                      vecmem::get_data(params_alpaka));
-        }
 
+            // Compare tracks found on the host and on the device.
+            traccc::collection_comparator<
+                traccc::track_candidate_container_types::host::header_type>
+                compare_track_candidates{"track candidates (header)"};
+            compare_track_candidates(
+                vecmem::get_data(track_candidates.get_headers()),
+                vecmem::get_data(track_candidates_alpaka.get_headers()));
+
+            unsigned int n_matches = 0;
+            for (unsigned int i = 0; i < track_candidates.size(); i++) {
+                auto iso = traccc::details::is_same_object(
+                    track_candidates.at(i).items);
+
+                for (unsigned int j = 0; j < track_candidates_alpaka.size();
+                     j++) {
+                    if (iso(track_candidates_alpaka.at(j).items)) {
+                        n_matches++;
+                        break;
+                    }
+                }
+            }
+
+            std::cout << "  Track candidates (item) matching rate: "
+                      << 100. * static_cast<double>(n_matches) /
+                             static_cast<double>(
+                                 std::max(track_candidates.size(),
+                                          track_candidates_alpaka.size()))
+                      << "%" << std::endl;
+
+            // Compare tracks fitted on the host and on the device.
+            traccc::collection_comparator<
+                traccc::track_state_container_types::host::header_type>
+                compare_track_states{"track states"};
+            compare_track_states(
+                vecmem::get_data(track_states.get_headers()),
+                vecmem::get_data(track_states_alpaka.get_headers()));
+        }
         /// Statistics
         n_measurements += measurements_per_event.size();
         n_spacepoints += spacepoints_per_event.size();
         n_seeds += seeds.size();
+        n_measurements_alpaka += measurements_per_event_alpaka.size();
         n_spacepoints_alpaka += spacepoints_per_event_alpaka.size();
         n_seeds_alpaka += seeds_alpaka.size();
+        n_found_tracks += track_candidates.size();
+        n_found_tracks_alpaka += track_candidates_alpaka.size();
+        n_fitted_tracks += track_states.size();
+        n_fitted_tracks_alpaka += track_states_alpaka.size();
 
         if (performance_opts.run) {
 
@@ -319,19 +482,22 @@ int seq_run(const traccc::opts::detector& detector_opts,
         sd_performance_writer.finalize();
     }
 
-    std::cout << "==> Statistics ... " << std::endl;
-    std::cout << "- read    " << n_cells << " cells" << std::endl;
-    std::cout << "- created (cpu)  " << n_measurements << " measurements     "
-              << std::endl;
-    std::cout << "- created (cpu)  " << n_spacepoints << " spacepoints     "
-              << std::endl;
-    std::cout << "- created (alpaka) " << n_spacepoints_alpaka
-              << " spacepoints     " << std::endl;
+    TRACCC_INFO("==> Statistics ... ");
+    TRACCC_INFO("- read    " << n_cells << " cells");
+    TRACCC_INFO("- created (cpu)  " << n_measurements << " measurements     ");
+    TRACCC_INFO("- created (alpaka)  " << n_measurements_alpaka
+                                       << " measurements     ");
+    TRACCC_INFO("- created (cpu)  " << n_spacepoints << " spacepoints     ");
+    TRACCC_INFO("- created (alpaka) " << n_spacepoints_alpaka
+                                      << " spacepoints     ");
 
-    std::cout << "- created  (cpu) " << n_seeds << " seeds" << std::endl;
-    std::cout << "- created (alpaka) " << n_seeds_alpaka << " seeds"
-              << std::endl;
-    std::cout << "==>Elapsed times...\n" << elapsedTimes << std::endl;
+    TRACCC_INFO("- created  (cpu) " << n_seeds << " seeds");
+    TRACCC_INFO("- created (alpaka) " << n_seeds_alpaka << " seeds");
+    TRACCC_INFO("- found (cpu)    " << n_found_tracks << " tracks");
+    TRACCC_INFO("- found (alpaka)   " << n_found_tracks_alpaka << " tracks");
+    TRACCC_INFO("- fitted (cpu)   " << n_fitted_tracks << " tracks");
+    TRACCC_INFO("- fitted (alpaka)  " << n_fitted_tracks_alpaka << " tracks");
+    TRACCC_INFO("==>Elapsed times... " << elapsedTimes);
 
     return 0;
 }
@@ -347,17 +513,22 @@ int main(int argc, char* argv[]) {
     traccc::opts::input_data input_opts;
     traccc::opts::clusterization clusterization_opts;
     traccc::opts::track_seeding seeding_opts;
+    traccc::opts::track_finding finding_opts;
+    traccc::opts::track_propagation propagation_opts;
+    traccc::opts::track_fitting fitting_opts;
     traccc::opts::performance performance_opts;
     traccc::opts::accelerator accelerator_opts;
     traccc::opts::program_options program_opts{
         "Full Tracking Chain Using Alpaka",
         {detector_opts, input_opts, clusterization_opts, seeding_opts,
-         performance_opts, accelerator_opts},
+         finding_opts, propagation_opts, performance_opts, fitting_opts,
+         accelerator_opts},
         argc,
         argv,
         logger->cloneWithSuffix("Options")};
 
     // Run the application.
     return seq_run(detector_opts, input_opts, clusterization_opts, seeding_opts,
+                   finding_opts, propagation_opts, fitting_opts,
                    performance_opts, accelerator_opts, logger->clone());
 }

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -81,6 +81,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
     traccc::alpaka::vecmem_resources::device_memory_resource device_mr;
 #endif
     traccc::memory_resource mr{device_mr, &host_mr};
+    vecmem::copy host_copy;
 
     // Construct the detector description object.
     traccc::silicon_detector_description::host host_det_descr{host_mr};
@@ -172,7 +173,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
         host_mr, logger().clone("HostTrackParEstAlg"));
     host_finding_algorithm finding_alg(finding_cfg,
                                        logger().clone("HostFindingAlg"));
-    host_fitting_algorithm fitting_alg(fitting_cfg, host_mr,
+    host_fitting_algorithm fitting_alg(fitting_cfg, host_mr, host_copy,
                                        logger().clone("HostFittingAlg"));
 
     traccc::alpaka::clusterization_algorithm ca_alpaka(

--- a/examples/run/alpaka/throughput_mt.cpp
+++ b/examples/run/alpaka/throughput_mt.cpp
@@ -1,36 +1,24 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
+// Project include(s).
+#include "traccc/alpaka/utils/get_vecmem_resource.hpp"
+
 // Local include(s).
 #include "../common/throughput_mt.hpp"
-
 #include "full_chain_algorithm.hpp"
-
-// VecMem include(s).
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-#include <vecmem/memory/cuda/host_memory_resource.hpp>
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-#include <vecmem/memory/hip/host_memory_resource.hpp>
-#else
-#include <vecmem/memory/host_memory_resource.hpp>
-#endif
 
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
     static const bool use_host_caching = true;
-    return traccc::throughput_mt<traccc::alpaka::full_chain_algorithm,
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                                 vecmem::cuda::host_memory_resource
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-                                 vecmem::hip::host_memory_resource
-#else
-                                 vecmem::host_memory_resource
-#endif
-                                 >("Multi-threaded Alpaka GPU throughput tests",
-                                   argc, argv, use_host_caching);
+    return traccc::throughput_mt<
+        traccc::alpaka::full_chain_algorithm,
+        traccc::alpaka::vecmem_resources::host_memory_resource>(
+        "Multi-threaded Alpaka GPU throughput tests", argc, argv,
+        use_host_caching);
 }

--- a/examples/run/alpaka/throughput_st.cpp
+++ b/examples/run/alpaka/throughput_st.cpp
@@ -1,37 +1,24 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
+// Project include(s).
+#include "traccc/alpaka/utils/get_vecmem_resource.hpp"
+
 // Local include(s).
 #include "../common/throughput_st.hpp"
-
 #include "full_chain_algorithm.hpp"
-
-// VecMem include(s).
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-#include <vecmem/memory/cuda/host_memory_resource.hpp>
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-#include <vecmem/memory/hip/host_memory_resource.hpp>
-#else
-#include <vecmem/memory/host_memory_resource.hpp>
-#endif
 
 int main(int argc, char* argv[]) {
 
     // Execute the throughput test.
     static const bool use_host_caching = true;
-    return traccc::throughput_st<traccc::alpaka::full_chain_algorithm,
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                                 vecmem::cuda::host_memory_resource
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-                                 vecmem::hip::host_memory_resource
-#else
-                                 vecmem::host_memory_resource
-#endif
-                                 >(
+    return traccc::throughput_st<
+        traccc::alpaka::full_chain_algorithm,
+        traccc::alpaka::vecmem_resources::host_memory_resource>(
         "Single-threaded Alpaka GPU throughput tests", argc, argv,
         use_host_caching);
 }


### PR DESCRIPTION
This builds on #925 and #918, adding in the updates to the examples to actual use this new code.

Here is the running total of follow up work. I've stuck the ones that changed first, then the rest directly copied over from the last PR.

 - ~~Test on an Intel GPU. Still not tested there, and there is a few spots that may not actually be functional, but it is difficult to test without hardware.~~ Intel hardware has been tested now, and we are getting somewhere! The Alpaka code functions up to, but not including the new finding code. I did a replacement of some of the thrust code there with `ifdef SYCL: oneDPL::XXX` and got a bit further into the finding, but I get a hang when attempting to launch one of the kernels (prop to next surface I believe). Going to follow up with later, but I suspect it is due to the difference in kernel writing between CUDA/HIP + SYCL (as referenced by the register spills I get when compiling for SYCL etc). May need to play with register sizes or see about splitting things to get it happy.

Copied over: 

 - "Unify Everything" : I.e. work to condense any / all accelerator specific code to a single place. The two main places that is still needed is the thrust device selection and also a unified interface for vecmem (we are almost there on that, but we need to work out the best way to optionally take a SYCL queue in, as we have to special case SYCL for that reason at the mo).

 - Fix any remaining bugs that exist in this implementation. When running all the work together, I'm seeing some instability, especially at higher values of mu, where the alpaka implementation will crash. That needs investigating, but potentially after....

 - Async-ify. Right now, we using a blocking queue and lots of `::alpaka::wait(queue)` calls. That is causing issues in at least one place (part of the instability mentioned above is due to the seeding code, and the fix there seems to be relaxing the synchronisation to only the required points, so the points around copies to host memory, rather than after every kernel), so I'm interested to see if that could be causing the other instability I'm seeing (which I've seemingly isolated to this new track finding code). That would bring closer parity to the CUDA code to, would just need to work out an interface to build an alpaka queue and then pass it everywhere.

 - Fix the MT throughput code. There is an old Alpaka issue that implies some of the accelerator back ends aren't / weren't thread safe, which could explain why the MT examples don't work....but the issue is from 2014 and hasn't been updated in a few years. Need to chase that up, and once all three PRs and other fixes are in, start to tackle exactly why the MT example doesn't run.
