### PR TITLE
test: Reduce navigation cache size for track finding

### DIFF
--- a/benchmarks/cuda/toy_detector_cuda.cpp
+++ b/benchmarks/cuda/toy_detector_cuda.cpp
@@ -43,9 +43,13 @@ BENCHMARK_DEFINE_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
         detray::constrained_step<typename detector_type::scalar_type>>;
     using host_detector_type = traccc::default_detector::host;
     using device_detector_type = traccc::default_detector::device;
-    using device_navigator_type = detray::navigator<const device_detector_type>;
+    using ckf_navigator_type =
+        detray::navigator<const device_detector_type,
+                          traccc::detail::ckf_nav_cache_size>;
+    using fitting_navigator_type =
+        detray::navigator<const device_detector_type>;
     using device_fitter_type =
-        traccc::kalman_fitter<rk_stepper_type, device_navigator_type>;
+        traccc::kalman_fitter<rk_stepper_type, fitting_navigator_type>;
 
     // Memory resources used by the application.
     vecmem::cuda::host_memory_resource cuda_host_mr;
@@ -73,7 +77,7 @@ BENCHMARK_DEFINE_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
     traccc::cuda::seeding_algorithm sa_cuda(seeding_cfg, grid_cfg, filter_cfg,
                                             mr, async_copy, stream);
     traccc::cuda::track_params_estimation tp_cuda(mr, async_copy, stream);
-    traccc::cuda::finding_algorithm<rk_stepper_type, device_navigator_type>
+    traccc::cuda::finding_algorithm<rk_stepper_type, ckf_navigator_type>
         device_finding(finding_cfg, mr, async_copy, stream);
     traccc::cuda::fitting_algorithm<device_fitter_type> device_fitting(
         fitting_cfg, mr, async_copy, stream);

--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -17,6 +17,12 @@
 
 namespace traccc {
 
+namespace detail {
+
+inline constexpr unsigned int ckf_nav_cache_size{3u};
+
+}  // namespace detail
+
 /// Configuration struct for track finding
 struct finding_config {
     /// Maxmimum number of branches per seed

--- a/core/include/traccc/utils/detector_type_utils.hpp
+++ b/core/include/traccc/utils/detector_type_utils.hpp
@@ -16,8 +16,9 @@
 namespace traccc {
 /// Helper type constructors to facilitate the consistent instantiation of
 /// tools such as steppers and fitters for specific detectors.
-template <typename detector_t>
-using navigator_for_t = detray::navigator<const detector_t>;
+template <typename detector_t,
+          unsigned int cache_size = detray::navigation::default_cache_size>
+using navigator_for_t = detray::navigator<const detector_t, cache_size>;
 
 template <typename detector_t>
 using stepper_for_t = ::detray::rk_stepper<

--- a/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.cpp
+++ b/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.cpp
@@ -29,8 +29,9 @@ combinatorial_kalman_filter_algorithm::operator()(
         detray::rk_stepper<bfield_type::view_t,
                            detector_type::host::algebra_type,
                            detray::constrained_step<scalar_type>>,
-        detray::navigator<const detector_type::host>>(det, field, measurements,
-                                                      seeds, m_config);
+        detray::navigator<const detector_type::host,
+                          traccc::detail::ckf_nav_cache_size>>(
+        det, field, measurements, seeds, m_config);
 }
 
 }  // namespace traccc::host

--- a/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.cpp
+++ b/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.cpp
@@ -29,8 +29,9 @@ combinatorial_kalman_filter_algorithm::operator()(
         detray::rk_stepper<bfield_type::view_t,
                            detector_type::host::algebra_type,
                            detray::constrained_step<scalar_type>>,
-        detray::navigator<const detector_type::host>>(det, field, measurements,
-                                                      seeds, m_config);
+        detray::navigator<const detector_type::host,
+                          traccc::detail::ckf_nav_cache_size>>(
+        det, field, measurements, seeds, m_config);
 }
 
 }  // namespace traccc::host

--- a/device/alpaka/src/finding/finding_algorithm.cpp
+++ b/device/alpaka/src/finding/finding_algorithm.cpp
@@ -487,7 +487,8 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 // Explicit template instantiation
 template class finding_algorithm<
     ::traccc::stepper_for_t<::traccc::default_detector::device>,
-    ::traccc::navigator_for_t<::traccc::default_detector::device>>;
+    ::traccc::navigator_for_t<::traccc::default_detector::device,
+                              traccc::detail::ckf_nav_cache_size>>;
 
 }  // namespace traccc::alpaka
 

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -458,5 +458,6 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
 // Explicit template instantiation
 template class finding_algorithm<
     stepper_for_t<::traccc::default_detector::device>,
-    navigator_for_t<::traccc::default_detector::device>>;
+    navigator_for_t<::traccc::default_detector::device,
+                    traccc::detail::ckf_nav_cache_size>>;
 }  // namespace traccc::cuda

--- a/device/cuda/src/finding/kernels/specializations/types.hpp
+++ b/device/cuda/src/finding/kernels/specializations/types.hpp
@@ -18,6 +18,7 @@
 namespace traccc::cuda {
 using default_finding_algorithm =
     finding_algorithm<stepper_for_t<traccc::default_detector::device>,
-                      navigator_for_t<traccc::default_detector::device>>;
+                      navigator_for_t<traccc::default_detector::device,
+                                      traccc::detail::ckf_nav_cache_size>>;
 
 }  // namespace traccc::cuda

--- a/examples/run/alpaka/full_chain_algorithm.hpp
+++ b/examples/run/alpaka/full_chain_algorithm.hpp
@@ -66,7 +66,11 @@ class full_chain_algorithm
                            device_detector_type::algebra_type,
                            detray::constrained_step<scalar_type>>;
     /// Navigator type used by the track finding and fitting algorithms
-    using navigator_type = detray::navigator<const device_detector_type>;
+    using ckf_navigator_type =
+        detray::navigator<const device_detector_type,
+                          traccc::detail::ckf_nav_cache_size>;
+    using fitting_navigator_type =
+        detray::navigator<const device_detector_type>;
     /// Spacepoint formation algorithm type
     using spacepoint_formation_algorithm =
         traccc::alpaka::spacepoint_formation_algorithm<
@@ -75,10 +79,10 @@ class full_chain_algorithm
     using clustering_algorithm = traccc::alpaka::clusterization_algorithm;
     /// Track finding algorithm type
     using finding_algorithm =
-        traccc::alpaka::finding_algorithm<stepper_type, navigator_type>;
+        traccc::alpaka::finding_algorithm<stepper_type, ckf_navigator_type>;
     /// Track fitting algorithm type
     using fitting_algorithm = traccc::alpaka::fitting_algorithm<
-        traccc::kalman_fitter<stepper_type, navigator_type>>;
+        traccc::kalman_fitter<stepper_type, fitting_navigator_type>>;
 
     /// @}
 

--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -75,10 +75,13 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         detray::rk_stepper<b_field_t::view_t,
                            traccc::default_detector::host::algebra_type,
                            detray::constrained_step<scalar_t>>;
-    using device_navigator_type =
+    using ckf_navigator_type =
+        detray::navigator<const traccc::default_detector::device,
+                          traccc::detail::ckf_nav_cache_size>;
+    using fitting_navigator_type =
         detray::navigator<const traccc::default_detector::device>;
     using device_fitter_type =
-        traccc::kalman_fitter<rk_stepper_type, device_navigator_type>;
+        traccc::kalman_fitter<rk_stepper_type, fitting_navigator_type>;
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED
     ::sycl::queue q;
@@ -179,7 +182,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     // Finding algorithm object
     traccc::host::combinatorial_kalman_filter_algorithm host_finding(
         cfg, logger().clone("HostFindingAlg"));
