### PR TITLE
Reduce CKF branching factor from 10 to 2

### DIFF
--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -23,7 +23,7 @@ struct finding_config {
     unsigned int max_num_branches_per_seed = 10;
 
     /// Maximum number of branches per surface
-    unsigned int max_num_branches_per_surface = 10;
+    unsigned int max_num_branches_per_surface = 2;
 
     /// Min/Max number of track candidates per track
     unsigned int min_track_candidates_per_track = 3;

--- a/tests/cuda/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cuda/test_ckf_combinatorics_telescope.cpp
@@ -142,12 +142,14 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
     cfg_no_limit.ptc_hypothesis = ptc;
     cfg_no_limit.max_num_branches_per_seed = 100000;
     cfg_no_limit.chi2_max = 30.f;
+    cfg_no_limit.max_num_branches_per_surface = 10;
 
     typename traccc::cuda::finding_algorithm<
         rk_stepper_type, device_navigator_type>::config_type cfg_limit;
     cfg_limit.ptc_hypothesis = ptc;
     cfg_limit.max_num_branches_per_seed = 500;
     cfg_limit.chi2_max = 30.f;
+    cfg_limit.max_num_branches_per_surface = 10;
 
     // Finding algorithm object
     traccc::cuda::finding_algorithm<rk_stepper_type, device_navigator_type>


### PR DESCRIPTION
Following #929, we can now reduce the branching factor without incurring a decrease in physics performance. This commit drops the branching dramatically from 10 to 2.