### PR TITLE
Acts v39.0.0, main branch (2025.04.30.)

### DIFF
--- a/extern/acts/CMakeLists.txt
+++ b/extern/acts/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2024 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,7 +13,7 @@ message( STATUS "Building Acts as part of the TRACCC project" )
 
 # Declare where to get Acts from.
 set( TRACCC_ACTS_SOURCE
-   "URL;https://github.com/acts-project/acts/archive/refs/tags/v38.2.0.tar.gz;URL_MD5;c70e730ec5a5b01d1824095631365925"
+   "URL;https://github.com/acts-project/acts/archive/refs/tags/v39.0.0.tar.gz;URL_MD5;a50bf40cb5bc6b831d13ee1eb89b0c14"
    CACHE STRING "Source for Acts, when built as part of this project" )
 mark_as_advanced( TRACCC_ACTS_SOURCE )
 FetchContent_Declare( Acts SYSTEM ${TRACCC_ACTS_SOURCE} )

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     - "cuda@12.5"
     - "gcc@13"
     # HEP dependencies
-    - "acts@38.2.0 +json"
+    - "acts@39.0.0 +json"
     - "root cxxstd=20"
     # General dependencies
     - "intel-oneapi-tbb@2021.12.0"


### PR DESCRIPTION
Updated to [Acts v39.0.0](https://github.com/acts-project/acts/releases/tag/v39.0.0).

This is mainly to eliminate all the warnings with Clang 20+. (oneAPI 2025.1.0) Like:

```
[build] /home/krasznaa/ATLAS/projects/traccc/traccc/out/build/full-fp32/_deps/acts-src/Core/include/Acts/Definitions/Units.hpp:215:1: warning: identifier '_mm' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
[build] /home/krasznaa/ATLAS/projects/traccc/traccc/out/build/full-fp32/_deps/acts-src/Core/include/Acts/Definitions/Units.hpp:208:31: note: expanded from macro 'ACTS_DEFINE_UNIT_LITERAL'
[build]   208 |   constexpr double operator"" _##name(unsigned long long x) { \
[build]       |                               ^
[build] <scratch space>:79:1: note: expanded from here
[build]    79 | _mm
[build]       | ^
```

Luckily there doesn't seem to have been any changes in Acts that would need an update in the traccc code.