### PR TITLE
Migrate fitting kernels to use a payload struct

### DIFF
--- a/device/alpaka/src/fitting/fitting_algorithm.cpp
+++ b/device/alpaka/src/fitting/fitting_algorithm.cpp
@@ -45,58 +45,16 @@ struct FillSortKeysKernel {
 };
 
 template <typename fitter_t>
-struct fit_payload {
-
-    /**
-     * @brief View object to the detector description
-     */
-    typename fitter_t::detector_type::view_type det_data;
-
-    /**
-     * @brief View object to the magnetic field description
-     */
-    typename fitter_t::bfield_type field_data;
-
-    /**
-     * @brief View object to the fitting configuration
-     */
-    typename fitter_t::config_type cfg;
-
-    /**
-     * @brief View object to the input track candidates
-     */
-    track_candidate_container_types::const_view track_candidates_view;
-
-    /**
-     * @brief View object to the input track parameters
-     */
-    vecmem::data::vector_view<const unsigned int> param_ids_view;
-
-    /**
-     * @brief View object to the output track states
-     */
-    track_state_container_types::view track_states_view;
-
-    /**
-     * @brief View object to the output barcode sequence
-     */
-    vecmem::data::jagged_vector_view<detray::geometry::barcode> barcodes_view;
-};
-
-template <typename fitter_t, typename detector_view_t>
 struct FitTrackKernel {
     template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  const fit_payload<fitter_t>* payload) const {
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc, const typename fitter_t::config_type cfg,
+        const device::fit_payload<fitter_t>* payload) const {
 
         device::global_index_t globalThreadIdx =
             ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
 
-        device::fit<fitter_t>(
-            globalThreadIdx, payload->det_data, payload->field_data,
-            payload->cfg, payload->track_candidates_view,
-            payload->param_ids_view, payload->track_states_view,
-            payload->barcodes_view);
+        device::fit<fitter_t>(globalThreadIdx, cfg, *payload);
     }
 };
 
@@ -181,30 +139,27 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
                             keys_device.end(), param_ids_device.begin());
 
         // Prepare the payload for the track fitting
-        fit_payload<fitter_t> payload{det_view,
-                                      field_view,
-                                      m_cfg,
-                                      track_candidates_view,
-                                      vecmem::get_data(param_ids_buffer),
-                                      track_states_view,
-                                      vecmem::get_data(seqs_buffer)};
+        device::fit_payload<fitter_t> payload{
+            .det_data = det_view,
+            .field_data = field_view,
+            .track_candidates_view = track_candidates_view,
+            .param_ids_view = vecmem::get_data(param_ids_buffer),
+            .track_states_view = track_states_view,
+            .barcodes_view = vecmem::get_data(seqs_buffer)};
         auto bufHost_fitPayload =
-            ::alpaka::allocBuf<fit_payload<fitter_t>, Idx>(devHost, 1u);
-        fit_payload<fitter_t>* fitPayload =
+            ::alpaka::allocBuf<device::fit_payload<fitter_t>, Idx>(devHost, 1u);
+        device::fit_payload<fitter_t>* fitPayload =
             ::alpaka::getPtrNative(bufHost_fitPayload);
         *fitPayload = payload;
 
         auto bufAcc_fitPayload =
-            ::alpaka::allocBuf<fit_payload<fitter_t>, Idx>(devAcc, 1u);
+            ::alpaka::allocBuf<device::fit_payload<fitter_t>, Idx>(devAcc, 1u);
         ::alpaka::memcpy(queue, bufAcc_fitPayload, bufHost_fitPayload);
         ::alpaka::wait(queue);
 
         // Run the track fitting
-        ::alpaka::exec<Acc>(
-            queue, workDiv,
-            FitTrackKernel<fitter_t,
-                           typename fitter_t::detector_type::view_type>{},
-            ::alpaka::getPtrNative(bufAcc_fitPayload));
+        ::alpaka::exec<Acc>(queue, workDiv, FitTrackKernel<fitter_t>{}, m_cfg,
+                            ::alpaka::getPtrNative(bufAcc_fitPayload));
         ::alpaka::wait(queue);
     }
 

