### PR TITLE
ref: Use track parameter vector directly in seeding

### DIFF
--- a/core/include/traccc/edm/track_parameters.hpp
+++ b/core/include/traccc/edm/track_parameters.hpp
@@ -27,10 +27,13 @@ template <detray::concepts::algebra algebra_t = traccc::default_algebra>
 using bound_track_parameters = detray::bound_track_parameters<algebra_t>;
 
 template <detray::concepts::algebra algebra_t = traccc::default_algebra>
+using bound_parameters_vector = detray::bound_parameters_vector<algebra_t>;
+
+template <detray::concepts::algebra algebra_t = traccc::default_algebra>
 using free_vector = typename free_track_parameters<algebra_t>::vector_type;
 
 template <detray::concepts::algebra algebra_t = traccc::default_algebra>
-using bound_vector = typename bound_track_parameters<algebra_t>::vector_type;
+using bound_vector = typename bound_parameters_vector<algebra_t>::vector_type;
 
 template <detray::concepts::algebra algebra_t = traccc::default_algebra>
 using bound_covariance =

--- a/core/include/traccc/seeding/detail/spacepoint_formation.hpp
+++ b/core/include/traccc/seeding/detail/spacepoint_formation.hpp
@@ -24,11 +24,12 @@ TRACCC_HOST_DEVICE inline bool is_valid_measurement(const measurement& meas);
 /// @param[out] sp          The spacepoint to fill
 /// @param[in]  det         The tracking geometry
 /// @param[in]  measurement The measurement to create the spacepoint out of
+/// @param[in]  gctx        The current geometry context
 ///
 template <typename soa_t, typename detector_t>
-TRACCC_HOST_DEVICE inline void fill_pixel_spacepoint(edm::spacepoint<soa_t>& sp,
-                                                     const detector_t& det,
-                                                     const measurement& meas);
+TRACCC_HOST_DEVICE inline void fill_pixel_spacepoint(
+    edm::spacepoint<soa_t>& sp, const detector_t& det, const measurement& meas,
+    const typename detector_t::geometry_context gctx = {});
 
 }  // namespace traccc::details
 

--- a/core/include/traccc/seeding/impl/spacepoint_formation.ipp
+++ b/core/include/traccc/seeding/impl/spacepoint_formation.ipp
@@ -17,20 +17,17 @@ namespace traccc::details {
 
 TRACCC_HOST_DEVICE inline bool is_valid_measurement(const measurement& meas) {
     // We use 2D (pixel) measurements only for spacepoint creation
-    if (meas.meas_dim == 2u) {
-        return true;
-    }
-    return false;
+    return (meas.meas_dim == 2u);
 }
 
 template <typename soa_t, typename detector_t>
-TRACCC_HOST_DEVICE inline void fill_pixel_spacepoint(edm::spacepoint<soa_t>& sp,
-                                                     const detector_t& det,
-                                                     const measurement& meas) {
+TRACCC_HOST_DEVICE inline void fill_pixel_spacepoint(
+    edm::spacepoint<soa_t>& sp, const detector_t& det, const measurement& meas,
+    const typename detector_t::geometry_context gctx) {
 
     // Get the global position of this silicon pixel measurement.
     const detray::tracking_surface sf{det, meas.surface_link};
-    const auto global = sf.local_to_global({}, meas.local, {});
+    const auto global = sf.local_to_global(gctx, meas.local, {});
 
     // Fill the spacepoint with the global position and the measurement.
     sp.x() = global[0];

--- a/core/src/seeding/track_params_estimation.cpp
+++ b/core/src/seeding/track_params_estimation.cpp
@@ -56,23 +56,14 @@ track_params_estimation::output_type track_params_estimation::operator()(
 
         // Calculate the track parameter vector.
         bound_track_parameters<>& track_params = result[i];
-        track_params.set_vector(
-            seed_to_bound_vector(measurements, spacepoints, seeds[i], bfield));
+        seed_to_bound_param_vector(track_params, measurements, spacepoints,
+                                   seeds[i], bfield);
 
         // Set Covariance
         for (std::size_t j = 0; j < e_bound_size; ++j) {
             getter::element(track_params.covariance(), j, j) =
                 stddev[j] * stddev[j];
         }
-
-        // Get geometry ID for bottom spacepoint
-        const edm::spacepoint_collection::const_device::const_proxy_type spB =
-            spacepoints.at(seeds[i].bottom_index());
-        assert(spB.measurement_index_2() ==
-               edm::spacepoint_collection::host::INVALID_MEASUREMENT_INDEX);
-        track_params.set_surface_link(
-            measurements.at(spB.measurement_index_1()).surface_link);
-        TRACCC_VERBOSE("  - bound track parameters: " << track_params);
     }
 
     // Return the result.

--- a/device/common/include/traccc/seeding/device/impl/estimate_track_params.ipp
+++ b/device/common/include/traccc/seeding/device/impl/estimate_track_params.ipp
@@ -42,26 +42,15 @@ inline void estimate_track_params(
         seeds_device.at(globalIndex);
 
     // Get bound track parameter
-    bound_track_parameters<> track_params;
-    track_params.set_vector(seed_to_bound_vector(
-        measurements_device, spacepoints_device, this_seed, bfield));
+    bound_track_parameters<>& track_params = params_device.at(globalIndex);
+    seed_to_bound_param_vector(track_params, measurements_device,
+                               spacepoints_device, this_seed, bfield);
 
     // Set Covariance
     for (std::size_t i = 0; i < e_bound_size; i++) {
         getter::element(track_params.covariance(), i, i) =
             stddev[i] * stddev[i];
     }
-
-    // Get geometry ID for bottom spacepoint
-    const edm::spacepoint_collection::const_device::const_proxy_type spB =
-        spacepoints_device.at(this_seed.bottom_index());
-    assert(spB.measurement_index_2() ==
-           edm::spacepoint_collection::const_device::INVALID_MEASUREMENT_INDEX);
-    track_params.set_surface_link(
-        measurements_device.at(spB.measurement_index_1()).surface_link);
-
-    // Save the object into global memory.
-    params_device.at(globalIndex) = track_params;
 }
 
 }  // namespace traccc::device


### PR DESCRIPTION
Use the track parameter vector class directly in seeding instead of the column matrix `bound_vector`. This has the advantage, that the assertions in the setters of the `track_parameter_vector` class in detray are getting checked in debug builds.

Also adds the geometry context to the spacepoint formation interface and prevents the transform3 in the spacepoint formation from calculating an additional cross product, by providing all axes to the constructor.