### PR TITLE
Fix dangling reference in full chain algorithms

### DIFF
--- a/device/alpaka/include/traccc/alpaka/clusterization/clusterization_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/clusterization/clusterization_algorithm.hpp
@@ -79,7 +79,7 @@ class clusterization_algorithm
     vecmem::data::vector_buffer<unsigned char> m_adjc_backup;
     vecmem::data::vector_buffer<device::details::index_t> m_adjv_backup;
     vecmem::unique_alloc_ptr<unsigned int> m_backup_mutex;
-    mutable std::once_flag m_setup_once;
+    std::unique_ptr<std::once_flag> m_setup_once;
 };
 
 }  // namespace traccc::alpaka

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -25,12 +25,13 @@ full_chain_algorithm::full_chain_algorithm(
     const silicon_detector_description::host& det_descr,
     host_detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
     : messaging(logger->clone()),
-      m_queue(),
-      m_vecmem_objects(m_queue),
+      m_queue(std::make_shared<traccc::alpaka::queue>()),
+      m_vecmem_objects(
+          std::make_shared<traccc::alpaka::vecmem_objects>(*m_queue)),
       m_host_mr(host_mr),
       m_cached_device_mr(
           std::make_unique<::vecmem::binary_page_memory_resource>(
-              m_vecmem_objects.device_mr())),
+              m_vecmem_objects->device_mr())),
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
       m_field(traccc::construct_const_bfield<host_detector_type::scalar_type>(
           m_field_vec)),
@@ -38,106 +39,46 @@ full_chain_algorithm::full_chain_algorithm(
       m_device_det_descr(
           static_cast<silicon_detector_description::buffer::size_type>(
               m_det_descr.get().size()),
-          m_vecmem_objects.device_mr()),
+          m_vecmem_objects->device_mr()),
       m_detector(detector),
       m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr},
-                       m_vecmem_objects.copy(), clustering_config),
-      m_measurement_sorting(m_vecmem_objects.copy(),
+                       m_vecmem_objects->copy(), clustering_config),
+      m_measurement_sorting(m_vecmem_objects->copy(),
                             logger->cloneWithSuffix("MeasSortingAlg")),
       m_spacepoint_formation(memory_resource{*m_cached_device_mr, &m_host_mr},
-                             m_vecmem_objects.copy(),
+                             m_vecmem_objects->copy(),
                              logger->cloneWithSuffix("SpFormationAlg")),
       m_seeding(finder_config, grid_config, filter_config,
                 memory_resource{*m_cached_device_mr, &m_host_mr},
-                m_vecmem_objects.copy(), logger->cloneWithSuffix("SeedingAlg")),
+                m_vecmem_objects->copy(),
+                logger->cloneWithSuffix("SeedingAlg")),
       m_track_parameter_estimation(
           memory_resource{*m_cached_device_mr, &m_host_mr},
-          m_vecmem_objects.copy(), logger->cloneWithSuffix("TrackParamEstAlg")),
+          m_vecmem_objects->copy(),
+          logger->cloneWithSuffix("TrackParamEstAlg")),
       m_finding(
           finding_config, memory_resource{*m_cached_device_mr, &m_host_mr},
-          m_vecmem_objects.copy(), logger->cloneWithSuffix("TrackFindingAlg")),
-      m_fitting(
-          fitting_config, memory_resource{*m_cached_device_mr, &m_host_mr},
-          m_vecmem_objects.copy(), logger->cloneWithSuffix("TrackFittingAlg")),
-      m_clustering_config(clustering_config),
-      m_finder_config(finder_config),
-      m_grid_config(grid_config),
-      m_filter_config(filter_config),
-      m_finding_config(finding_config),
-      m_fitting_config(fitting_config) {
-
+          m_vecmem_objects->copy(), logger->cloneWithSuffix("TrackFindingAlg")),
+      m_fitting(fitting_config,
+                memory_resource{*m_cached_device_mr, &m_host_mr},
+                m_vecmem_objects->copy(),
+                logger->cloneWithSuffix("TrackFittingAlg")) {
     std::cout << traccc::alpaka::get_device_info() << std::endl;
 
     // Copy the detector (description) to the device.
     m_vecmem_objects
-        .copy()(::vecmem::get_data(m_det_descr.get()), m_device_det_descr)
+        ->copy()(::vecmem::get_data(m_det_descr.get()), m_device_det_descr)
         ->ignore();
     if (m_detector != nullptr) {
         m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
-                                               m_vecmem_objects.device_mr(),
-                                               m_vecmem_objects.copy());
+                                               m_vecmem_objects->device_mr(),
+                                               m_vecmem_objects->copy());
         m_device_detector_view = detray::get_data(m_device_detector);
     }
 }
 