--- a/device/common/include/traccc/fitting/device/fit.hpp
+++ b/device/common/include/traccc/fitting/device/fit.hpp
@@ -17,6 +17,40 @@
 
 namespace traccc::device {
 
+// Payload for the fitting algorithm
+template <typename fitter_t>
+struct fit_payload {
+    /**
+     * @brief View object to the detector description
+     */
+    typename fitter_t::detector_type::view_type det_data;
+
+    /**
+     * @brief View object to the magnetic field description
+     */
+    typename fitter_t::bfield_type field_data;
+
+    /**
+     * @brief View object to the input track candidates
+     */
+    track_candidate_container_types::const_view track_candidates_view;
+
+    /**
+     * @brief View object to the input track parameters
+     */
+    vecmem::data::vector_view<const unsigned int> param_ids_view;
+
+    /**
+     * @brief View object to the output track states
+     */
+    track_state_container_types::view track_states_view;
+
+    /**
+     * @brief View object to the output barcode sequence
+     */
+    vecmem::data::jagged_vector_view<detray::geometry::barcode> barcodes_view;
+};
+
 /// Function used for fitting a track for a given track candidates
 ///
 /// @param[in] globalIndex   The index of the current thread
@@ -26,15 +60,9 @@ namespace traccc::device {
 /// @param[out] barcodes_view The barcode sequence for backward filter
 ///
 template <typename fitter_t>
-TRACCC_HOST_DEVICE inline void fit(
-    global_index_t globalIndex,
-    typename fitter_t::detector_type::view_type det_data,
-    const typename fitter_t::bfield_type field_data,
-    const typename fitter_t::config_type cfg,
-    track_candidate_container_types::const_view track_candidates_view,
-    const vecmem::data::vector_view<const unsigned int>& param_ids_view,
-    track_state_container_types::view track_states_view,
-    vecmem::data::jagged_vector_view<detray::geometry::barcode> barcodes_view);
+TRACCC_HOST_DEVICE inline void fit(global_index_t globalIndex,
+                                   const typename fitter_t::config_type cfg,
+                                   const fit_payload<fitter_t>&);
 
 }  // namespace traccc::device
 

--- a/device/cuda/src/fitting/fitting_algorithm.cu
+++ b/device/cuda/src/fitting/fitting_algorithm.cu
@@ -39,18 +39,11 @@ __global__ void fill_sort_keys(
                            keys_view, ids_view);
 }
 
-template <typename fitter_t, typename detector_view_t>
-__global__ void fit(
-    detector_view_t det_data, const typename fitter_t::bfield_type field_data,
-    const typename fitter_t::config_type cfg,
-    track_candidate_container_types::const_view track_candidates_view,
-    vecmem::data::vector_view<const unsigned int> param_ids_view,
-    track_state_container_types::view track_states_view,
-    vecmem::data::jagged_vector_view<detray::geometry::barcode> seqs_view) {
+template <typename fitter_t>
+__global__ void fit(const typename fitter_t::config_type cfg,
+                    const device::fit_payload<fitter_t> payload) {
 
-    device::fit<fitter_t>(details::global_index1(), det_data, field_data, cfg,
-                          track_candidates_view, param_ids_view,
-                          track_states_view, seqs_view);
+    device::fit<fitter_t>(details::global_index1(), cfg, payload);
 }
 
 }  // namespace kernels
@@ -133,8 +126,13 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
 
         // Run the track fitting
         kernels::fit<fitter_t><<<nBlocks, nThreads, 0, stream>>>(
-            det_view, field_view, m_cfg, track_candidates_view,
-            param_ids_buffer, track_states_buffer, seqs_buffer);
+            m_cfg, device::fit_payload<fitter_t>{
+                       .det_data = det_view,
+                       .field_data = field_view,
+                       .track_candidates_view = track_candidates_view,
+                       .param_ids_view = param_ids_buffer,
+                       .track_states_view = track_states_buffer,
+                       .barcodes_view = seqs_buffer});
         TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
     }
 


### PR DESCRIPTION
This commit migrates the CUDA and SYCL fitting kernels to use payloads like the Alpaka algorithm does, thereby harmonizing the interface between these different implementations.