### PR TITLE
Simplified Seed Selection, main branch (2025.05.05.)

### DIFF
--- a/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
+++ b/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
@@ -83,7 +83,7 @@ inline void select_seeds(
     const traccc::details::spacepoint_grid_types::const_device sp_device(
         sp_view);
 
-    device_triplet_collection_types::const_device triplets(triplet_view);
+    const device_triplet_collection_types::const_device triplets(triplet_view);
     edm::seed_collection::device seeds_device(seed_view);
 
     // Current work item = middle spacepoint
@@ -176,15 +176,10 @@ inline void select_seeds(
 
             n_seeds_per_spM++;
 
-            const edm::seed_collection::device::size_type iseed =
-                seeds_device.push_back_default();
-            edm::seed_collection::device::proxy_type seed =
-                seeds_device.at(iseed);
-            seed.bottom_index() =
-                sp_device.bin(spB_loc.bin_idx)[spB_loc.sp_idx];
-            seed.middle_index() =
-                sp_device.bin(spM_loc.bin_idx)[spM_loc.sp_idx];
-            seed.top_index() = sp_device.bin(spT_loc.bin_idx)[spT_loc.sp_idx];
+            seeds_device.push_back(
+                {sp_device.bin(spB_loc.bin_idx)[spB_loc.sp_idx],
+                 sp_device.bin(spM_loc.bin_idx)[spM_loc.sp_idx],
+                 sp_device.bin(spT_loc.bin_idx)[spT_loc.sp_idx]});
         }
     }
 }


### PR DESCRIPTION
I have still not gone through all of the code, there could be other instances of such simplifications as well, but this one I bumped into by chance. With the latest version of [vecmem](https://github.com/acts-project/vecmem) one can now fill resizable SoA containers a bit more easily in device code.