### PR TITLE
Accelerate and fix bug in performance code

### DIFF
--- a/performance/include/traccc/resolution/fitting_performance_writer.hpp
+++ b/performance/include/traccc/resolution/fitting_performance_writer.hpp
@@ -73,16 +73,14 @@ class fitting_performance_writer {
         assert(!trk_state.is_hole);
         assert(trk_state.is_smoothed);
 
-        std::map<measurement, std::map<particle, std::size_t>> meas_to_ptc_map;
-        std::map<measurement, std::pair<point3, point3>> meas_to_param_map;
+        bool use_found = !evt_data.m_found_meas_to_ptc_map.empty();
 
-        if (!evt_data.m_found_meas_to_ptc_map.empty()) {
-            meas_to_ptc_map = evt_data.m_found_meas_to_ptc_map;
-            meas_to_param_map = evt_data.m_found_meas_to_param_map;
-        } else {
-            meas_to_ptc_map = evt_data.m_meas_to_ptc_map;
-            meas_to_param_map = evt_data.m_meas_to_param_map;
-        }
+        const std::map<measurement, std::map<particle, std::size_t>>&
+            meas_to_ptc_map = use_found ? evt_data.m_found_meas_to_ptc_map
+                                        : evt_data.m_meas_to_ptc_map;
+        const std::map<measurement, std::pair<point3, point3>>&
+            meas_to_param_map = use_found ? evt_data.m_found_meas_to_param_map
+                                          : evt_data.m_meas_to_param_map;
 
         const measurement meas = trk_state.get_measurement();
 

--- a/performance/src/resolution/res_plot_tool.cpp
+++ b/performance/src/resolution/res_plot_tool.cpp
@@ -130,11 +130,11 @@ void res_plot_tool::fill(res_plot_cache& cache,
 
 #ifdef TRACCC_HAVE_ROOT
         const auto eta_idx =
-            std::min(cache.resolutions_eta[par_name]->FindBin(eta) - 1,
-                     cache.resolutions_eta[par_name]->GetNbinsX() - 1);
+            std::clamp(cache.resolutions_eta[par_name]->FindBin(eta) - 1, 0,
+                       cache.resolutions_eta[par_name]->GetNbinsX() - 1);
         const auto pT_idx =
-            std::min(cache.resolutions_pT[par_name]->FindBin(pT) - 1,
-                     cache.resolutions_pT[par_name]->GetNbinsX() - 1);
+            std::clamp(cache.resolutions_pT[par_name]->FindBin(pT) - 1, 0,
+                       cache.resolutions_pT[par_name]->GetNbinsX() - 1);
 
         cache.residuals.at(par_name)->Fill(residual);
         if (idx < e_bound_size) {


### PR DESCRIPTION
This commit accelerates some of the performance code and fixes a bug in it. The bug fix concerns very low eta tracks which would be put into the non-existant bin -1. The optimizations are simple (using references and precomputing some mappings which cause the performance comparison code to speed up by a factor 20 for $\mu = 80$ events.