### PR TITLE
Use pvalue for resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Demonstrator tracking chain for accelerators.
 |                    | Seed finding           | ✅  | ✅   | ✅   | ✅     | ⚪     | ⚪      |
 |                    | Track param estimation | ✅  | ✅   | ✅   | ✅     | ⚪     | ⚪      |
 | **Track finding**  | Combinatorial KF       | ✅  | ✅   | ✅   | 🟡     | ⚪     | ⚪      |
-| **Track fitting**  | KF                     | ✅  | ✅   | 🟡   | ⚪     | ⚪     | ⚪      |
 | **Ambiguity resolution**  | Greedy resolver   | ✅  | ⚪   |  ⚪  | ⚪     | ⚪     | ⚪      |
+| **Track fitting**  | KF                     | ✅  | ✅   | 🟡   | ⚪     | ⚪     | ⚪      |
 
 ✅: exists, 🟡: work started, ⚪: work not started yet
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -115,8 +115,11 @@ traccc_add_library( traccc_core core TYPE SHARED
   "src/seeding/silicon_pixel_spacepoint_formation_algorithm_defdet.cpp"
   "src/seeding/silicon_pixel_spacepoint_formation_algorithm_teldet.cpp"
   # Ambiguity resolution
+  "include/traccc/ambiguity_resolution/ambiguity_resolution_config.hpp"
   "include/traccc/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp"
-  "src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cpp" )
+  "src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cpp"
+  "include/traccc/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.hpp"
+  "src/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.cpp")
 target_link_libraries( traccc_core
   PUBLIC Eigen3::Eigen vecmem::core detray::core detray::detectors
          traccc::algebra ActsCore )

--- a/core/include/traccc/ambiguity_resolution/ambiguity_resolution_config.hpp
+++ b/core/include/traccc/ambiguity_resolution/ambiguity_resolution_config.hpp
@@ -1,0 +1,29 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// System include(s).
+#include <cstdint>
+#include <limits>
+
+namespace traccc {
+
+/// Configuration struct for ambiguity resolution
+struct ambiguity_resolution_config {
+
+    /// Minimum number of measurement to form a track.
+    unsigned int min_meas_per_track = 3;
+
+    /// Max iteration to remove the bad tracks
+    unsigned int max_iterations = std::numeric_limits<unsigned int>::max();
+
+    /// Max shared measurements to break the iteration
+    unsigned int max_shared_meas = 1;
+};
+
+}  // namespace traccc

--- a/core/include/traccc/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp
+++ b/core/include/traccc/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp
@@ -1,165 +1,56 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-// System include
-#include <algorithm>
-#include <initializer_list>
-#include <iostream>
-#include <limits>
-#include <map>
-#include <set>
-#include <unordered_map>
-#include <vector>
-
-// VecMem include(s).
-#include <vecmem/containers/vector.hpp>
-
 // Project include(s).
-#include "traccc/definitions/qualifiers.hpp"
-#include "traccc/edm/track_candidate.hpp"
+#include "traccc/ambiguity_resolution/ambiguity_resolution_config.hpp"
 #include "traccc/edm/track_state.hpp"
 #include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/memory_resource.hpp"
 #include "traccc/utils/messaging.hpp"
 
-// Greedy ambiguity resolution adapted from ACTS code
-
-namespace traccc {
+namespace traccc::host {
 
 /// Evicts tracks that seem to be duplicates or fakes. This algorithm takes a
 /// greedy approach in the sense that it will remove the track which looks "most
-/// duplicate/fake" first and continues the same process with the rest. That
-/// process continues until the final state conditions are met.
-///
-/// The implementation works as follows:
-///  1) Calculate shared hits per track.
-///  2) If the maximum shared hits criteria is met, we are done.
-///     This is the configurable amount of shared hits we are ok with
-///     in our experiment.
-///  3) Else, remove the track with the highest relative shared hits (i.e.
-///     shared hits / hits).
-///  4) Back to square 1.
+/// duplicate/fake"
 class greedy_ambiguity_resolution_algorithm
-    : public algorithm<track_state_container_types::host(
-          const typename track_state_container_types::host&)>,
+    : public algorithm<track_candidate_container_types::host(
+          const typename track_candidate_container_types::const_view&)>,
       public messaging {
 
     public:
-    struct config_t {
-
-        config_t(){};
-
-        /// Maximum amount of shared hits per track. One (1) means "no shared
-        /// hit allowed".
-        std::uint32_t maximum_shared_hits = 1;
-
-        /// Maximum number of iterations.
-        std::uint32_t maximum_iterations = 1000000;
-
-        /// Minimum number of measurement to form a track.
-        std::size_t n_measurements_min = 3;
-
-        // True if obvious errors should be checked after the completion
-        // of the algorithm.
-        bool check_obvious_errs = true;
-
-        // Displays a warning if:
-        // (number of measurements of ID 0 / total number of measurements)
-        // is greater than measurement_id_0_warning_threshold.
-        float measurement_id_0_warning_threshold = 0.1f;
-
-        bool verbose_error = true;
-        bool verbose_warning = true;
-        bool verbose_info = false;
-        bool verbose_debug = false;
-    };
-
-    struct state_t {
-        std::size_t number_of_tracks{};
-
-        /// For this whole comment section, track_index refers to the index of a
-        /// track in the initial input container.
-        ///
-        /// There is no (track_id) in this algorithm, only (track_index).
-
-        /// Associates each track_index with the track's chi2 value
-        std::vector<traccc::scalar> track_chi2;
-
-        /// Associates each track_index to the track's (measurement_id)s list
-        std::vector<std::vector<std::size_t>> measurements_per_track;
-
-        /// Associates each measurement_id to a set of (track_index)es sharing
-        /// it
-        std::unordered_map<std::size_t, std::set<std::size_t>>
-            tracks_per_measurement;
-
-        /// Associates each track_index to its number of shared measurements
-        /// (among other tracks)
-        std::vector<std::size_t> shared_measurements_per_track;
-
-        /// Keeps the selected tracks indexes that have not (yet) been removed
-        /// by the algorithm
-        std::set<std::size_t> selected_tracks;
-    };
+    using config_type = ambiguity_resolution_config;
 
     /// Constructor for the greedy ambiguity resolution algorithm
     ///
     /// @param cfg  Configuration object
-    // greedy_ambiguity_resolution_algorithm(const config_type& cfg) :
-    // _config(cfg) {}
     greedy_ambiguity_resolution_algorithm(
-        const config_t cfg,
+        const config_type& cfg, traccc::memory_resource& mr,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone())
-        : messaging(std::move(logger)), _config{cfg} {}
+        : messaging(std::move(logger)), m_config{cfg}, m_mr{mr} {}
 
     /// Run the algorithm
     ///
-    /// @param track_states the container of the fitted track parameters
+    /// @param track_candidates the container of found patterns
     /// @return the container without ambiguous tracks
-    track_state_container_types::host operator()(
-        const typename track_state_container_types::host& track_states)
-        const override;
+    track_candidate_container_types::host operator()(
+        const track_candidate_container_types::const_view&
+            track_candidates_view) const override;
+
+    /// Get configuration
+    config_type& get_config() { return m_config; }
 
     private:
-    /// Computes the initial state for the input data. This function accumulates
-    /// information that will later be used to accelerate the ambiguity
-    /// resolution.
-    ///
-    /// @param track_states The input track container (output of the fitting
-    /// algorithm).
-    /// @param state An empty state object which is expected to be default
-    /// constructed.
-    void compute_initial_state(
-        const typename track_state_container_types::host& track_states,
-        state_t& state) const;
-
-    /// Updates the state iteratively by evicting one track after the other
-    /// until the final state conditions are met.
-    ///
-    /// @param state A state object that was previously filled by the
-    /// initialization.
-    void resolve(state_t& state) const;
-
-    /// Check for obvious errors returned by the algorithm:
-    /// - Returned tracks should be independent of each other: they should share
-    ///   a maximum of (_config.maximum_shared_hits - 1) hits per track.
-    /// - Each removed track should share at least (_config.maximum_shared_hits)
-    ///   with another initial track.
-    ///
-    /// @param initial_track_states The input track container, as given to
-    /// compute_initial_state.
-    /// @param final_state The state object after the resolve method has been
-    /// called.
-    bool check_obvious_errors(
-        const typename track_state_container_types::host& initial_track_states,
-        state_t& final_state) const;
-
-    config_t _config;
+    /// Algorithm configuration
+    config_type m_config;
+    /// The memory resource to use
+    traccc::memory_resource m_mr;
 };
 
-}  // namespace traccc
+}  // namespace traccc::host

--- a/core/include/traccc/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp
+++ b/core/include/traccc/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp
@@ -9,7 +9,7 @@
 
 // Project include(s).
 #include "traccc/ambiguity_resolution/ambiguity_resolution_config.hpp"
-#include "traccc/edm/track_state.hpp"
+#include "traccc/edm/track_candidate.hpp"
 #include "traccc/utils/algorithm.hpp"
 #include "traccc/utils/memory_resource.hpp"
 #include "traccc/utils/messaging.hpp"

