### PR TITLE
CUDA VSCode Debugging, main branch (2025.05.11.)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+   "version": "0.2.0",
+   "configurations": [
+      {
+         "name": "Debug NVIDIA Executable",
+         "type": "cuda-gdb",
+         "request": "launch",
+         "program": "${command:cmake.launchTargetPath}",
+         "cwd" : "${command:cmake.launchTargetDirectory}"
+      }
+   ]
+}


### PR DESCRIPTION
While working on #971, I made quite some use of this setup. Hopefully others will find it useful too.

First off, you have to have the [Nsight Visual Studio Code Edition](https://marketplace.visualstudio.com/items/?itemName=NVIDIA.nsight-vscode-edition) plugin installed in your VSCode session.

![image](https://github.com/user-attachments/assets/c07091d9-46ef-472d-94ef-ec3ccd70a7cd)

Then, you have to select one of the NVIDIA executables of the project as your active launch target. Like:

![Screenshot from 2025-05-11 09-31-19](https://github.com/user-attachments/assets/44f8dc18-b5a7-4657-937a-4e27c7bd0c73)

(In this example I selected `traccc_seq_example_cuda`. The configuration preset is something I use locally, which extends `cuda-fp32` with `-DCMAKE_CUDA_ARCHITECTURES=native`.)

Finally, you can launch a debugging session from VSCode's "debug pane". In this example I've set a breakpoint by hand just for this demonstration.

![Screenshot from 2025-05-11 09-35-34](https://github.com/user-attachments/assets/30a48be4-847c-491d-b7ea-6710b4e92b56)

Having been able to inspect variables graphically like this, helped me out in a number of cases already...