### PR TITLE
Alpaka VecMem Interface, main branch (2025.05.01.)

### DIFF
--- a/device/alpaka/CMakeLists.txt
+++ b/device/alpaka/CMakeLists.txt
@@ -30,6 +30,12 @@ traccc_add_alpaka_library( traccc_alpaka alpaka TYPE SHARED
   "include/traccc/alpaka/utils/make_prefix_sum_buff.hpp"
   "src/utils/make_prefix_sum_buff.cpp"
   "src/utils/get_device_info.cpp"
+  "include/traccc/alpaka/utils/queue.hpp"
+  "src/utils/queue.cpp"
+  "src/utils/get_queue.hpp"
+  "src/utils/get_queue.cpp"
+  "include/traccc/alpaka/utils/vecmem_objects.hpp"
+  "src/utils/vecmem_objects.cpp"
   # Clusterization
   "include/traccc/alpaka/clusterization/clusterization_algorithm.hpp"
   "src/clusterization/clusterization_algorithm.cpp"

--- a/device/alpaka/include/traccc/alpaka/utils/queue.hpp
+++ b/device/alpaka/include/traccc/alpaka/utils/queue.hpp
@@ -1,0 +1,54 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// System include(s).
+#include <cstddef>
+#include <limits>
+#include <memory>
+
+namespace traccc::alpaka {
+
+/// Owning wrapper around @c ::alpaka::Queue
+class queue {
+
+    public:
+    /// Invalid/default device identifier
+    static constexpr std::size_t INVALID_DEVICE =
+        std::numeric_limits<std::size_t>::max();
+
+    /// Construct a new stream (possibly for a specified device)
+    explicit queue(std::size_t device = INVALID_DEVICE);
+
+    /// Move constructor
+    queue(queue&& parent) noexcept;
+
+    /// Destructor
+    ~queue();
+
+    /// Move assignment
+    queue& operator=(queue&& rhs) noexcept;
+
+    /// Access a typeless pointer to the managed @c ::alpaka::Queue object
+    void* alpakaQueue();
+    /// Access a typeless pointer to the managed @c ::alpaka::Queue object
+    const void* alpakaQueue() const;
+
+    /// Wait for all queued tasks from the stream to complete
+    void synchronize();
+
+    private:
+    /// Type holing the implementation
+    struct impl;
+    /// Smart pointer to the implementation
+    std::unique_ptr<impl> m_impl;
+
+};  // class queue
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/include/traccc/alpaka/utils/vecmem_objects.hpp
+++ b/device/alpaka/include/traccc/alpaka/utils/vecmem_objects.hpp
@@ -1,0 +1,55 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "traccc/alpaka/utils/queue.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/utils/copy.hpp>
+
+namespace traccc::alpaka {
+
+/// Helper class for instantiating the correct vecmem objects for the way
+/// the @c traccc::alpaka library was built.
+class vecmem_objects {
+
+    public:
+    /// Constructor from a queue
+    explicit vecmem_objects(queue& q);
+    /// Move constructor
+    vecmem_objects(vecmem_objects&&) noexcept;
+    /// Destructor
+    ~vecmem_objects();
+
+    /// Move assignment
+    vecmem_objects& operator=(vecmem_objects&&) noexcept;
+
+    /// The host memory resource to use
+    vecmem::memory_resource& host_mr() const;
+    /// The device memory resource to use
+    vecmem::memory_resource& device_mr() const;
+    /// The shared/managed memory resource to use
+    vecmem::memory_resource& shared_mr() const;
+
+    /// The (synchronous) copy object to use
+    vecmem::copy& copy() const;
+    /// The asynchronous copy object to use
+    vecmem::copy& async_copy() const;
+
+    private:
+    /// Type holing the implementation
+    struct impl;
+    /// Smart pointer to the implementation
+    std::unique_ptr<impl> m_impl;
+
+};  // class vecmem_objects
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/src/utils/get_queue.cpp
+++ b/device/alpaka/src/utils/get_queue.cpp
@@ -1,0 +1,29 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "get_queue.hpp"
+
+// System include(s).
+#include <cassert>
+
+namespace traccc::alpaka::details {
+
+Queue& get_queue(queue& q) {
+
+    assert(q.alpakaQueue() != nullptr);
+    return *(reinterpret_cast<Queue*>(q.alpakaQueue()));
+}
+
+const Queue& get_queue(const queue& q) {
+
+    assert(q.alpakaQueue() != nullptr);
+    return *(reinterpret_cast<const Queue*>(q.alpakaQueue()));
+}
+
+}  // namespace traccc::alpaka::details

--- a/device/alpaka/src/utils/get_queue.hpp
+++ b/device/alpaka/src/utils/get_queue.hpp
@@ -1,0 +1,23 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "traccc/alpaka/utils/queue.hpp"
+#include "utils.hpp"
+
+namespace traccc::alpaka::details {
+
+/// Helper function for getting a @c Queue out of @c queue (non-const)
+Queue& get_queue(queue& q);
+
+/// Helper function for getting a @c Queue out of @c queue (const)
+const Queue& get_queue(const queue& q);
+
+}  // namespace traccc::alpaka::details

--- a/device/alpaka/src/utils/queue.cpp
+++ b/device/alpaka/src/utils/queue.cpp
@@ -1,0 +1,54 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "traccc/alpaka/utils/queue.hpp"
+
+#include "utils.hpp"
+
+// Alpaka include(s).
+#include <alpaka/alpaka.hpp>
+
+namespace traccc::alpaka {
+
+struct queue::impl {
+
+    /// Constructor
+    /// @param device The device to create the queue for
+    explicit impl(std::size_t device)
+        : m_queue(::alpaka::getDevByIdx(::alpaka::Platform<Acc>{}, device)) {}
+
+    /// The real Alpaka queue object
+    Queue m_queue;
+
+};  // struct queue::impl
+
+queue::queue(std::size_t device) : m_impl{std::make_unique<impl>(device)} {}
+
+queue::queue(queue&&) noexcept = default;
+
+queue::~queue() = default;
+
+queue& queue::operator=(queue&& rhs) noexcept = default;
+
+void* queue::alpakaQueue() {
+
+    return &(m_impl->m_queue);
+}
+
+const void* queue::alpakaQueue() const {
+
+    return &(m_impl->m_queue);
+}
+
+void queue::synchronize() {
+
+    ::alpaka::wait(m_impl->m_queue);
+}
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/src/utils/vecmem_objects.cpp
+++ b/device/alpaka/src/utils/vecmem_objects.cpp
@@ -1,0 +1,125 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "traccc/alpaka/utils/vecmem_objects.hpp"
+
+#include "get_queue.hpp"
+
+// VecMem include(s).
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/memory/cuda/host_memory_resource.hpp>
+#include <vecmem/memory/cuda/managed_memory_resource.hpp>
+#include <vecmem/utils/cuda/async_copy.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#include <vecmem/memory/hip/device_memory_resource.hpp>
+#include <vecmem/memory/hip/host_memory_resource.hpp>
+#include <vecmem/memory/hip/managed_memory_resource.hpp>
+#include <vecmem/utils/hip/copy.hpp>
+#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+#include <vecmem/memory/sycl/device_memory_resource.hpp>
+#include <vecmem/memory/sycl/host_memory_resource.hpp>
+#include <vecmem/memory/sycl/shared_memory_resource.hpp>
+#include <vecmem/utils/sycl/async_copy.hpp>
+#include <vecmem/utils/sycl/copy.hpp>
+#else
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/utils/copy.hpp>
+#endif
+
+namespace traccc::alpaka {
+
+struct vecmem_objects::impl {
+
+    /// Constructor
+    explicit impl([[maybe_unused]] queue& q)
+        :
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+          m_host_mr(),
+          m_device_mr(::alpaka::getNativeHandle(
+              ::alpaka::getDev(details::get_queue(q)))),
+          m_shared_mr(),
+          m_copy(),
+          m_async_copy(::alpaka::getNativeHandle(details::get_queue(q)))
+#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+          m_queue(::alpaka::getNativeHandle(details::get_queue(q))),
+          m_host_mr(&m_queue),
+          m_device_mr(&m_queue),
+          m_shared_mr(&m_queue),
+          m_copy(&m_queue),
+          m_async_copy(&m_queue)
+#else
+          m_host_mr(),
+          m_device_mr(),
+          m_shared_mr(),
+          m_copy(),
+          m_async_copy()
+#endif
+    {
+    }
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+    vecmem::cuda::host_memory_resource m_host_mr;
+    vecmem::cuda::device_memory_resource m_device_mr;
+    vecmem::cuda::managed_memory_resource m_shared_mr;
+    vecmem::cuda::copy m_copy;
+    vecmem::cuda::async_copy m_async_copy;
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+    vecmem::hip::host_memory_resource m_host_mr;
+    vecmem::hip::device_memory_resource m_device_mr;
+    vecmem::hip::managed_memory_resource m_shared_mr;
+    vecmem::hip::copy m_copy;
+    vecmem::hip::copy m_async_copy;
+#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+    ::sycl::queue m_queue;
+    vecmem::sycl::host_memory_resource m_host_mr;
+    vecmem::sycl::device_memory_resource m_device_mr;
+    vecmem::sycl::shared_memory_resource m_shared_mr;
+    vecmem::sycl::copy m_copy;
+    vecmem::sycl::async_copy m_async_copy;
+#else
+    vecmem::host_memory_resource m_host_mr;
+    vecmem::host_memory_resource m_device_mr;
+    vecmem::host_memory_resource m_shared_mr;
+    vecmem::copy m_copy;
+    vecmem::copy m_async_copy;
+#endif
+
+};  // struct vecmem_objects::impl
+
+vecmem_objects::vecmem_objects(queue& q) : m_impl{std::make_unique<impl>(q)} {}
+
+vecmem_objects::vecmem_objects(vecmem_objects&&) noexcept = default;
+
+vecmem_objects::~vecmem_objects() = default;
+
+vecmem_objects& vecmem_objects::operator=(vecmem_objects&&) noexcept = default;
+
+vecmem::memory_resource& vecmem_objects::host_mr() const {
+    return m_impl->m_host_mr;
+}
+
+vecmem::memory_resource& vecmem_objects::device_mr() const {
+    return m_impl->m_device_mr;
+}
+
+vecmem::memory_resource& vecmem_objects::shared_mr() const {
+    return m_impl->m_shared_mr;
+}
+
+vecmem::copy& vecmem_objects::copy() const {
+    return m_impl->m_copy;
+}
+
+vecmem::copy& vecmem_objects::async_copy() const {
+    return m_impl->m_async_copy;
+}
+
+}  // namespace traccc::alpaka


### PR DESCRIPTION
This is a proposal for how I'd imagine using Alpaka in the longer term. This was triggered by #958, whose code I didn't really like. But since I have very little experience with Alpaka, I wanted to try out for myself what sort of code could be written.

@CrossR, @StewMH, this is how I imagine that things could look like. :thinking:
  - `traccc::alpaka::queue` is the same sort of thing that you tried to make as well Ryan. I just simplified it so that it would only expose the underlying Alpaka queue, and not try to be too smart with the native devices/queues.
  - `traccc::alpaka::vecmem_objects` has the interface that Ryan made, just with a (in my mind) much simpler implementation.

You see, once you hide the choice of VecMem objects behind such a non-specific interface, you can just use simple pre-processor statements in the background. There's no need to mix pre-processor formalism with traits in this case.

Please check if this sort of a setup could be made to work with the existing algorithms. Since that I didn't really try...