--- a/core/include/traccc/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.hpp
+++ b/core/include/traccc/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.hpp
@@ -1,0 +1,140 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// System include
+#include <algorithm>
+#include <initializer_list>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+// VecMem include(s).
+#include <vecmem/containers/vector.hpp>
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/track_candidate.hpp"
+#include "traccc/edm/track_state.hpp"
+#include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/messaging.hpp"
+
+// Greedy ambiguity resolution adapted from ACTS code
+
+namespace traccc::legacy {
+
+/// Evicts tracks that seem to be duplicates or fakes. This algorithm takes a
+/// greedy approach in the sense that it will remove the track which looks "most
+/// duplicate/fake" first and continues the same process with the rest. That
+/// process continues until the final state conditions are met.
+///
+/// The implementation works as follows:
+///  1) Calculate shared hits per track.
+///  2) If the maximum shared hits criteria is met, we are done.
+///     This is the configurable amount of shared hits we are ok with
+///     in our experiment.
+///  3) Else, remove the track with the highest relative shared hits (i.e.
+///     shared hits / hits).
+///  4) Back to square 1.
+class greedy_ambiguity_resolution_algorithm
+    : public algorithm<track_candidate_container_types::host(
+          const typename track_candidate_container_types::host&)>,
+      public messaging {
+
+    public:
+    struct config_t {
+
+        config_t(){};
+
+        /// Maximum amount of shared hits per track. One (1) means "no shared
+        /// hit allowed".
+        std::uint32_t maximum_shared_hits = 1;
+
+        /// Maximum number of iterations.
+        std::uint32_t maximum_iterations = 1000000;
+
+        /// Minimum number of measurement to form a track.
+        std::size_t n_measurements_min = 3;
+    };
+
+    struct state_t {
+        std::size_t number_of_tracks{};
+
+        /// For this whole comment section, track_index refers to the index of a
+        /// track in the initial input container.
+        ///
+        /// There is no (track_id) in this algorithm, only (track_index).
+
+        /// Associates each track_index with the track's chi2 value
+        std::vector<traccc::scalar> track_chi2;
+
+        /// Associates each track_index to the track's (measurement_id)s list
+        std::vector<std::vector<std::size_t>> measurements_per_track;
+
+        /// Associates each measurement_id to a set of (track_index)es sharing
+        /// it
+        std::unordered_map<std::size_t, std::set<std::size_t>>
+            tracks_per_measurement;
+
+        /// Associates each track_index to its number of shared measurements
+        /// (among other tracks)
+        std::vector<std::size_t> shared_measurements_per_track;
+
+        /// Keeps the selected tracks indexes that have not (yet) been removed
+        /// by the algorithm
+        std::set<std::pair<std::size_t, std::size_t>> selected_tracks;
+    };
+
+    /// Constructor for the greedy ambiguity resolution algorithm
+    ///
+    /// @param cfg  Configuration object
+    // greedy_ambiguity_resolution_algorithm(const config_type& cfg) :
+    // _config(cfg) {}
+    greedy_ambiguity_resolution_algorithm(
+        const config_t cfg,
+        std::unique_ptr<const Logger> logger = getDummyLogger().clone())
+        : messaging(std::move(logger)), _config{cfg} {}
+
+    /// Run the algorithm
+    ///
+    /// @param track_states the container of the fitted track parameters
+    /// @return the container without ambiguous tracks
+    track_candidate_container_types::host operator()(
+        const typename track_candidate_container_types::host& track_states)
+        const override;
+
+    /// Get configuration
+    config_t& get_config() { return _config; }
+
+    private:
+    /// Computes the initial state for the input data. This function accumulates
+    /// information that will later be used to accelerate the ambiguity
+    /// resolution.
+    ///
+    /// @param track_states The input track container (output of the fitting
+    /// algorithm).
+    /// @param state An empty state object which is expected to be default
+    /// constructed.
+    void compute_initial_state(
+        const typename track_candidate_container_types::host& track_states,
+        state_t& state) const;
+
+    /// Updates the state iteratively by evicting one track after the other
+    /// until the final state conditions are met.
+    ///
+    /// @param state A state object that was previously filled by the
+    /// initialization.
+    void resolve(state_t& state) const;
+
+    config_t _config;
+};
+
+}  // namespace traccc::legacy

--- a/core/include/traccc/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.hpp
+++ b/core/include/traccc/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.hpp
@@ -73,8 +73,8 @@ class greedy_ambiguity_resolution_algorithm
         ///
         /// There is no (track_id) in this algorithm, only (track_index).
 
-        /// Associates each track_index with the track's chi2 value
-        std::vector<traccc::scalar> track_chi2;
+        /// Associates each track_index with the track's p-value
+        std::vector<traccc::scalar> track_pval;
 
         /// Associates each track_index to the track's (measurement_id)s list
         std::vector<std::vector<std::size_t>> measurements_per_track;

--- a/core/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cpp
+++ b/core/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cpp
@@ -1,496 +1,219 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
+// Local include(s).
 #include "traccc/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp"
-
-// System include
-#include <algorithm>
-#include <initializer_list>
-#include <iomanip>
-#include <iostream>
-#include <limits>
-#include <map>
-#include <set>
-#include <sstream>
-#include <unordered_map>
-#include <vector>
-
-// VecMem include(s).
-#include <vecmem/containers/vector.hpp>
 
 // Project include(s).
 #include "traccc/definitions/primitives.hpp"
-#include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/track_candidate.hpp"
-#include "traccc/edm/track_state.hpp"
-#include "traccc/utils/algorithm.hpp"
 
-// Greedy ambiguity resolution adapted from ACTS code
+// System include
+#include <algorithm>
+#include <vector>
 
