### PR TITLE
Find Best Host Measurements, main branch (2025.05.31.)

### DIFF
--- a/tests/cpu/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cpu/test_ckf_combinatorics_telescope.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -115,10 +115,12 @@ TEST_P(CpuCkfCombinatoricsTelescopeTests, Run) {
     traccc::finding_config cfg_no_limit;
     cfg_no_limit.max_num_branches_per_seed =
         std::numeric_limits<unsigned int>::max();
+    cfg_no_limit.max_num_branches_per_surface = 10;
     cfg_no_limit.chi2_max = 30.f;
 
     traccc::finding_config cfg_limit;
     cfg_limit.max_num_branches_per_seed = 500;
+    cfg_limit.max_num_branches_per_surface = 10;
     cfg_limit.chi2_max = 30.f;
 
     // Finding algorithm object


### PR DESCRIPTION
In order to fix the currently failing unit tests, I added measurement sorting to the host track finding algorithm. That should implement a "similar enough" logic as what was added in #929.

With that added, I spent an embarrassing amount of time trying to understand why `CpuCkfCombinatoricsTelescopeTests` broke. :frowning: That turned out to be due to an oversight in #989. The test implicitly relied on the per surface branching fraction being large. :thinking: