### PR TITLE
Add translation to silicon detector description

### DIFF
--- a/core/include/traccc/geometry/silicon_detector_description.hpp
+++ b/core/include/traccc/geometry/silicon_detector_description.hpp
@@ -191,6 +191,20 @@ class silicon_detector_description_interface : public BASE {
     TRACCC_HOST_DEVICE
     const auto& dimensions() const { return BASE::template get<7>(); }
 
+    /// The local translation vector to model e.g. Lorentz shifts
+    ///
+    /// @return A vector by which to translate the measurement in the local
+    /// coordinate frame.
+    ///
+    /// @{
+    TRACCC_HOST_DEVICE
+    auto& measurement_translation() { return BASE::template get<8>(); }
+
+    TRACCC_HOST_DEVICE
+    const auto& measurement_translation() const {
+        return BASE::template get<8>();
+    }
+    /// @}
     /// @}
 
 };  // class silicon_detector_description_interface
@@ -202,6 +216,7 @@ using silicon_detector_description = vecmem::edm::container<
     vecmem::edm::type::vector<geometry_id>, vecmem::edm::type::vector<scalar>,
     vecmem::edm::type::vector<scalar>, vecmem::edm::type::vector<scalar>,
     vecmem::edm::type::vector<scalar>, vecmem::edm::type::vector<scalar>,
-    vecmem::edm::type::vector<unsigned char> >;
+    vecmem::edm::type::vector<unsigned char>,
+    vecmem::edm::type::vector<vector2>>;
 
 }  // namespace traccc

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -133,7 +133,7 @@ inline void aggregate_cluster(
     /*
      * Fill output vector with calculated cluster properties
      */
-    out.local = mean + offset;
+    out.local = mean + offset + module_descr.measurement_translation();
     out.variance = var;
     out.surface_link = module_descr.geometry_id();
     // Set a unique identifier for the measurement.

--- a/io/src/read_detector_description.cpp
+++ b/io/src/read_detector_description.cpp
@@ -73,6 +73,7 @@ void read_csv_dd(traccc::silicon_detector_description::host& dd,
         // the surface in question.
         dd.geometry_id().back() = detray::geometry::barcode{geom_id};
         dd.acts_geometry_id().back() = geom_id;
+        dd.measurement_translation().back() = {0.f, 0.f};
 
         // Find the module's digitization configuration.
         const traccc::digitization_config::Iterator digi_it =
@@ -126,6 +127,7 @@ void read_json_dd(traccc::silicon_detector_description::host& dd,
         // the surface in question.
         dd.geometry_id().back() = surface_desc.barcode();
         dd.acts_geometry_id().back() = geom_id;
+        dd.measurement_translation().back() = {0.f, 0.f};
 
         // Find the module's digitization configuration.
         const traccc::digitization_config::Iterator digi_it =

--- a/tests/common/tests/cca_test.hpp
+++ b/tests/common/tests/cca_test.hpp
@@ -153,6 +153,7 @@ class ConnectedComponentAnalysisTests
             dd.reference_y()[i] = -0.5f;
             dd.pitch_x()[i] = pitch;
             dd.pitch_y()[i] = pitch;
+            dd.measurement_translation()[i] = {0.f, 0.f};
         }
 
         traccc::edm::silicon_cell_collection::host cells{mr};


### PR DESCRIPTION
In order to model the Lorentz shift and other effects, we will need to be able to apply a module-specific translation to measurements created in the clustering algorithm. This commit adds the infrastructure to do that.

Note that properly modelling the Lorentz shift will allow us to achieve a 1:1 match between the Athena and traccc clustering.

Tagging @paradajzblond.