### PR TITLE
Make Greedy solver handel duplicate measurements in patterns

### DIFF
--- a/tests/cpu/test_ambiguity_resolution.cpp
+++ b/tests/cpu/test_ambiguity_resolution.cpp
@@ -57,9 +57,9 @@ TEST(AmbiguitySolverTests, GreedyResolverTest0) {
     track_candidate_container_types::host trk_cands;
 
     trk_cands.resize(3u);
-    fill_pattern(trk_cands, 0, 0.23f, {1, 3, 5, 11});
-    fill_pattern(trk_cands, 1, 0.85f, {6, 7, 8, 9, 10, 12});
-    fill_pattern(trk_cands, 2, 0.42f, {2, 4, 13});
+    fill_pattern(trk_cands, 0, 0.23f, {5, 1, 11, 3});
+    fill_pattern(trk_cands, 1, 0.85f, {12, 10, 9, 8, 7, 6});
+    fill_pattern(trk_cands, 2, 0.42f, {4, 2, 13});
 
     traccc::host::greedy_ambiguity_resolution_algorithm::config_type
         resolution_config;
@@ -72,11 +72,11 @@ TEST(AmbiguitySolverTests, GreedyResolverTest0) {
         // All tracks are accepted as they have more than three measurements
         ASSERT_EQ(res_trk_cands.size(), 3u);
         ASSERT_EQ(get_pattern(res_trk_cands, 0),
-                  std::vector<std::size_t>({1, 3, 5, 11}));
+                  std::vector<std::size_t>({5, 1, 11, 3}));
         ASSERT_EQ(get_pattern(res_trk_cands, 1),
-                  std::vector<std::size_t>({6, 7, 8, 9, 10, 12}));
+                  std::vector<std::size_t>({12, 10, 9, 8, 7, 6}));
         ASSERT_EQ(get_pattern(res_trk_cands, 2),
-                  std::vector<std::size_t>({2, 4, 13}));
+                  std::vector<std::size_t>({4, 2, 13}));
     }
 
     {
@@ -85,7 +85,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest0) {
         // Only the second track with six measurements is accepted
         ASSERT_EQ(res_trk_cands.size(), 1u);
         ASSERT_EQ(get_pattern(res_trk_cands, 0),
-                  std::vector<std::size_t>({6, 7, 8, 9, 10, 12}));
+                  std::vector<std::size_t>({12, 10, 9, 8, 7, 6}));
     }
 
     /*******************
@@ -101,6 +101,12 @@ TEST(AmbiguitySolverTests, GreedyResolverTest0) {
         legacy_resolution_alg.get_config().n_measurements_min = 3;
         auto res_trk_cands = legacy_resolution_alg(trk_cands);
         ASSERT_EQ(res_trk_cands.size(), 3u);
+        ASSERT_EQ(get_pattern(res_trk_cands, 0),
+                  std::vector<std::size_t>({5, 1, 11, 3}));
+        ASSERT_EQ(get_pattern(res_trk_cands, 1),
+                  std::vector<std::size_t>({12, 10, 9, 8, 7, 6}));
+        ASSERT_EQ(get_pattern(res_trk_cands, 2),
+                  std::vector<std::size_t>({4, 2, 13}));
     }
 
     {
@@ -113,7 +119,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest0) {
         auto res_trk_cands = legacy_resolution_alg(trk_cands);
         ASSERT_EQ(res_trk_cands.size(), 1u);
         ASSERT_EQ(get_pattern(res_trk_cands, 0),
-                  std::vector<std::size_t>({6, 7, 8, 9, 10, 12}));
+                  std::vector<std::size_t>({12, 10, 9, 8, 7, 6}));
     }
 }
 
@@ -122,8 +128,8 @@ TEST(AmbiguitySolverTests, GreedyResolverTest1) {
     track_candidate_container_types::host trk_cands;
 
     trk_cands.resize(2u);
-    fill_pattern(trk_cands, 0, 0.12f, {1, 3, 5, 11, 14, 16, 18});
-    fill_pattern(trk_cands, 1, 0.53f, {3, 5, 6, 13});
+    fill_pattern(trk_cands, 0, 0.12f, {5, 14, 1, 11, 18, 16, 3});
+    fill_pattern(trk_cands, 1, 0.53f, {3, 6, 5, 13});
 
     traccc::host::greedy_ambiguity_resolution_algorithm::config_type
         resolution_config;
@@ -137,7 +143,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest1) {
         // shared measurement (2/7) is lower than the one of the second track
         // (2/4)
         ASSERT_EQ(get_pattern(res_trk_cands, 0),
-                  std::vector<std::size_t>({1, 3, 5, 11, 14, 16, 18}));
+                  std::vector<std::size_t>({5, 14, 1, 11, 18, 16, 3}));
     }
 
     /*******************
@@ -157,7 +163,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest1) {
         // shared measurement (2/7) is lower than the one of the second track
         // (2/4)
         ASSERT_EQ(get_pattern(res_trk_cands, 0),
-                  std::vector<std::size_t>({1, 3, 5, 11, 14, 16, 18}));
+                  std::vector<std::size_t>({5, 14, 1, 11, 18, 16, 3}));
     }
 }
 
@@ -188,10 +194,10 @@ TEST(AmbiguitySolverTests, GreedyResolverTest3) {
 
     track_candidate_container_types::host trk_cands;
     trk_cands.resize(6u);
-    fill_pattern(trk_cands, 0, 0.2f, {1, 3, 5, 11});
-    fill_pattern(trk_cands, 1, 0.5f, {2, 6});
-    fill_pattern(trk_cands, 2, 0.4f, {3, 6, 12, 14, 19, 21});
-    fill_pattern(trk_cands, 3, 0.1f, {2, 7, 11, 13, 16});
+    fill_pattern(trk_cands, 0, 0.2f, {5, 1, 11, 3});
+    fill_pattern(trk_cands, 1, 0.5f, {6, 2});
+    fill_pattern(trk_cands, 2, 0.4f, {3, 21, 12, 6, 19, 14});
+    fill_pattern(trk_cands, 3, 0.1f, {13, 16, 2, 7, 11});
     fill_pattern(trk_cands, 4, 0.3f, {1, 7, 8});
     fill_pattern(trk_cands, 5, 0.6f, {1, 3, 11, 22});
 
@@ -205,9 +211,9 @@ TEST(AmbiguitySolverTests, GreedyResolverTest3) {
         ASSERT_EQ(res_trk_cands.size(), 2u);
 
         ASSERT_EQ(get_pattern(res_trk_cands, 0),
-                  std::vector<std::size_t>({3, 6, 12, 14, 19, 21}));
+                  std::vector<std::size_t>({3, 21, 12, 6, 19, 14}));
         ASSERT_EQ(get_pattern(res_trk_cands, 1),
-                  std::vector<std::size_t>({2, 7, 11, 13, 16}));
+                  std::vector<std::size_t>({13, 16, 2, 7, 11}));
     }
 
     // Legacy algorithm
@@ -220,9 +226,9 @@ TEST(AmbiguitySolverTests, GreedyResolverTest3) {
         ASSERT_EQ(res_trk_cands.size(), 2u);
 
         ASSERT_EQ(get_pattern(res_trk_cands, 0),
-                  std::vector<std::size_t>({3, 6, 12, 14, 19, 21}));
+                  std::vector<std::size_t>({3, 21, 12, 6, 19, 14}));
         ASSERT_EQ(get_pattern(res_trk_cands, 1),
-                  std::vector<std::size_t>({2, 7, 11, 13, 16}));
+                  std::vector<std::size_t>({13, 16, 2, 7, 11}));
     }
 }
 
@@ -304,5 +310,56 @@ TEST(AmbiguitySolverTests, GreedyResolverTest4) {
         ASSERT_EQ(res_trk_cands.at(i).header,
                   legacy_res_trk_cands.at(i).header);
         ASSERT_EQ(res_trk_cands.at(i).items, legacy_res_trk_cands.at(i).items);
+    }
+}
+
+TEST(AmbiguitySolverTests, GreedyResolverTest5) {
+
+    track_candidate_container_types::host trk_cands;
+    trk_cands.resize(4u);
+    fill_pattern(trk_cands, 0, 0.2f, {1, 2, 1, 1});
+    fill_pattern(trk_cands, 1, 0.5f, {3, 2, 1});
+    fill_pattern(trk_cands, 2, 0.4f, {2, 4, 5, 7, 2});
+    fill_pattern(trk_cands, 3, 0.1f, {6, 6, 6, 6});
+
+    traccc::host::greedy_ambiguity_resolution_algorithm::config_type
+        resolution_config;
+    traccc::host::greedy_ambiguity_resolution_algorithm resolution_alg(
+        resolution_config, mr);
+
+    {
+        auto res_trk_cands = resolution_alg(traccc::get_data(trk_cands));
+        ASSERT_EQ(res_trk_cands.size(), 2u);
+
+        ASSERT_EQ(get_pattern(res_trk_cands, 0),
+                  std::vector<std::size_t>({3, 2, 1}));
+        ASSERT_EQ(get_pattern(res_trk_cands, 1),
+                  std::vector<std::size_t>({6, 6, 6, 6}));
+    }
+}
+
+TEST(AmbiguitySolverTests, GreedyResolverTest6) {
+
+    track_candidate_container_types::host trk_cands;
+    trk_cands.resize(5u);
+    fill_pattern(trk_cands, 0, 0.2f, {7, 3, 5, 7, 7, 7, 2});
+    fill_pattern(trk_cands, 1, 0.5f, {2});
+    fill_pattern(trk_cands, 2, 0.4f, {8, 9, 7, 2, 3, 4, 3, 7});
+    fill_pattern(trk_cands, 3, 0.1f, {8, 9, 0, 8, 1, 4, 6});
+    fill_pattern(trk_cands, 4, 0.9f, {10, 3, 2});
+
+    traccc::host::greedy_ambiguity_resolution_algorithm::config_type
+        resolution_config;
+    traccc::host::greedy_ambiguity_resolution_algorithm resolution_alg(
+        resolution_config, mr);
+
+    {
+        auto res_trk_cands = resolution_alg(traccc::get_data(trk_cands));
+        ASSERT_EQ(res_trk_cands.size(), 2u);
+
+        ASSERT_EQ(get_pattern(res_trk_cands, 0),
+                  std::vector<std::size_t>({7, 3, 5, 7, 7, 7, 2}));
+        ASSERT_EQ(get_pattern(res_trk_cands, 1),
+                  std::vector<std::size_t>({8, 9, 0, 8, 1, 4, 6}));
     }
 }


### PR DESCRIPTION
This is from PR #943

One problem of the current and legacy greedy resolver is that the algorithm fails when there is a duplicate measurement in the pattern. This happens occasionally when CKF unexpectedly adds duplicate measurement in the pattern.

While that's mainly due to the bug in the CKF but it does not hurt to make the greedy resolver to handle such cases correctly.  

I also added a couple of tests for duplicate measurements and complicated the patterns of the existing tests.
