### PR TITLE
Track Finding Tweaks, main branch (2025.05.21.)

### DIFF
--- a/core/include/traccc/finding/details/find_tracks.hpp
+++ b/core/include/traccc/finding/details/find_tracks.hpp
@@ -17,6 +17,7 @@
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/sanity/contiguous_on.hpp"
+#include "traccc/utils/logging.hpp"
 #include "traccc/utils/particle.hpp"
 #include "traccc/utils/prob.hpp"
 #include "traccc/utils/projections.hpp"
@@ -45,6 +46,7 @@ namespace traccc::host::details {
 /// @param seeds_view        All seeds in an event to start the track finding
 ///                          with
 /// @param config            The track finding configuration
+/// @param log               The logger object to use
 ///
 /// @return A container of the found track candidates
 ///
@@ -54,12 +56,15 @@ track_candidate_container_types::host find_tracks(
     const typename stepper_t::magnetic_field_type& field,
     const measurement_collection_types::const_view& measurements_view,
     const bound_track_parameters_collection_types::const_view& seeds_view,
-    const finding_config& config) {
+    const finding_config& config, const Logger& log) {
 
     assert(config.min_step_length_for_next_surface >
                math::fabs(config.propagation.navigation.overstep_tolerance) &&
            "Min step length for the next surface should be higher than the "
            "overstep tolerance");
+
+    // Create a logger.
+    auto logger = [&log]() -> const Logger& { return log; };
 
     /*****************************************************************
      * Types used by the track finding
@@ -148,6 +153,10 @@ track_candidate_container_types::host find_tracks(
     for (unsigned int step = 0u; step < config.max_track_candidates_per_track;
          step++) {
 
+        TRACCC_VERBOSE("Starting step "
+                       << step + 1 << " / "
+                       << config.max_track_candidates_per_track);
+
         // Iterate over input parameters
         const std::size_t n_in_params = in_params.size();
 
@@ -181,6 +190,11 @@ track_candidate_container_types::host find_tracks(
                      : links[step - 1][param_to_link[step - 1][in_param_id]]
                            .n_skipped);
 
+            TRACCC_VERBOSE("Processing input parameter "
+                           << in_param_id + 1 << " / " << n_in_params << ": "
+                           << in_param << " (orig_param_id=" << orig_param_id
+                           << ", skip_counter=" << skip_counter << ")");
+
             /*************************
              * Material interaction
              *************************/
@@ -188,16 +202,22 @@ track_candidate_container_types::host find_tracks(
             // Get surface corresponding to bound params
             const detray::tracking_surface sf{det, in_param.surface_link()};
 
-            const typename navigator_t::detector_type::geometry_context ctx{};
+            TRACCC_VERBOSE(
+                "  free params: " << sf.bound_to_free_vector({}, in_param));
 
             // Apply interactor
-            typename interactor_type::state interactor_state;
-            interactor_type{}.update(
-                ctx,
-                detail::correct_particle_hypothesis(config.ptc_hypothesis,
-                                                    in_param),
-                in_param, interactor_state,
-                static_cast<int>(detray::navigation::direction::e_forward), sf);
+            if (sf.has_material()) {
+                const typename navigator_t::detector_type::geometry_context
+                    ctx{};
+                typename interactor_type::state interactor_state;
+                interactor_type{}.update(
+                    ctx,
+                    detail::correct_particle_hypothesis(config.ptc_hypothesis,
+                                                        in_param),
+                    in_param, interactor_state,
+                    static_cast<int>(detray::navigation::direction::e_forward),
+                    sf);
+            }
 
             // Get barcode and measurements range on surface
             const auto bcd = in_param.surface_link();
@@ -259,6 +279,9 @@ track_candidate_container_types::host find_tracks(
                          .n_skipped = skip_counter,
                          .chi2 = chi2});
                     updated_params.push_back(trk_state.filtered());
+                    TRACCC_VERBOSE("updated_params["
+                                   << updated_params.size() - 1
+                                   << "] = " << updated_params.back());
                 }
             }
 