-    traccc::alpaka::finding_algorithm<rk_stepper_type, device_navigator_type>
+    traccc::alpaka::finding_algorithm<rk_stepper_type, ckf_navigator_type>
         device_finding(cfg, mr, copy, logger().clone("AlpakaFindingAlg"));
 
     // Fitting algorithm object

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -133,17 +133,21 @@ int seq_run(const traccc::opts::detector& detector_opts,
         detray::rk_stepper<bfield_type::view_t,
                            traccc::default_detector::host::algebra_type,
                            detray::constrained_step<scalar_type>>;
-    using device_navigator_type =
+
+    using ckf_navigator_type =
+        detray::navigator<const traccc::default_detector::device,
+                          traccc::detail::ckf_nav_cache_size>;
+    using fitting_navigator_type =
         detray::navigator<const traccc::default_detector::device>;
 
     using host_finding_algorithm =
         traccc::host::combinatorial_kalman_filter_algorithm;
     using device_finding_algorithm =
-        traccc::alpaka::finding_algorithm<stepper_type, device_navigator_type>;
+        traccc::alpaka::finding_algorithm<stepper_type, ckf_navigator_type>;
 
     using host_fitting_algorithm = traccc::host::kalman_fitting_algorithm;
     using device_fitting_algorithm = traccc::alpaka::fitting_algorithm<
-        traccc::kalman_fitter<stepper_type, device_navigator_type>>;
+        traccc::kalman_fitter<stepper_type, fitting_navigator_type>>;
 
     // Algorithm configuration(s).
     detray::propagation::config propagation_config(propagation_opts);

--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -68,7 +68,12 @@ class full_chain_algorithm
                            device_detector_type::algebra_type,
                            detray::constrained_step<scalar_type>>;
     /// Navigator type used by the track finding and fitting algorithms
-    using navigator_type = detray::navigator<const device_detector_type>;
+    using ckf_navigator_type =
+        detray::navigator<const device_detector_type,
+                          traccc::detail::ckf_nav_cache_size>;
+    using fitting_navigator_type =
+        detray::navigator<const device_detector_type>;
+
     /// Spacepoint formation algorithm type
     using spacepoint_formation_algorithm =
         traccc::cuda::spacepoint_formation_algorithm<
@@ -77,10 +82,10 @@ class full_chain_algorithm
     using clustering_algorithm = traccc::cuda::clusterization_algorithm;
     /// Track finding algorithm type
     using finding_algorithm =
-        traccc::cuda::finding_algorithm<stepper_type, navigator_type>;
+        traccc::cuda::finding_algorithm<stepper_type, ckf_navigator_type>;
     /// Track fitting algorithm type
     using fitting_algorithm = traccc::cuda::fitting_algorithm<
-        traccc::kalman_fitter<stepper_type, navigator_type>>;
+        traccc::kalman_fitter<stepper_type, fitting_navigator_type>>;
 
     /// @}
 

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -77,10 +77,13 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         detray::rk_stepper<b_field_t::view_t,
                            traccc::default_detector::host::algebra_type,
                            detray::constrained_step<scalar_t>>;
-    using device_navigator_type =
+    using ckf_navigator_type =
+        detray::navigator<const traccc::default_detector::device,
+                          traccc::detail::ckf_nav_cache_size>;
+    using fitting_navigator_type =
         detray::navigator<const traccc::default_detector::device>;
     using device_fitter_type =
-        traccc::kalman_fitter<rk_stepper_type, device_navigator_type>;
+        traccc::kalman_fitter<rk_stepper_type, fitting_navigator_type>;
 
     // Memory resources used by the application.
     vecmem::host_memory_resource host_mr;
@@ -177,7 +180,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
     // Finding algorithm object
     traccc::host::combinatorial_kalman_filter_algorithm host_finding(
         cfg, logger().clone("HostFindingAlg"));
-    traccc::cuda::finding_algorithm<rk_stepper_type, device_navigator_type>
+    traccc::cuda::finding_algorithm<rk_stepper_type, ckf_navigator_type>
         device_finding(cfg, mr, async_copy, stream,
                        logger().clone("CudaFindingAlg"));
 

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -136,17 +136,20 @@ int seq_run(const traccc::opts::detector& detector_opts,
         detray::rk_stepper<bfield_type::view_t,
                            traccc::default_detector::host::algebra_type,
                            detray::constrained_step<scalar_type>>;
-    using device_navigator_type =
+    using ckf_navigator_type =
+        detray::navigator<const traccc::default_detector::device,
+                          traccc::detail::ckf_nav_cache_size>;
+    using fitting_navigator_type =
         detray::navigator<const traccc::default_detector::device>;
 
     using host_finding_algorithm =
         traccc::host::combinatorial_kalman_filter_algorithm;
     using device_finding_algorithm =
-        traccc::cuda::finding_algorithm<stepper_type, device_navigator_type>;
+        traccc::cuda::finding_algorithm<stepper_type, ckf_navigator_type>;
 
     using host_fitting_algorithm = traccc::host::kalman_fitting_algorithm;
     using device_fitting_algorithm = traccc::cuda::fitting_algorithm<
-        traccc::kalman_fitter<stepper_type, device_navigator_type>>;
+        traccc::kalman_fitter<stepper_type, fitting_navigator_type>>;
 
     // Algorithm configuration(s).
     detray::propagation::config propagation_config(propagation_opts);

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -71,10 +71,13 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
     using rk_stepper_type =
         detray::rk_stepper<b_field_t::view_t, traccc::default_algebra,
                            detray::constrained_step<scalar_type>>;
-    using device_navigator_type =
+    using ckf_navigator_type =
+        detray::navigator<const traccc::default_detector::device,
+                          traccc::detail::ckf_nav_cache_size>;
+    using fitting_navigator_type =
         detray::navigator<const traccc::default_detector::device>;
     using device_fitter_type =
-        traccc::kalman_fitter<rk_stepper_type, device_navigator_type>;
+        traccc::kalman_fitter<rk_stepper_type, fitting_navigator_type>;
 
     // Memory resources used by the application.
     vecmem::host_memory_resource host_mr;
@@ -153,7 +156,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
     // Finding algorithm object
     traccc::host::combinatorial_kalman_filter_algorithm host_finding(
         cfg, logger().clone("HostFindingAlg"));
-    traccc::cuda::finding_algorithm<rk_stepper_type, device_navigator_type>
+    traccc::cuda::finding_algorithm<rk_stepper_type, ckf_navigator_type>
         device_finding(cfg, mr, async_copy, stream,
                        logger().clone("CudaFindingAlg"));
 

--- a/tests/common/tests/ckf_telescope_test.hpp
+++ b/tests/common/tests/ckf_telescope_test.hpp
@@ -9,14 +9,25 @@
 
 // Project include(s).
 #include "kalman_fitting_telescope_test.hpp"
+#include "traccc/finding/finding_config.hpp"
 
 namespace traccc {
 
 /// Combinatorial Kalman Finding Test with Sparse tracks
-class CkfSparseTrackTelescopeTests : public KalmanFittingTelescopeTests {};
+class CkfSparseTrackTelescopeTests : public KalmanFittingTelescopeTests {
+    public:
+    using ckf_navigator_type =
+        detray::navigator<const device_detector_type,
+                          traccc::detail::ckf_nav_cache_size>;
+};
 
 /// Combinatorial Kalman Finding Test with Identical tracks
-class CkfCombinatoricsTelescopeTests : public KalmanFittingTelescopeTests {};
+class CkfCombinatoricsTelescopeTests : public KalmanFittingTelescopeTests {
+    public:
+    using ckf_navigator_type =
+        detray::navigator<const device_detector_type,
+                          traccc::detail::ckf_nav_cache_size>;
+};
 
 /// Combinatorial Kalman Finding Test with Identical tracks (CPU)
 class CpuCkfCombinatoricsTelescopeTests

--- a/tests/common/tests/ckf_toy_detector_test.hpp
+++ b/tests/common/tests/ckf_toy_detector_test.hpp
@@ -9,10 +9,16 @@
 
 // Project include(s).
 #include "kalman_fitting_toy_detector_test.hpp"
+#include "traccc/finding/finding_config.hpp"
 
 namespace traccc {
 
 /// Combinatorial Kalman Finding Test to Comapre CPU results
-class CkfToyDetectorTests : public KalmanFittingToyDetectorTests {};
+class CkfToyDetectorTests : public KalmanFittingToyDetectorTests {
+    public:
+    using ckf_navigator_type =
+        detray::navigator<const device_detector_type,
+                          traccc::detail::ckf_nav_cache_size>;
+};
 
 }  // namespace traccc

--- a/tests/cuda/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cuda/test_ckf_combinatorics_telescope.cpp
@@ -138,21 +138,21 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
 
     // Finding algorithm configuration
     typename traccc::cuda::finding_algorithm<
-        rk_stepper_type, device_navigator_type>::config_type cfg_no_limit;
+        rk_stepper_type, ckf_navigator_type>::config_type cfg_no_limit;
     cfg_no_limit.ptc_hypothesis = ptc;
     cfg_no_limit.max_num_branches_per_seed = 100000;
     cfg_no_limit.chi2_max = 30.f;
 
     typename traccc::cuda::finding_algorithm<
-        rk_stepper_type, device_navigator_type>::config_type cfg_limit;
+        rk_stepper_type, ckf_navigator_type>::config_type cfg_limit;
     cfg_limit.ptc_hypothesis = ptc;
     cfg_limit.max_num_branches_per_seed = 500;
     cfg_limit.chi2_max = 30.f;
 
     // Finding algorithm object
-    traccc::cuda::finding_algorithm<rk_stepper_type, device_navigator_type>
+    traccc::cuda::finding_algorithm<rk_stepper_type, ckf_navigator_type>
         device_finding(cfg_no_limit, mr, copy, stream);
-    traccc::cuda::finding_algorithm<rk_stepper_type, device_navigator_type>
+    traccc::cuda::finding_algorithm<rk_stepper_type, ckf_navigator_type>
         device_finding_limit(cfg_limit, mr, copy, stream);
 
     // Iterate over events

--- a/tests/cuda/test_ckf_toy_detector.cpp
+++ b/tests/cuda/test_ckf_toy_detector.cpp
@@ -136,7 +136,7 @@ TEST_P(CkfToyDetectorTests, Run) {
 
     // Finding algorithm configuration
     typename traccc::cuda::finding_algorithm<
-        rk_stepper_type, device_navigator_type>::config_type cfg;
+        rk_stepper_type, ckf_navigator_type>::config_type cfg;
     cfg.ptc_hypothesis = ptc;
     cfg.max_num_branches_per_seed = 500;
     cfg.propagation.navigation.search_window = search_window;
@@ -145,7 +145,7 @@ TEST_P(CkfToyDetectorTests, Run) {
     traccc::host::combinatorial_kalman_filter_algorithm host_finding(cfg);
 
     // Finding algorithm object
-    traccc::cuda::finding_algorithm<rk_stepper_type, device_navigator_type>
+    traccc::cuda::finding_algorithm<rk_stepper_type, ckf_navigator_type>
         device_finding(cfg, mr, copy, stream);
 
     // Iterate over events


### PR DESCRIPTION
The cache is not really used in the CKF, so keep its size minimal