### PR TITLE
Add loggers to performance writer classes

### DIFF
--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -86,11 +86,14 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // Performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{});
+        traccc::seeding_performance_writer::config{},
+        logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{});
+        traccc::finding_performance_writer::config{},
+        logger().clone("FindingPerformanceWriter"));
     traccc::fitting_performance_writer fit_performance_writer(
-        traccc::fitting_performance_writer::config{});
+        traccc::fitting_performance_writer::config{},
+        logger().clone("FittingPerformanceWriter"));
 
     traccc::nseed_performance_writer nsd_performance_writer(
         "nseed_performance_",

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -198,7 +198,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{});
+        traccc::seeding_performance_writer::config{},
+        logger().clone("SeedingPerformanceWriter"));
 
     traccc::performance::timing_info elapsedTimes;
 

--- a/examples/run/cpu/misaligned_truth_fitting_example.cpp
+++ b/examples/run/cpu/misaligned_truth_fitting_example.cpp
@@ -71,7 +71,8 @@ int main(int argc, char* argv[]) {
 
     // Performance writer
     traccc::fitting_performance_writer fit_performance_writer(
-        traccc::fitting_performance_writer::config{});
+        traccc::fitting_performance_writer::config{},
+        logger().clone("FittingPerformanceWriter"));
 
     /*****************************
      * Build a geometry

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -73,15 +73,19 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // Performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{});
+        traccc::seeding_performance_writer::config{},
+        logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{});
+        traccc::finding_performance_writer::config{},
+        logger().clone("FindingPerformanceWriter"));
     traccc::finding_performance_writer::config ar_writer_cfg;
     ar_writer_cfg.file_path = "performance_track_ambiguity_resolution.root";
     ar_writer_cfg.algorithm_name = "ambiguity_resolution";
-    traccc::finding_performance_writer ar_performance_writer(ar_writer_cfg);
+    traccc::finding_performance_writer ar_performance_writer(
+        ar_writer_cfg, logger().clone("AmbiResFindingPerformanceWriter"));
     traccc::fitting_performance_writer fit_performance_writer(
-        traccc::fitting_performance_writer::config{});
+        traccc::fitting_performance_writer::config{},
+        logger().clone("FittingPerformanceWriter"));
 
     // Output stats
     uint64_t n_spacepoints = 0;

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -149,15 +149,19 @@ int seq_run(const traccc::opts::input_data& input_opts,
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{});
+        traccc::seeding_performance_writer::config{},
+        logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{});
+        traccc::finding_performance_writer::config{},
+        logger().clone("FindingPerformanceWriter"));
     traccc::finding_performance_writer::config ar_writer_cfg;
     ar_writer_cfg.file_path = "performance_track_ambiguity_resolution.root";
     ar_writer_cfg.algorithm_name = "ambiguity_resolution";
-    traccc::finding_performance_writer ar_performance_writer(ar_writer_cfg);
+    traccc::finding_performance_writer ar_performance_writer(
+        ar_writer_cfg, logger().clone("AmbiResFindingPerformanceWriter"));
     traccc::fitting_performance_writer fit_performance_writer(
-        traccc::fitting_performance_writer::config{});
+        traccc::fitting_performance_writer::config{},
+        logger().clone("FittingPerformanceWriter"));
 
     // Timers
     traccc::performance::timing_info elapsedTimes;

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -58,9 +58,11 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
     // Performance writer
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{});
+        traccc::finding_performance_writer::config{},
+        logger().clone("FindingPerformanceWriter"));
     traccc::fitting_performance_writer fit_performance_writer(
-        traccc::fitting_performance_writer::config{});
+        traccc::fitting_performance_writer::config{},
+        logger().clone("FittingPerformanceWriter"));
 
     /*****************************
      * Build a geometry

--- a/examples/run/cpu/truth_fitting_example.cpp
+++ b/examples/run/cpu/truth_fitting_example.cpp
@@ -70,7 +70,8 @@ int main(int argc, char* argv[]) {
 
     // Performance writer
     traccc::fitting_performance_writer fit_performance_writer(
-        traccc::fitting_performance_writer::config{});
+        traccc::fitting_performance_writer::config{},
+        logger().clone("FittingPerformanceWriter"));
 
     /*****************************
      * Build a geometry

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -91,11 +91,14 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // Performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{});
+        traccc::seeding_performance_writer::config{},
+        logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{});
+        traccc::finding_performance_writer::config{},
+        logger().clone("FindingPerformanceWriter"));
     traccc::fitting_performance_writer fit_performance_writer(
-        traccc::fitting_performance_writer::config{});
+        traccc::fitting_performance_writer::config{},
+        logger().clone("FittingPerformanceWriter"));
 
     traccc::nseed_performance_writer nsd_performance_writer(
         "nseed_performance_",

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -219,7 +219,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{});
+        traccc::seeding_performance_writer::config{},
+        logger().clone("SeedingPerformanceWriter"));
 
     traccc::performance::timing_info elapsedTimes;
 

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -85,9 +85,11 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
     // Performance writer
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{});
+        traccc::finding_performance_writer::config{},
+        logger().clone("FindingPerformanceWriter"));
     traccc::fitting_performance_writer fit_performance_writer(
-        traccc::fitting_performance_writer::config{});
+        traccc::fitting_performance_writer::config{},
+        logger().clone("FittingPerformanceWriter"));
 
     // Output Stats
     uint64_t n_found_tracks = 0;

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -96,7 +96,8 @@ int main(int argc, char* argv[]) {
 
     // Performance writer
     traccc::fitting_performance_writer fit_performance_writer(
-        traccc::fitting_performance_writer::config{});
+        traccc::fitting_performance_writer::config{},
+        logger().clone("FittingPerformanceWriter"));
 
     // Output Stats
     std::size_t n_fitted_tracks = 0;

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -77,7 +77,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{});
+        traccc::seeding_performance_writer::config{},
+        logger().clone("SeedingPerformanceWriter"));
 
     traccc::performance::timing_info elapsedTimes;
 

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -74,7 +74,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
 
     // Performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{});
+        traccc::seeding_performance_writer::config{},
+        logger().clone("SeedingPerformanceWriter"));
 
     // Output stats
     uint64_t n_spacepoints = 0;

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -201,7 +201,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{});
+        traccc::seeding_performance_writer::config{},
+        logger().clone("SeedingPerformanceWriter"));
 
     traccc::performance::timing_info elapsedTimes;
 

--- a/performance/include/traccc/efficiency/finding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/finding_performance_writer.hpp
@@ -10,6 +10,7 @@
 // Local include(s).
 #include "traccc/resolution/stat_plot_tool_config.hpp"
 #include "traccc/utils/helpers.hpp"
+#include "traccc/utils/messaging.hpp"
 
 // Project include(s).
 #include "traccc/edm/track_candidate.hpp"
@@ -31,7 +32,7 @@ struct finding_performance_writer_data;
 
 }  // namespace details
 
-class finding_performance_writer {
+class finding_performance_writer : public messaging {
 
     public:
     /// Configuration for the tool
@@ -65,7 +66,8 @@ class finding_performance_writer {
     /// Construct from configuration and log level.
     /// @param cfg The configuration
     ///
-    finding_performance_writer(const config& cfg);
+    finding_performance_writer(const config& cfg,
+                               std::unique_ptr<const traccc::Logger> logger);
 
     /// Destructor
     ~finding_performance_writer();

--- a/performance/include/traccc/efficiency/seeding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/seeding_performance_writer.hpp
@@ -9,6 +9,7 @@
 
 // Local include(s).
 #include "traccc/utils/helpers.hpp"
+#include "traccc/utils/messaging.hpp"
 
 // Project include(s).
 #include "traccc/edm/measurement.hpp"
@@ -31,7 +32,7 @@ struct seeding_performance_writer_data;
 
 }  // namespace details
 
-class seeding_performance_writer {
+class seeding_performance_writer : public messaging {
 
     public:
     /// Configuration for the tool
@@ -60,7 +61,8 @@ class seeding_performance_writer {
     /// Construct from configuration and log level.
     /// @param cfg The configuration
     ///
-    seeding_performance_writer(const config& cfg);
+    seeding_performance_writer(const config& cfg,
+                               std::unique_ptr<const traccc::Logger> logger);
 
     /// Destructor
     ~seeding_performance_writer();

--- a/performance/include/traccc/resolution/fitting_performance_writer.hpp
+++ b/performance/include/traccc/resolution/fitting_performance_writer.hpp
@@ -10,6 +10,7 @@
 // Library include(s).
 #include "traccc/resolution/res_plot_tool_config.hpp"
 #include "traccc/resolution/stat_plot_tool_config.hpp"
+#include "traccc/utils/messaging.hpp"
 
 // Project include(s).
 #include "traccc/edm/particle.hpp"
@@ -29,7 +30,7 @@ struct fitting_performance_writer_data;
 
 }  // namespace details
 
-class fitting_performance_writer {
+class fitting_performance_writer : public messaging {
 
     public:
     struct config {
@@ -43,7 +44,8 @@ class fitting_performance_writer {
     };
 
     /// Constructor with writer config
-    fitting_performance_writer(const config& cfg);
+    fitting_performance_writer(const config& cfg,
+                               std::unique_ptr<const traccc::Logger> logger);
 
     /// Destructor that closes the file
     ~fitting_performance_writer();

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -12,6 +12,7 @@
 #include "duplication_plot_tool.hpp"
 #include "eff_plot_tool.hpp"
 #include "fake_tracks_plot_tool.hpp"
+#include "traccc/utils/logging.hpp"
 #include "track_classification.hpp"
 
 // ROOT include(s).
@@ -61,8 +62,10 @@ struct finding_performance_writer_data {
 
 }  // namespace details
 
-finding_performance_writer::finding_performance_writer(const config& cfg)
-    : m_cfg(cfg),
+finding_performance_writer::finding_performance_writer(
+    const config& cfg, std::unique_ptr<const traccc::Logger> logger)
+    : messaging(std::move(logger)),
+      m_cfg(cfg),
       m_data(std::make_unique<details::finding_performance_writer_data>(cfg)) {
 
     m_data->m_eff_plot_tool.book(m_cfg.algorithm_name,

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -49,8 +49,10 @@ struct seeding_performance_writer_data {
 
 }  // namespace details
 
-seeding_performance_writer::seeding_performance_writer(const config& cfg)
-    : m_cfg(cfg),
+seeding_performance_writer::seeding_performance_writer(
+    const config& cfg, std::unique_ptr<const traccc::Logger> logger)
+    : messaging(std::move(logger)),
+      m_cfg(cfg),
       m_data(std::make_unique<details::seeding_performance_writer_data>(cfg)) {
 
     m_data->m_eff_plot_tool.book("seeding", m_data->m_eff_plot_cache);

--- a/performance/src/resolution/fitting_performance_writer.cpp
+++ b/performance/src/resolution/fitting_performance_writer.cpp
@@ -41,8 +41,10 @@ struct fitting_performance_writer_data {
 
 }  // namespace details
 
-fitting_performance_writer::fitting_performance_writer(const config& cfg)
-    : m_cfg(cfg),
+fitting_performance_writer::fitting_performance_writer(
+    const config& cfg, std::unique_ptr<const traccc::Logger> logger)
+    : messaging(std::move(logger)),
+      m_cfg(cfg),
       m_data(std::make_unique<details::fitting_performance_writer_data>(cfg)) {
 
     m_data->m_res_plot_tool.book(m_data->m_res_plot_cache);

--- a/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
@@ -53,7 +53,9 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
     // Performance writer
     traccc::fitting_performance_writer::config fit_writer_cfg;
     fit_writer_cfg.file_path = "performance_track_fitting_" + name + ".root";
-    traccc::fitting_performance_writer fit_performance_writer(fit_writer_cfg);
+    traccc::fitting_performance_writer fit_performance_writer(
+        fit_writer_cfg, traccc::getDefaultLogger("FittingPerformanceWriter",
+                                                 traccc::Logging::Level::INFO));
 
     /*****************************
      * Build a telescope geometry

--- a/tests/cpu/test_kalman_fitter_momentum_resolution.cpp
+++ b/tests/cpu/test_kalman_fitter_momentum_resolution.cpp
@@ -54,7 +54,9 @@ TEST_P(KalmanFittingMomentumResolutionTests, Run) {
     fit_writer_cfg.res_config.var_binning["residual_qopT"] =
         plot_helpers::binning("r_{q/p_{T}} [c/GeV]", 1000, -0.1f, 0.1f);
     fit_writer_cfg.file_path = "performance_track_fitting_" + name + ".root";
-    traccc::fitting_performance_writer fit_performance_writer(fit_writer_cfg);
+    traccc::fitting_performance_writer fit_performance_writer(
+        fit_writer_cfg, traccc::getDefaultLogger("FittingPerformanceWriter",
+                                                 traccc::Logging::Level::INFO));
 
     // Set qop stddev to 10% of truth qop
     const scalar qop_stddev = 0.1f / p;

--- a/tests/cpu/test_kalman_fitter_telescope.cpp
+++ b/tests/cpu/test_kalman_fitter_telescope.cpp
@@ -52,8 +52,9 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     // Performance writer
     traccc::fitting_performance_writer::config fit_writer_cfg;
     fit_writer_cfg.file_path = "performance_track_fitting_" + name + ".root";
-    traccc::fitting_performance_writer fit_performance_writer(fit_writer_cfg);
-
+    traccc::fitting_performance_writer fit_performance_writer(
+        fit_writer_cfg, traccc::getDefaultLogger("FittingPerformanceWriter",
+                                                 traccc::Logging::Level::INFO));
     /*****************************
      * Build a telescope geometry
      *****************************/

