### PR TITLE
Refactor B-field and detector typedefs

### DIFF
--- a/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
+++ b/benchmarks/common/benchmarks/toy_detector_benchmark.hpp
@@ -16,9 +16,10 @@
 #include "traccc/simulation/measurement_smearer.hpp"
 #include "traccc/simulation/simulator.hpp"
 #include "traccc/simulation/smearing_writer.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
+#include <covfie/core/field.hpp>
 #include <detray/io/frontend/detector_writer.hpp>
 #include <detray/test/utils/detectors/build_toy_detector.hpp>
 #include <detray/test/utils/simulation/event_generator/track_generators.hpp>
@@ -66,7 +67,8 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
 
     // B field value and its type
     // @TODO: Set B field as argument
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_type>>;
+    using b_field_t =
+        covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
 
     static constexpr traccc::vector3 B{0, 0, 2 * traccc::unit<scalar_type>::T};
 
@@ -89,7 +91,7 @@ class ToyDetectorBenchmark : public benchmark::Fixture {
             detray::build_toy_detector<algebra_type>(host_mr, get_toy_config());
 
         // B field
-        auto field = detray::bfield::create_const_field<scalar_type>(B);
+        b_field_t field = traccc::construct_const_bfield<scalar_type>(B);
 
         // Origin of particles
         using generator_type = detray::random_track_generator<

--- a/benchmarks/cpu/toy_detector_cpu.cpp
+++ b/benchmarks/cpu/toy_detector_cpu.cpp
@@ -24,7 +24,6 @@
 #include "benchmarks/toy_detector_benchmark.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 
 // VecMem include(s).
@@ -50,7 +49,7 @@ BENCHMARK_DEFINE_F(ToyDetectorBenchmark, CPU)(benchmark::State& state) {
         sim_dir + "toy_detector_surface_grids.json");
 
     // B field
-    auto field = detray::bfield::create_const_field<scalar_type>(B);
+    auto field = traccc::construct_const_bfield<scalar_type>(B);
 
     // Algorithms
     traccc::host::seeding_algorithm sa(seeding_cfg, grid_cfg, filter_cfg,

--- a/benchmarks/cuda/toy_detector_cuda.cpp
+++ b/benchmarks/cuda/toy_detector_cuda.cpp
@@ -22,7 +22,6 @@
 #include "benchmarks/toy_detector_benchmark.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
@@ -68,8 +67,8 @@ BENCHMARK_DEFINE_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
         sim_dir + "toy_detector_surface_grids.json");
 
     // B field
-    auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(B);
+    b_field_t field =
+        traccc::construct_const_bfield<host_detector_type::scalar_type>(B);
 
     // Algorithms
     traccc::cuda::seeding_algorithm sa_cuda(seeding_cfg, grid_cfg, filter_cfg,

--- a/core/include/traccc/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/core/include/traccc/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -14,10 +14,8 @@
 #include "traccc/finding/finding_config.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/messaging.hpp"
-
-// Detray include(s).
-#include <detray/detectors/bfield.hpp>
 
 namespace traccc::host {
 
@@ -29,14 +27,14 @@ namespace traccc::host {
 class combinatorial_kalman_filter_algorithm
     : public algorithm<track_candidate_container_types::host(
           const default_detector::host&,
-          const detray::bfield::const_field_t<
-              default_detector::host::scalar_type>::view_t&,
+          const covfie::field<const_bfield_backend_t<
+              default_detector::host::scalar_type>>::view_t&,
           const measurement_collection_types::const_view&,
           const bound_track_parameters_collection_types::const_view&)>,
       public algorithm<track_candidate_container_types::host(
           const telescope_detector::host&,
-          const detray::bfield::const_field_t<
-              telescope_detector::host::scalar_type>::view_t&,
+          const covfie::field<traccc::const_bfield_backend_t<
+              telescope_detector::host::scalar_type>>::view_t&,
           const measurement_collection_types::const_view&,
           const bound_track_parameters_collection_types::const_view&)>,
       public messaging {
@@ -64,8 +62,8 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const default_detector::host& det,
-        const detray::bfield::const_field_t<
-            default_detector::host::scalar_type>::view_t& field,
+        const covfie::field<traccc::const_bfield_backend_t<
+            default_detector::host::scalar_type>>::view_t& field,
         const measurement_collection_types::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;
@@ -82,8 +80,8 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const telescope_detector::host& det,
-        const detray::bfield::const_field_t<
-            telescope_detector::host::scalar_type>::view_t& field,
+        const covfie::field<traccc::const_bfield_backend_t<
+            telescope_detector::host::scalar_type>>::view_t& field,
         const measurement_collection_types::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;

--- a/core/include/traccc/fitting/kalman_fitting_algorithm.hpp
+++ b/core/include/traccc/fitting/kalman_fitting_algorithm.hpp
@@ -13,10 +13,11 @@
 #include "traccc/fitting/fitting_config.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/messaging.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
+#include <covfie/core/field.hpp>
 
 // VecMem include(s).
 #include <vecmem/memory/memory_resource.hpp>
@@ -30,13 +31,13 @@ namespace traccc::host {
 class kalman_fitting_algorithm
     : public algorithm<track_state_container_types::host(
           const default_detector::host&,
-          const detray::bfield::const_field_t<
-              default_detector::host::scalar_type>::view_t&,
+          const covfie::field<const_bfield_backend_t<
+              default_detector::host::scalar_type>>::view_t&,
           const track_candidate_container_types::const_view&)>,
       public algorithm<track_state_container_types::host(
           const telescope_detector::host&,
-          const detray::bfield::const_field_t<
-              telescope_detector::host::scalar_type>::view_t&,
+          const covfie::field<const_bfield_backend_t<
+              telescope_detector::host::scalar_type>>::view_t&,
           const track_candidate_container_types::const_view&)>,
       public messaging {
 
@@ -65,8 +66,8 @@ class kalman_fitting_algorithm
     ///
     output_type operator()(
         const default_detector::host& det,
-        const detray::bfield::const_field_t<
-            default_detector::host::scalar_type>::view_t& field,
+        const covfie::field<traccc::const_bfield_backend_t<
+            default_detector::host::scalar_type>>::view_t& field,
         const track_candidate_container_types::const_view& track_candidates)
         const override;
 
@@ -80,8 +81,8 @@ class kalman_fitting_algorithm
     ///
     output_type operator()(
         const telescope_detector::host& det,
-        const detray::bfield::const_field_t<
-            telescope_detector::host::scalar_type>::view_t& field,
+        const covfie::field<traccc::const_bfield_backend_t<
+            telescope_detector::host::scalar_type>>::view_t& field,
         const track_candidate_container_types::const_view& track_candidates)
         const override;
 

--- a/core/include/traccc/utils/bfield.hpp
+++ b/core/include/traccc/utils/bfield.hpp
@@ -1,0 +1,37 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <covfie/core/backend/primitive/constant.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/vector.hpp>
+#include <detray/navigation/navigator.hpp>
+#include <detray/propagator/rk_stepper.hpp>
+#include <traccc/fitting/kalman_filter/kalman_fitter.hpp>
+
+namespace traccc {
+template <typename scalar_t>
+using const_bfield_backend_t =
+    ::covfie::backend::constant<::covfie::vector::vector_d<scalar_t, 3>,
+                                ::covfie::vector::vector_d<scalar_t, 3>>;
+
+template <typename scalar_t>
+::covfie::field<const_bfield_backend_t<scalar_t>> construct_const_bfield(
+    scalar_t x, scalar_t y, scalar_t z) {
+    return ::covfie::field<const_bfield_backend_t<scalar_t>>{
+        ::covfie::make_parameter_pack(
+            typename const_bfield_backend_t<scalar_t>::configuration_t{x, y,
+                                                                       z})};
+}
+
+template <typename scalar_t>
+::covfie::field<const_bfield_backend_t<scalar_t>> construct_const_bfield(
+    const vector3& v) {
+    return construct_const_bfield(v[0], v[1], v[2]);
+}
+}  // namespace traccc

--- a/core/include/traccc/utils/detector_type_utils.hpp
+++ b/core/include/traccc/utils/detector_type_utils.hpp
@@ -1,0 +1,32 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <covfie/core/field.hpp>
+#include <detray/navigation/navigator.hpp>
+#include <detray/propagator/rk_stepper.hpp>
+#include <traccc/fitting/kalman_filter/kalman_fitter.hpp>
+#include <traccc/utils/bfield.hpp>
+
+namespace traccc {
+/// Helper type constructors to facilitate the consistent instantiation of
+/// tools such as steppers and fitters for specific detectors.
+template <typename detector_t>
+using navigator_for_t = detray::navigator<const detector_t>;
+
+template <typename detector_t>
+using stepper_for_t = ::detray::rk_stepper<
+    typename ::covfie::field<
+        const_bfield_backend_t<typename detector_t::scalar_type>>::view_t,
+    typename detector_t::algebra_type,
+    ::detray::constrained_step<typename detector_t::scalar_type>>;
+
+template <typename detector_t>
+using fitter_for_t =
+    kalman_fitter<stepper_for_t<detector_t>, navigator_for_t<detector_t>>;
+}  // namespace traccc

--- a/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.cpp
+++ b/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.cpp
@@ -8,32 +8,33 @@
 // Local include(s).
 #include "traccc/finding/combinatorial_kalman_filter_algorithm.hpp"
 #include "traccc/finding/details/find_tracks.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 
-namespace traccc::host {
+namespace {
+using detector_type = traccc::default_detector;
+using scalar_type = detector_type::host::scalar_type;
+using bfield_type = covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
+}  // namespace
 
+namespace traccc::host {
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
-    const default_detector::host& det,
-    const detray::bfield::const_field_t<
-        default_detector::host::scalar_type>::view_t& field,
+    const detector_type::host& det, const bfield_type::view_t& field,
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
-    using scalar_type = default_detector::host::scalar_type;
-
     // Perform the track finding using the templated implementation.
     return details::find_tracks<
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
-                           default_detector::host::algebra_type,
+        detray::rk_stepper<bfield_type::view_t,
+                           detector_type::host::algebra_type,
                            detray::constrained_step<scalar_type>>,
-        detray::navigator<const default_detector::host>>(
-        det, field, measurements, seeds, m_config);
+        detray::navigator<const detector_type::host>>(det, field, measurements,
+                                                      seeds, m_config);
 }
 
 }  // namespace traccc::host

--- a/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.cpp
+++ b/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.cpp
@@ -8,32 +8,33 @@
 // Local include(s).
 #include "traccc/finding/combinatorial_kalman_filter_algorithm.hpp"
 #include "traccc/finding/details/find_tracks.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 
-namespace traccc::host {
+namespace {
+using detector_type = traccc::telescope_detector;
+using scalar_type = detector_type::host::scalar_type;
+using bfield_type = covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
+}  // namespace
 
+namespace traccc::host {
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
-    const telescope_detector::host& det,
-    const detray::bfield::const_field_t<
-        telescope_detector::host::scalar_type>::view_t& field,
+    const detector_type::host& det, const bfield_type::view_t& field,
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
-    using scalar_type = telescope_detector::host::scalar_type;
-
     // Perform the track finding using the templated implementation.
     return details::find_tracks<
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
-                           telescope_detector::host::algebra_type,
+        detray::rk_stepper<bfield_type::view_t,
+                           detector_type::host::algebra_type,
                            detray::constrained_step<scalar_type>>,
-        detray::navigator<const telescope_detector::host>>(
-        det, field, measurements, seeds, m_config);
+        detray::navigator<const detector_type::host>>(det, field, measurements,
+                                                      seeds, m_config);
 }
 
 }  // namespace traccc::host

--- a/core/src/fitting/kalman_fitting_algorithm_constant_field_default_detector.cpp
+++ b/core/src/fitting/kalman_fitting_algorithm_constant_field_default_detector.cpp
@@ -9,27 +9,29 @@
 #include "traccc/fitting/details/fit_tracks.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 #include "traccc/fitting/kalman_fitting_algorithm.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // Detray include(s).
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 
+namespace {
+using detector_type = traccc::default_detector;
+using scalar_type = detector_type::host::scalar_type;
+using bfield_type = covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
+}  // namespace
+
 namespace traccc::host {
 
 kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
-    const default_detector::host& det,
-    const detray::bfield::const_field_t<
-        traccc::default_detector::host::scalar_type>::view_t& field,
+    const detector_type::host& det, const bfield_type::view_t& field,
     const track_candidate_container_types::const_view& track_candidates) const {
 
-    using scalar_type = traccc::default_detector::host::scalar_type;
-
     // Create the fitter object.
-    kalman_fitter<
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
-                           traccc::default_detector::host::algebra_type,
-                           detray::constrained_step<scalar_type>>,
-        detray::navigator<const traccc::default_detector::host>>
+    kalman_fitter<detray::rk_stepper<bfield_type::view_t,
+                                     detector_type::host::algebra_type,
+                                     detray::constrained_step<scalar_type>>,
+                  detray::navigator<const detector_type::host>>
         fitter{det, field, m_config};
 
     // Perform the track fitting using a common, templated function.

--- a/core/src/fitting/kalman_fitting_algorithm_constant_field_telescope_detector.cpp
+++ b/core/src/fitting/kalman_fitting_algorithm_constant_field_telescope_detector.cpp
@@ -9,27 +9,29 @@
 #include "traccc/fitting/details/fit_tracks.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 #include "traccc/fitting/kalman_fitting_algorithm.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // Detray include(s).
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 
+namespace {
+using detector_type = traccc::telescope_detector;
+using scalar_type = detector_type::host::scalar_type;
+using bfield_type = covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
+}  // namespace
+
 namespace traccc::host {
 
 kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
-    const telescope_detector::host& det,
-    const detray::bfield::const_field_t<
-        traccc::telescope_detector::host::scalar_type>::view_t& field,
+    const detector_type::host& det, const bfield_type::view_t& field,
     const track_candidate_container_types::const_view& track_candidates) const {
 
-    using scalar_type = traccc::telescope_detector::host::scalar_type;
-
     // Create the fitter object.
-    kalman_fitter<
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
-                           traccc::telescope_detector::host::algebra_type,
-                           detray::constrained_step<scalar_type>>,
-        detray::navigator<const traccc::telescope_detector::host>>
+    kalman_fitter<detray::rk_stepper<bfield_type::view_t,
+                                     detector_type::host::algebra_type,
+                                     detray::constrained_step<scalar_type>>,
+                  detray::navigator<const detector_type::host>>
         fitter{det, field, m_config};
 
     // Perform the track fitting using a common, templated function.

--- a/device/alpaka/src/finding/finding_algorithm.cpp
+++ b/device/alpaka/src/finding/finding_algorithm.cpp
@@ -25,10 +25,10 @@
 #include "traccc/finding/device/find_tracks.hpp"
 #include "traccc/finding/device/propagate_to_next_surface.hpp"
 #include "traccc/geometry/detector.hpp"
+#include "traccc/utils/detector_type_utils.hpp"
 #include "traccc/utils/projections.hpp"
 
 // detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 
@@ -488,14 +488,9 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 }
 
 // Explicit template instantiation
-using default_detector_type = traccc::default_detector::device;
-using default_stepper_type = detray::rk_stepper<
-    covfie::field<detray::bfield::const_bknd_t<
-        default_detector_type::scalar_type>>::view_t,
-    default_detector_type::algebra_type,
-    detray::constrained_step<default_detector_type::scalar_type>>;
-using default_navigator_type = detray::navigator<const default_detector_type>;
-template class finding_algorithm<default_stepper_type, default_navigator_type>;
+template class finding_algorithm<
+    ::traccc::stepper_for_t<::traccc::default_detector::device>,
+    ::traccc::navigator_for_t<::traccc::default_detector::device>>;
 
 }  // namespace traccc::alpaka
 

--- a/device/alpaka/src/fitting/fitting_algorithm.cpp
+++ b/device/alpaka/src/fitting/fitting_algorithm.cpp
@@ -13,9 +13,10 @@
 #include "traccc/fitting/device/fit.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 #include "traccc/geometry/detector.hpp"
+#include "traccc/utils/bfield.hpp"
+#include "traccc/utils/detector_type_utils.hpp"
 
 // detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 
 // Thrust include(s).
@@ -167,15 +168,6 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
 }
 
 // Explicit template instantiation
-using default_detector_type = traccc::default_detector::device;
-using default_stepper_type = detray::rk_stepper<
-    covfie::field<detray::bfield::const_bknd_t<
-        default_detector_type::scalar_type>>::view_t,
-    default_detector_type::algebra_type,
-    detray::constrained_step<default_detector_type::scalar_type>>;
-using default_navigator_type = detray::navigator<const default_detector_type>;
-using default_fitter_type =
-    kalman_fitter<default_stepper_type, default_navigator_type>;
-template class fitting_algorithm<default_fitter_type>;
-
+template class fitting_algorithm<
+    fitter_for_t<traccc::default_detector::device>>;
 }  // namespace traccc::alpaka

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -24,10 +24,10 @@
 #include "traccc/edm/device/sort_key.hpp"
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/geometry/detector.hpp"
+#include "traccc/utils/detector_type_utils.hpp"
 #include "traccc/utils/projections.hpp"
 
 // detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 
@@ -462,13 +462,7 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 }
 
 // Explicit template instantiation
-using default_detector_type = traccc::default_detector::device;
-using default_stepper_type = detray::rk_stepper<
-    covfie::field<detray::bfield::const_bknd_t<
-        default_detector_type::scalar_type>>::view_t,
-    default_detector_type::algebra_type,
-    detray::constrained_step<default_detector_type::scalar_type>>;
-using default_navigator_type = detray::navigator<const default_detector_type>;
-template class finding_algorithm<default_stepper_type, default_navigator_type>;
-
+template class finding_algorithm<
+    stepper_for_t<::traccc::default_detector::device>,
+    navigator_for_t<::traccc::default_detector::device>>;
 }  // namespace traccc::cuda

--- a/device/cuda/src/finding/kernels/specializations/types.hpp
+++ b/device/cuda/src/finding/kernels/specializations/types.hpp
@@ -12,24 +12,16 @@
 #include "traccc/finding/actors/ckf_aborter.hpp"
 #include "traccc/finding/actors/interaction_register.hpp"
 #include "traccc/geometry/detector.hpp"
+#include "traccc/utils/detector_type_utils.hpp"
 
 // Detray include(s)
-#include <detray/detectors/bfield.hpp>
 #include <detray/propagator/actors.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 
 namespace traccc::cuda::kernels {
-
-using default_detector_type = traccc::default_detector::device;
-using default_stepper_type = detray::rk_stepper<
-    covfie::field<detray::bfield::const_bknd_t<
-        default_detector_type::scalar_type>>::view_t,
-    default_detector_type::algebra_type,
-    detray::constrained_step<default_detector_type::scalar_type>>;
-using default_navigator_type = detray::navigator<const default_detector_type>;
-
 using default_finding_algorithm =
-    finding_algorithm<default_stepper_type, default_navigator_type>;
+    finding_algorithm<stepper_for_t<traccc::default_detector::device>,
+                      navigator_for_t<traccc::default_detector::device>>;
 
 }  // namespace traccc::cuda::kernels

--- a/device/cuda/src/fitting/fitting_algorithm.cu
+++ b/device/cuda/src/fitting/fitting_algorithm.cu
@@ -14,9 +14,9 @@
 #include "traccc/fitting/device/fit.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 #include "traccc/geometry/detector.hpp"
+#include "traccc/utils/detector_type_utils.hpp"
 
 // detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/propagator/rk_stepper.hpp>
 
 // Thrust include(s).
@@ -142,15 +142,6 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
 }
 
 // Explicit template instantiation
-using default_detector_type = traccc::default_detector::device;
-using default_stepper_type = detray::rk_stepper<
-    covfie::field<detray::bfield::const_bknd_t<
-        default_detector_type::scalar_type>>::view_t,
-    default_detector_type::algebra_type,
-    detray::constrained_step<default_detector_type::scalar_type>>;
-using default_navigator_type = detray::navigator<const default_detector_type>;
-using default_fitter_type =
-    kalman_fitter<default_stepper_type, default_navigator_type>;
-template class fitting_algorithm<default_fitter_type>;
-
+template class fitting_algorithm<
+    fitter_for_t<traccc::default_detector::device>>;
 }  // namespace traccc::cuda

--- a/device/sycl/include/traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -17,11 +17,10 @@
 #include "traccc/finding/finding_config.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/bfield.hpp"
+#include "traccc/utils/detector_type_utils.hpp"
 #include "traccc/utils/memory_resource.hpp"
 #include "traccc/utils/messaging.hpp"
-
-// Detray include(s).
-#include <detray/detectors/bfield.hpp>
 
 // VecMem include(s).
 #include <vecmem/utils/copy.hpp>
@@ -35,14 +34,14 @@ namespace traccc::sycl {
 class combinatorial_kalman_filter_algorithm
     : public algorithm<track_candidate_container_types::buffer(
           const default_detector::view&,
-          const detray::bfield::const_field_t<
-              default_detector::device::scalar_type>::view_t&,
+          const covfie::field<traccc::const_bfield_backend_t<
+              default_detector::device::scalar_type>>::view_t&,
           const measurement_collection_types::const_view&,
           const bound_track_parameters_collection_types::const_view&)>,
       public algorithm<track_candidate_container_types::buffer(
           const telescope_detector::view&,
-          const detray::bfield::const_field_t<
-              telescope_detector::device::scalar_type>::view_t&,
+          const covfie::field<traccc::const_bfield_backend_t<
+              default_detector::device::scalar_type>>::view_t&,
           const measurement_collection_types::const_view&,
           const bound_track_parameters_collection_types::const_view&)>,
       public messaging {
@@ -71,8 +70,8 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const default_detector::view& det,
-        const detray::bfield::const_field_t<
-            default_detector::device::scalar_type>::view_t& field,
+        const covfie::field<const_bfield_backend_t<
+            telescope_detector::device::scalar_type>>::view_t& field,
         const measurement_collection_types::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;
@@ -89,8 +88,8 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const telescope_detector::view& det,
-        const detray::bfield::const_field_t<
-            telescope_detector::device::scalar_type>::view_t& field,
+        const covfie::field<const_bfield_backend_t<
+            telescope_detector::device::scalar_type>>::view_t& field,
         const measurement_collection_types::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;

--- a/device/sycl/include/traccc/sycl/fitting/kalman_fitting_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/fitting/kalman_fitting_algorithm.hpp
@@ -16,11 +16,9 @@
 #include "traccc/fitting/fitting_config.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/memory_resource.hpp"
 #include "traccc/utils/messaging.hpp"
-
-// Detray include(s).
-#include <detray/detectors/bfield.hpp>
 
 // VecMem include(s).
 #include <vecmem/utils/copy.hpp>
@@ -34,13 +32,13 @@ namespace traccc::sycl {
 class kalman_fitting_algorithm
     : public algorithm<track_state_container_types::buffer(
           const default_detector::view&,
-          const detray::bfield::const_field_t<
-              default_detector::device::scalar_type>::view_t&,
+          const covfie::field<const_bfield_backend_t<
+              default_detector::device::scalar_type>>::view_t&,
           const track_candidate_container_types::const_view&)>,
       public algorithm<track_state_container_types::buffer(
           const telescope_detector::view&,
-          const detray::bfield::const_field_t<
-              telescope_detector::device::scalar_type>::view_t&,
+          const covfie::field<const_bfield_backend_t<
+              telescope_detector::device::scalar_type>>::view_t&,
           const track_candidate_container_types::const_view&)>,
       public messaging {
 
@@ -69,8 +67,8 @@ class kalman_fitting_algorithm
     ///
     output_type operator()(
         const default_detector::view& det,
-        const detray::bfield::const_field_t<
-            default_detector::device::scalar_type>::view_t& field,
+        const covfie::field<traccc::const_bfield_backend_t<
+            default_detector::device::scalar_type>>::view_t& field,
         const track_candidate_container_types::const_view& track_candidates)
         const override;
 
@@ -84,8 +82,8 @@ class kalman_fitting_algorithm
     ///
     output_type operator()(
         const telescope_detector::view& det,
-        const detray::bfield::const_field_t<
-            telescope_detector::device::scalar_type>::view_t& field,
+        const covfie::field<traccc::const_bfield_backend_t<
+            telescope_detector::device::scalar_type>>::view_t& field,
         const track_candidate_container_types::const_view& track_candidates)
         const override;
 

--- a/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.sycl
+++ b/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.sycl
@@ -9,9 +9,9 @@
 #include "../utils/get_queue.hpp"
 #include "find_tracks.hpp"
 #include "traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
@@ -24,8 +24,8 @@ struct ckf_constant_field_default_detector;
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
     const default_detector::view& det,
-    const detray::bfield::const_field_t<
-        default_detector::device::scalar_type>::view_t& field,
+    const covfie::field<traccc::const_bfield_backend_t<
+        default_detector::device::scalar_type>>::view_t& field,
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
@@ -33,9 +33,10 @@ combinatorial_kalman_filter_algorithm::operator()(
 
     // Perform the track finding using the templated implementation.
     return details::find_tracks<
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
-                           default_detector::device::algebra_type,
-                           detray::constrained_step<scalar_type>>,
+        detray::rk_stepper<
+            covfie::field<traccc::const_bfield_backend_t<scalar_type>>::view_t,
+            default_detector::device::algebra_type,
+            detray::constrained_step<scalar_type>>,
         detray::navigator<const default_detector::device>,
         kernels::ckf_constant_field_default_detector>(
         det, field, measurements, seeds, m_config, m_mr, m_copy,

--- a/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.sycl
+++ b/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.sycl
@@ -9,9 +9,9 @@
 #include "../utils/get_queue.hpp"
 #include "find_tracks.hpp"
 #include "traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
@@ -24,8 +24,8 @@ struct ckf_constant_field_telescope_detector;
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
     const telescope_detector::view& det,
-    const detray::bfield::const_field_t<
-        telescope_detector::device::scalar_type>::view_t& field,
+    const covfie::field<traccc::const_bfield_backend_t<
+        telescope_detector::device::scalar_type>>::view_t& field,
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
@@ -33,9 +33,10 @@ combinatorial_kalman_filter_algorithm::operator()(
 
     // Perform the track finding using the templated implementation.
     return details::find_tracks<
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
-                           telescope_detector::device::algebra_type,
-                           detray::constrained_step<scalar_type>>,
+        detray::rk_stepper<
+            covfie::field<traccc::const_bfield_backend_t<scalar_type>>::view_t,
+            telescope_detector::device::algebra_type,
+            detray::constrained_step<scalar_type>>,
         detray::navigator<const telescope_detector::device>,
         kernels::ckf_constant_field_telescope_detector>(
         det, field, measurements, seeds, m_config, m_mr, m_copy,

--- a/device/sycl/src/fitting/kalman_fitting_algorithm_constant_field_default_detector.sycl
+++ b/device/sycl/src/fitting/kalman_fitting_algorithm_constant_field_default_detector.sycl
@@ -27,15 +27,18 @@ struct fit_tracks_constant_field_default_detector;
 
 kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
     const default_detector::view& det,
-    const detray::bfield::const_field_t<
-        default_detector::device::scalar_type>::view_t& field,
+    const covfie::field<traccc::const_bfield_backend_t<
+        default_detector::device::scalar_type>>::view_t& field,
     const track_candidate_container_types::const_view& track_candidates) const {
 
     using scalar_type = default_detector::device::scalar_type;
 
+    using bfield_type =
+        covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
+
     // Construct the fitter type.
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
+        detray::rk_stepper<bfield_type::view_t,
                            default_detector::device::algebra_type,
                            detray::constrained_step<scalar_type>>;
     using navigator_type = detray::navigator<const default_detector::device>;

--- a/device/sycl/src/fitting/kalman_fitting_algorithm_constant_field_telescope_detector.sycl
+++ b/device/sycl/src/fitting/kalman_fitting_algorithm_constant_field_telescope_detector.sycl
@@ -27,15 +27,18 @@ struct fit_tracks_constant_field_telescope_detector;
 
 kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
     const telescope_detector::view& det,
-    const detray::bfield::const_field_t<
-        telescope_detector::device::scalar_type>::view_t& field,
+    const covfie::field<traccc::const_bfield_backend_t<
+        telescope_detector::device::scalar_type>>::view_t& field,
     const track_candidate_container_types::const_view& track_candidates) const {
 
     using scalar_type = telescope_detector::device::scalar_type;
 
+    using bfield_type =
+        covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
+
     // Construct the fitter type.
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
+        detray::rk_stepper<bfield_type::view_t,
                            telescope_detector::device::algebra_type,
                            detray::constrained_step<scalar_type>>;
     using navigator_type = detray::navigator<const telescope_detector::device>;

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -38,9 +38,8 @@ full_chain_algorithm::full_chain_algorithm(
       m_cached_device_mr(
           std::make_unique<::vecmem::binary_page_memory_resource>(m_device_mr)),
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
-      m_field(
-          detray::bfield::create_const_field<host_detector_type::scalar_type>(
-              m_field_vec)),
+      m_field(traccc::construct_const_bfield<host_detector_type::scalar_type>(
+          m_field_vec)),
       m_det_descr(det_descr),
       m_device_det_descr(
           static_cast<silicon_detector_description::buffer::size_type>(

--- a/examples/run/alpaka/full_chain_algorithm.hpp
+++ b/examples/run/alpaka/full_chain_algorithm.hpp
@@ -24,11 +24,11 @@
 #include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/silicon_detector_description.hpp"
 #include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/messaging.hpp"
 
 // Detray include(s).
 #include <detray/core/detector.hpp>
-#include <detray/detectors/bfield.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
@@ -62,9 +62,12 @@ class full_chain_algorithm
 
     using scalar_type = device_detector_type::scalar_type;
 
+    using bfield_type =
+        covfie::field<traccc::const_bfield_backend_t<traccc::scalar>>;
+
     /// Stepper type used by the track finding and fitting algorithms
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
+        detray::rk_stepper<bfield_type::view_t,
                            device_detector_type::algebra_type,
                            detray::constrained_step<scalar_type>>;
     /// Navigator type used by the track finding and fitting algorithms
@@ -141,7 +144,7 @@ class full_chain_algorithm
     /// Constant B field for the (seed) track parameter estimation
     traccc::vector3 m_field_vec;
     /// Constant B field for the track finding and fitting
-    detray::bfield::const_field_t<traccc::scalar> m_field;
+    bfield_type m_field;
 
     /// Detector description
     std::reference_wrapper<const silicon_detector_description::host>

--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -45,7 +45,6 @@
 
 // Detray include(s).
 #include <cmath>
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
@@ -76,7 +75,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     /// Type declarations
     using scalar_t = traccc::default_detector::host::scalar_type;
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_t>>;
+    using b_field_t = covfie::field<traccc::const_bfield_backend_t<scalar_t>>;
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t,
                            traccc::default_detector::host::algebra_type,
@@ -137,7 +136,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * traccc::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
+    auto field = traccc::construct_const_bfield<traccc::scalar>(B);
 
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host host_det{mng_mr};

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -44,7 +44,6 @@
 #include "traccc/seeding/track_params_estimation.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
@@ -131,8 +130,12 @@ int seq_run(const traccc::opts::detector& detector_opts,
     using device_spacepoint_formation_algorithm =
         traccc::alpaka::spacepoint_formation_algorithm<
             traccc::default_detector::device>;
+
+    using bfield_type =
+        covfie::field<traccc::const_bfield_backend_t<traccc::scalar>>;
+
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
+        detray::rk_stepper<bfield_type::view_t,
                            traccc::default_detector::host::algebra_type,
                            detray::constrained_step<scalar_type>>;
     using device_navigator_type =
@@ -159,8 +162,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
     // Constant B field for the track finding and fitting
     const traccc::vector3 field_vec = {0.f, 0.f,
                                        seeding_opts.seedfinder.bFieldInZ};
-    const detray::bfield::const_field_t<traccc::scalar> field =
-        detray::bfield::create_const_field<traccc::scalar>(field_vec);
+    const covfie::field<traccc::const_bfield_backend_t<traccc::scalar>> field =
+        traccc::construct_const_bfield<traccc::scalar>(field_vec);
 
     traccc::host::clusterization_algorithm ca(
         host_mr, logger().clone("HostClusteringAlg"));

--- a/examples/run/cpu/full_chain_algorithm.cpp
+++ b/examples/run/cpu/full_chain_algorithm.cpp
@@ -21,8 +21,9 @@ full_chain_algorithm::full_chain_algorithm(
     detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
     : messaging(logger->clone()),
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
-      m_field(detray::bfield::create_const_field<
-              typename detector_type::scalar_type>(m_field_vec)),
+      m_field(
+          traccc::construct_const_bfield<typename detector_type::scalar_type>(
+              m_field_vec)),
       m_det_descr(det_descr),
       m_detector(detector),
       m_clusterization(mr, logger->cloneWithSuffix("ClusteringAlg")),

--- a/examples/run/cpu/full_chain_algorithm.hpp
+++ b/examples/run/cpu/full_chain_algorithm.hpp
@@ -19,11 +19,11 @@
 #include "traccc/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
 #include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/messaging.hpp"
 
 // Detray include(s).
 #include <detray/core/detector.hpp>
-#include <detray/detectors/bfield.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
@@ -63,6 +63,9 @@ class full_chain_algorithm : public algorithm<track_state_container_types::host(
     /// Track fitting algorithm type
     using fitting_algorithm = traccc::host::kalman_fitting_algorithm;
 
+    using bfield_type =
+        covfie::field<traccc::const_bfield_backend_t<traccc::scalar>>;
+
     /// @}
 
     /// Algorithm constructor
@@ -97,7 +100,7 @@ class full_chain_algorithm : public algorithm<track_state_container_types::host(
     /// Constant B field for the (seed) track parameter estimation
     traccc::vector3 m_field_vec;
     /// Constant B field for the track finding and fitting
-    detray::bfield::const_field_t<typename detector_type::scalar_type> m_field;
+    bfield_type m_field;
 
     /// Detector description
     std::reference_wrapper<const silicon_detector_description::host>

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -42,7 +42,6 @@
 
 // Detray include(s).
 #include <detray/core/detector.hpp>
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
@@ -103,7 +102,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * traccc::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
+    const covfie::field<traccc::const_bfield_backend_t<traccc::scalar>> field =
+        traccc::construct_const_bfield<traccc::scalar>(B);
 
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host detector{host_mr};

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -23,6 +23,7 @@
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // performance
 #include "traccc/efficiency/finding_performance_writer.hpp"
@@ -44,7 +45,6 @@
 #include "traccc/options/track_seeding.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
@@ -116,8 +116,8 @@ int seq_run(const traccc::opts::input_data& input_opts,
     // Constant B field for the track finding and fitting
     const traccc::vector3 field_vec = {0.f, 0.f,
                                        seeding_opts.seedfinder.bFieldInZ};
-    const detray::bfield::const_field_t<traccc::scalar> field =
-        detray::bfield::create_const_field<traccc::scalar>(field_vec);
+    const covfie::field<traccc::const_bfield_backend_t<traccc::scalar>> field =
+        traccc::construct_const_bfield<traccc::scalar>(field_vec);
 
     // Algorithm configuration(s).
     detray::propagation::config propagation_config(propagation_opts);

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -29,7 +29,6 @@
 
 // Detray include(s).
 #include <detray/core/detector.hpp>
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
@@ -76,7 +75,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * traccc::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
+    const covfie::field<traccc::const_bfield_backend_t<traccc::scalar>> field =
+        traccc::construct_const_bfield<traccc::scalar>(B);
 
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host detector{host_mr};

--- a/examples/run/cpu/truth_fitting_example.cpp
+++ b/examples/run/cpu/truth_fitting_example.cpp
@@ -23,7 +23,6 @@
 
 // Detray include(s).
 #include <detray/core/detector.hpp>
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
@@ -83,7 +82,8 @@ int main(int argc, char* argv[]) {
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * traccc::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
+    const covfie::field<traccc::const_bfield_backend_t<traccc::scalar>> field =
+        traccc::construct_const_bfield<traccc::scalar>(B);
 
     // Read the detector
     detray::io::detector_reader_config reader_cfg{};

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -45,9 +45,8 @@ full_chain_algorithm::full_chain_algorithm(
           std::make_unique<vecmem::binary_page_memory_resource>(m_device_mr)),
       m_copy(m_stream.cudaStream()),
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
-      m_field(
-          detray::bfield::create_const_field<host_detector_type::scalar_type>(
-              m_field_vec)),
+      m_field(traccc::construct_const_bfield<host_detector_type::scalar_type>(
+          m_field_vec)),
       m_det_descr(det_descr),
       m_device_det_descr(
           static_cast<silicon_detector_description::buffer::size_type>(

--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -23,11 +23,11 @@
 #include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/silicon_detector_description.hpp"
 #include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/detector_type_utils.hpp"
 #include "traccc/utils/messaging.hpp"
 
 // Detray include(s).
 #include <detray/core/detector.hpp>
-#include <detray/detectors/bfield.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
@@ -64,9 +64,12 @@ class full_chain_algorithm
 
     using scalar_type = device_detector_type::scalar_type;
 
+    using bfield_type =
+        covfie::field<traccc::const_bfield_backend_t<traccc::scalar>>;
+
     /// Stepper type used by the track finding and fitting algorithms
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
+        detray::rk_stepper<bfield_type::view_t,
                            device_detector_type::algebra_type,
                            detray::constrained_step<scalar_type>>;
     /// Navigator type used by the track finding and fitting algorithms
@@ -138,7 +141,7 @@ class full_chain_algorithm
     /// Constant B field for the (seed) track parameter estimation
     traccc::vector3 m_field_vec;
     /// Constant B field for the track finding and fitting
-    detray::bfield::const_field_t<traccc::scalar> m_field;
+    bfield_type m_field;
 
     /// Detector description
     std::reference_wrapper<const silicon_detector_description::host>

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -41,9 +41,9 @@
 #include "traccc/resolution/fitting_performance_writer.hpp"
 #include "traccc/seeding/seeding_algorithm.hpp"
 #include "traccc/seeding/track_params_estimation.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
@@ -77,7 +77,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     /// Type declarations
     using scalar_t = traccc::default_detector::host::scalar_type;
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_t>>;
+    using b_field_t = covfie::field<traccc::const_bfield_backend_t<scalar_t>>;
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t,
                            traccc::default_detector::host::algebra_type,
@@ -128,7 +128,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * traccc::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
+    const b_field_t field = traccc::construct_const_bfield<traccc::scalar>(B);
 
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host host_det{mng_mr};

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -44,7 +44,6 @@
 #include "traccc/seeding/track_params_estimation.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
@@ -136,8 +135,10 @@ int seq_run(const traccc::opts::detector& detector_opts,
     using device_spacepoint_formation_algorithm =
         traccc::cuda::spacepoint_formation_algorithm<
             traccc::default_detector::device>;
+    using bfield_type =
+        covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
+        detray::rk_stepper<bfield_type::view_t,
                            traccc::default_detector::host::algebra_type,
                            detray::constrained_step<scalar_type>>;
     using device_navigator_type =
@@ -164,8 +165,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
     // Constant B field for the track finding and fitting
     const traccc::vector3 field_vec = {0.f, 0.f,
                                        seeding_opts.seedfinder.bFieldInZ};
-    const detray::bfield::const_field_t<traccc::scalar> field =
-        detray::bfield::create_const_field<traccc::scalar>(field_vec);
+    const covfie::field<traccc::const_bfield_backend_t<traccc::scalar>> field =
+        traccc::construct_const_bfield<traccc::scalar>(field_vec);
 
     traccc::host::clusterization_algorithm ca(
         host_mr, logger().clone("HostClusteringAlg"));

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -35,10 +35,10 @@
 #include "traccc/performance/container_comparator.hpp"
 #include "traccc/performance/timer.hpp"
 #include "traccc/resolution/fitting_performance_writer.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/seed_generator.hpp"
 
 // detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
@@ -71,7 +71,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
     /// Type declarations
     using scalar_type = traccc::default_detector::device::scalar_type;
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_type>>;
+    using b_field_t =
+        covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t, traccc::default_algebra,
                            detray::constrained_step<scalar_type>>;
@@ -106,7 +107,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * traccc::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
+    const covfie::field<traccc::const_bfield_backend_t<traccc::scalar>> field =
+        traccc::construct_const_bfield<traccc::scalar>(B);
 
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host detector{mng_mr};

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -29,10 +29,10 @@
 #include "traccc/performance/container_comparator.hpp"
 #include "traccc/performance/timer.hpp"
 #include "traccc/resolution/fitting_performance_writer.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/seed_generator.hpp"
 
 // detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
@@ -80,7 +80,8 @@ int main(int argc, char* argv[]) {
     using device_detector_type = traccc::default_detector::device;
 
     using scalar_type = device_detector_type::scalar_type;
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_type>>;
+    using b_field_t =
+        covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t, traccc::default_algebra,
                            detray::constrained_step<scalar_type>>;
@@ -110,7 +111,7 @@ int main(int argc, char* argv[]) {
     // B field value and its type
     // @TODO: Set B field as argument
     const traccc::vector3 B{0, 0, 2 * traccc::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
+    auto field = traccc::construct_const_bfield<traccc::scalar>(B);
 
     // Read the detector
     detray::io::detector_reader_config reader_cfg{};

--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -21,7 +21,6 @@
 #include "traccc/utils/algorithm.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
@@ -61,8 +60,12 @@ class full_chain_algorithm
 
     /// Stepper type used by the track finding and fitting algorithms
     using scalar_type = device_detector_type::scalar_type;
+
+    using bfield_type =
+        covfie::field<traccc::const_bfield_backend_t<traccc::scalar>>;
+
     using stepper_type =
-        detray::rk_stepper<detray::bfield::const_field_t<scalar_type>::view_t,
+        detray::rk_stepper<bfield_type::view_t,
                            device_detector_type::algebra_type,
                            detray::constrained_step<scalar_type>>;
     /// Navigator type used by the track finding and fitting algorithms
@@ -132,7 +135,7 @@ class full_chain_algorithm
     /// Constant B field for the (seed) track parameter estimation
     traccc::vector3 m_field_vec;
     /// Constant B field for the track finding and fitting
-    detray::bfield::const_field_t<scalar_type> m_field;
+    bfield_type m_field;
 
     /// Detector description
     std::reference_wrapper<const silicon_detector_description::host>

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -66,9 +66,8 @@ full_chain_algorithm::full_chain_algorithm(
       m_cached_device_mr{m_device_mr},
       m_copy{&(m_data->m_queue)},
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
-      m_field{
-          detray::bfield::create_const_field<host_detector_type::scalar_type>(
-              m_field_vec)},
+      m_field{traccc::construct_const_bfield<host_detector_type::scalar_type>(
+          m_field_vec)},
       m_det_descr(det_descr),
       m_device_det_descr{
           static_cast<silicon_detector_description::buffer::size_type>(

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -152,10 +152,12 @@ int seq_run(const traccc::opts::detector& detector_opts,
 
     // Constant B field for the track finding and fitting
     using scalar_type = traccc::default_detector::host::scalar_type;
+    using bfield_type =
+        covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
     const traccc::vector3 field_vec = {0.f, 0.f,
                                        seeding_opts.seedfinder.bFieldInZ};
-    const detray::bfield::const_field_t<scalar_type> field =
-        detray::bfield::create_const_field<scalar_type>(field_vec);
+    const bfield_type field =
+        traccc::construct_const_bfield<scalar_type>(field_vec);
 
     // Algorithm configuration(s).
     detray::propagation::config propagation_config(propagation_opts);

--- a/examples/simulation/simulate.cpp
+++ b/examples/simulation/simulate.cpp
@@ -18,9 +18,9 @@
 #include "traccc/simulation/measurement_smearer.hpp"
 #include "traccc/simulation/simulator.hpp"
 #include "traccc/simulation/smearing_writer.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_reader.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
@@ -65,9 +65,9 @@ int main(int argc, char* argv[]) {
     // B field value and its type
     // @TODO: Set B field as argument
     using b_field_t =
-        covfie::field<detray::bfield::const_bknd_t<traccc::scalar>>;
+        covfie::field<traccc::const_bfield_backend_t<traccc::scalar>>;
     const traccc::vector3 B{0, 0, 2 * traccc::unit<traccc::scalar>::T};
-    auto field = detray::bfield::create_const_field<traccc::scalar>(B);
+    const b_field_t field = traccc::construct_const_bfield<traccc::scalar>(B);
 
     // Read the detector
     detray::io::detector_reader_config reader_cfg{};

--- a/examples/simulation/simulate_telescope.cpp
+++ b/examples/simulation/simulate_telescope.cpp
@@ -17,9 +17,9 @@
 #include "traccc/simulation/measurement_smearer.hpp"
 #include "traccc/simulation/simulator.hpp"
 #include "traccc/simulation/smearing_writer.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/geometry/mask.hpp>
 #include <detray/geometry/shapes/rectangle2D.hpp>
 #include <detray/io/frontend/detector_writer.hpp>
@@ -69,9 +69,9 @@ int simulate(const traccc::opts::generation& generation_opts,
     }
 
     // B field value and its type
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar>>;
+    using b_field_t = covfie::field<traccc::const_bfield_backend_t<scalar>>;
     const vector3 B{0, 0, 2 * traccc::unit<scalar>::T};
-    auto field = detray::bfield::create_const_field<scalar>(B);
+    b_field_t field = traccc::construct_const_bfield<scalar>(B);
 
     // Set material and thickness
     detray::material<scalar> mat;

--- a/examples/simulation/simulate_toy_detector.cpp
+++ b/examples/simulation/simulate_toy_detector.cpp
@@ -17,9 +17,9 @@
 #include "traccc/simulation/measurement_smearer.hpp"
 #include "traccc/simulation/simulator.hpp"
 #include "traccc/simulation/smearing_writer.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_writer.hpp>
 #include <detray/test/utils/detectors/build_toy_detector.hpp>
 #include <detray/test/utils/simulation/event_generator/track_generators.hpp>
@@ -53,9 +53,9 @@ int simulate(const traccc::opts::generation& generation_opts,
 
     // B field value and its type
     // @TODO: Set B field as argument
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar>>;
+    using b_field_t = covfie::field<traccc::const_bfield_backend_t<scalar>>;
     const vector3 B{0, 0, 2 * traccc::unit<scalar>::T};
-    auto field = detray::bfield::create_const_field<scalar>(B);
+    b_field_t field = traccc::construct_const_bfield<scalar>(B);
 
     // Create the toy geometry
     detray::toy_det_config<scalar> toy_cfg{};

--- a/examples/simulation/simulate_wire_chamber.cpp
+++ b/examples/simulation/simulate_wire_chamber.cpp
@@ -17,9 +17,9 @@
 #include "traccc/simulation/measurement_smearer.hpp"
 #include "traccc/simulation/simulator.hpp"
 #include "traccc/simulation/smearing_writer.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_writer.hpp>
 #include <detray/test/utils/detectors/build_wire_chamber.hpp>
 #include <detray/test/utils/simulation/event_generator/track_generators.hpp>
@@ -53,9 +53,9 @@ int simulate(const traccc::opts::generation& generation_opts,
 
     // B field value and its type
     // @TODO: Set B field as argument
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar>>;
+    using b_field_t = covfie::field<traccc::const_bfield_backend_t<scalar>>;
     const vector3 B{0, 0, 2 * traccc::unit<scalar>::T};
-    auto field = detray::bfield::create_const_field<scalar>(B);
+    const b_field_t field = traccc::construct_const_bfield<traccc::scalar>(B);
 
     // Set Configuration
     detray::wire_chamber_config<scalar> wire_chamber_cfg{};

--- a/extern/covfie/CMakeLists.txt
+++ b/extern/covfie/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Fetching covfie as part of the traccc project" )
 
 # Declare where to get covfie from.
 set( TRACCC_COVFIE_SOURCE
-   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.12.1.tar.gz;URL_MD5;1512b389d8d7d08ef3bd30d6b18dcee1"
+   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.13.0.tar.gz;URL_MD5;9dbff64d68a9d8c88acff12e8f99584a"
    CACHE STRING "Source for covfie, when built as part of this project" )
 mark_as_advanced( TRACCC_COVFIE_SOURCE )
 FetchContent_Declare( covfie SYSTEM ${TRACCC_COVFIE_SOURCE} )
@@ -25,6 +25,7 @@ set( COVFIE_BUILD_BENCHMARKS OFF CACHE BOOL "Build covfie benchmarks")
 
 set( COVFIE_PLATFORM_CPU ON CACHE BOOL "Enable covfie CPU platform")
 set( COVFIE_PLATFORM_CUDA ${TRACCC_BUILD_CUDA} CACHE BOOL "Enable covfie CUDA platform")
+set( COVFIE_PLATFORM_SYCL ${TRACCC_BUILD_SYCL} CACHE BOOL "Enable covfie SYCL platform")
 
 set( COVFIE_QUIET ON CACHE BOOL "Quiet covfie feature warnings")
 

--- a/tests/common/tests/kalman_fitting_test.hpp
+++ b/tests/common/tests/kalman_fitting_test.hpp
@@ -11,10 +11,10 @@
 #include "traccc/definitions/common.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 #include "traccc/geometry/detector.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // detray include(s).
 #include <detray/definitions/pdg_particle.hpp>
-#include <detray/detectors/bfield.hpp>
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/propagator.hpp>
 #include <detray/propagator/rk_stepper.hpp>
@@ -37,7 +37,8 @@ class KalmanFittingTests : public testing::Test {
     using device_detector_type = traccc::default_detector::device;
 
     using scalar_type = device_detector_type::scalar_type;
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar_type>>;
+    using b_field_t =
+        covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t, traccc::default_algebra,
                            detray::constrained_step<scalar_type>>;

--- a/tests/common/tests/kalman_fitting_toy_detector_test.hpp
+++ b/tests/common/tests/kalman_fitting_toy_detector_test.hpp
@@ -11,7 +11,6 @@
 #include "kalman_fitting_test.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_writer.hpp>
 #include <detray/test/utils/detectors/build_toy_detector.hpp>
 

--- a/tests/common/tests/kalman_fitting_wire_chamber_test.hpp
+++ b/tests/common/tests/kalman_fitting_wire_chamber_test.hpp
@@ -11,7 +11,6 @@
 #include "kalman_fitting_test.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/io/frontend/detector_writer.hpp>
 #include <detray/test/utils/detectors/build_wire_chamber.hpp>
 

--- a/tests/cpu/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cpu/test_ckf_combinatorics_telescope.cpp
@@ -11,6 +11,7 @@
 #include "traccc/io/utils.hpp"
 #include "traccc/resolution/fitting_performance_writer.hpp"
 #include "traccc/simulation/simulator.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/ranges.hpp"
 
 // Test include(s).
@@ -64,8 +65,8 @@ TEST_P(CpuCkfCombinatoricsTelescopeTests, Run) {
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
 
-    auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+    const covfie::field<traccc::const_bfield_backend_t<traccc::scalar>> field =
+        traccc::construct_const_bfield<traccc::scalar>(
             std::get<13>(GetParam()));
 
     /***************************

--- a/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
@@ -75,7 +75,7 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
 
     auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+        traccc::construct_const_bfield<host_detector_type::scalar_type>(
             std::get<13>(GetParam()));
 
     /***************************

--- a/tests/cpu/test_kalman_fitter_hole_count.cpp
+++ b/tests/cpu/test_kalman_fitter_hole_count.cpp
@@ -73,7 +73,7 @@ TEST_P(KalmanFittingHoleCountTests, Run) {
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
     auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+        traccc::construct_const_bfield<host_detector_type::scalar_type>(
             std::get<13>(GetParam()));
 
     /***************************

--- a/tests/cpu/test_kalman_fitter_momentum_resolution.cpp
+++ b/tests/cpu/test_kalman_fitter_momentum_resolution.cpp
@@ -83,7 +83,7 @@ TEST_P(KalmanFittingMomentumResolutionTests, Run) {
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
     auto field =
-        detray::bfield::create_const_field<scalar>(std::get<13>(GetParam()));
+        traccc::construct_const_bfield<scalar>(std::get<13>(GetParam()));
 
     const auto vol0 = detray::tracking_volume{host_det, 0u};
 

--- a/tests/cpu/test_kalman_fitter_telescope.cpp
+++ b/tests/cpu/test_kalman_fitter_telescope.cpp
@@ -72,7 +72,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
     auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+        traccc::construct_const_bfield<host_detector_type::scalar_type>(
             std::get<13>(GetParam()));
 
     /***************************

--- a/tests/cpu/test_kalman_fitter_wire_chamber.cpp
+++ b/tests/cpu/test_kalman_fitter_wire_chamber.cpp
@@ -68,8 +68,8 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
 
     const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(host_mr, reader_cfg);
-    auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(B);
+    const covfie::field<traccc::const_bfield_backend_t<traccc::scalar>> field =
+        traccc::construct_const_bfield<traccc::scalar>(B);
 
     /***************************
      * Generate simulation data

--- a/tests/cpu/test_simulation.cpp
+++ b/tests/cpu/test_simulation.cpp
@@ -12,9 +12,9 @@
 #include "traccc/io/csv/make_measurement_reader.hpp"
 #include "traccc/io/csv/make_particle_reader.hpp"
 #include "traccc/simulation/simulator.hpp"
+#include "traccc/utils/bfield.hpp"
 
 // Detray include(s).
-#include <detray/detectors/bfield.hpp>
 #include <detray/geometry/mask.hpp>
 #include <detray/geometry/shapes/line.hpp>
 #include <detray/geometry/shapes/rectangle2D.hpp>
@@ -70,9 +70,9 @@ GTEST_TEST(traccc_simulation, toy_detector_simulation) {
     vecmem::host_memory_resource host_mr;
 
     // Create B field
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar>>;
+    using b_field_t = covfie::field<traccc::const_bfield_backend_t<scalar>>;
     const vector3 B{0.f, 0.f, 2.f * traccc::unit<scalar>::T};
-    auto field = detray::bfield::create_const_field<scalar>(B);
+    b_field_t field = traccc::construct_const_bfield<scalar>(B);
 
     // Create geometry
     detray::toy_det_config<scalar> toy_cfg{};
@@ -224,9 +224,9 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
     std::filesystem::create_directory(directory);
 
     // Field
-    using b_field_t = covfie::field<detray::bfield::const_bknd_t<scalar>>;
+    using b_field_t = covfie::field<traccc::const_bfield_backend_t<scalar>>;
     const vector3 B{0.f, 0.f, 2.f * traccc::unit<scalar>::T};
-    auto field = detray::bfield::create_const_field<scalar>(B);
+    b_field_t field = traccc::construct_const_bfield<scalar>(B);
 
     // Momentum
     const scalar mom = std::get<1>(GetParam());

--- a/tests/cuda/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cuda/test_ckf_combinatorics_telescope.cpp
@@ -12,6 +12,7 @@
 #include "traccc/io/read_measurements.hpp"
 #include "traccc/io/utils.hpp"
 #include "traccc/simulation/simulator.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/event_data.hpp"
 #include "traccc/utils/ranges.hpp"
 
@@ -74,7 +75,7 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
 
     auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+        traccc::construct_const_bfield<host_detector_type::scalar_type>(
             std::get<13>(GetParam()));
 
     // Detector view object

--- a/tests/cuda/test_ckf_toy_detector.cpp
+++ b/tests/cuda/test_ckf_toy_detector.cpp
@@ -14,6 +14,7 @@
 #include "traccc/io/utils.hpp"
 #include "traccc/performance/container_comparator.hpp"
 #include "traccc/simulation/simulator.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/event_data.hpp"
 #include "traccc/utils/ranges.hpp"
 #include "traccc/utils/seed_generator.hpp"
@@ -71,7 +72,7 @@ TEST_P(CkfToyDetectorTests, Run) {
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
 
     auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(B);
+        traccc::construct_const_bfield<host_detector_type::scalar_type>(B);
 
     // Detector view object
     auto det_view = detray::get_data(host_det);

--- a/tests/cuda/test_kalman_fitter_telescope.cpp
+++ b/tests/cuda/test_kalman_fitter_telescope.cpp
@@ -14,6 +14,7 @@
 #include "traccc/performance/details/is_same_object.hpp"
 #include "traccc/resolution/fitting_performance_writer.hpp"
 #include "traccc/simulation/simulator.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/memory_resource.hpp"
 #include "traccc/utils/ranges.hpp"
 #include "traccc/utils/seed_generator.hpp"
@@ -84,7 +85,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     auto det_view = detray::get_data(host_det);
 
     auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+        traccc::construct_const_bfield<host_detector_type::scalar_type>(
             std::get<13>(GetParam()));
 
     /***************************

--- a/tests/sycl/test_ckf_combinatorics_telescope.cpp
+++ b/tests/sycl/test_ckf_combinatorics_telescope.cpp
@@ -84,7 +84,7 @@ TEST_P(CkfCombinatoricsTelescopeTests, Run) {
         (path / "telescope_detector_homogeneous_material.json").native(), "");
 
     auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(
+        traccc::construct_const_bfield<host_detector_type::scalar_type>(
             std::get<13>(GetParam()));
 
     // Detector view object

--- a/tests/sycl/test_ckf_toy_detector.cpp
+++ b/tests/sycl/test_ckf_toy_detector.cpp
@@ -20,6 +20,7 @@
 #include "traccc/performance/container_comparator.hpp"
 #include "traccc/simulation/simulator.hpp"
 #include "traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp"
+#include "traccc/utils/bfield.hpp"
 #include "traccc/utils/event_data.hpp"
 #include "traccc/utils/ranges.hpp"
 
@@ -80,7 +81,7 @@ TEST_P(CkfToyDetectorTests, Run) {
         (path / "toy_detector_surface_grids.json").native());
 
     auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(B);
+        traccc::construct_const_bfield<host_detector_type::scalar_type>(B);
 
     // Detector view object
     auto det_view = detray::get_data(host_det);

--- a/tests/sycl/test_kalman_fitter_telescope.sycl
+++ b/tests/sycl/test_kalman_fitter_telescope.sycl
@@ -106,7 +106,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     // Detector view object
     auto det_view = detray::get_data(host_det);
     auto field =
-        detray::bfield::create_const_field<host_detector_type::scalar_type>(B);
+        traccc::construct_const_bfield<host_detector_type::scalar_type>(B);
 
     /***************************
      * Generate simulation data


### PR DESCRIPTION
The primary purpose of this PR is to replace all uses of `detray::bfield` with traccc's internal magnetic field type definitions, in order to facilitate the switch to supporting heterogeneous magnetic fields in addition to constant ones. Along the way, this commit also changes some other detector typedefs to make them more consistent, more concise, and more readable.