-full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
-    : messaging(parent.logger().clone()),
-      m_queue(),
-      m_vecmem_objects(m_queue),
-      m_host_mr(parent.m_host_mr),
-      m_cached_device_mr(
-          std::make_unique<::vecmem::binary_page_memory_resource>(
-              m_vecmem_objects.device_mr())),
-      m_field_vec(parent.m_field_vec),
-      m_field(parent.m_field),
-      m_det_descr(parent.m_det_descr),
-      m_device_det_descr(
-          static_cast<silicon_detector_description::buffer::size_type>(
-              m_det_descr.get().size()),
-          m_vecmem_objects.device_mr()),
-      m_detector(parent.m_detector),
-      m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr},
-                       m_vecmem_objects.copy(), parent.m_clustering_config),
-      m_measurement_sorting(m_vecmem_objects.copy(),
-                            parent.logger().cloneWithSuffix("MeasSortingAlg")),
-      m_spacepoint_formation(memory_resource{*m_cached_device_mr, &m_host_mr},
-                             m_vecmem_objects.copy(),
-                             parent.logger().cloneWithSuffix("SpFormationAlg")),
-      m_seeding(parent.m_finder_config, parent.m_grid_config,
-                parent.m_filter_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr},
-                m_vecmem_objects.copy(),
-                parent.logger().cloneWithSuffix("SeedingAlg")),
-      m_track_parameter_estimation(
-          memory_resource{*m_cached_device_mr, &m_host_mr},
-          m_vecmem_objects.copy(),
-          parent.logger().cloneWithSuffix("TrackParamEstAlg")),
-      m_finding(parent.m_finding_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr},
-                m_vecmem_objects.copy(),
-                parent.logger().cloneWithSuffix("TrackFindingAlg")),
-      m_fitting(parent.m_fitting_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr},
-                m_vecmem_objects.copy(),
-                parent.logger().cloneWithSuffix("TrackFittingAlg")),
-      m_clustering_config(parent.m_clustering_config),
-      m_finder_config(parent.m_finder_config),
-      m_grid_config(parent.m_grid_config),
-      m_filter_config(parent.m_filter_config),
-      m_finding_config(parent.m_finding_config),
-      m_fitting_config(parent.m_fitting_config) {
-
-    // Copy the detector (description) to the device.
-    m_vecmem_objects
-        .copy()(::vecmem::get_data(m_det_descr.get()), m_device_det_descr)
-        ->ignore();
-    if (m_detector != nullptr) {
-        m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
-                                               m_vecmem_objects.device_mr(),
-                                               m_vecmem_objects.copy());
-        m_device_detector_view = detray::get_data(m_device_detector);
-    }
-}
+full_chain_algorithm::full_chain_algorithm(
+    full_chain_algorithm&& other) noexcept = default;
 
 full_chain_algorithm::~full_chain_algorithm() = default;
 
@@ -147,7 +88,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     // Create device copy of input collections
     edm::silicon_cell_collection::buffer cells_buffer(
         static_cast<unsigned int>(cells.size()), *m_cached_device_mr);
-    m_vecmem_objects.copy()(::vecmem::get_data(cells), cells_buffer)->ignore();
+    m_vecmem_objects->copy()(::vecmem::get_data(cells), cells_buffer)->ignore();
 
     // Run the clusterization.
     const clusterization_algorithm::output_type measurements =
@@ -174,7 +115,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
 
         // Copy a limited amount of result data back to the host.
         output_type result{&m_host_mr};
-        m_vecmem_objects.copy()(track_states.headers, result)->wait();
+        m_vecmem_objects->copy()(track_states.headers, result)->wait();
         return result;
 
     }
@@ -184,7 +125,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
 
         // Copy the measurements back to the host.
         measurement_collection_types::host measurements_host(&m_host_mr);
-        m_vecmem_objects.copy()(measurements, measurements_host)->wait();
+        m_vecmem_objects->copy()(measurements, measurements_host)->wait();
 
         // Return an empty object.
         return {};

--- a/examples/run/alpaka/full_chain_algorithm.hpp
+++ b/examples/run/alpaka/full_chain_algorithm.hpp
@@ -99,15 +99,11 @@ class full_chain_algorithm
                          host_detector_type* detector,
                          std::unique_ptr<const traccc::Logger> logger);
 
