### PR TITLE
Add measurement voting ambiguity resolution

### DIFF
--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -35,6 +35,14 @@ struct finding_config {
     /// Maximum number of consecutive holes
     unsigned int max_num_consecutive_skipped = 1;
 
+    /// Maximum number of tracks per measurement; if zero, don't prune
+    unsigned int max_num_tracks_per_measurement = 0;
+
+    /// If `max_num_tracks_per_measurement` is enabled, i.e. if it is non-zero
+    /// then this value determines the minimum fraction of measurements in
+    /// each track that vote for it
+    float min_measurement_voting_fraction = 0.5f;
+
     /// Minimum step length that track should make to reach the next surface. It
     /// should be set higher than the overstep tolerance not to make it stay on
     /// the same surface

--- a/device/common/include/traccc/finding/device/build_tracks.hpp
+++ b/device/common/include/traccc/finding/device/build_tracks.hpp
@@ -44,6 +44,11 @@ struct build_tracks_payload {
      * @brief View object to the vector of track candidates
      */
     edm::track_container<default_algebra>::view tracks_view;
+
+    /**
+     * @brief Optional mapping from tip index to output index
+     */
+    const unsigned int* tip_to_output_map = nullptr;
 };
 
 /// Function for building full tracks from the link container:

--- a/device/common/include/traccc/finding/device/impl/build_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/build_tracks.ipp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include <type_traits>
+
 #include "traccc/utils/prob.hpp"
 
 namespace traccc::device {
@@ -32,8 +34,17 @@ TRACCC_HOST_DEVICE inline void build_tracks(
         return;
     }
 
+    const auto output_idx = payload.tip_to_output_map != nullptr
+                                ? payload.tip_to_output_map[globalIndex]
+                                : globalIndex;
+
+    if (output_idx ==
+        std::numeric_limits<std::decay_t<decltype(output_idx)>>::max()) {
+        return;
+    }
+
     const auto tip = tips.at(globalIndex);
-    auto track = track_candidates.at(globalIndex);
+    auto track = track_candidates.at(output_idx);
 
     // Get the link corresponding to tip
     auto L = links.at(tip);

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -74,6 +74,9 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/finding/kernels/build_tracks.cu"
   "src/finding/kernels/build_tracks.cuh"
   "src/finding/kernels/find_tracks.cuh"
+  "src/finding/kernels/gather_best_tips_per_measurement.cu"
+  "src/finding/kernels/gather_measurement_votes.cu"
+  "src/finding/kernels/update_tip_length_buffer.cu"
   "src/finding/kernels/propagate_to_next_surface.hpp"
   # Ambiguity resolution
   "include/traccc/cuda/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp"

--- a/device/cuda/src/finding/kernels/gather_best_tips_per_measurement.cu
+++ b/device/cuda/src/finding/kernels/gather_best_tips_per_measurement.cu
@@ -1,0 +1,155 @@
+/** traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "gather_best_tips_per_measurement.cuh"
+
+namespace traccc::cuda::kernels {
+
+__global__ void gather_best_tips_per_measurement(
+    const vecmem::data::vector_view<const unsigned int> tips_view,
+    const vecmem::data::vector_view<const candidate_link> links_view,
+    const edm::measurement_collection<default_algebra>::const_view
+        measurements_view,
+    vecmem::data::vector_view<unsigned long long int> insertion_mutex_view,
+    vecmem::data::vector_view<unsigned int> tip_index_view,
+    vecmem::data::vector_view<scalar> tip_pval_view,
+    const unsigned int max_num_tracks_per_measurement) {
+    unsigned int tip_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    const vecmem::device_vector<const unsigned int> tips(tips_view);
+    const vecmem::device_vector<const candidate_link> links(links_view);
+    const edm::measurement_collection<default_algebra>::const_device
+        measurements(measurements_view);
+    vecmem::device_vector<unsigned long long int> insertion_mutex(
+        insertion_mutex_view);
+    vecmem::device_vector<unsigned int> tip_index(tip_index_view);
+    vecmem::device_vector<scalar> tip_pval(tip_pval_view);
+    const unsigned int n_meas = measurements.size();
+
+    scalar pval = 0.f;
+    unsigned int link_idx = 0;
+    unsigned int num_states = 0;
+
+    bool need_to_write = true;
+    candidate_link L;
+
+    if (tip_idx < tips.size()) {
+        link_idx = tips.at(tip_idx);
+        const auto link = links.at(link_idx);
+        pval = prob(link.chi2_sum, static_cast<scalar>(link.ndf_sum) - 5.f);
+        num_states = link.step + 1 - link.n_skipped;
+
+        L = link;
+
+        // Skip any holes at the start; there shouldn't be any.
+        while (L.meas_idx >= n_meas && L.step != 0u) {
+            L = links.at(L.previous_candidate_idx);
+        }
+    } else {
+        need_to_write = false;
+    }
+
+    unsigned int current_state = 0;
+
+    while (__syncthreads_or(current_state < num_states || need_to_write)) {
+        if (current_state < num_states || need_to_write) {
+            assert(L.meas_idx < n_meas);
+
+            if (need_to_write) {
+                vecmem::device_atomic_ref<unsigned long long int> mutex(
+                    insertion_mutex.at(L.meas_idx));
+
+                unsigned long long int assumed = mutex.load();
+                unsigned long long int desired_set;
+                auto [locked, size, worst] =
+                    device::decode_insertion_mutex(assumed);
+
+                if (need_to_write && size >= max_num_tracks_per_measurement &&
+                    pval <= worst) {
+                    need_to_write = false;
+                }
+
+                bool holds_lock = false;
+
+                if (need_to_write && !locked) {
+                    desired_set =
+                        device::encode_insertion_mutex(true, size, worst);
+
+                    if (mutex.compare_exchange_strong(assumed, desired_set)) {
+                        holds_lock = true;
+                    }
+                }
+
+                if (holds_lock) {
+                    unsigned int new_size;
+                    unsigned int offset =
+                        L.meas_idx * max_num_tracks_per_measurement;
+                    unsigned int out_idx;
+
+                    if (size == max_num_tracks_per_measurement) {
+                        new_size = size;
+
+                        scalar worst_pval = std::numeric_limits<scalar>::max();
+
+                        for (unsigned int i = 0; i < size; ++i) {
+                            if (tip_pval.at(offset + i) < worst_pval) {
+                                worst_pval = tip_pval.at(offset + i);
+                                out_idx = i;
+                            }
+                        }
+                    } else {
+                        new_size = size + 1;
+                        out_idx = size;
+                    }
+
+                    tip_index.at(offset + out_idx) = tip_idx;
+                    tip_pval.at(offset + out_idx) = pval;
+
+                    scalar new_worst = std::numeric_limits<scalar>::max();
+
+                    for (unsigned int i = 0; i < new_size; ++i) {
+                        new_worst =
+                            std::min(new_worst, tip_pval.at(offset + i));
+                    }
+
+                    [[maybe_unused]] bool cas_result =
+                        mutex.compare_exchange_strong(
+                            desired_set, device::encode_insertion_mutex(
+                                             false, new_size, new_worst));
+
+                    assert(cas_result);
+
+                    need_to_write = false;
+                }
+            }
+
+            if (!need_to_write) {
+                if (current_state < num_states - 1) {
+                    L = links.at(L.previous_candidate_idx);
+                    while (L.meas_idx >= n_meas && L.step != 0u) {
+                        L = links.at(L.previous_candidate_idx);
+                    }
+                    need_to_write = true;
+                } else {
+#ifndef NDEBUG
+                    if (L.step != 0) {
+                        do {
+                            L = links.at(L.previous_candidate_idx);
+                        } while (L.meas_idx >= n_meas && L.step != 0u);
+                        assert(L.meas_idx >= n_meas);
+                    }
+                    assert(L.step == 0);
+#endif
+                }
+
+                current_state++;
+            }
+        }
+    }
+}
+
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/finding/kernels/gather_best_tips_per_measurement.cuh
+++ b/device/cuda/src/finding/kernels/gather_best_tips_per_measurement.cuh
@@ -1,0 +1,30 @@
+/** traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/containers/vector.hpp>
+
+#include "traccc/definitions/common.hpp"
+#include "traccc/device/array_insertion_mutex.hpp"
+#include "traccc/edm/measurement_collection.hpp"
+#include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/finding_config.hpp"
+#include "traccc/utils/prob.hpp"
+
+namespace traccc::cuda::kernels {
+
+__global__ void gather_best_tips_per_measurement(
+    const vecmem::data::vector_view<const unsigned int> tips_view,
+    const vecmem::data::vector_view<const candidate_link> links_view,
+    const edm::measurement_collection<default_algebra>::const_view
+        measurements_view,
+    vecmem::data::vector_view<unsigned long long int> insertion_mutex_view,
+    vecmem::data::vector_view<unsigned int> tip_index_view,
+    vecmem::data::vector_view<scalar> tip_pval_view,
+    const unsigned int max_num_tracks_per_measurement);
+
+}

--- a/device/cuda/src/finding/kernels/gather_measurement_votes.cu
+++ b/device/cuda/src/finding/kernels/gather_measurement_votes.cu
@@ -1,0 +1,42 @@
+/** traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "gather_measurement_votes.cuh"
+
+namespace traccc::cuda::kernels {
+
+__global__ void gather_measurement_votes(
+    const vecmem::data::vector_view<const unsigned long long int>
+        insertion_mutex_view,
+    const vecmem::data::vector_view<const unsigned int> tip_index_view,
+    vecmem::data::vector_view<unsigned int> votes_per_tip_view,
+    const unsigned int max_num_tracks_per_measurement) {
+    unsigned int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    unsigned int measurement_idx = thread_idx / max_num_tracks_per_measurement;
+    unsigned int tip_idx = thread_idx % max_num_tracks_per_measurement;
+
+    const vecmem::device_vector<const unsigned long long int> insertion_mutex(
+        insertion_mutex_view);
+    const vecmem::device_vector<const unsigned int> tip_index(tip_index_view);
+    vecmem::device_vector<unsigned int> votes_per_tip(votes_per_tip_view);
+
+    if (measurement_idx >= insertion_mutex.size()) {
+        return;
+    }
+
+    auto [locked, size, worst] =
+        device::decode_insertion_mutex(insertion_mutex.at(measurement_idx));
+
+    if (tip_idx < size) {
+        vecmem::device_atomic_ref<unsigned int>(
+            votes_per_tip.at(tip_index.at(thread_idx)))
+            .fetch_add(1u);
+    }
+}
+
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/finding/kernels/gather_measurement_votes.cuh
+++ b/device/cuda/src/finding/kernels/gather_measurement_votes.cuh
@@ -1,0 +1,27 @@
+/** traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/containers/vector.hpp>
+
+#include "traccc/definitions/common.hpp"
+#include "traccc/device/array_insertion_mutex.hpp"
+#include "traccc/edm/measurement_collection.hpp"
+#include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/finding_config.hpp"
+#include "traccc/utils/prob.hpp"
+
+namespace traccc::cuda::kernels {
+
+__global__ void gather_measurement_votes(
+    const vecmem::data::vector_view<const unsigned long long int>
+        insertion_mutex_view,
+    const vecmem::data::vector_view<const unsigned int> tip_index_view,
+    vecmem::data::vector_view<unsigned int> votes_per_tip_view,
+    const unsigned int max_num_tracks_per_measurement);
+
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/finding/kernels/update_tip_length_buffer.cu
+++ b/device/cuda/src/finding/kernels/update_tip_length_buffer.cu
@@ -1,0 +1,52 @@
+/** traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "update_tip_length_buffer.cuh"
+
+namespace traccc::cuda::kernels {
+
+__global__ void update_tip_length_buffer(
+    const vecmem::data::vector_view<const unsigned int> old_tip_length_view,
+    vecmem::data::vector_view<unsigned int> new_tip_length_view,
+    const vecmem::data::vector_view<const unsigned int> measurement_votes_view,
+    unsigned int* tip_to_output_map, unsigned int* tip_to_output_map_idx,
+    float min_measurement_voting_fraction) {
+    const unsigned int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    assert(tip_to_output_map != nullptr);
+    assert(tip_to_output_map_idx != nullptr);
+
+    const vecmem::device_vector<const unsigned int> old_tip_length(
+        old_tip_length_view);
+    vecmem::device_vector<unsigned int> new_tip_length(new_tip_length_view);
+    const vecmem::device_vector<const unsigned int> measurement_votes(
+        measurement_votes_view);
+
+    if (thread_idx >= measurement_votes_view.size()) {
+        return;
+    }
+
+    const unsigned int total_measurements = old_tip_length.at(thread_idx);
+    const unsigned int total_votes = measurement_votes.at(thread_idx);
+
+    assert(total_votes <= total_measurements);
+
+    const scalar vote_fraction = static_cast<scalar>(total_votes) /
+                                 static_cast<scalar>(total_measurements);
+
+    if (vote_fraction < min_measurement_voting_fraction) {
+        tip_to_output_map[thread_idx] =
+            std::numeric_limits<unsigned int>::max();
+    } else {
+        const auto new_idx =
+            vecmem::device_atomic_ref(*tip_to_output_map_idx).fetch_add(1u);
+        new_tip_length.at(new_idx) = total_measurements;
+        tip_to_output_map[thread_idx] = new_idx;
+    }
+}
+
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/finding/kernels/update_tip_length_buffer.cuh
+++ b/device/cuda/src/finding/kernels/update_tip_length_buffer.cuh
@@ -1,0 +1,27 @@
+/** traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <vecmem/containers/device_vector.hpp>
+#include <vecmem/containers/vector.hpp>
+
+#include "traccc/definitions/common.hpp"
+#include "traccc/device/array_insertion_mutex.hpp"
+#include "traccc/edm/measurement_collection.hpp"
+#include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/finding_config.hpp"
+#include "traccc/utils/prob.hpp"
+
+namespace traccc::cuda::kernels {
+
+__global__ void update_tip_length_buffer(
+    const vecmem::data::vector_view<const unsigned int> old_tip_length_view,
+    vecmem::data::vector_view<unsigned int> new_tip_length_view,
+    const vecmem::data::vector_view<const unsigned int> measurement_votes_view,
+    unsigned int* tip_to_output_map, unsigned int* tip_to_output_map_idx,
+    float min_measurement_voting_fraction);
+
+}  // namespace traccc::cuda::kernels

--- a/examples/options/src/track_finding.cpp
+++ b/examples/options/src/track_finding.cpp
@@ -35,6 +35,17 @@ track_finding::track_finding() : interface("Track Finding Options") {
         po::value(&m_config.max_num_branches_per_surface)
             ->default_value(m_config.max_num_branches_per_surface),
         "Max number of branches per surface");
+    m_desc.add_options()(
+        "max-num-tracks-per-measurement",
+        po::value(&m_config.max_num_tracks_per_measurement)
+            ->default_value(m_config.max_num_tracks_per_measurement),
+        "Max number of tracks per input measurement; zero disables pruning");
+    m_desc.add_options()(
+        "min-measurement-voting-fraction",
+        po::value(&m_config.min_measurement_voting_fraction)
+            ->default_value(m_config.min_measurement_voting_fraction),
+        "Min fraction of voting measurements; only used if "
+        "`max-num-tracks-per-measurement` is non-zero");
     m_desc.add_options()("track-candidates-range",
                          po::value(&m_track_candidates_range)
                              ->value_name("MIN:MAX")
@@ -109,6 +120,12 @@ std::unique_ptr<configuration_printable> track_finding::as_printable() const {
     cat->add_child(std::make_unique<configuration_kv_pair>(
         "Max branches at surface",
         std::to_string(m_config.max_num_branches_per_surface)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Max tracks per measurement",
+        std::to_string(m_config.max_num_tracks_per_measurement)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Min measurement voting fraction",
+        std::to_string(m_config.min_measurement_voting_fraction)));
     std::ostringstream candidate_ss;
     candidate_ss << m_track_candidates_range;
     cat->add_child(std::make_unique<configuration_kv_pair>(


### PR DESCRIPTION
This draft PR introduces an ambiguity resolution in the track finding algorithm that takes two arguments, namely the number of votes per measurement $N$ and the required voting fraction per track $q$. It works simply; first, we compute the $N$ best (highest $p$-value) tracks per _measurement_, and then each measurement votes on the up-to $N$ tracks that are most likely to belong to that measurement. A track is then kept if out its $K$ track states, it receives at least $qK$ votes. In other words, if for fraction $q$ of the track's states it is one of the $N$ most likely tracks, we keep it.

In a $\langle\mu\rangle = 200$ ODD event with $N = 5$ and $k = 0.8$, this reduces the number of tracks from 146,238 to 24,356. On that same event, the three kernels required to perform the ambiguity resolution take 575 microseconds.

> [!WARNING]
> An analysis of the physics performance of this change is still WIP.