### PR TITLE
VecMem 1.16.0 Update, main branch (2025.05.05.)

### DIFF
--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -124,7 +124,7 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
         const std::size_t first_event = input_opts.skip;
         const std::size_t last_event = input_opts.skip + input_opts.events;
         for (std::size_t i = first_event; i < last_event; ++i) {
-            input.push_back({uncached_host_mr});
+            input.emplace_back(uncached_host_mr);
         }
         // Read the input cells into memory in parallel.
         tbb::parallel_for(

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -105,7 +105,7 @@ int throughput_st(std::string_view description, int argc, char* argv[],
         input.reserve(input_opts.events);
         for (std::size_t i = input_opts.skip;
              i < input_opts.skip + input_opts.events; ++i) {
-            input.push_back({uncached_host_mr});
+            input.emplace_back(uncached_host_mr);
             static constexpr bool DEDUPLICATE = true;
             io::read_cells(input.back(), i, input_opts.directory,
                            logger->clone(), &det_descr, input_opts.format,

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.14.0.tar.gz;URL_MD5;4f91ff58af080d4bc6e2d74fa3051ede"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.16.0.tar.gz;URL_MD5;387f7832c349d4d3b3f6e6b16990f7a7"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem SYSTEM ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
The main reason for the update is https://github.com/acts-project/vecmem/pull/313, to make sure that SoA elements could be copied conveniently (amongst others) in device code. But the new tag of course brings a bunch of other updates as well.

With all the `explicit` makings added in VecMem, surprisingly only the throughput testing code needed to be adjusted ever so slightly.