-    /// Copy constructor
-    ///
-    /// An explicit copy constructor is necessary because in the MT tests
-    /// we do want to copy such objects, but a default copy-constructor can
-    /// not be generated for them.
-    ///
-    /// @param parent The parent algorithm chain to copy
-    ///
-    full_chain_algorithm(const full_chain_algorithm& parent);
+    full_chain_algorithm() = delete;
+    full_chain_algorithm(const full_chain_algorithm& other) = delete;
+    full_chain_algorithm(full_chain_algorithm&& other) noexcept;
+    full_chain_algorithm& operator=(const full_chain_algorithm& other) = delete;
+    full_chain_algorithm& operator=(full_chain_algorithm&& other) = delete;
 
     /// Algorithm destructor
     ~full_chain_algorithm();
@@ -122,9 +118,9 @@ class full_chain_algorithm
 
     private:
     /// Alpaka Queue
-    traccc::alpaka::queue m_queue;
+    std::shared_ptr<traccc::alpaka::queue> m_queue;
     /// Alpaka Vecmem objects, to get the memory resources
-    traccc::alpaka::vecmem_objects m_vecmem_objects;
+    std::shared_ptr<traccc::alpaka::vecmem_objects> m_vecmem_objects;
 
     /// Host memory resource
     ::vecmem::memory_resource& m_host_mr;
@@ -168,26 +164,6 @@ class full_chain_algorithm
     fitting_algorithm m_fitting;
 
     /// @}
-
-    /// @name Algorithm configurations
-    /// @{
-
-    /// Configuration for clustering
-    clustering_config m_clustering_config;
-    /// Configuration for the seed finding
-    seedfinder_config m_finder_config;
-    /// Configuration for the spacepoint grid formation
-    spacepoint_grid_config m_grid_config;
-    /// Configuration for the seed filtering
-    seedfilter_config m_filter_config;
-
-    /// Configuration for the track finding
-    finding_algorithm::config_type m_finding_config;
-    /// Configuration for the track fitting
-    fitting_algorithm::config_type m_fitting_config;
-
-    /// @}
-
 };  // class full_chain_algorithm
 
 }  // namespace traccc::alpaka