--- a/tests/cpu/test_kalman_fitter_wire_chamber.cpp
+++ b/tests/cpu/test_kalman_fitter_wire_chamber.cpp
@@ -48,7 +48,9 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
     // Performance writer
     traccc::fitting_performance_writer::config fit_writer_cfg;
     fit_writer_cfg.file_path = "performance_track_fitting_" + name + ".root";
-    traccc::fitting_performance_writer fit_performance_writer(fit_writer_cfg);
+    traccc::fitting_performance_writer fit_performance_writer(
+        fit_writer_cfg, traccc::getDefaultLogger("FittingPerformanceWriter",
+                                                 traccc::Logging::Level::INFO));
 
     /*****************************
      * Build a drift chamber

--- a/tests/cuda/test_kalman_fitter_telescope.cpp
+++ b/tests/cuda/test_kalman_fitter_telescope.cpp
@@ -60,7 +60,9 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     // Performance writer
     traccc::fitting_performance_writer::config fit_writer_cfg;
     fit_writer_cfg.file_path = "performance_track_fitting_" + name + ".root";
-    traccc::fitting_performance_writer fit_performance_writer(fit_writer_cfg);
+    traccc::fitting_performance_writer fit_performance_writer(
+        fit_writer_cfg, traccc::getDefaultLogger("FittingPerformanceWriter",
+                                                 traccc::Logging::Level::INFO));
 
     /*****************************
      * Build a telescope geometry

--- a/tests/sycl/test_kalman_fitter_telescope.cpp
+++ b/tests/sycl/test_kalman_fitter_telescope.cpp
@@ -60,7 +60,9 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     // Performance writer
     traccc::fitting_performance_writer::config fit_writer_cfg;
     fit_writer_cfg.file_path = "performance_track_fitting_" + name + ".root";
-    traccc::fitting_performance_writer fit_performance_writer(fit_writer_cfg);
+    traccc::fitting_performance_writer fit_performance_writer(
+        fit_writer_cfg, traccc::getDefaultLogger("FittingPerformanceWriter",
+                                                 traccc::Logging::Level::INFO));
 
     /*****************************
      * Build a telescope geometry


### PR DESCRIPTION
This commit adds logging infrastructure to the performance writing classes. These classes observe a lot about the quality and validity of our results, so they are a prime place to output some information on traccc's results.