### PR TITLE
VecMem 1.18.0 Update, main branch (2025.05.30.)

### DIFF
--- a/device/common/include/traccc/device/impl/container_d2h_copy_alg.ipp
+++ b/device/common/include/traccc/device/impl/container_d2h_copy_alg.ipp
@@ -32,53 +32,27 @@ container_d2h_copy_alg<CONTAINER_TYPES>::operator()(input_type input) const {
     vecmem::memory_resource* host_mr =
         (m_mr.host != nullptr) ? m_mr.host : &(m_mr.main);
 
-    // Create a temporary buffer that will receive the device memory.
-    const typename std::remove_reference<typename std::remove_cv<
-        input_type>::type>::type::header_vector::size_type size =
-        input.headers.size();
-    std::vector<std::size_t> capacities(size, 0);
-    std::transform(input.items.host_ptr(), input.items.host_ptr() + size,
-                   capacities.begin(),
-                   [](const auto& view) { return view.capacity(); });
-    typename CONTAINER_TYPES::buffer hostBuffer{{size, *host_mr},
-                                                {capacities, *host_mr}};
-    vecmem::copy::event_type host_header_setup_event =
-        m_hostCopy.setup(hostBuffer.headers);
-    vecmem::copy::event_type host_item_setup_event =
-        m_hostCopy.setup(hostBuffer.items);
-    host_header_setup_event->wait();
-    host_item_setup_event->wait();
-
-    // Copy the device container into this temporary host buffer.
-    vecmem::copy::event_type device_header_copy_event = m_deviceCopy(
-        input.headers, hostBuffer.headers, vecmem::copy::type::device_to_host);
-    vecmem::copy::event_type device_item_copy_event = m_deviceCopy(
-        input.items, hostBuffer.items, vecmem::copy::type::device_to_host);
+    // Copy the device container into 2 temporary host buffers.
+    auto header_buffer = m_deviceCopy.to(input.headers, *host_mr,
+                                         vecmem::copy::type::device_to_host);
+    auto item_buffer = m_deviceCopy.to(input.items, *host_mr, nullptr,
+                                       vecmem::copy::type::device_to_host);
 
     // Create the result object, giving it the appropriate memory resource for
     // all of its elements.
-    output_type result{size, host_mr};
+    output_type result{header_buffer.size(), host_mr};
     for (std::size_t i = 0; i < result.size(); ++i) {
         result[i].items =
             typename CONTAINER_TYPES::host::item_vector::value_type{host_mr};
     }
 
-    // Wait for the D->H copies to finish.
-    device_header_copy_event->wait();
-    device_item_copy_event->wait();
-
     // Perform the H->H copy.
     vecmem::copy::event_type host_header_copy_event =
-        m_hostCopy(hostBuffer.headers, result.get_headers());
+        m_hostCopy(header_buffer, result.get_headers());
     vecmem::copy::event_type host_item_copy_event =
-        m_hostCopy(hostBuffer.items, result.get_items());
+        m_hostCopy(item_buffer, result.get_items());
     host_header_copy_event->wait();
     host_item_copy_event->wait();
-
-    const auto sizes = m_deviceCopy.get_sizes(input.items);
-    for (std::size_t i = 0; i < result.size(); ++i) {
-        result[i].items.resize(sizes[i]);
-    }
 
     // Return the host object.
     return result;

--- a/device/common/include/traccc/device/impl/container_h2d_copy_alg.ipp
+++ b/device/common/include/traccc/device/impl/container_h2d_copy_alg.ipp
@@ -64,23 +64,11 @@ container_h2d_copy_alg<CONTAINER_TYPES>::operator()(
     vecmem::memory_resource* host_mr =
         (m_mr.host != nullptr) ? m_mr.host : &(m_mr.main);
 
-    // Create/set the host buffer.
-    hostBuffer =
-        typename CONTAINER_TYPES::buffer{{size, *host_mr}, {sizes, *host_mr}};
-    vecmem::copy::event_type host_header_setup_event =
-        m_hostCopy.setup(hostBuffer.headers);
-    vecmem::copy::event_type host_items_setup_event =
-        m_hostCopy.setup(hostBuffer.items);
-    host_header_setup_event->wait();
-    host_items_setup_event->wait();
-
     // Copy the data into the host buffer.
-    vecmem::copy::event_type host_header_copy_event =
-        m_hostCopy(input.headers, hostBuffer.headers);
-    vecmem::copy::event_type host_items_copy_event =
-        m_hostCopy(input.items, hostBuffer.items);
-    host_header_copy_event->wait();
-    host_items_copy_event->wait();
+    hostBuffer.headers = m_hostCopy.to(input.headers, *host_mr,
+                                       vecmem::copy::type::host_to_host);
+    hostBuffer.items = m_hostCopy.to(input.items, *host_mr, nullptr,
+                                     vecmem::copy::type::host_to_host);
 
     // Create the output buffer with the correct sizes.
     output_type result{{size, m_mr.main}, {sizes, m_mr.main, m_mr.host}};

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.17.0.tar.gz;URL_MD5;952880576a8420af8308a3ffcc329ffe"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.18.0.tar.gz;URL_MD5;288ec7bb30e209ab5cc2e7f4a209c7ac"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem SYSTEM ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Updated the project to [vecmem-1.18.0](https://github.com/acts-project/vecmem/releases/tag/v1.18.0).

The main thing the new version brings is a fix to some (more or less) corner cases with memory copies. Like the one that @beomki-yeo ran into in #943. With those fixed, I was able to simplify the container copy algorithms a bit. (Even if these will disappear once the SoA migration is done, this cleanup still seemed like a good idea.)