--- a/examples/run/cpu/full_chain_algorithm.cpp
+++ b/examples/run/cpu/full_chain_algorithm.cpp
@@ -20,26 +20,26 @@ full_chain_algorithm::full_chain_algorithm(
     const silicon_detector_description::host& det_descr,
     detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
     : messaging(logger->clone()),
+      m_mr(mr),
+      m_copy(std::make_shared<vecmem::copy>()),
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
       m_field(
           traccc::construct_const_bfield<typename detector_type::scalar_type>(
               m_field_vec)),
       m_det_descr(det_descr),
       m_detector(detector),
-      m_clusterization(mr, logger->cloneWithSuffix("ClusteringAlg")),
-      m_spacepoint_formation(mr, logger->cloneWithSuffix("SpFormationAlg")),
-      m_seeding(finder_config, grid_config, filter_config, mr,
+      m_clusterization(m_mr, logger->cloneWithSuffix("ClusteringAlg")),
+      m_spacepoint_formation(m_mr, logger->cloneWithSuffix("SpFormationAlg")),
+      m_seeding(finder_config, grid_config, filter_config, m_mr,
                 logger->cloneWithSuffix("SeedingAlg")),
-      m_track_parameter_estimation(mr,
+      m_track_parameter_estimation(m_mr,
                                    logger->cloneWithSuffix("TrackParamEstAlg")),
       m_finding(finding_config, logger->cloneWithSuffix("TrackFindingAlg")),
-      m_fitting(fitting_config, mr, m_copy,
-                logger->cloneWithSuffix("TrackFittingAlg")),
-      m_finder_config(finder_config),
-      m_grid_config(grid_config),
-      m_filter_config(filter_config),
-      m_finding_config(finding_config),
-      m_fitting_config(fitting_config) {}
+      m_fitting(fitting_config, m_mr, *m_copy,
+                logger->cloneWithSuffix("TrackFittingAlg")) {}
+
+full_chain_algorithm::full_chain_algorithm(
+    full_chain_algorithm&& other) noexcept = default;
 
 full_chain_algorithm::output_type full_chain_algorithm::operator()(
     const edm::silicon_cell_collection::host& cells) const {

--- a/examples/run/cpu/full_chain_algorithm.hpp
+++ b/examples/run/cpu/full_chain_algorithm.hpp
@@ -24,6 +24,7 @@
 #include "traccc/utils/propagation.hpp"
 
 // VecMem include(s).
+#include <memory>
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/utils/copy.hpp>
 
@@ -81,6 +82,12 @@ class full_chain_algorithm : public algorithm<track_state_container_types::host(
                          detector_type* detector,
                          std::unique_ptr<const traccc::Logger> logger);
 
+    full_chain_algorithm() = delete;
+    full_chain_algorithm(const full_chain_algorithm& other) = delete;
+    full_chain_algorithm(full_chain_algorithm&& other) noexcept;
+    full_chain_algorithm& operator=(const full_chain_algorithm& other) = delete;
+    full_chain_algorithm& operator=(full_chain_algorithm&& other) = delete;
+
     /// Reconstruct track parameters in the entire detector
     ///
     /// @param cells The cells for every detector module in the event
@@ -90,8 +97,10 @@ class full_chain_algorithm : public algorithm<track_state_container_types::host(
         const edm::silicon_cell_collection::host& cells) const override;
 
     private:
+    /// The host memory resource
+    vecmem::memory_resource& m_mr;
     /// Vecmem copy object
-    vecmem::copy m_copy;
+    std::shared_ptr<vecmem::copy> m_copy;
     /// Constant B field for the (seed) track parameter estimation
     traccc::vector3 m_field_vec;
     /// Constant B field for the track finding and fitting
@@ -119,23 +128,6 @@ class full_chain_algorithm : public algorithm<track_state_container_types::host(
     finding_algorithm m_finding;
     /// Track fitting algorithm
     fitting_algorithm m_fitting;
-
-    /// @}
-
-    /// @name Algorithm configurations
-    /// @{
-
-    /// Configuration for the seed finding
-    seedfinder_config m_finder_config;
-    /// Configuration for the spacepoint grid formation
-    spacepoint_grid_config m_grid_config;
-    /// Configuration for the seed filtering
-    seedfilter_config m_filter_config;
-
-    /// Configuration for the track finding
-    finding_algorithm::config_type m_finding_config;
-    /// Configuration for the track fitting
-    fitting_algorithm::config_type m_fitting_config;
 
     /// @}
 };  // class full_chain_algorithm

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -13,6 +13,7 @@
 
 // System include(s).
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 
 /// Helper macro for checking the return value of CUDA function calls
@@ -39,11 +40,12 @@ full_chain_algorithm::full_chain_algorithm(
     host_detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
     : messaging(logger->clone()),
       m_host_mr(host_mr),
-      m_stream(),
-      m_device_mr(),
+      m_stream(std::make_shared<stream>()),
+      m_device_mr(std::make_shared<vecmem::cuda::device_memory_resource>()),
       m_cached_device_mr(
-          std::make_unique<vecmem::binary_page_memory_resource>(m_device_mr)),
-      m_copy(m_stream.cudaStream()),
+          std::make_shared<vecmem::binary_page_memory_resource>(*m_device_mr)),
+      m_copy(
+          std::make_shared<vecmem::cuda::async_copy>(m_stream->cudaStream())),
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
       m_field(traccc::construct_const_bfield<host_detector_type::scalar_type>(
           m_field_vec)),
@@ -51,35 +53,28 @@ full_chain_algorithm::full_chain_algorithm(
       m_device_det_descr(
           static_cast<silicon_detector_description::buffer::size_type>(
               m_det_descr.get().size()),
-          m_device_mr),
+          *m_device_mr),
       m_detector(detector),
-      m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                       m_stream, clustering_config),
+      m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr},
+                       *m_copy, *m_stream, clustering_config),
       m_measurement_sorting(memory_resource{*m_cached_device_mr, &m_host_mr},
-                            m_copy, m_stream,
+                            *m_copy, *m_stream,
                             logger->cloneWithSuffix("MeasSortingAlg")),
       m_spacepoint_formation(memory_resource{*m_cached_device_mr, &m_host_mr},
-                             m_copy, m_stream,
+                             *m_copy, *m_stream,
                              logger->cloneWithSuffix("SpFormationAlg")),
       m_seeding(finder_config, grid_config, filter_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                m_stream, logger->cloneWithSuffix("SeedingAlg")),
+                memory_resource{*m_cached_device_mr, &m_host_mr}, *m_copy,
+                *m_stream, logger->cloneWithSuffix("SeedingAlg")),
       m_track_parameter_estimation(
-          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy, m_stream,
+          memory_resource{*m_cached_device_mr, &m_host_mr}, *m_copy, *m_stream,
           logger->cloneWithSuffix("TrackParEstAlg")),
       m_finding(finding_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                m_stream, logger->cloneWithSuffix("TrackFindingAlg")),
+                memory_resource{*m_cached_device_mr, &m_host_mr}, *m_copy,
+                *m_stream, logger->cloneWithSuffix("TrackFindingAlg")),
       m_fitting(fitting_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                m_stream, logger->cloneWithSuffix("TrackFittingAlg")),
