### PR TITLE
CUDA Ambiguity Clang Fixes, main branch (2025.05.30.)

### DIFF
--- a/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
+++ b/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
@@ -119,7 +119,7 @@ greedy_ambiguity_resolution_algorithm::operator()(
     m_copy.get().setup(meas_ids_buffer)->ignore();
 
     const unsigned int n_cands_total =
-        std::accumulate(candidate_sizes.begin(), candidate_sizes.end(), 0);
+        std::accumulate(candidate_sizes.begin(), candidate_sizes.end(), 0u);
 
     vecmem::data::vector_buffer<std::size_t> flat_meas_ids_buffer{
         n_cands_total, m_mr.main, vecmem::data::buffer_type::resizable};

--- a/tests/cuda/test_ambiguity_resolution.cpp
+++ b/tests/cuda/test_ambiguity_resolution.cpp
@@ -267,9 +267,9 @@ TEST(CudaAmbiguitySolverTests, CPU_Comparison) {
         traccc::track_candidate_container_types>
         track_candidate_d2h{mr, copy};
 
-    for (int i_evt = 0; i_evt < 5; i_evt++) {
+    for (std::size_t i_evt = 0u; i_evt < 5u; i_evt++) {
 
-        std::size_t sd = 42 + i_evt;
+        std::size_t sd = 42u + i_evt;
         std::mt19937 gen(sd);
         std::cout << "Event: " << i_evt << " Seed: " << sd << std::endl;
 


### PR DESCRIPTION
When building the latest version of the code using Clang as the host compiler, it complains about a few implicit sign conversions. This is just to fix these.