### PR TITLE
SYCL Fixes, main branch (2025.04.30.)

### DIFF
--- a/core/include/traccc/utils/prob.hpp
+++ b/core/include/traccc/utils/prob.hpp
@@ -297,7 +297,7 @@ TRACCC_HOST_DEVICE inline scalar_t lgam(scalar_t x) {
     if (x >= std::numeric_limits<scalar_t>::infinity())
         return (std::numeric_limits<scalar_t>::infinity());
 
-    if (x < -34.0) {
+    if (x < -34.0f) {
         q = -x;
 
         // For x > 34
@@ -311,7 +311,7 @@ TRACCC_HOST_DEVICE inline scalar_t lgam(scalar_t x) {
         else
             sgngam = 1;
         z = q - p;
-        if (z > 0.5) {
+        if (z > 0.5f) {
             p += 1.0f;
             z = p - q;
         }
@@ -323,7 +323,7 @@ TRACCC_HOST_DEVICE inline scalar_t lgam(scalar_t x) {
         return (z);
     }
 
-    if (x < 13.0) {
+    if (x < 13.0f) {
         z = 1.0f;
         p = 0.0f;
         u = x;
@@ -344,7 +344,7 @@ TRACCC_HOST_DEVICE inline scalar_t lgam(scalar_t x) {
             z = -z;
         } else
             sgngam = 1;
-        if (u == 2.0)
+        if (u == static_cast<scalar_t>(2.0))
             return (std::log(z));
         p -= 2.0f;
         x = x + p;
@@ -364,11 +364,11 @@ TRACCC_HOST_DEVICE inline scalar_t lgam_impl(scalar_t x) {
         return (sgngam * std::numeric_limits<scalar_t>::infinity());
 
     q = (x - 0.5f) * std::log(x) - x + log_gamma<scalar_t>::LS2PI;
-    if (x > 1.0e8)
+    if (x > 1.0e8f)
         return (q);
 
     p = 1.0f / (x * x);
-    if (x >= 1000.0)
+    if (x >= 1000.0f)
         q +=
             ((7.9365079365079365079365e-4f * p - 2.7777777777777777777778e-3f) *
                  p +

--- a/device/sycl/src/sanity/contiguous_on.hpp
+++ b/device/sycl/src/sanity/contiguous_on.hpp
@@ -1,7 +1,7 @@
 /**
  * traccc library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -104,7 +104,7 @@ is_contiguous_on(P&& projection, vecmem::memory_resource& mr,
     // This should never be a performance-critical step, so we can keep the
     // block size fixed.
     constexpr int local_size = 512;
-    constexpr int local_size_2d = 32;
+    constexpr int local_size_2d = 16;
 
     // Grab the number of elements in our vector.
     const typename VIEW::size_type n = copy.get_size(view);


### PR DESCRIPTION
These are for making our code "more compatible" with Intel GPUs. With these updates applied the unit tests at least run successfully.

The track finding unfortunately doesn't.

```
...
Detector check: OK
WARNING: No entries in volume finder

Detector check: OK
15:34:54    TracccExampleSeqSycl          WARNING   28 duplicate cells found in /home/krasznaa/ATLAS/projects/traccc/traccc/data/odd/geant4_10muon_10GeV/event000000000-cells.csv
terminate called after throwing an instance of 'sycl::_V1::exception'
  what():  The program was built for 1 devices
Build program log for 'Intel(R) Iris(R) Xe Graphics':

error: Total size of kernel arguments exceeds limit! Total arguments size: 2072, limit: 2048
in kernel: 'typeinfo name for traccc::sycl::details::kernels::find_tracks<traccc::sycl::kernels::ckf_constant_field_default_detector>'
error: backend compiler failed build.

error: Total size of kernel arguments exceeds limit! Total arguments size: 2072, limit: 2048
in kernel: 'typeinfo name for traccc::sycl::details::kernels::find_tracks<traccc::sycl::kernels::ckf_constant_field_default_detector>'
error: backend compiler failed build.

Aborted (core dumped)
```

But that's for another day to sort out...