-      m_clustering_config(clustering_config),
-      m_finder_config(finder_config),
-      m_grid_config(grid_config),
-      m_filter_config(filter_config),
-      m_finding_config(finding_config),
-      m_fitting_config(fitting_config) {
-
+                memory_resource{*m_cached_device_mr, &m_host_mr}, *m_copy,
+                *m_stream, logger->cloneWithSuffix("TrackFittingAlg")) {
     // Tell the user what device is being used.
     int device = 0;
     CUDA_ERROR_CHECK(cudaGetDevice(&device));
@@ -90,66 +85,17 @@ full_chain_algorithm::full_chain_algorithm(
               << ", device: " << props.pciDeviceID << "]" << std::endl;
 
     // Copy the detector (description) to the device.
-    m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->ignore();
+    (*m_copy)(vecmem::get_data(m_det_descr.get()), m_device_det_descr)
+        ->ignore();
     if (m_detector != nullptr) {
         m_device_detector =
-            detray::get_buffer(*m_detector, m_device_mr, m_copy);
+            detray::get_buffer(*m_detector, *m_device_mr, *m_copy);
         m_device_detector_view = detray::get_data(m_device_detector);
     }
 }
 
-full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
-    : messaging(parent.logger().clone()),
-      m_host_mr(parent.m_host_mr),
-      m_stream(),
-      m_device_mr(),
-      m_cached_device_mr(
-          std::make_unique<vecmem::binary_page_memory_resource>(m_device_mr)),
-      m_copy(m_stream.cudaStream()),
-      m_field_vec(parent.m_field_vec),
-      m_field(parent.m_field),
-      m_det_descr(parent.m_det_descr),
-      m_device_det_descr(
-          static_cast<silicon_detector_description::buffer::size_type>(
-              m_det_descr.get().size()),
-          m_device_mr),
-      m_detector(parent.m_detector),
-      m_clusterization(memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                       m_stream, parent.m_clustering_config),
-      m_measurement_sorting(memory_resource{*m_cached_device_mr, &m_host_mr},
-                            m_copy, m_stream,
-                            parent.logger().cloneWithSuffix("MeasSortingAlg")),
-      m_spacepoint_formation(memory_resource{*m_cached_device_mr, &m_host_mr},
-                             m_copy, m_stream,
-                             parent.logger().cloneWithSuffix("SpFormationAlg")),
-      m_seeding(parent.m_finder_config, parent.m_grid_config,
-                parent.m_filter_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                m_stream, parent.logger().cloneWithSuffix("SeedingAlg")),
-      m_track_parameter_estimation(
-          memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy, m_stream,
-          parent.logger().cloneWithSuffix("TrackParamEstAlg")),
-      m_finding(parent.m_finding_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                m_stream, parent.logger().cloneWithSuffix("TrackFindingAlg")),
-      m_fitting(parent.m_fitting_config,
-                memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                m_stream, parent.logger().cloneWithSuffix("TrackFittingAlg")),
-      m_clustering_config(parent.m_clustering_config),
-      m_finder_config(parent.m_finder_config),
-      m_grid_config(parent.m_grid_config),
-      m_filter_config(parent.m_filter_config),
-      m_finding_config(parent.m_finding_config),
-      m_fitting_config(parent.m_fitting_config) {
-
-    // Copy the detector (description) to the device.
-    m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->ignore();
-    if (m_detector != nullptr) {
-        m_device_detector =
-            detray::get_buffer(*m_detector, m_device_mr, m_copy);
-        m_device_detector_view = detray::get_data(m_device_detector);
-    }
-}
+full_chain_algorithm::full_chain_algorithm(
+    full_chain_algorithm&& other) noexcept = default;
 
 full_chain_algorithm::~full_chain_algorithm() = default;
 
@@ -159,7 +105,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     // Create device copy of input collections
     edm::silicon_cell_collection::buffer cells_buffer(
         static_cast<unsigned int>(cells.size()), *m_cached_device_mr);
-    m_copy(vecmem::get_data(cells), cells_buffer)->ignore();
+    (*m_copy)(vecmem::get_data(cells), cells_buffer)->ignore();
 
     // Run the clusterization (asynchronously).
     const clusterization_algorithm::output_type measurements =
@@ -186,7 +132,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
 
         // Copy a limited amount of result data back to the host.
         output_type result{&m_host_mr};
-        m_copy(track_states.headers, result)->wait();
+        (*m_copy)(track_states.headers, result)->wait();
         return result;
 
     }
@@ -196,7 +142,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
 
         // Copy the measurements back to the host.
         measurement_collection_types::host measurements_host(&m_host_mr);
-        m_copy(measurements, measurements_host)->wait();
+        (*m_copy)(measurements, measurements_host)->wait();
 
         // Return an empty object.
         return {};

