### PR TITLE
Add Track Fit to SYCL Throughput Measurements, main branch (2025.06.06.)

### DIFF
--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -9,12 +9,12 @@
 
 // Project include(s).
 #include "traccc/edm/silicon_cell_collection.hpp"
-#include "traccc/fitting/kalman_fitting_algorithm.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/silicon_detector_description.hpp"
 #include "traccc/sycl/clusterization/clusterization_algorithm.hpp"
 #include "traccc/sycl/clusterization/measurement_sorting_algorithm.hpp"
 #include "traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp"
+#include "traccc/sycl/fitting/kalman_fitting_algorithm.hpp"
 #include "traccc/sycl/seeding/seeding_algorithm.hpp"
 #include "traccc/sycl/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp"
 #include "traccc/sycl/seeding/track_params_estimation.hpp"
@@ -41,7 +41,7 @@ struct full_chain_algorithm_data;
 /// At least as much as is implemented in the project at any given moment.
 ///
 class full_chain_algorithm
-    : public algorithm<edm::track_candidate_collection<default_algebra>::host(
+    : public algorithm<vecmem::vector<fitting_result<default_algebra>>(
           const edm::silicon_cell_collection::host&)>,
       public messaging {
 
@@ -75,7 +75,7 @@ class full_chain_algorithm
     using finding_algorithm =
         traccc::sycl::combinatorial_kalman_filter_algorithm;
     /// Track fitting algorithm type
-    using fitting_algorithm = traccc::host::kalman_fitting_algorithm;
+    using fitting_algorithm = traccc::sycl::kalman_fitting_algorithm;
 
     /// @}
 
@@ -160,6 +160,8 @@ class full_chain_algorithm
     track_params_estimation m_track_parameter_estimation;
     /// Track finding algorithm
     finding_algorithm m_finding;
+    /// Track fitting algorithm
+    fitting_algorithm m_fitting;
 
     /// @}
 
@@ -179,6 +181,8 @@ class full_chain_algorithm
 
     /// Configuration for the track finding
     finding_algorithm::config_type m_finding_config;
+    /// Configuration for the track fitting
+    fitting_algorithm::config_type m_fitting_config;
 
     /// @}
 };  // class full_chain_algorithm

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -55,7 +55,7 @@ full_chain_algorithm::full_chain_algorithm(
     const spacepoint_grid_config& grid_config,
     const seedfilter_config& filter_config,
     const finding_algorithm::config_type& finding_config,
-    const fitting_algorithm::config_type&,
+    const fitting_algorithm::config_type& fitting_config,
     const silicon_detector_description::host& det_descr,
     host_detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
     : messaging(logger->clone()),
@@ -97,11 +97,15 @@ full_chain_algorithm::full_chain_algorithm(
       m_finding{finding_config,
                 memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
                 m_data->m_queue_wrapper, logger->clone("TrackFindingAlg")},
+      m_fitting{fitting_config,
+                memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
+                m_data->m_queue_wrapper, logger->clone("TrackFittingAlg")},
       m_clustering_config(clustering_config),
       m_finder_config(finder_config),
       m_grid_config(grid_config),
       m_filter_config(filter_config),
-      m_finding_config(finding_config) {
+      m_finding_config(finding_config),
+      m_fitting_config(fitting_config) {
 
     // Tell the user what device is being used.
     std::cout
@@ -158,11 +162,15 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
       m_finding{parent.m_finding_config,
                 memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
                 m_data->m_queue_wrapper, parent.logger().clone("FindingAlg")},
+      m_fitting{parent.m_fitting_config,
+                memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
+                m_data->m_queue_wrapper, parent.logger().clone("FittingAlg")},
       m_clustering_config(parent.m_clustering_config),
       m_finder_config(parent.m_finder_config),
       m_grid_config(parent.m_grid_config),
       m_filter_config(parent.m_filter_config),
-      m_finding_config(parent.m_finding_config) {
+      m_finding_config(parent.m_finding_config),
+      m_fitting_config(parent.m_fitting_config) {
 
     // Copy the detector (description) to the device.
     m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->wait();
@@ -204,11 +212,13 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
         const finding_algorithm::output_type track_candidates = m_finding(
             m_device_detector_view, m_field, measurements, track_params);
 
-        // Get the final data back to the host.
-        output_type result(m_host_mr.get());
-        m_copy(track_candidates, result)->wait();
+        // Run the track fitting (asynchronously).
+        const fitting_algorithm::output_type track_states = m_fitting(
+            m_device_detector_view, m_field, {track_candidates, measurements});
 
-        // Return the host container.
+        // Copy a limited amount of result data back to the host.
+        output_type result{&(m_host_mr.get())};
+        m_copy(track_states.headers, result)->wait();
         return result;
     }
     // If not, copy the measurements back to the host, and return
@@ -221,7 +231,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
         m_copy(measurements, measurements_host)->wait();
 
         // Return an empty object.
-        return output_type{m_host_mr.get()};
+        return {};
     }
 }
 


### PR DESCRIPTION
Added track fitting to the SYCL throughput examples.

Since at least naively, it seems to be "doing something". :thinking: Though in a separate PR I'll also extend the other examples with fitting, to see what's what. :thinking:

On my own machine, things seem to behave in a "believable fashion". I.e. I see the following:

```
[bash][Legolas]:build > ONEAPI_DEVICE_SELECTOR=cuda:* ./bin/traccc_throughput_mt_sycl --input-directory=/data/hdd-4tb-1/acts_data/odd-20240509/geant4_ttbar_mu200/ --input-events=100 --processed-events=100 --cpu-threads=4
11:22:57    ThroughputExampleOptions      INFO      
11:22:57    ThroughputExampleOptions      INFO      Running Multi-threaded SYCL GPU throughput tests
11:22:57    ThroughputExampleOptions      INFO
...
11:23:04    ThroughputExample             WARNING   16998 duplicate cells found in /data/hdd-4tb-1/acts_data/odd-20240509/geant4_ttbar_mu200/event000000017-cells.csv
Using SYCL device: NVIDIA GeForce RTX 3080
Using SYCL device: NVIDIA GeForce RTX 3080
Using SYCL device: NVIDIA GeForce RTX 3080
Using SYCL device: NVIDIA GeForce RTX 3080
Using SYCL device: NVIDIA GeForce RTX 3080
Warm-up processing [==================================================] 100% [00m:00s]                                                                                                                     
Event processing   [==================================================] 100% [00m:00s]                                                                                                                     
11:23:32 AM ThroughputExample             INFO      Reconstructed track parameters: 6451349
11:23:32 AM ThroughputExample             INFO      Time totals:                   File reading  4123 ms
11:23:32 AM ThroughputExample             INFO                  Warm-up processing  2779 ms
11:23:32 AM ThroughputExample             INFO                    Event processing  25307 ms
11:23:32 AM ThroughputExample             INFO      Throughput:            Warm-up processing  277.905 ms/event, 3.59835 events/s
11:23:32 AM ThroughputExample             INFO                    Event processing  253.07 ms/event, 3.95147 events/s
[bash][Legolas]:build >
```

```
[bash][Legolas]:build > ONEAPI_DEVICE_SELECTOR=hip:* ./bin/traccc_throughput_mt_sycl --input-directory=/data/hdd-4tb-1/acts_data/odd-20240509/geant4_ttbar_mu200/ --input-events=100 --processed-events=100 --cpu-threads=4
11:24:32    ThroughputExampleOptions      INFO      
11:24:32    ThroughputExampleOptions      INFO      Running Multi-threaded SYCL GPU throughput tests
11:24:32    ThroughputExampleOptions      INFO
...
11:24:41    ThroughputExample             WARNING   23406 duplicate cells found in /data/hdd-4tb-1/acts_data/odd-20240509/geant4_ttbar_mu200/event000000010-cells.csv
Using SYCL device: AMD Radeon PRO W7600
Using SYCL device: AMD Radeon PRO W7600
Using SYCL device: AMD Radeon PRO W7600
Using SYCL device: AMD Radeon PRO W7600
Using SYCL device: AMD Radeon PRO W7600
Warm-up processing [==================================================] 100% [00m:00s]                                                                                                                     
Event processing   [==================================================] 100% [00m:00s]                                                                                                                     
11:25:23 AM ThroughputExample             INFO      Reconstructed track parameters: 6619927
11:25:23 AM ThroughputExample             INFO      Time totals:                   File reading  7319 ms
11:25:23 AM ThroughputExample             INFO                  Warm-up processing  3794 ms
11:25:23 AM ThroughputExample             INFO                    Event processing  35374 ms
11:25:23 AM ThroughputExample             INFO      Throughput:            Warm-up processing  379.493 ms/event, 2.63509 events/s
11:25:23 AM ThroughputExample             INFO                    Event processing  353.742 ms/event, 2.82692 events/s
[bash][Legolas]:build >
```

With the native CUDA throughput test doing the following on the RTX3080:

```
[bash][Legolas]:build > ./bin/traccc_throughput_mt_cuda --input-directory=/data/hdd-4tb-1/acts_data/odd-20240509/geant4_ttbar_mu200/ --input-events=100 --processed-events=100 --cpu-threads=4
11:26:17    ThroughputExampleOptions      INFO      
11:26:17    ThroughputExampleOptions      INFO      Running Multi-threaded CUDA GPU throughput tests
11:26:17    ThroughputExampleOptions      INFO
...
11:26:24    ThroughputExample             WARNING   18092 duplicate cells found in /data/hdd-4tb-1/acts_data/odd-20240509/geant4_ttbar_mu200/event000000036-cells.csv
Using CUDA device: NVIDIA GeForce RTX 3080 [id: 0, bus: 1, device: 0]
Using CUDA device: NVIDIA GeForce RTX 3080 [id: 0, bus: 1, device: 0]
Using CUDA device: NVIDIA GeForce RTX 3080 [id: 0, bus: 1, device: 0]
Using CUDA device: NVIDIA GeForce RTX 3080 [id: 0, bus: 1, device: 0]
Using CUDA device: NVIDIA GeForce RTX 3080 [id: 0, bus: 1, device: 0]
Warm-up processing [==================================================] 100% [00m:00s]                                                                                                                     
Event processing   [==================================================] 100% [00m:00s]                                                                                                                     
11:26:47 AM ThroughputExample             INFO      Reconstructed track parameters: 6559901
11:26:47 AM ThroughputExample             INFO      Time totals:                   File reading  4214 ms
11:26:47 AM ThroughputExample             INFO                  Warm-up processing  2024 ms
11:26:47 AM ThroughputExample             INFO                    Event processing  20079 ms
11:26:47 AM ThroughputExample             INFO      Throughput:            Warm-up processing  202.417 ms/event, 4.9403 events/s
11:26:47 AM ThroughputExample             INFO                    Event processing  200.797 ms/event, 4.98017 events/s
[bash][Legolas]:build >
```

I.e. while SYCL is clearly not doing as good of a job, this I find very believable. Since that code is not too careful with asynchronous execution these days...