### PR TITLE
Add cluster link back to the measurement EDM

### DIFF
--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -51,6 +51,9 @@ struct measurement {
 
     /// subspace
     subspace<default_algebra, e_bound_size, 2u> subs{{0u, 1u}};
+
+    /// Cluster link
+    std::size_t cluster_link = std::numeric_limits<std::size_t>::max();
 };
 
 /// Comparison / ordering operator for measurements


### PR DESCRIPTION
I am adding it back as @krasznaa requested
But #930 does not include any cluster info in the measurement EDM. @stephenswat do we need it or not?