### PR TITLE
fix: IO sorting

### DIFF
--- a/io/include/traccc/io/read_measurements.hpp
+++ b/io/include/traccc/io/read_measurements.hpp
@@ -17,6 +17,7 @@
 // System include(s).
 #include <cstddef>
 #include <string_view>
+#include <vector>
 
 namespace traccc::io {
 
@@ -31,10 +32,11 @@ namespace traccc::io {
 /// @param[in]  detector  detray detector
 /// @param[in]  format    The format of the measurement data files (to read)
 ///
-void read_measurements(measurement_collection_types::host& measurements,
-                       std::size_t event, std::string_view directory,
-                       const traccc::default_detector::host* detector = nullptr,
-                       data_format format = data_format::csv);
+std::vector<std::size_t> read_measurements(
+    measurement_collection_types::host& measurements, std::size_t event,
+    std::string_view directory,
+    const traccc::default_detector::host* detector = nullptr,
+    const bool sort_measurements = true, data_format format = data_format::csv);
 
 /// Read measurement data into memory
 ///
@@ -45,9 +47,9 @@ void read_measurements(measurement_collection_types::host& measurements,
 /// @param[in]  detector  detray detector
 /// @param[in]  format   The format of the measurement data files (to read)
 ///
-void read_measurements(measurement_collection_types::host& measurements,
-                       std::string_view filename,
-                       const traccc::default_detector::host* detector = nullptr,
-                       data_format format = data_format::csv);
+std::vector<std::size_t> read_measurements(
+    measurement_collection_types::host& measurements, std::string_view filename,
+    const traccc::default_detector::host* detector = nullptr,
+    const bool sort_measurements = true, data_format format = data_format::csv);
 
 }  // namespace traccc::io

--- a/io/src/csv/read_measurements.hpp
+++ b/io/src/csv/read_measurements.hpp
@@ -13,6 +13,7 @@
 
 // System include(s).
 #include <string_view>
+#include <vector>
 
 namespace traccc::io::csv {
 
@@ -23,9 +24,9 @@ namespace traccc::io::csv {
 /// @param[in]  detector  detray detector
 /// @param[in]  do_sort      Whether to sort the measurements or not
 ///
-void read_measurements(measurement_collection_types::host& measurements,
-                       std::string_view filename,
-                       const traccc::default_detector::host* detector = nullptr,
-                       const bool do_sort = true);
+std::vector<std::size_t> read_measurements(
+    measurement_collection_types::host& measurements, std::string_view filename,
+    const traccc::default_detector::host* detector = nullptr,
+    const bool do_sort = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_particles.hpp
+++ b/io/src/csv/read_particles.hpp
@@ -37,6 +37,7 @@ void read_particles(particle_container_types::host& particles,
                     std::string_view particles_file, std::string_view hits_file,
                     std::string_view measurements_file,
                     std::string_view hit_map_file,
-                    const traccc::default_detector::host* detector);
+                    const traccc::default_detector::host* detector,
+                    const bool sort_measurements = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_spacepoints.hpp
+++ b/io/src/csv/read_spacepoints.hpp
@@ -32,6 +32,7 @@ void read_spacepoints(edm::spacepoint_collection::host& spacepoints,
                       std::string_view hit_filename,
                       std::string_view meas_filename,
                       std::string_view meas_hit_map_filename,
-                      const traccc::default_detector::host* detector = nullptr);
+                      const traccc::default_detector::host* detector = nullptr,
+                      const bool sort_measurements = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/read_measurements.cpp
+++ b/io/src/read_measurements.cpp
@@ -17,21 +17,20 @@
 
 namespace traccc::io {
 
-void read_measurements(measurement_collection_types::host& measurements,
-                       std::size_t event, std::string_view directory,
-                       const traccc::default_detector::host* detector,
-                       data_format format) {
+std::vector<std::size_t> read_measurements(
+    measurement_collection_types::host& measurements, std::size_t event,
+    std::string_view directory, const traccc::default_detector::host* detector,
+    const bool sort_measurements, data_format format) {
 
     switch (format) {
         case data_format::csv: {
-            read_measurements(
+            return read_measurements(
                 measurements,
                 get_absolute_path((std::filesystem::path(directory) /
                                    std::filesystem::path(get_event_filename(
                                        event, "-measurements.csv")))
                                       .native()),
-                detector, format);
-            break;
+                detector, sort_measurements, format);
         }
         case data_format::binary: {
 
@@ -41,19 +40,18 @@ void read_measurements(measurement_collection_types::host& measurements,
                                    std::filesystem::path(get_event_filename(
                                        event, "-measurements.dat")))
                                       .native()));
-            break;
+            return {};
         }
         default:
             throw std::invalid_argument("Unsupported data format");
     }
 }
 
-void read_measurements(measurement_collection_types::host& measurements,
-                       std::string_view filename,
-                       const traccc::default_detector::host* detector,
-                       data_format format) {
+std::vector<std::size_t> read_measurements(
+    measurement_collection_types::host& measurements, std::string_view filename,
+    const traccc::default_detector::host* detector,
+    const bool sort_measurements, data_format format) {
 
-    static constexpr bool sort_measurements = true;
     switch (format) {
         case data_format::csv:
             return csv::read_measurements(measurements, filename, detector,


### PR DESCRIPTION
This is a hotfix for the csv io (there are probably better solutions to this), where after sorting the measurement container, the hit to measurement indices are incorrect. This has lead to seeds in the toy detector benchmark that point inwards to the IP.  Now, `read_measurement` keeps track of the measurement ids throughout sorting and returns a vector that maps the initial index to the one after sorting. However, in the current implementation it sorts the collection twice for that.