--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -100,15 +100,11 @@ class full_chain_algorithm
                          host_detector_type* detector,
                          std::unique_ptr<const traccc::Logger> logger);
 
-    /// Copy constructor
-    ///
-    /// An explicit copy constructor is necessary because in the MT tests
-    /// we do want to copy such objects, but a default copy-constructor can
-    /// not be generated for them.
-    ///
-    /// @param parent The parent algorithm chain to copy
-    ///
-    full_chain_algorithm(const full_chain_algorithm& parent);
+    full_chain_algorithm() = delete;
+    full_chain_algorithm(const full_chain_algorithm& other) = delete;
+    full_chain_algorithm(full_chain_algorithm&& other) noexcept;
+    full_chain_algorithm& operator=(const full_chain_algorithm& other) = delete;
+    full_chain_algorithm& operator=(full_chain_algorithm&& other) = delete;
 
     /// Algorithm destructor
     ~full_chain_algorithm();
@@ -125,13 +121,13 @@ class full_chain_algorithm
     /// Host memory resource
     vecmem::memory_resource& m_host_mr;
     /// CUDA stream to use
-    stream m_stream;
+    std::shared_ptr<stream> m_stream;
     /// Device memory resource
-    vecmem::cuda::device_memory_resource m_device_mr;
+    std::shared_ptr<vecmem::cuda::device_memory_resource> m_device_mr;
     /// Device caching memory resource
-    std::unique_ptr<vecmem::binary_page_memory_resource> m_cached_device_mr;
+    std::shared_ptr<vecmem::binary_page_memory_resource> m_cached_device_mr;
     /// (Asynchronous) Memory copy object
-    mutable vecmem::cuda::async_copy m_copy;
+    std::shared_ptr<vecmem::cuda::async_copy> m_copy;
 
     /// Constant B field for the (seed) track parameter estimation
     traccc::vector3 m_field_vec;
@@ -168,25 +164,6 @@ class full_chain_algorithm
     finding_algorithm m_finding;
     /// Track fitting algorithm
     fitting_algorithm m_fitting;
-
-    /// @}
-
-    /// @name Algorithm configurations
-    /// @{
-
-    /// Configuration for clustering
-    clustering_config m_clustering_config;
-    /// Configuration for the seed finding
-    seedfinder_config m_finder_config;
-    /// Configuration for the spacepoint grid formation
-    spacepoint_grid_config m_grid_config;
-    /// Configuration for the seed filtering
-    seedfilter_config m_filter_config;
-
-    /// Configuration for the track finding
-    finding_algorithm::config_type m_finding_config;
-    /// Configuration for the track fitting
-    fitting_algorithm::config_type m_fitting_config;
 
     /// @}
 };  // class full_chain_algorithm

--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -95,15 +95,11 @@ class full_chain_algorithm
                          host_detector_type* detector,
                          std::unique_ptr<const traccc::Logger> logger);
 
-    /// Copy constructor
-    ///
-    /// An explicit copy constructor is necessary because in the MT tests
-    /// we do want to copy such objects, but a default copy-constructor can
-    /// not be generated for them.
-    ///
-    /// @param parent The parent algorithm chain to copy
-    ///
-    full_chain_algorithm(const full_chain_algorithm& parent);
+    full_chain_algorithm() = delete;
+    full_chain_algorithm(const full_chain_algorithm& other) = delete;
+    full_chain_algorithm(full_chain_algorithm&& other) noexcept;
+    full_chain_algorithm& operator=(const full_chain_algorithm& other) = delete;
+    full_chain_algorithm& operator=(full_chain_algorithm&& other) = delete;
 
     /// Algorithm destructor
     ~full_chain_algorithm();
@@ -122,11 +118,11 @@ class full_chain_algorithm
     /// Host memory resource
     std::reference_wrapper<vecmem::memory_resource> m_host_mr;
     /// Device memory resource
-    vecmem::sycl::device_memory_resource m_device_mr;
+    std::shared_ptr<vecmem::sycl::device_memory_resource> m_device_mr;
     /// Device caching memory resource
-    mutable vecmem::binary_page_memory_resource m_cached_device_mr;
+    std::shared_ptr<vecmem::binary_page_memory_resource> m_cached_device_mr;
     /// Memory copy object
-    mutable vecmem::sycl::async_copy m_copy;
+    std::shared_ptr<vecmem::sycl::async_copy> m_copy;
 
     /// Constant B field for the (seed) track parameter estimation
     traccc::vector3 m_field_vec;
@@ -162,23 +158,6 @@ class full_chain_algorithm
     finding_algorithm m_finding;
 
     /// @}