@@ -278,6 +301,9 @@ track_candidate_container_types::host find_tracks(
                      .chi2 = std::numeric_limits<traccc::scalar>::max()});
 
                 updated_params.push_back(in_param);
+                TRACCC_VERBOSE("updated_params["
+                               << updated_params.size() - 1
+                               << "] = " << updated_params.back());
                 n_branches++;
             }
         }

--- a/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.cpp
+++ b/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_default_detector.cpp
@@ -29,8 +29,8 @@ combinatorial_kalman_filter_algorithm::operator()(
         detray::rk_stepper<bfield_type::view_t,
                            detector_type::host::algebra_type,
                            detray::constrained_step<scalar_type>>,
-        detray::navigator<const detector_type::host>>(det, field, measurements,
-                                                      seeds, m_config);
+        detray::navigator<const detector_type::host>>(
+        det, field, measurements, seeds, m_config, logger());
 }
 
 }  // namespace traccc::host

--- a/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.cpp
+++ b/core/src/finding/combinatorial_kalman_filter_algorithm_constant_field_telescope_detector.cpp
@@ -29,8 +29,8 @@ combinatorial_kalman_filter_algorithm::operator()(
         detray::rk_stepper<bfield_type::view_t,
                            detector_type::host::algebra_type,
                            detray::constrained_step<scalar_type>>,
-        detray::navigator<const detector_type::host>>(det, field, measurements,
-                                                      seeds, m_config);
+        detray::navigator<const detector_type::host>>(
+        det, field, measurements, seeds, m_config, logger());
 }
 
 }  // namespace traccc::host

--- a/core/src/seeding/track_params_estimation.cpp
+++ b/core/src/seeding/track_params_estimation.cpp
@@ -39,6 +39,21 @@ track_params_estimation::output_type track_params_estimation::operator()(
     for (edm::seed_collection::const_device::size_type i = 0; i < num_seeds;
          ++i) {
 
+        TRACCC_VERBOSE("Creating track parameters for seed " << i + 1 << " / "
+                                                             << num_seeds);
+        TRACCC_VERBOSE("  - bottom spacepoint: "
+                       << spacepoints.at(seeds.at(i).bottom_index()).global()
+                       << ", radius: "
+                       << spacepoints.at(seeds.at(i).bottom_index()).radius());
+        TRACCC_VERBOSE("  - middle spacepoint: "
+                       << spacepoints.at(seeds.at(i).middle_index()).global()
+                       << ", radius: "
+                       << spacepoints.at(seeds.at(i).middle_index()).radius());
+        TRACCC_VERBOSE("  - top spacepoint: "
+                       << spacepoints.at(seeds.at(i).top_index()).global()
+                       << ", radius: "
+                       << spacepoints.at(seeds.at(i).top_index()).radius());
+
         // Calculate the track parameter vector.
         bound_track_parameters<>& track_params = result[i];
         track_params.set_vector(
@@ -57,6 +72,7 @@ track_params_estimation::output_type track_params_estimation::operator()(
                edm::spacepoint_collection::host::INVALID_MEASUREMENT_INDEX);
         track_params.set_surface_link(
             measurements.at(spB.measurement_index_1()).surface_link);
+        TRACCC_VERBOSE("  - bound track parameters: " << track_params);
     }
 
     // Return the result.


### PR DESCRIPTION
Updates to help with understanding the current assertion failures coming from Detray.

There was a missing protection in the host code against considering material interaction on surfaces that have no material attached. #969 protected the device code against this, but the host code didn't receive this update.

Then, since I added a bunch of verbose printouts in the code to try to understand the next set of assertions, I thought I might as well request these printouts to be added to the repository. 🤔 The printed messages are pretty rough, but they are already better than nothing in my mind.