### PR TITLE
Clean Device Track Finding, main branch (2025.05.08.)

### DIFF
--- a/device/alpaka/include/traccc/alpaka/finding/finding_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/finding/finding_algorithm.hpp
@@ -30,8 +30,8 @@ class finding_algorithm
     : public algorithm<track_candidate_container_types::buffer(
           const typename navigator_t::detector_type::view_type&,
           const typename stepper_t::magnetic_field_type&,
-          const typename measurement_collection_types::view&,
-          const bound_track_parameters_collection_types::buffer&)>,
+          const measurement_collection_types::const_view&,
+          const bound_track_parameters_collection_types::const_view&)>,
       public messaging {
 
     /// Detector type
@@ -84,8 +84,8 @@ class finding_algorithm
     track_candidate_container_types::buffer operator()(
         const typename detector_type::view_type& det_view,
         const bfield_type& field_view,
-        const typename measurement_collection_types::view& measurements,
-        const bound_track_parameters_collection_types::buffer& seeds)
+        const measurement_collection_types::const_view& measurements,
+        const bound_track_parameters_collection_types::const_view& seeds)
         const override;
 
     private:

--- a/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/finding/finding_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -32,8 +32,8 @@ class finding_algorithm
     : public algorithm<track_candidate_container_types::buffer(
           const typename navigator_t::detector_type::view_type&,
           const typename stepper_t::magnetic_field_type&,
-          const typename measurement_collection_types::view&,
-          const bound_track_parameters_collection_types::buffer&)>,
+          const measurement_collection_types::const_view&,
+          const bound_track_parameters_collection_types::const_view&)>,
       public messaging {
 
     /// Detector type
@@ -86,8 +86,8 @@ class finding_algorithm
     track_candidate_container_types::buffer operator()(
         const typename detector_type::view_type& det_view,
         const bfield_type& field_view,
-        const typename measurement_collection_types::view& measurements,
-        const bound_track_parameters_collection_types::buffer& seeds)
+        const measurement_collection_types::const_view& measurements,
+        const bound_track_parameters_collection_types::const_view& seeds)
         const override;
 
     private:


### PR DESCRIPTION
While working on the EDM, I found that the CUDA and Alpaka track finding algorithms are currently implemented in a bit of a sketchy way. Providing a not-too-perfect API.

While fixing that, I also simplified the algorithm implementations a little. (More so for Alpaka than for CUDA...)

Pinging @CrossR as well.