-
-    /// @}
-
-    /// @name Algorithm configurations
-    /// @{
-
-    /// Configuration for clustering
-    clustering_config m_clustering_config;
-    /// Configuration for the seed finding
-    seedfinder_config m_finder_config;
-    /// Configuration for the spacepoint grid formation
-    spacepoint_grid_config m_grid_config;
-    /// Configuration for the seed filtering
-    seedfilter_config m_filter_config;
-
-    /// Configuration for the track finding
-    finding_algorithm::config_type m_finding_config;
 
     /// @}
 };  // class full_chain_algorithm

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -62,9 +62,11 @@ full_chain_algorithm::full_chain_algorithm(
       m_data(std::make_unique<details::full_chain_algorithm_data>(
           ::handle_async_error)),
       m_host_mr(host_mr),
-      m_device_mr{&(m_data->m_queue)},
-      m_cached_device_mr{m_device_mr},
-      m_copy{&(m_data->m_queue)},
+      m_device_mr{std::make_shared<vecmem::sycl::device_memory_resource>(
+          &(m_data->m_queue))},
+      m_cached_device_mr{
+          std::make_shared<vecmem::binary_page_memory_resource>(*m_device_mr)},
+      m_copy{std::make_shared<vecmem::sycl::async_copy>(&(m_data->m_queue))},
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
       m_field{traccc::construct_const_bfield<host_detector_type::scalar_type>(
           m_field_vec)},
@@ -72,36 +74,32 @@ full_chain_algorithm::full_chain_algorithm(
       m_device_det_descr{
           static_cast<silicon_detector_description::buffer::size_type>(
               m_det_descr.get().size()),
-          m_device_mr},
+          *m_device_mr},
       m_detector(detector),
       m_device_detector{},
-      m_clusterization{memory_resource{m_cached_device_mr, &(m_host_mr.get())},
-                       m_copy, m_data->m_queue_wrapper, clustering_config,
+      m_clusterization{memory_resource{*m_cached_device_mr, &(m_host_mr.get())},
+                       *m_copy, m_data->m_queue_wrapper, clustering_config,
                        logger->clone("ClusteringAlg")},
       m_measurement_sorting(
-          memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
+          memory_resource{*m_cached_device_mr, &(m_host_mr.get())}, *m_copy,
           m_data->m_queue_wrapper, logger->clone("MeasSortingAlg")),
       m_spacepoint_formation{
-          memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
+          memory_resource{*m_cached_device_mr, &(m_host_mr.get())}, *m_copy,
           m_data->m_queue_wrapper, logger->clone("SpFormationAlg")},
       m_seeding{finder_config,
                 grid_config,
                 filter_config,
-                memory_resource{m_cached_device_mr, &(m_host_mr.get())},
-                m_copy,
+                memory_resource{*m_cached_device_mr, &(m_host_mr.get())},
+                *m_copy,
                 m_data->m_queue_wrapper,
                 logger->clone("SeedingAlg")},
       m_track_parameter_estimation{
-          memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
+          memory_resource{*m_cached_device_mr, &(m_host_mr.get())}, *m_copy,
           m_data->m_queue_wrapper, logger->clone("TrackParEstAlg")},
       m_finding{finding_config,
-                memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-                m_data->m_queue_wrapper, logger->clone("TrackFindingAlg")},
-      m_clustering_config(clustering_config),
-      m_finder_config(finder_config),
-      m_grid_config(grid_config),
-      m_filter_config(filter_config),
-      m_finding_config(finding_config) {
+                memory_resource{*m_cached_device_mr, &(m_host_mr.get())},
+                *m_copy, m_data->m_queue_wrapper,
+                logger->clone("TrackFindingAlg")} {
 
     // Tell the user what device is being used.
     std::cout
@@ -110,68 +108,16 @@ full_chain_algorithm::full_chain_algorithm(
         << std::endl;
 
     // Copy the detector (description) to the device.
-    m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->wait();
+    (*m_copy)(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->wait();
     if (m_detector != nullptr) {
         m_device_detector =
-            detray::get_buffer(*m_detector, m_device_mr, m_copy);
+            detray::get_buffer(*m_detector, *m_device_mr, *m_copy);
         m_device_detector_view = detray::get_data(m_device_detector);
     }
 }
 
-full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
-    : messaging(parent.logger().clone()),
-      m_data(std::make_unique<details::full_chain_algorithm_data>(
-          ::handle_async_error)),
-      m_host_mr(parent.m_host_mr),
-      m_device_mr{&(m_data->m_queue)},
-      m_cached_device_mr{m_device_mr},
-      m_copy{&(m_data->m_queue)},
-      m_field_vec{parent.m_field_vec},
-      m_field{parent.m_field},
-      m_det_descr(parent.m_det_descr),
-      m_device_det_descr{
-          static_cast<silicon_detector_description::buffer::size_type>(
-              m_det_descr.get().size()),
-          m_device_mr},
-      m_detector(parent.m_detector),
-      m_device_detector{},
-      m_clusterization{memory_resource{m_cached_device_mr, &(m_host_mr.get())},
-                       m_copy, m_data->m_queue_wrapper,
-                       parent.m_clustering_config,
-                       parent.logger().clone("ClusteringAlg")},
-      m_measurement_sorting(
-          memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-          m_data->m_queue_wrapper, parent.logger().clone("MeasSortingAlg")),
-      m_spacepoint_formation{
-          memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-          m_data->m_queue_wrapper, parent.logger().clone("SpFormationAlg")},
-      m_seeding{parent.m_finder_config,
-                parent.m_grid_config,
-                parent.m_filter_config,
-                memory_resource{m_cached_device_mr, &(m_host_mr.get())},
-                m_copy,
-                m_data->m_queue_wrapper,
-                parent.logger().clone("SeedingAlg")},
-      m_track_parameter_estimation{
-          memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-          m_data->m_queue_wrapper, parent.logger().clone("TrackParEstAlg")},
-      m_finding{parent.m_finding_config,
-                memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-                m_data->m_queue_wrapper, parent.logger().clone("FindingAlg")},
-      m_clustering_config(parent.m_clustering_config),
-      m_finder_config(parent.m_finder_config),
-      m_grid_config(parent.m_grid_config),
-      m_filter_config(parent.m_filter_config),
-      m_finding_config(parent.m_finding_config) {
-
-    // Copy the detector (description) to the device.
-    m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->wait();
-    if (m_detector != nullptr) {
-        m_device_detector =
-            detray::get_buffer(*m_detector, m_device_mr, m_copy);
-        m_device_detector_view = detray::get_data(m_device_detector);
-    }
-}
+full_chain_algorithm::full_chain_algorithm(full_chain_algorithm&&) noexcept =
+    default;
 
 full_chain_algorithm::~full_chain_algorithm() = default;
 
@@ -180,8 +126,8 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
 
     // Create device copy of input collections
     edm::silicon_cell_collection::buffer cells_buffer{
-        static_cast<unsigned int>(cells.size()), m_cached_device_mr};
-    m_copy(vecmem::get_data(cells), cells_buffer)->wait();
+        static_cast<unsigned int>(cells.size()), *m_cached_device_mr};
+    (*m_copy)(vecmem::get_data(cells), cells_buffer)->wait();
 
     // Execute the algorithms.
     const clusterization_algorithm::output_type measurements =
@@ -197,8 +143,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
             m_spacepoint_formation(m_device_detector_view, measurements);
         const track_params_estimation::output_type track_params =
             m_track_parameter_estimation(measurements, spacepoints,
-                                         m_seeding(spacepoints),
-                                         {0.f, 0.f, m_finder_config.bFieldInZ});
+                                         m_seeding(spacepoints), m_field_vec);
 
         // Run the track finding.
         const finding_algorithm::output_type track_candidates = m_finding(
@@ -206,7 +151,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
 
         // Get the final data back to the host.
         finding_result_collection_types::host result(&(m_host_mr.get()));
-        m_copy(track_candidates.headers, result)->wait();
+        (*m_copy)(track_candidates.headers, result)->wait();
 
         // Return the host container.
         return result;
@@ -218,7 +163,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
         // Copy the measurements back to the host.
         measurement_collection_types::host measurements_host(
             &(m_host_mr.get()));
-        m_copy(measurements, measurements_host)->wait();
+        (*m_copy)(measurements, measurements_host)->wait();
 
         // Return an empty object.
         return {};


### PR DESCRIPTION
A segmentation fault spotted by @CrossR has exposed a few problems in the way we handle full chain algorithms in our examples code. Fundamentally, the problem is that we create a full chain algorithm `A` which contains a copy object `A.copy` and a subalgorithm `A.subalg`. This subalgorithm has a copy object reference `A.subalg.copy = A.copy`. We then move `A` into `A'` which properly moves `A.copy` into `A'.copy` and `A.subalg` into `A'.subalg`, but the reference `A'.subalg.copy` still points to `A.copy` and not `A'.copy`, leading to a dangling reference.

I fixed this problem by using smart pointers, which avoid having the copy object embedded in the algorithm. I also had to make some further changes to make the algorithms properly movable, but this allowed me to remove some of the very verbose custom move- and copy constructors we had!