### PR TITLE
Fix traccc::full_chain_algorithm Copying, main branch (2025.06.06.)

### DIFF
--- a/examples/run/cpu/full_chain_algorithm.cpp
+++ b/examples/run/cpu/full_chain_algorithm.cpp
@@ -20,6 +20,7 @@ full_chain_algorithm::full_chain_algorithm(
     const silicon_detector_description::host& det_descr,
     detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
     : messaging(logger->clone()),
+      m_copy{std::make_unique<vecmem::copy>()},
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
       m_field(
           traccc::construct_const_bfield<typename detector_type::scalar_type>(
@@ -33,7 +34,7 @@ full_chain_algorithm::full_chain_algorithm(
       m_track_parameter_estimation(mr,
                                    logger->cloneWithSuffix("TrackParamEstAlg")),
       m_finding(finding_config, mr, logger->cloneWithSuffix("TrackFindingAlg")),
-      m_fitting(fitting_config, mr, m_copy,
+      m_fitting(fitting_config, mr, *m_copy,
                 logger->cloneWithSuffix("TrackFittingAlg")),
       m_finder_config(finder_config),
       m_grid_config(grid_config),

--- a/examples/run/cpu/full_chain_algorithm.hpp
+++ b/examples/run/cpu/full_chain_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,6 +29,7 @@
 
 // System include(s).
 #include <functional>
+#include <memory>
 
 namespace traccc {
 
@@ -91,7 +92,7 @@ class full_chain_algorithm : public algorithm<track_state_container_types::host(
 
     private:
     /// Vecmem copy object
-    vecmem::copy m_copy;
+    std::unique_ptr<vecmem::copy> m_copy;
     /// Constant B field for the (seed) track parameter estimation
     traccc::vector3 m_field_vec;
     /// Constant B field for the track finding and fitting


### PR DESCRIPTION
While we sort out some deeper questions in #979, here I'd like to fix the actual issue breaking `traccc_throughput_mt` since a while. With the minimum change necessary.

It is not to say though that memory management in all the algorithms should not be cleaned up more thoroughly. But for a change I'd like to make a small PR...