-namespace traccc {
+namespace traccc::host {
 
-/// Run the algorithm
-///
-/// @param track_states the container of the fitted track parameters
-/// @return the container without ambiguous tracks
-track_state_container_types::host
+track_candidate_container_types::host
 greedy_ambiguity_resolution_algorithm::operator()(
-    const typename track_state_container_types::host& track_states) const {
+    const track_candidate_container_types::const_view& track_candidates_view)
+    const {
 
-    state_t state;
-    compute_initial_state(track_states, state);
-    resolve(state);
+    const track_candidate_container_types::const_device track_candidates(
+        track_candidates_view);
 
-    if (_config.check_obvious_errs) {
-        TRACCC_DEBUG("Checking result validity...");
-        check_obvious_errors(track_states, state);
+    const std::size_t n_tracks = track_candidates.size();
+
+    // Make the output container
+    track_candidate_container_types::host output{&m_mr.main};
+
+    if (n_tracks == 0) {
+        return output;
     }
 
-    // Copy the tracks to be retained in the return value
+    // Make sure that max_shared_meas is largen than zero
+    assert(m_config.max_shared_meas > 0u);
 
-    track_state_container_types::host res;
-    res.reserve(state.selected_tracks.size());
+    // Accepted ids to iterate
+    std::vector<unsigned int> accepted_ids(n_tracks);
+    std::iota(accepted_ids.begin(), accepted_ids.end(), 0);
 
-    TRACCC_DEBUG(
-        "state.selected_tracks.size() = " << state.selected_tracks.size());
+    // Make measurement ID, chi2 and n_measurement vector
+    std::vector<std::vector<std::size_t>> meas_ids(n_tracks);
+    std::vector<traccc::scalar> chi_squares(n_tracks);
+    std::vector<std::size_t> n_meas(n_tracks);
 
-    for (std::size_t index : state.selected_tracks) {
-        // track_states is a host_container<fitting_result<default_algebra>,
-        // track_state<default_algebra>>
-        auto const [sm_headers, sm_items] = track_states.at(index);
+    for (unsigned int i = 0; i < n_tracks; i++) {
+        // Fill the chi-squares vectors
+        chi_squares[i] = track_candidates.at(i).header.trk_quality.chi2;
 
-        // Copy header
-        fitting_result<default_algebra> header = sm_headers;
+        const auto& candidates = track_candidates.at(i).items;
+        const unsigned int n_cands = candidates.size();
 
-        // Copy states
-        vecmem::vector<track_state<default_algebra>> states;
-        states.reserve(sm_items.size());
-        for (auto const& item : sm_items) {
-            states.push_back(item);
-        }
-
-        res.push_back(header, states);
-    }
-    return res;
-}
-
-void greedy_ambiguity_resolution_algorithm::compute_initial_state(
-    const typename track_state_container_types::host& track_states,
-    state_t& state) const {
-
-    // Number of measurements, to display a warning if too many measurements
-    // share the identifier 0
-    std::size_t mcount_all = 0;     // Total number of measurements
-    std::size_t mcount_idzero = 0;  // Number of measurements of id 0
-
-    // Displays a warning if (mcount_idzero / mcount_all) > warning_threshold
-    float warning_threshold = _config.measurement_id_0_warning_threshold;
-
-    // For each track of the input container
-    std::size_t n_track_states = track_states.size();
-    for (std::size_t track_index = 0; track_index < n_track_states;
-         ++track_index) {
-
-        // fit_res is a fitting_result<default_algebra>
-        // states  is a vecmem_vector<track_state<default_algebra>>
-        auto const& [fit_res, states] = track_states.at(track_index);
-
-        // Kick out tracks that do not fulfill our initial requirements
-        if (states.size() < _config.n_measurements_min) {
-            continue;
-        }
-
-        // Create the list of measurement_id of the current track
-        std::vector<std::size_t> measurements;
-        std::unordered_map<std::size_t, std::size_t> already_added_mes;
-        bool duplicated_measurements = false;
-
-        for (auto const& st : states) {
-            std::size_t mid = st.get_measurement().measurement_id;
-            ++mcount_all;
-            if (mid == 0) {
-                ++mcount_idzero;
-            }
-
-            // If the same measurement is found multiple times in a single
-            // track: remove duplicates.
-            auto dm = already_added_mes.insert(
-                std::pair<std::size_t, std::size_t>(mid, 1));
-
-            // If the measurement was already present in already_added_mes
-            if (!dm.second) {
-                // Increment the count for this measurement_id
-                ++(dm.first->second);
-                duplicated_measurements = true;
-                TRACCC_DEBUG("(1/3) Track " << track_index
-                                            << " has duplicated measurement "
-                                            << mid << ".");
-            } else {
-                measurements.push_back(mid);
-            }
-        }
-
-        // If at least one measurement is found multiple times in this track:
-        // print warning message and display the track's measurement list
-        if (duplicated_measurements) {
-            std::stringstream ss;
-            ss << "Track " << track_index << " has duplicated measurement(s):";
-
-            for (const auto& m : already_added_mes) {
-                if (m.second != 1) {
-                    ss << " " << m.first << " (" << m.second << " times)";
-                }
-            }
-
-            ss << ". Measurement list:";
-            for (auto const& st : states) {
-                ss << " " << st.get_measurement().measurement_id;
-            }
-
-            TRACCC_WARNING(ss.str());
-        }
-
-        // Add this track chi2 value
-        state.track_chi2.push_back(fit_res.trk_quality.chi2);
-        // Add all the (measurement_id)s of this track
-        state.measurements_per_track.push_back(std::move(measurements));
-        // Initially, every track is in the selected_track list. They will later
-        // be removed according to the algorithm.
-        state.selected_tracks.insert(state.number_of_tracks);
-        ++state.number_of_tracks;
-    }
-
-    // Associate each measurement to the tracks sharing it
-    for (std::size_t track_index = 0; track_index < state.number_of_tracks;
-         ++track_index) {
-        for (auto meas_id : state.measurements_per_track[track_index]) {
-            state.tracks_per_measurement[meas_id].insert(track_index);
-        }
-    }
-
-    // Finally, we can accumulate the number of shared measurements per track
-    state.shared_measurements_per_track =
-        std::vector<std::size_t>(state.number_of_tracks, 0);
-
-    for (std::size_t track_index = 0; track_index < state.number_of_tracks;
-         ++track_index) {
-        for (auto meas_index : state.measurements_per_track[track_index]) {
-            if (state.tracks_per_measurement[meas_index].size() > 1) {
-                ++state.shared_measurements_per_track[track_index];
-            }
-        }
-    }
-
-    if (mcount_all == 0) {
-        TRACCC_ERROR("No measurements.");
-    } else {
-        if (mcount_idzero == mcount_all) {
-            TRACCC_ERROR(
-                "Measurements must have unique IDs. But here, each measurement "
-                "has 0 as ID (measurement.measurement_id == 0). This may be "
-                "solved by loading measurement_id from the appropriate file, "
-                "or by assigning a unique ID to each new measurement during "
-                "CCA.");
+        if (n_cands < m_config.min_meas_per_track) {
+            // Reject if the number of measurements is less than the cut
+            const auto it =
+                std::lower_bound(accepted_ids.begin(), accepted_ids.end(), i);
+            assert(it != accepted_ids.end() && *it == i);
+            accepted_ids.erase(it);
         } else {
-            double ratio = static_cast<float>(mcount_idzero) /
-                           static_cast<float>(mcount_all);
-            if (ratio > warning_threshold) {
-                std::stringstream stream;
-                stream << std::fixed << std::setprecision(2) << (ratio * 100.)
-                       << "% of input measurements have an ID equal to 0 "
-                          "(measurement.measurement_id == 0). This may be "
-                          "suspicious.";
-                TRACCC_WARNING(stream.str());
+            // Fill measurement ids and n_measurements
+            meas_ids[i].reserve(n_cands);
+            for (const auto& cand : candidates) {
+                meas_ids[i].push_back(cand.measurement_id);
             }
+            n_meas[i] = n_cands;
+            assert(n_cands == meas_ids[i].size());
         }
     }
-}
 
-/// Check for obvious errors returned by the algorithm:
-/// - Returned tracks should be independent of each other: they should
-/// share a maximum of (_config.maximum_shared_hits - 1) hits per track.
-/// - Each removed track should share at least
-/// (_config.maximum_shared_hits) with another initial track.
-///
-/// @param initial_track_states The input track container, as given to
-/// compute_initial_state.
-/// @param final_state The state object after the resolve method has
-/// been called.
-bool greedy_ambiguity_resolution_algorithm::check_obvious_errors(
-    const typename track_state_container_types::host& initial_track_states,
-    state_t& final_state) const {
+    // Record the tracks per measurement
+    std::vector<std::vector<unsigned int>> tracks_per_measurement;
 
-    // Associates every measurement_id to the number of tracks that shares it
-    // (during initial state)
-    std::unordered_map<std::size_t, std::size_t> initial_measurement_count;
-
-    // Initialize initial_measurement_count
-    for (std::size_t track_index = 0; track_index < initial_track_states.size();
-         ++track_index) {
-        // fit_res is a fitting_result<default_algebra>
-        // states  is a vecmem_vector<track_state<default_algebra>>
-        auto const& [fit_res, states] = initial_track_states.at(track_index);
-
-        std::set<std::size_t> already_added_mes;
-
-        for (auto const& st : states) {
-            std::size_t meas_id = st.get_measurement().measurement_id;
-
-            // If the same measurement is found multiple times in a single
-            // track: remove duplicates.
-            if (already_added_mes.find(meas_id) != already_added_mes.end()) {
-                TRACCC_DEBUG("(2/3) Track " << track_index
-                                            << " has duplicated measurement "
-                                            << meas_id << ".");
-                continue;
+    for (const auto& i : accepted_ids) {
+        const auto& candidates = track_candidates.at(i).items;
+        for (const auto& cand : candidates) {
+            if (tracks_per_measurement.size() < cand.measurement_id + 1) {
+                tracks_per_measurement.resize(cand.measurement_id + 1);
             }
-            already_added_mes.insert(meas_id);
+            tracks_per_measurement[cand.measurement_id].push_back(i);
+        }
+    }
 
-            std::unordered_map<std::size_t, std::size_t>::iterator meas_it =
-                initial_measurement_count.find(meas_id);
-
-            if (meas_it == initial_measurement_count.end()) {
-                // not found: for now, this measurement only belongs to one
-                // track
-                initial_measurement_count[meas_id] = 1;
-            } else {
-                // found: this measurement is shared between at least two tracks
-                ++(meas_it->second);
+    // Count the number of shared measurements
+    std::vector<unsigned int> n_shared(n_tracks);
+    for (const auto& i : accepted_ids) {
+        for (const auto& meas_id : meas_ids[i]) {
+            if (tracks_per_measurement[meas_id].size() > 1) {
+                n_shared[i]++;
             }
         }
     }
 
-    bool all_removed_tracks_alright = true;
-    // =========================================================================
-    // Checks that every removed track had at least
-    // (_config.maximum_shared_hits) common measurements with other tracks
-    // =========================================================================
-    std::size_t n_initial_track_states = initial_track_states.size();
-    for (std::size_t track_index = 0; track_index < n_initial_track_states;
-         ++track_index) {
-        auto const& [fit_res, states] = initial_track_states.at(track_index);
+    // Precompute max sizes for 2D cache table
+    const auto max_n_meas = *std::max_element(n_meas.begin(), n_meas.end());
+    const auto max_n_shared =
+        *std::max_element(n_shared.begin(), n_shared.end());
 
-        // Skip this track if it has to be kept (i.e. exists in selected_tracks)
-        if (final_state.selected_tracks.find(track_index) !=
-            final_state.selected_tracks.end()) {
-            continue;
+    // Initialize 2D cache table for relative shared measurements
+    std::vector<std::vector<traccc::scalar>> cache(
+        max_n_meas + 1, std::vector<traccc::scalar>(max_n_shared + 1));
+    std::vector<traccc::scalar> rel_shared(n_tracks);
+    for (const auto& i : accepted_ids) {
+        const auto n_s = n_shared[i];
+        const auto n_m = n_meas[i];
+        assert(n_m <= max_n_meas && n_s <= max_n_shared);
+        if (cache[n_m][n_s] == 0.f && n_s > 0) {
+            cache[n_m][n_s] = static_cast<traccc::scalar>(n_s) /
+                              static_cast<traccc::scalar>(n_m);
         }
-
-        // So if the current track has been removed from selected_tracks:
-
-        std::size_t shared_hits = 0;
-        for (auto const& st : states) {
-            auto meas_id = st.get_measurement().measurement_id;
-
-            std::unordered_map<std::size_t, std::size_t>::iterator meas_it =
-                initial_measurement_count.find(meas_id);
-
-            if (meas_it == initial_measurement_count.end()) {
-                // Should never happen
-                TRACCC_ERROR(
-                    "track_index("
-                    << track_index
-                    << ") which is a removed track, has a measurement not "
-                    << "present in initial_measurement_count. This should "
-                    << "never happen and is an implementation error.\n");
-                all_removed_tracks_alright = false;
-            } else if (meas_it->second > 1) {
-                ++shared_hits;
-            }
-        }
-
-        if (shared_hits < _config.maximum_shared_hits) {
-            TRACCC_ERROR(
-                "track_index("
-                << track_index
-                << ") which is a removed track, should at least share "
-                << _config.maximum_shared_hits
-                << " measurement(s) with other tracks, but only shares "
-                << shared_hits);
-            all_removed_tracks_alright = false;
-        }
+        rel_shared[i] = cache[n_m][n_s];
     }
 
-    if (all_removed_tracks_alright) {
-        TRACCC_INFO(
-            "OK 1/2: every removed track had at least one common measurement "
-            "with another track.");
-    }
+    // Sort the track id with rel_shared and chi2 to find the worst track fast
+    std::vector<unsigned int> sorted_ids = accepted_ids;
 
-    // =========================================================================
-    // Checks that returned tracks are independent of each other: they should
-    // share a maximum of (_config.maximum_shared_hits - 1) hits per track.
-    // =========================================================================
-
-    // Used for return value and final message
-    bool independent_tracks = true;
-
-    // Associates each measurement_id to a list of (track_index)es
-    std::unordered_map<std::size_t, std::vector<std::size_t>>
-        tracks_per_measurements;
-
-    // Only for measurements shared between too many tracks: associates each
-    // measurement_id to a list of (track_index)es
-    std::unordered_map<std::size_t, std::vector<std::size_t>>
-        tracks_per_meas_err;
-
-    // Initializes tracks_per_measurements
-    for (std::size_t track_index : final_state.selected_tracks) {
-        auto const& [fit_res, states] = initial_track_states.at(track_index);
-
-        std::set<std::size_t> already_added_mes;
-
-        for (auto const& mes : states) {
-            std::size_t meas_id = mes.get_measurement().measurement_id;
-
-            // If the same measurement is found multiple times in a single
-            // track: remove duplicates.
-            if (already_added_mes.find(meas_id) != already_added_mes.end()) {
-                TRACCC_DEBUG("(3/3) Track " << track_index
-                                            << " has duplicated measurement "
-                                            << meas_id << ".");
-            } else {
-                already_added_mes.insert(meas_id);
-                tracks_per_measurements[meas_id].push_back(track_index);
-            }
+    auto track_comparator = [&rel_shared, &chi_squares](unsigned int a,
+                                                        unsigned int b) {
+        if (rel_shared[a] != rel_shared[b]) {
+            return rel_shared[a] < rel_shared[b];
         }
-    }
+        return chi_squares[a] < chi_squares[b];
+    };
+    std::sort(sorted_ids.begin(), sorted_ids.end(), track_comparator);
 
-    // Displays common tracks per measurement if it exceeds the maximum count
-    for (auto const& val : tracks_per_measurements) {
-        auto const& tracks_per_mes = val.second;
-        if (tracks_per_mes.size() > _config.maximum_shared_hits) {
-            std::stringstream ss;
-            ss << "Measurement " << val.first << " is shared between "
-               << tracks_per_mes.size()
-               << " tracks, superior to _config.maximum_shared_hits("
-               << _config.maximum_shared_hits
-               << "). It is shared between tracks:";
+    // Iterate over tracks
+    for (unsigned int iter = 0; iter < m_config.max_iterations; iter++) {
+        // Terminate if there are no tracks to iterate
+        if (accepted_ids.empty()) {
+            break;
+        }
 
-            for (std::size_t track_index : tracks_per_mes) {
-                ss << " " << track_index;
-            }
+        unsigned int max_shared{0u};
+        for (const auto& i : accepted_ids) {
+            if (n_shared[i] > max_shared)
+                max_shared = n_shared[i];
+        }
 
-            TRACCC_ERROR(ss.str());
+        // Terminate if the max shared measurements is less than the cut value
+        if (max_shared < m_config.max_shared_meas) {
+            break;
+        }
 
-            // Displays each track's measurements:
-            for (std::size_t track_index : tracks_per_mes) {
-                std::stringstream ssm;
-                ssm << "    Track(" << track_index << ")'s measurements:";
-                auto const& [fit_res, states] =
-                    initial_track_states.at(track_index);
+        // The last element of sorted vector is the worst track
+        const unsigned int worst_track = sorted_ids.back();
 
-                for (auto const& st : states) {
-                    auto meas_id = st.get_measurement().measurement_id;
-                    ssm << " " << meas_id;
+        // Remove the worst track from the accepted ids
+        const auto it1 = std::lower_bound(accepted_ids.begin(),
+                                          accepted_ids.end(), worst_track);
+        assert(it1 != accepted_ids.end() && *it1 == worst_track);
+        accepted_ids.erase(it1);
+
+        // Pop the worst (rejected) id from the sorted ids
+        sorted_ids.pop_back();
+
+        const auto& meas_ids_to_remove = meas_ids[worst_track];
+        for (const auto& id : meas_ids_to_remove) {
+            auto& tracks = tracks_per_measurement[id];
+
+            // Remove the worst (rejected) id from the tracks associated with
+            // measurement
+            const auto it2 =
+                std::lower_bound(tracks.begin(), tracks.end(), worst_track);
+            assert(it2 != tracks.end() && *it2 == worst_track);
+            tracks.erase(it2);
+
+            // If there is only one track associated with measurement, the
+            // number of shared measurement can be reduced by one
+            if (tracks.size() == 1) {
+                const auto tid = tracks[0];
+                n_shared[tid]--;
+
+                const auto n_s = n_shared[tid];
+                const auto n_m = n_meas[tid];
+                assert(n_m <= max_n_meas && n_s <= max_n_shared);
+                if (cache[n_m][n_s] == 0.f && n_s > 0) {
+                    cache[n_m][n_s] = static_cast<traccc::scalar>(n_s) /
+                                      static_cast<traccc::scalar>(n_m);
                 }
-                TRACCC_ERROR(ssm.str());
+                rel_shared[tid] = cache[n_m][n_s];
+
+                // Reposition the track to the next of the worse track which is
+                // firstly found during the reverse iteration
+                const auto it3 =
+                    std::find(sorted_ids.begin(), sorted_ids.end(), tid);
+                assert(it3 != sorted_ids.end());
+                const auto it4 = std::lower_bound(sorted_ids.begin(), it3, tid,
+                                                  track_comparator);
+                sorted_ids.erase(it3);
+                sorted_ids.insert(it4, tid);
             }
-
-            independent_tracks = false;
         }
+
+        // Make sure that sorted_ids stays sorted
+        assert(std::is_sorted(sorted_ids.begin(), sorted_ids.end(),
+                              track_comparator));
     }
 
-    if (independent_tracks) {
-        TRACCC_INFO(
-            "OK 2/2: each selected_track shares at most "
-            "(_config.maximum_shared_hits - 1)(="
-            << _config.maximum_shared_hits - 1 << ") measurement(s)");
+    // Fill the output container with accepted tracks
+    output.reserve(accepted_ids.size());
+    for (const auto& i : accepted_ids) {
+        vecmem::vector<traccc::track_candidate> output_cands;
+
+        const auto& input_cands = track_candidates.at(i).items;
+
+        output_cands.insert(output_cands.end(), input_cands.begin(),
+                            input_cands.end());
+
+        output.push_back(std::move(track_candidates.at(i).header),
+                         std::move(output_cands));
     }
 
-    return (all_removed_tracks_alright && independent_tracks);
+    return output;
 }
 
-namespace {
-
-/// Removes a track from the state which has to be done for multiple properties
-/// because of redundancy.
-static void remove_track(greedy_ambiguity_resolution_algorithm::state_t& state,
-                         std::size_t track_index) {
-    for (auto meas_index : state.measurements_per_track[track_index]) {
-        state.tracks_per_measurement[meas_index].erase(track_index);
-
-        if (state.tracks_per_measurement[meas_index].size() == 1) {
-            auto j_track = *state.tracks_per_measurement[meas_index].begin();
-            --state.shared_measurements_per_track[j_track];
-        }
-    }
-    state.selected_tracks.erase(track_index);
-}
-}  // namespace
-
-void greedy_ambiguity_resolution_algorithm::resolve(state_t& state) const {
-    /// Compares two tracks based on the number of shared measurements in order
-    /// to decide if we already met the final state.
-    auto shared_measurements_comperator = [&state](std::size_t a,
-                                                   std::size_t b) {
-        return state.shared_measurements_per_track[a] <
-               state.shared_measurements_per_track[b];
-    };
-
-    /// Compares two tracks in order to find the one which should be evicted.
-    /// First we compare the relative amount of shared measurements. If that is
-    /// indecisive we use the chi2.
-    auto track_comperator = [&state](std::size_t a, std::size_t b) {
-        /// Helper to calculate the relative amount of shared measurements.
-        auto relative_shared_measurements = [&state](std::size_t i) {
-            return static_cast<double>(state.shared_measurements_per_track[i]) /
-                   static_cast<double>(state.measurements_per_track[i].size());
-        };
-
-        if (relative_shared_measurements(a) !=
-            relative_shared_measurements(b)) {
-            return relative_shared_measurements(a) <
-                   relative_shared_measurements(b);
-        }
-        return state.track_chi2[a] < state.track_chi2[b];
-    };
-
-    std::size_t iteration_count = 0;
-    for (std::size_t i = 0; i < _config.maximum_iterations; ++i) {
-        // Lazy out if there is nothing to filter on.
-        if (state.selected_tracks.empty()) {
-            TRACCC_DEBUG("No tracks left - exit loop");
-            break;
-        }
-
-        // Find the maximum amount of shared measurements per track to decide if
-        // we are done or not.
-        auto maximum_shared_measurements = *std::max_element(
-            state.selected_tracks.begin(), state.selected_tracks.end(),
-            shared_measurements_comperator);
-
-        TRACCC_DEBUG(
-            "Current maximum shared measurements "
-            << state
-                   .shared_measurements_per_track[maximum_shared_measurements]);
-
-        if (state.shared_measurements_per_track[maximum_shared_measurements] <
-            _config.maximum_shared_hits) {
-            break;
-        }
-
-        // Find the "worst" track by comparing them to each other
-        auto bad_track =
-            *std::max_element(state.selected_tracks.begin(),
-                              state.selected_tracks.end(), track_comperator);
-
-        TRACCC_DEBUG("Remove track "
-                     << bad_track << " n_meas "
-                     << state.measurements_per_track[bad_track].size()
-                     << " nShared "
-                     << state.shared_measurements_per_track[bad_track]
-                     << " chi2 " << state.track_chi2[bad_track]);
-
-        remove_track(state, bad_track);
-        ++iteration_count;
-    }
-
-    TRACCC_DEBUG("Iteration_count: " << iteration_count);
-}
-
-}  // namespace traccc
+}  // namespace traccc::host

--- a/core/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cpp
+++ b/core/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cpp
@@ -42,14 +42,14 @@ greedy_ambiguity_resolution_algorithm::operator()(
     std::vector<unsigned int> accepted_ids(n_tracks);
     std::iota(accepted_ids.begin(), accepted_ids.end(), 0);
 
-    // Make measurement ID, chi2 and n_measurement vector
+    // Make measurement ID, pval and n_measurement vector
     std::vector<std::vector<std::size_t>> meas_ids(n_tracks);
-    std::vector<traccc::scalar> chi_squares(n_tracks);
+    std::vector<traccc::scalar> pvals(n_tracks);
     std::vector<std::size_t> n_meas(n_tracks);
 
     for (unsigned int i = 0; i < n_tracks; i++) {
-        // Fill the chi-squares vectors
-        chi_squares[i] = track_candidates.at(i).header.trk_quality.chi2;
+        // Fill the pval vectors
+        pvals[i] = track_candidates.at(i).header.trk_quality.pval;
 
         const auto& candidates = track_candidates.at(i).items;
         const unsigned int n_cands = candidates.size();
@@ -114,15 +114,15 @@ greedy_ambiguity_resolution_algorithm::operator()(
         rel_shared[i] = cache[n_m][n_s];
     }
 
-    // Sort the track id with rel_shared and chi2 to find the worst track fast
+    // Sort the track id with rel_shared and pval to find the worst track fast
     std::vector<unsigned int> sorted_ids = accepted_ids;
 
-    auto track_comparator = [&rel_shared, &chi_squares](unsigned int a,
-                                                        unsigned int b) {
+    auto track_comparator = [&rel_shared, &pvals](unsigned int a,
+                                                  unsigned int b) {
         if (rel_shared[a] != rel_shared[b]) {
             return rel_shared[a] < rel_shared[b];
         }
-        return chi_squares[a] < chi_squares[b];
+        return pvals[a] > pvals[b];
     };
     std::sort(sorted_ids.begin(), sorted_ids.end(), track_comparator);
 

--- a/core/src/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.cpp
+++ b/core/src/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.cpp
@@ -115,8 +115,8 @@ void greedy_ambiguity_resolution_algorithm::compute_initial_state(
             }
         }
 
-        // Add this track chi2 value
-        state.track_chi2.push_back(fit_res.trk_quality.chi2);
+        // Add this track pval value
+        state.track_pval.push_back(fit_res.trk_quality.pval);
         // Add all the (measurement_id)s of this track
         state.measurements_per_track.push_back(std::move(measurements));
         // Initially, every track is in the selected_track list. They will later
@@ -177,7 +177,7 @@ void greedy_ambiguity_resolution_algorithm::resolve(state_t& state) const {
 
     /// Compares two tracks in order to find the one which should be evicted.
     /// First we compare the relative amount of shared measurements. If that is
-    /// indecisive we use the chi2.
+    /// indecisive we use the pval.
     auto track_comperator = [&state](std::pair<std::size_t, std::size_t> a,
                                      std::pair<std::size_t, std::size_t> b) {
         /// Helper to calculate the relative amount of shared measurements.
@@ -191,7 +191,7 @@ void greedy_ambiguity_resolution_algorithm::resolve(state_t& state) const {
             return relative_shared_measurements(a.second) <
                    relative_shared_measurements(b.second);
         }
-        return state.track_chi2[a.second] < state.track_chi2[b.second];
+        return state.track_pval[a.second] > state.track_pval[b.second];
     };
 
     std::size_t iteration_count = 0;

--- a/core/src/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.cpp
+++ b/core/src/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.cpp
@@ -1,0 +1,229 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "traccc/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.hpp"
+
+// System include
+#include <algorithm>
+#include <initializer_list>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <set>
+#include <sstream>
+#include <unordered_map>
+#include <vector>
+
+// VecMem include(s).
+#include <vecmem/containers/vector.hpp>
+
+// Project include(s).
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/track_candidate.hpp"
+#include "traccc/edm/track_state.hpp"
+#include "traccc/utils/algorithm.hpp"
+
+// Greedy ambiguity resolution adapted from ACTS code
+
+namespace traccc::legacy {
+
+/// Run the algorithm
+///
+/// @param track_states the container of the fitted track parameters
+/// @return the container without ambiguous tracks
+track_candidate_container_types::host
+greedy_ambiguity_resolution_algorithm::operator()(
+    const typename track_candidate_container_types::host& track_states) const {
+
+    state_t state;
+    compute_initial_state(track_states, state);
+    resolve(state);
+
+    // Copy the tracks to be retained in the return value
+
+    track_candidate_container_types::host res;
+    res.reserve(state.selected_tracks.size());
+
+    TRACCC_DEBUG(
+        "state.selected_tracks.size() = " << state.selected_tracks.size());
+
+    for (auto index : state.selected_tracks) {
+        // track_states is a host_container<fitting_result<default_algebra>,
+        // track_state<default_algebra>>
+        auto const [sm_headers, sm_items] = track_states.at(index.first);
+
+        // Copy header
+        finding_result header = sm_headers;
+
+        // Copy states
+        vecmem::vector<track_candidate> states;
+        states.reserve(sm_items.size());
+        for (auto const& item : sm_items) {
+            states.push_back(item);
+        }
+
+        res.push_back(header, states);
+    }
+    return res;
+}
+
+void greedy_ambiguity_resolution_algorithm::compute_initial_state(
+    const typename track_candidate_container_types::host& track_states,
+    state_t& state) const {
+
+    // For each track of the input container
+    std::size_t n_track_states = track_states.size();
+    for (std::size_t track_index = 0; track_index < n_track_states;
+         ++track_index) {
+
+        // fit_res is a fitting_result<default_algebra>
+        // states  is a vecmem_vector<track_state<default_algebra>>
+        auto const& [fit_res, states] = track_states.at(track_index);
+
+        // Kick out tracks that do not fulfill our initial requirements
+        if (states.size() < _config.n_measurements_min) {
+            continue;
+        }
+
+        // Create the list of measurement_id of the current track
+        std::vector<std::size_t> measurements;
+        std::unordered_map<std::size_t, std::size_t> already_added_mes;
+
+        for (auto const& st : states) {
+            std::size_t mid = st.measurement_id;
+
+            // If the same measurement is found multiple times in a single
+            // track: remove duplicates.
+            auto dm = already_added_mes.insert(
+                std::pair<std::size_t, std::size_t>(mid, 1));
+
+            // If the measurement was already present in already_added_mes
+            if (!dm.second) {
+                // Increment the count for this measurement_id
+                ++(dm.first->second);
+                TRACCC_DEBUG("(1/3) Track " << track_index
+                                            << " has duplicated measurement "
+                                            << mid << ".");
+            } else {
+                measurements.push_back(mid);
+            }
+        }
+
+        // Add this track chi2 value
+        state.track_chi2.push_back(fit_res.trk_quality.chi2);
+        // Add all the (measurement_id)s of this track
+        state.measurements_per_track.push_back(std::move(measurements));
+        // Initially, every track is in the selected_track list. They will later
+        // be removed according to the algorithm.
+        state.selected_tracks.insert({track_index, state.number_of_tracks});
+        ++state.number_of_tracks;
+    }
+
+    // Associate each measurement to the tracks sharing it
+    for (std::size_t track_index = 0; track_index < state.number_of_tracks;
+         ++track_index) {
+        for (auto meas_id : state.measurements_per_track[track_index]) {
+            state.tracks_per_measurement[meas_id].insert(track_index);
+        }
+    }
+
+    // Finally, we can accumulate the number of shared measurements per track
+    state.shared_measurements_per_track =
+        std::vector<std::size_t>(state.number_of_tracks, 0);
+
+    for (std::size_t track_index = 0; track_index < state.number_of_tracks;
+         ++track_index) {
+        for (auto meas_index : state.measurements_per_track[track_index]) {
+            if (state.tracks_per_measurement[meas_index].size() > 1) {
+                ++state.shared_measurements_per_track[track_index];
+            }
+        }
+    }
+}
+
+namespace {
+
+/// Removes a track from the state which has to be done for multiple properties
+/// because of redundancy.
+static void remove_track(greedy_ambiguity_resolution_algorithm::state_t& state,
+                         std::pair<std::size_t, std::size_t> track_index) {
+    for (auto meas_index : state.measurements_per_track[track_index.second]) {
+        state.tracks_per_measurement[meas_index].erase(track_index.second);
+
+        if (state.tracks_per_measurement[meas_index].size() == 1) {
+            auto j_track = *state.tracks_per_measurement[meas_index].begin();
+            --state.shared_measurements_per_track[j_track];
+        }
+    }
+    state.selected_tracks.erase(track_index);
+}
+}  // namespace
+
+void greedy_ambiguity_resolution_algorithm::resolve(state_t& state) const {
+    /// Compares two tracks based on the number of shared measurements in order
+    /// to decide if we already met the final state.
+    auto shared_measurements_comperator =
+        [&state](std::pair<std::size_t, std::size_t> a,
+                 std::pair<std::size_t, std::size_t> b) {
+            return state.shared_measurements_per_track[a.second] <
+                   state.shared_measurements_per_track[b.second];
+        };
+
+    /// Compares two tracks in order to find the one which should be evicted.
+    /// First we compare the relative amount of shared measurements. If that is
+    /// indecisive we use the chi2.
+    auto track_comperator = [&state](std::pair<std::size_t, std::size_t> a,
+                                     std::pair<std::size_t, std::size_t> b) {
+        /// Helper to calculate the relative amount of shared measurements.
+        auto relative_shared_measurements = [&state](std::size_t i) {
+            return static_cast<double>(state.shared_measurements_per_track[i]) /
+                   static_cast<double>(state.measurements_per_track[i].size());
+        };
+
+        if (relative_shared_measurements(a.second) !=
+            relative_shared_measurements(b.second)) {
+            return relative_shared_measurements(a.second) <
+                   relative_shared_measurements(b.second);
+        }
+        return state.track_chi2[a.second] < state.track_chi2[b.second];
+    };
+
+    std::size_t iteration_count = 0;
+    for (std::size_t i = 0; i < _config.maximum_iterations; ++i) {
+        // Lazy out if there is nothing to filter on.
+        if (state.selected_tracks.empty()) {
+            TRACCC_DEBUG("No tracks left - exit loop");
+            break;
+        }
+
+        // Find the maximum amount of shared measurements per track to decide if
+        // we are done or not.
+        auto maximum_shared_measurements = *std::max_element(
+            state.selected_tracks.begin(), state.selected_tracks.end(),
+            shared_measurements_comperator);
+
+        if (state.shared_measurements_per_track[maximum_shared_measurements
+                                                    .second] <
+            _config.maximum_shared_hits) {
+            break;
+        }
+
+        // Find the "worst" track by comparing them to each other
+        auto bad_track =
+            *std::max_element(state.selected_tracks.begin(),
+                              state.selected_tracks.end(), track_comperator);
+
+        remove_track(state, bad_track);
+        ++iteration_count;
+    }
+
+    TRACCC_DEBUG("Iteration_count: " << iteration_count);
+}
+
+}  // namespace traccc::legacy

--- a/examples/options/include/traccc/options/track_resolution.hpp
+++ b/examples/options/include/traccc/options/track_resolution.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,26 +8,29 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/ambiguity_resolution/ambiguity_resolution_config.hpp"
+#include "traccc/options/details/config_provider.hpp"
 #include "traccc/options/details/interface.hpp"
 
 namespace traccc::opts {
 
 /// Configuration for track ambiguity resulution
-class track_resolution : public interface {
+class track_resolution : public interface,
+                         public config_provider<ambiguity_resolution_config> {
 
     public:
-    /// @name Options
-    /// @{
-
-    /// Whether to perform ambiguity resolution
-    bool run = true;
-
-    /// @}
-
     /// Constructor
     track_resolution();
 
+    /// Configuration conversion operators
+    operator ambiguity_resolution_config() const override;
+
+    /// Configuration conversion operators
     std::unique_ptr<configuration_printable> as_printable() const override;
+
+    private:
+    /// The internal configuration
+    ambiguity_resolution_config m_config;
 };  // class track_resolution
 
 }  // namespace traccc::opts

--- a/examples/options/src/track_resolution.cpp
+++ b/examples/options/src/track_resolution.cpp
@@ -21,9 +21,22 @@ namespace po = boost::program_options;
 track_resolution::track_resolution()
     : interface("Track Ambiguity Resolution Options") {
 
-    m_desc.add_options()("perform-ambiguity-resolution",
-                         po::value(&run)->default_value(run),
-                         "Perform track ambiguity resolution");
+    m_desc.add_options()("min-meas-per-track",
+                         po::value(&m_config.min_meas_per_track)
+                             ->default_value(m_config.min_meas_per_track),
+                         "Min number of measurements per track");
+    m_desc.add_options()("max-iterations",
+                         po::value(&m_config.max_iterations)
+                             ->default_value(m_config.max_iterations),
+                         " Max iteration to remove the bad tracks");
+    m_desc.add_options()("max-shared-meas",
+                         po::value(&m_config.max_shared_meas)
+                             ->default_value(m_config.max_shared_meas),
+                         "Min number of shared measurements for competition");
+}
+
+track_resolution::operator ambiguity_resolution_config() const {
+    return m_config;
 }
 
 std::unique_ptr<configuration_printable> track_resolution::as_printable()
@@ -31,8 +44,14 @@ std::unique_ptr<configuration_printable> track_resolution::as_printable()
     auto cat = std::make_unique<configuration_category>(m_description);
 
     cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Run ambiguity resolution", std::format("{}", run)));
-
+        "Min number of measurements per track",
+        std::to_string(m_config.min_meas_per_track)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Max iteration to remove the bad tracks",
+        std::to_string(m_config.max_iterations)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Max shared meas to break the iteration",
+        std::to_string(m_config.max_shared_meas)));
     return cat;
 }
 }  // namespace traccc::opts

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -9,6 +9,7 @@
 #include "traccc/definitions/common.hpp"
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/geometry/detector.hpp"
+#include "traccc/utils/memory_resource.hpp"
 
 // io
 #include "traccc/io/read_detector.hpp"
@@ -62,8 +63,8 @@ using namespace traccc;
 int seq_run(const traccc::opts::track_seeding& seeding_opts,
             const traccc::opts::track_finding& finding_opts,
             const traccc::opts::track_propagation& propagation_opts,
-            const traccc::opts::track_fitting& fitting_opts,
             const traccc::opts::track_resolution& resolution_opts,
+            const traccc::opts::track_fitting& fitting_opts,
             const traccc::opts::input_data& input_opts,
             const traccc::opts::detector& detector_opts,
             const traccc::opts::performance& performance_opts,
@@ -72,6 +73,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // Memory resource used by the EDM.
     vecmem::host_memory_resource host_mr;
+    traccc::memory_resource mr{host_mr, &host_mr};
+
     // Copy obejct
     vecmem::copy copy;
 
@@ -80,21 +83,20 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         traccc::seeding_performance_writer::config{});
     traccc::finding_performance_writer find_performance_writer(
         traccc::finding_performance_writer::config{});
-    traccc::fitting_performance_writer fit_performance_writer(
-        traccc::fitting_performance_writer::config{});
-
     traccc::finding_performance_writer::config ar_writer_cfg;
     ar_writer_cfg.file_path = "performance_track_ambiguity_resolution.root";
     ar_writer_cfg.algorithm_name = "ambiguity_resolution";
     traccc::finding_performance_writer ar_performance_writer(ar_writer_cfg);
+    traccc::fitting_performance_writer fit_performance_writer(
+        traccc::fitting_performance_writer::config{});
 
     // Output stats
     uint64_t n_spacepoints = 0;
     uint64_t n_measurements = 0;
     uint64_t n_seeds = 0;
     uint64_t n_found_tracks = 0;
-    uint64_t n_fitted_tracks = 0;
     uint64_t n_ambiguity_free_tracks = 0;
+    uint64_t n_fitted_tracks = 0;
 
     /*****************************
      * Build a geometry
@@ -129,17 +131,18 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     traccc::host::combinatorial_kalman_filter_algorithm host_finding(
         cfg, logger().clone("FindingAlg"));
 
+    traccc::host::greedy_ambiguity_resolution_algorithm::config_type
+        host_ambiguity_config(resolution_opts);
+    traccc::host::greedy_ambiguity_resolution_algorithm
+        host_ambiguity_resolution(host_ambiguity_config, mr,
+                                  logger().clone("AmbiguityResolution"));
+
     // Fitting algorithm object
     traccc::fitting_config fit_cfg(fitting_opts);
     fit_cfg.propagation = propagation_config;
 
     traccc::host::kalman_fitting_algorithm host_fitting(
         fit_cfg, host_mr, copy, logger().clone("FittingAlg"));
-
-    traccc::greedy_ambiguity_resolution_algorithm::config_t
-        host_ambiguity_config{};
-    traccc::greedy_ambiguity_resolution_algorithm host_ambiguity_resolution(
-        host_ambiguity_config, logger().clone("AmbiguityResolution"));
 
     // Loop over events
     for (std::size_t event = input_opts.skip;
@@ -174,8 +177,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
         // Run CKF and KF if we are using a detray geometry
         traccc::track_candidate_container_types::host track_candidates;
+        traccc::track_candidate_container_types::host track_candidates_ar;
         traccc::track_state_container_types::host track_states;
-        traccc::track_state_container_types::host track_states_ar;
 
         /*------------------------
            Track Finding with CKF
@@ -186,22 +189,21 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             vecmem::get_data(params));
         n_found_tracks += track_candidates.size();
 
-        /*------------------------
-           Track Fitting with KF
-          ------------------------*/
-
-        track_states =
-            host_fitting(detector, field, traccc::get_data(track_candidates));
-        n_fitted_tracks += track_states.size();
-
         /*-----------------------------------------
            Ambiguity Resolution with Greedy Solver
           -----------------------------------------*/
 
-        if (resolution_opts.run) {
-            track_states_ar = host_ambiguity_resolution(track_states);
-            n_ambiguity_free_tracks += track_states_ar.size();
-        }
+        track_candidates_ar =
+            host_ambiguity_resolution(traccc::get_data(track_candidates));
+        n_ambiguity_free_tracks += track_candidates_ar.size();
+
+        /*------------------------
+           Track Fitting with KF
+          ------------------------*/
+
+        track_states = host_fitting(detector, field,
+                                    traccc::get_data(track_candidates_ar));
+        n_fitted_tracks += track_states.size();
 
         /*------------
            Statistics
@@ -228,10 +230,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             find_performance_writer.write(traccc::get_data(track_candidates),
                                           evt_data);
 
-            if (resolution_opts.run) {
-                ar_performance_writer.write(traccc::get_data(track_states_ar),
-                                            evt_data);
-            }
+            ar_performance_writer.write(traccc::get_data(track_candidates_ar),
+                                        evt_data);
 
             for (unsigned int i = 0; i < track_states.size(); i++) {
                 const auto& trk_states_per_track = track_states.at(i).items;
@@ -247,10 +247,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     if (performance_opts.run) {
         sd_performance_writer.finalize();
         find_performance_writer.finalize();
+        ar_performance_writer.finalize();
         fit_performance_writer.finalize();
-        if (resolution_opts.run) {
-            ar_performance_writer.finalize();
-        }
     }
 
     TRACCC_INFO("==> Statistics ... ");
@@ -258,14 +256,9 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     TRACCC_INFO("- read    " << n_measurements << " measurements");
     TRACCC_INFO("- created (cpu)  " << n_seeds << " seeds");
     TRACCC_INFO("- created (cpu)  " << n_found_tracks << " found tracks");
+    TRACCC_INFO("- created (cpu)  " << n_ambiguity_free_tracks
+                                    << " ambiguity free tracks");
     TRACCC_INFO("- created (cpu)  " << n_fitted_tracks << " fitted tracks");
-
-    if (resolution_opts.run) {
-        TRACCC_INFO("- created (cpu)  " << n_ambiguity_free_tracks
-                                        << " ambiguity free tracks");
-    } else {
-        TRACCC_INFO("- ambiguity resolution: deactivated");
-    }
 
     return EXIT_SUCCESS;
 }
@@ -282,19 +275,19 @@ int main(int argc, char* argv[]) {
     traccc::opts::track_seeding seeding_opts;
     traccc::opts::track_finding finding_opts;
     traccc::opts::track_propagation propagation_opts;
-    traccc::opts::track_fitting fitting_opts;
     traccc::opts::track_resolution resolution_opts;
+    traccc::opts::track_fitting fitting_opts;
     traccc::opts::performance performance_opts;
     traccc::opts::program_options program_opts{
         "Full Tracking Chain on the Host (without clusterization)",
         {detector_opts, input_opts, seeding_opts, finding_opts,
-         propagation_opts, fitting_opts, resolution_opts, performance_opts},
+         propagation_opts, resolution_opts, fitting_opts, performance_opts},
         argc,
         argv,
         logger->cloneWithSuffix("Options")};
 
     // Run the application.
-    return seq_run(seeding_opts, finding_opts, propagation_opts, fitting_opts,
-                   resolution_opts, input_opts, detector_opts, performance_opts,
-                   logger->clone());
+    return seq_run(seeding_opts, finding_opts, propagation_opts,
+                   resolution_opts, fitting_opts, input_opts, detector_opts,
+                   performance_opts, logger->clone());
 }

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -7,6 +7,7 @@
 
 // core
 #include "traccc/geometry/detector.hpp"
+#include "traccc/utils/memory_resource.hpp"
 
 // io
 #include "traccc/io/read_cells.hpp"
@@ -69,14 +70,16 @@ int seq_run(const traccc::opts::input_data& input_opts,
             const traccc::opts::track_seeding& seeding_opts,
             const traccc::opts::track_finding& finding_opts,
             const traccc::opts::track_propagation& propagation_opts,
-            const traccc::opts::track_fitting& fitting_opts,
             const traccc::opts::track_resolution& resolution_opts,
+            const traccc::opts::track_fitting& fitting_opts,
             const traccc::opts::performance& performance_opts,
             std::unique_ptr<const traccc::Logger> ilogger) {
     TRACCC_LOCAL_LOGGER(std::move(ilogger));
 
     // Memory resource used by the application.
     vecmem::host_memory_resource host_mr;
+    traccc::memory_resource mr{host_mr, &host_mr};
+
     // Copy obejct
     vecmem::copy copy;
 
@@ -103,8 +106,8 @@ int seq_run(const traccc::opts::input_data& input_opts,
     uint64_t n_spacepoints = 0;
     uint64_t n_seeds = 0;
     uint64_t n_found_tracks = 0;
-    uint64_t n_fitted_tracks = 0;
     uint64_t n_ambiguity_free_tracks = 0;
+    uint64_t n_fitted_tracks = 0;
 
     // Type definitions
     using spacepoint_formation_algorithm =
@@ -125,6 +128,9 @@ int seq_run(const traccc::opts::input_data& input_opts,
     finding_algorithm::config_type finding_cfg(finding_opts);
     finding_cfg.propagation = propagation_config;
 
+    traccc::host::greedy_ambiguity_resolution_algorithm::config_type
+        resolution_config(resolution_opts);
+
     fitting_algorithm::config_type fitting_cfg(fitting_opts);
     fitting_cfg.propagation = propagation_config;
 
@@ -141,23 +147,22 @@ int seq_run(const traccc::opts::input_data& input_opts,
     traccc::host::track_params_estimation tp(host_mr,
                                              logger().clone("TrackParEstAlg"));
     finding_algorithm finding_alg(finding_cfg, logger().clone("FindingAlg"));
+    traccc::host::greedy_ambiguity_resolution_algorithm resolution_alg(
+        resolution_config, mr, logger().clone("AmbiguityResolutionAlg"));
     fitting_algorithm fitting_alg(fitting_cfg, host_mr, copy,
                                   logger().clone("FittingAlg"));
-    traccc::greedy_ambiguity_resolution_algorithm::config_t resolution_config;
-    traccc::greedy_ambiguity_resolution_algorithm resolution_alg(
-        resolution_config, logger().clone("AmbiguityResolutionAlg"));
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
         traccc::seeding_performance_writer::config{});
     traccc::finding_performance_writer find_performance_writer(
         traccc::finding_performance_writer::config{});
-    traccc::fitting_performance_writer fit_performance_writer(
-        traccc::fitting_performance_writer::config{});
     traccc::finding_performance_writer::config ar_writer_cfg;
     ar_writer_cfg.file_path = "performance_track_ambiguity_resolution.root";
     ar_writer_cfg.algorithm_name = "ambiguity_resolution";
     traccc::finding_performance_writer ar_performance_writer(ar_writer_cfg);
+    traccc::fitting_performance_writer fit_performance_writer(
+        traccc::fitting_performance_writer::config{});
 
     // Timers
     traccc::performance::timing_info elapsedTimes;
@@ -176,9 +181,9 @@ int seq_run(const traccc::opts::input_data& input_opts,
         traccc::host::seeding_algorithm::output_type seeds{host_mr};
         traccc::host::track_params_estimation::output_type params{&host_mr};
         finding_algorithm::output_type track_candidates{&host_mr};
+        traccc::host::greedy_ambiguity_resolution_algorithm::output_type
+            resolved_track_candidates{&host_mr};
         fitting_algorithm::output_type track_states{&host_mr};
-        traccc::greedy_ambiguity_resolution_algorithm::output_type
-            resolved_track_states{&host_mr};
 
         {  // Start measuring wall time.
             traccc::performance::timer timer_wall{"Wall time", elapsedTimes};
@@ -268,19 +273,22 @@ int seq_run(const traccc::opts::input_data& input_opts,
                         event, output_opts.directory, output_opts.format,
                         traccc::get_data(track_candidates), detector);
                 }
+
+                {
+                    // Perform ambiguity resolution only if asked for.
+                    traccc::performance::timer timer{
+                        "Track ambiguity resolution", elapsedTimes};
+                    resolved_track_candidates =
+                        resolution_alg(traccc::get_data(track_candidates));
+                }
+
                 {
                     traccc::performance::timer timer{"Track fitting",
                                                      elapsedTimes};
                     track_states = fitting_alg(
-                        detector, field, traccc::get_data(track_candidates));
+                        detector, field,
+                        traccc::get_data(resolved_track_candidates));
                 }
-            }
-
-            // Perform ambiguity resolution only if asked for.
-            if (resolution_opts.run) {
-                traccc::performance::timer timer{"Track ambiguity resolution",
-                                                 elapsedTimes};
-                resolved_track_states = resolution_alg(track_states);
             }
 
             /*----------------------------
@@ -292,8 +300,8 @@ int seq_run(const traccc::opts::input_data& input_opts,
             n_spacepoints += spacepoints_per_event.size();
             n_seeds += seeds.size();
             n_found_tracks += track_candidates.size();
+            n_ambiguity_free_tracks += resolved_track_candidates.size();
             n_fitted_tracks += track_states.size();
-            n_ambiguity_free_tracks += resolved_track_states.size();
 
         }  // Stop measuring Wall time.
 
@@ -315,6 +323,8 @@ int seq_run(const traccc::opts::input_data& input_opts,
                 vecmem::get_data(measurements_per_event), evt_data);
             find_performance_writer.write(traccc::get_data(track_candidates),
                                           evt_data);
+            ar_performance_writer.write(
+                traccc::get_data(resolved_track_candidates), evt_data);
 
             for (unsigned int i = 0; i < track_states.size(); i++) {
                 const auto& trk_states_per_track = track_states.at(i).items;
@@ -324,21 +334,14 @@ int seq_run(const traccc::opts::input_data& input_opts,
                 fit_performance_writer.write(trk_states_per_track, fit_res,
                                              detector, evt_data);
             }
-
-            if (resolution_opts.run) {
-                ar_performance_writer.write(
-                    traccc::get_data(resolved_track_states), evt_data);
-            }
         }
     }
 
     if (performance_opts.run) {
         sd_performance_writer.finalize();
         find_performance_writer.finalize();
+        ar_performance_writer.finalize();
         fit_performance_writer.finalize();
-        if (resolution_opts.run) {
-            ar_performance_writer.finalize();
-        }
     }
 
     std::cout << "==> Statistics ... " << std::endl;
@@ -349,9 +352,9 @@ int seq_run(const traccc::opts::input_data& input_opts,
               << std::endl;
     std::cout << "- created  " << n_seeds << " seeds" << std::endl;
     std::cout << "- found    " << n_found_tracks << " tracks" << std::endl;
-    std::cout << "- fitted   " << n_fitted_tracks << " tracks" << std::endl;
     std::cout << "- resolved " << n_ambiguity_free_tracks << " tracks"
               << std::endl;
+    std::cout << "- fitted   " << n_fitted_tracks << " tracks" << std::endl;
     std::cout << "==> Elapsed times...\n" << elapsedTimes << std::endl;
 
     return EXIT_SUCCESS;
@@ -371,20 +374,21 @@ int main(int argc, char* argv[]) {
     traccc::opts::track_seeding seeding_opts;
     traccc::opts::track_finding finding_opts;
     traccc::opts::track_propagation propagation_opts;
-    traccc::opts::track_fitting fitting_opts;
     traccc::opts::track_resolution resolution_opts;
+    traccc::opts::track_fitting fitting_opts;
     traccc::opts::performance performance_opts;
     traccc::opts::program_options program_opts{
         "Full Tracking Chain on the Host",
         {detector_opts, input_opts, output_opts, clusterization_opts,
-         seeding_opts, finding_opts, fitting_opts, propagation_opts,
-         resolution_opts, performance_opts},
+         seeding_opts, finding_opts, resolution_opts, fitting_opts,
+         propagation_opts, performance_opts},
         argc,
         argv,
         logger->cloneWithSuffix("Options")};
 
     // Run the application.
     return seq_run(input_opts, output_opts, detector_opts, clusterization_opts,
-                   seeding_opts, finding_opts, propagation_opts, fitting_opts,
-                   resolution_opts, performance_opts, logger->clone());
+                   seeding_opts, finding_opts, propagation_opts,
+                   resolution_opts, fitting_opts, performance_opts,
+                   logger->clone());
 }

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -8,6 +8,7 @@
 traccc_add_test(cpu
     "compare_with_acts_seeding.cpp"
     "seq_single_module.cpp"
+    "test_ambiguity_resolution.cpp"
     "test_cca.cpp"
     "test_ckf_combinatorics_telescope.cpp"
     "test_ckf_sparse_tracks_telescope.cpp"

--- a/tests/cpu/test_ambiguity_resolution.cpp
+++ b/tests/cpu/test_ambiguity_resolution.cpp
@@ -1,0 +1,302 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "traccc/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp"
+#include "traccc/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.hpp"
+#include "traccc/utils/memory_resource.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <random>
+
+using namespace traccc;
+
+namespace {
+vecmem::host_memory_resource host_mr;
+traccc::memory_resource mr{host_mr, &host_mr};
+
+}  // namespace
+
+void fill_pattern(track_candidate_container_types::host& track_candidates,
+                  const std::size_t idx, const traccc::scalar chi2,
+                  const std::vector<std::size_t>& pattern) {
+
+    track_candidates.at(idx).header.trk_quality.chi2 = chi2;
+
+    auto& cands = track_candidates.at(idx).items;
+    for (const auto& meas_id : pattern) {
+        cands.push_back({});
+        cands.back().measurement_id = meas_id;
+    }
+}
+
+std::vector<std::size_t> get_pattern(
+    track_candidate_container_types::host& track_candidates,
+    const std::size_t idx) {
+    std::vector<std::size_t> ret;
+    auto& cands = track_candidates.at(idx).items;
+    for (const auto& cand : cands) {
+        ret.push_back(cand.measurement_id);
+    }
+
+    return ret;
+}
+
+TEST(AmbiguitySolverTests, GreedyResolverTest0) {
+
+    track_candidate_container_types::host trk_cands;
+
+    trk_cands.resize(3u);
+    fill_pattern(trk_cands, 0, 8.3f, {1, 3, 5, 11});
+    fill_pattern(trk_cands, 1, 2.2f, {6, 7, 8, 9, 10, 12});
+    fill_pattern(trk_cands, 2, 3.7f, {2, 4, 13});
+
+    traccc::host::greedy_ambiguity_resolution_algorithm::config_type
+        resolution_config;
+
+    traccc::host::greedy_ambiguity_resolution_algorithm resolution_alg(
+        resolution_config, mr);
+    {
+        resolution_alg.get_config().min_meas_per_track = 3;
+        auto res_trk_cands = resolution_alg(traccc::get_data(trk_cands));
+        // All tracks are accepted as they have more than three measurements
+        ASSERT_EQ(res_trk_cands.size(), 3u);
+    }
+
+    {
+        resolution_alg.get_config().min_meas_per_track = 5;
+        auto res_trk_cands = resolution_alg(traccc::get_data(trk_cands));
+        // Only the second track with six measurements is accepted
+        ASSERT_EQ(res_trk_cands.size(), 1u);
+        ASSERT_EQ(get_pattern(res_trk_cands, 0),
+                  std::vector<std::size_t>({6, 7, 8, 9, 10, 12}));
+    }
+
+    /*******************
+     * Legacy algorithm
+     * *****************/
+
+    {
+        traccc::legacy::greedy_ambiguity_resolution_algorithm::config_t
+            legacy_cfg;
+        traccc::legacy::greedy_ambiguity_resolution_algorithm
+            legacy_resolution_alg(legacy_cfg);
+
+        legacy_resolution_alg.get_config().n_measurements_min = 3;
+        auto res_trk_cands = legacy_resolution_alg(trk_cands);
+        ASSERT_EQ(res_trk_cands.size(), 3u);
+    }
+
+    {
+        traccc::legacy::greedy_ambiguity_resolution_algorithm::config_t
+            legacy_cfg;
+        traccc::legacy::greedy_ambiguity_resolution_algorithm
+            legacy_resolution_alg(legacy_cfg);
+
+        legacy_resolution_alg.get_config().n_measurements_min = 5;
+        auto res_trk_cands = legacy_resolution_alg(trk_cands);
+        ASSERT_EQ(res_trk_cands.size(), 1u);
+        ASSERT_EQ(get_pattern(res_trk_cands, 0),
+                  std::vector<std::size_t>({6, 7, 8, 9, 10, 12}));
+    }
+}
+
+TEST(AmbiguitySolverTests, GreedyResolverTest1) {
+
+    track_candidate_container_types::host trk_cands;
+
+    trk_cands.resize(2u);
+    fill_pattern(trk_cands, 0, 4.3f, {1, 3, 5, 11, 14, 16, 18});
+    fill_pattern(trk_cands, 1, 1.2f, {3, 5, 6, 13});
+
+    traccc::host::greedy_ambiguity_resolution_algorithm::config_type
+        resolution_config;
+    traccc::host::greedy_ambiguity_resolution_algorithm resolution_alg(
+        resolution_config, mr);
+    {
+        auto res_trk_cands = resolution_alg(traccc::get_data(trk_cands));
+        ASSERT_EQ(res_trk_cands.size(), 1u);
+
+        // The first track is selected over the second one as its relative
+        // shared measurement (2/7) is lower than the one of the second track
+        // (2/4)
+        ASSERT_EQ(get_pattern(res_trk_cands, 0),
+                  std::vector<std::size_t>({1, 3, 5, 11, 14, 16, 18}));
+    }
+
+    /*******************
+     * Legacy algorithm
+     * *****************/
+
+    {
+        traccc::legacy::greedy_ambiguity_resolution_algorithm::config_t
+            legacy_cfg;
+        traccc::legacy::greedy_ambiguity_resolution_algorithm
+            legacy_resolution_alg(legacy_cfg);
+
+        auto res_trk_cands = legacy_resolution_alg(trk_cands);
+        ASSERT_EQ(res_trk_cands.size(), 1u);
+
+        // The first track is selected over the second one as its relative
+        // shared measurement (2/7) is lower than the one of the second track
+        // (2/4)
+        ASSERT_EQ(get_pattern(res_trk_cands, 0),
+                  std::vector<std::size_t>({1, 3, 5, 11, 14, 16, 18}));
+    }
+}
+
+TEST(AmbiguitySolverTests, GreedyResolverTest2) {
+
+    track_candidate_container_types::host trk_cands;
+
+    trk_cands.resize(2u);
+    fill_pattern(trk_cands, 0, 4.3f, {1, 3, 5, 11});
+    fill_pattern(trk_cands, 1, 1.2f, {3, 5, 6, 13});
+
+    traccc::host::greedy_ambiguity_resolution_algorithm::config_type
+        resolution_config;
+    traccc::host::greedy_ambiguity_resolution_algorithm resolution_alg(
+        resolution_config, mr);
+    {
+        auto res_trk_cands = resolution_alg(traccc::get_data(trk_cands));
+        ASSERT_EQ(res_trk_cands.size(), 1u);
+
+        // The second track is selected over the first one as their relative
+        // shared measurement (2/4) is the same but its chi square is smaller
+        ASSERT_EQ(get_pattern(res_trk_cands, 0),
+                  std::vector<std::size_t>({3, 5, 6, 13}));
+    }
+}
+
+TEST(AmbiguitySolverTests, GreedyResolverTest3) {
+
+    track_candidate_container_types::host trk_cands;
+    trk_cands.resize(6u);
+    fill_pattern(trk_cands, 0, 5.3f, {1, 3, 5, 11});
+    fill_pattern(trk_cands, 1, 2.4f, {2, 6});
+    fill_pattern(trk_cands, 2, 2.5f, {3, 6, 12, 14, 19, 21});
+    fill_pattern(trk_cands, 3, 13.3f, {2, 7, 11, 13, 16});
+    fill_pattern(trk_cands, 4, 4.1f, {1, 7, 8});
+    fill_pattern(trk_cands, 5, 1.1f, {1, 3, 11, 22});
+
+    traccc::host::greedy_ambiguity_resolution_algorithm::config_type
+        resolution_config;
+    traccc::host::greedy_ambiguity_resolution_algorithm resolution_alg(
+        resolution_config, mr);
+
+    {
+        auto res_trk_cands = resolution_alg(traccc::get_data(trk_cands));
+        ASSERT_EQ(res_trk_cands.size(), 2u);
+
+        ASSERT_EQ(get_pattern(res_trk_cands, 0),
+                  std::vector<std::size_t>({3, 6, 12, 14, 19, 21}));
+        ASSERT_EQ(get_pattern(res_trk_cands, 1),
+                  std::vector<std::size_t>({2, 7, 11, 13, 16}));
+    }
+
+    // Legacy algorithm
+    traccc::legacy::greedy_ambiguity_resolution_algorithm::config_t legacy_cfg;
+    traccc::legacy::greedy_ambiguity_resolution_algorithm legacy_resolution_alg(
+        legacy_cfg);
+
+    {
+        auto res_trk_cands = legacy_resolution_alg(trk_cands);
+        ASSERT_EQ(res_trk_cands.size(), 2u);
+
+        ASSERT_EQ(get_pattern(res_trk_cands, 0),
+                  std::vector<std::size_t>({3, 6, 12, 14, 19, 21}));
+        ASSERT_EQ(get_pattern(res_trk_cands, 1),
+                  std::vector<std::size_t>({2, 7, 11, 13, 16}));
+    }
+}
+
+// Comparison to the legacy algorithm.
+TEST(AmbiguitySolverTests, GreedyResolverTest4) {
+
+    std::size_t n_tracks = 10000u;
+
+    track_candidate_container_types::host trk_cands;
+    trk_cands.resize(n_tracks);
+    std::mt19937 gen(42);
+
+    for (std::size_t i = 0; i < n_tracks; i++) {
+
+        std::uniform_int_distribution<std::size_t> track_length_dist(1, 20);
+        std::uniform_int_distribution<std::size_t> meas_id_dist(0, 10000);
+        std::uniform_real_distribution<traccc::scalar> chi2_dist(0.0f, 10.0f);
+
+        const std::size_t track_length = track_length_dist(gen);
+        const traccc::scalar chi2 = chi2_dist(gen);
+        std::vector<std::size_t> pattern;
+        while (pattern.size() < track_length) {
+
+            const std::size_t meas_id = meas_id_dist(gen);
+            if (std::find(pattern.begin(), pattern.end(), meas_id) ==
+                pattern.end()) {
+                pattern.push_back(meas_id);
+            }
+        }
+
+        std::sort(pattern.begin(), pattern.end());
+        auto last = std::unique(pattern.begin(), pattern.end());
+
+        // There should not be duplicate
+        ASSERT_EQ(last, pattern.end());
+        pattern.erase(last, pattern.end());
+
+        // Make sure that partern size is eqaul to the track length
+        ASSERT_EQ(pattern.size(), track_length);
+
+        // Fill the pattern
+        fill_pattern(trk_cands, i, chi2, pattern);
+    }
+
+    traccc::host::greedy_ambiguity_resolution_algorithm::config_type
+        resolution_config;
+    traccc::host::greedy_ambiguity_resolution_algorithm resolution_alg(
+        resolution_config, mr);
+
+    auto start_new = std::chrono::high_resolution_clock::now();
+
+    auto res_trk_cands = resolution_alg(traccc::get_data(trk_cands));
+
+    auto end_new = std::chrono::high_resolution_clock::now();
+    auto duration_new = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_new - start_new);
+    std::cout << " Time for the new method " << duration_new.count() << " ms"
+              << std::endl;
+
+    // Legacy algorithm
+    traccc::legacy::greedy_ambiguity_resolution_algorithm::config_t legacy_cfg;
+    traccc::legacy::greedy_ambiguity_resolution_algorithm legacy_resolution_alg(
+        legacy_cfg);
+
+    auto start_legacy = std::chrono::high_resolution_clock::now();
+
+    auto legacy_res_trk_cands = legacy_resolution_alg(trk_cands);
+
+    auto end_legacy = std::chrono::high_resolution_clock::now();
+    auto duration_legacy =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end_legacy -
+                                                              start_legacy);
+    std::cout << " Time for the legacy method " << duration_legacy.count()
+              << " ms" << std::endl;
+
+    std::size_t n_res_tracks = res_trk_cands.size();
+    ASSERT_EQ(n_res_tracks, legacy_res_trk_cands.size());
+    for (std::size_t i = 0; i < n_res_tracks; i++) {
+        ASSERT_EQ(res_trk_cands.at(i).header,
+                  legacy_res_trk_cands.at(i).header);
+        ASSERT_EQ(res_trk_cands.at(i).items, legacy_res_trk_cands.at(i).items);
+    }
+}

--- a/tests/cpu/test_ambiguity_resolution.cpp
+++ b/tests/cpu/test_ambiguity_resolution.cpp
@@ -28,10 +28,10 @@ traccc::memory_resource mr{host_mr, &host_mr};
 }  // namespace
 
 void fill_pattern(track_candidate_container_types::host& track_candidates,
-                  const std::size_t idx, const traccc::scalar chi2,
+                  const std::size_t idx, const traccc::scalar pval,
                   const std::vector<std::size_t>& pattern) {
 
-    track_candidates.at(idx).header.trk_quality.chi2 = chi2;
+    track_candidates.at(idx).header.trk_quality.pval = pval;
 
     auto& cands = track_candidates.at(idx).items;
     for (const auto& meas_id : pattern) {
@@ -57,9 +57,9 @@ TEST(AmbiguitySolverTests, GreedyResolverTest0) {
     track_candidate_container_types::host trk_cands;
 
     trk_cands.resize(3u);
-    fill_pattern(trk_cands, 0, 8.3f, {1, 3, 5, 11});
-    fill_pattern(trk_cands, 1, 2.2f, {6, 7, 8, 9, 10, 12});
-    fill_pattern(trk_cands, 2, 3.7f, {2, 4, 13});
+    fill_pattern(trk_cands, 0, 0.23f, {1, 3, 5, 11});
+    fill_pattern(trk_cands, 1, 0.85f, {6, 7, 8, 9, 10, 12});
+    fill_pattern(trk_cands, 2, 0.42f, {2, 4, 13});
 
     traccc::host::greedy_ambiguity_resolution_algorithm::config_type
         resolution_config;
@@ -116,8 +116,8 @@ TEST(AmbiguitySolverTests, GreedyResolverTest1) {
     track_candidate_container_types::host trk_cands;
 
     trk_cands.resize(2u);
-    fill_pattern(trk_cands, 0, 4.3f, {1, 3, 5, 11, 14, 16, 18});
-    fill_pattern(trk_cands, 1, 1.2f, {3, 5, 6, 13});
+    fill_pattern(trk_cands, 0, 0.12f, {1, 3, 5, 11, 14, 16, 18});
+    fill_pattern(trk_cands, 1, 0.53f, {3, 5, 6, 13});
 
     traccc::host::greedy_ambiguity_resolution_algorithm::config_type
         resolution_config;
@@ -160,8 +160,8 @@ TEST(AmbiguitySolverTests, GreedyResolverTest2) {
     track_candidate_container_types::host trk_cands;
 
     trk_cands.resize(2u);
-    fill_pattern(trk_cands, 0, 4.3f, {1, 3, 5, 11});
-    fill_pattern(trk_cands, 1, 1.2f, {3, 5, 6, 13});
+    fill_pattern(trk_cands, 0, 0.8f, {1, 3, 5, 11});
+    fill_pattern(trk_cands, 1, 0.9f, {3, 5, 6, 13});
 
     traccc::host::greedy_ambiguity_resolution_algorithm::config_type
         resolution_config;
@@ -172,7 +172,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest2) {
         ASSERT_EQ(res_trk_cands.size(), 1u);
 
         // The second track is selected over the first one as their relative
-        // shared measurement (2/4) is the same but its chi square is smaller
+        // shared measurement (2/4) is the same but its p-value is higher
         ASSERT_EQ(get_pattern(res_trk_cands, 0),
                   std::vector<std::size_t>({3, 5, 6, 13}));
     }
@@ -182,12 +182,12 @@ TEST(AmbiguitySolverTests, GreedyResolverTest3) {
 
     track_candidate_container_types::host trk_cands;
     trk_cands.resize(6u);
-    fill_pattern(trk_cands, 0, 5.3f, {1, 3, 5, 11});
-    fill_pattern(trk_cands, 1, 2.4f, {2, 6});
-    fill_pattern(trk_cands, 2, 2.5f, {3, 6, 12, 14, 19, 21});
-    fill_pattern(trk_cands, 3, 13.3f, {2, 7, 11, 13, 16});
-    fill_pattern(trk_cands, 4, 4.1f, {1, 7, 8});
-    fill_pattern(trk_cands, 5, 1.1f, {1, 3, 11, 22});
+    fill_pattern(trk_cands, 0, 0.2f, {1, 3, 5, 11});
+    fill_pattern(trk_cands, 1, 0.5f, {2, 6});
+    fill_pattern(trk_cands, 2, 0.4f, {3, 6, 12, 14, 19, 21});
+    fill_pattern(trk_cands, 3, 0.1f, {2, 7, 11, 13, 16});
+    fill_pattern(trk_cands, 4, 0.3f, {1, 7, 8});
+    fill_pattern(trk_cands, 5, 0.6f, {1, 3, 11, 22});
 
     traccc::host::greedy_ambiguity_resolution_algorithm::config_type
         resolution_config;
@@ -233,10 +233,10 @@ TEST(AmbiguitySolverTests, GreedyResolverTest4) {
 
         std::uniform_int_distribution<std::size_t> track_length_dist(1, 20);
         std::uniform_int_distribution<std::size_t> meas_id_dist(0, 10000);
-        std::uniform_real_distribution<traccc::scalar> chi2_dist(0.0f, 10.0f);
+        std::uniform_real_distribution<traccc::scalar> pval_dist(0.0f, 1.0f);
 
         const std::size_t track_length = track_length_dist(gen);
-        const traccc::scalar chi2 = chi2_dist(gen);
+        const traccc::scalar pval = pval_dist(gen);
         std::vector<std::size_t> pattern;
         while (pattern.size() < track_length) {
 
@@ -258,7 +258,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest4) {
         ASSERT_EQ(pattern.size(), track_length);
 
         // Fill the pattern
-        fill_pattern(trk_cands, i, chi2, pattern);
+        fill_pattern(trk_cands, i, pval, pattern);
     }
 
     traccc::host::greedy_ambiguity_resolution_algorithm::config_type


### PR DESCRIPTION
Based on #923

This PR replace chi2 criteria with p-value criteria because p-value includes both chi2 and NDF for fair comparison between tracks