### PR TITLE
Throughput Output Formatting Improvements, main branch (2025.06.06.)

### DIFF
--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -61,6 +61,7 @@
 #include <atomic>
 #include <cstdlib>
 #include <ctime>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -134,8 +135,9 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
                      event != event_range.end(); ++event) {
                     static constexpr bool DEDUPLICATE = true;
                     io::read_cells(input.at(event - input_opts.skip), event,
-                                   input_opts.directory, logger().clone(),
-                                   &det_descr, input_opts.format, DEDUPLICATE,
+                                   input_opts.directory,
+                                   logger().clone("io::read_cells"), &det_descr,
+                                   input_opts.format, DEDUPLICATE,
                                    input_opts.use_acts_geom_source);
                 }
             });
@@ -187,7 +189,7 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
              fitting_cfg,
              det_descr,
              (detector_opts.use_detray_detector ? &detector : nullptr),
-             logger().clone()});
+             logger().clone(std::format("FullChainAlg{}", i))});
     }
 
     // Set up the TBB arena and thread group. From here on out TBB is only
@@ -297,14 +299,14 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
 
     // Print some results.
     TRACCC_INFO("Reconstructed track parameters: " << rec_track_params.load());
-    TRACCC_INFO("Time totals: " << times);
+    TRACCC_INFO("Time totals:\n" << times);
 
     performance::throughput throughput_wu{throughput_opts.cold_run_events,
                                           times, "Warm-up processing"};
     performance::throughput throughput_pr{throughput_opts.processed_events,
                                           times, "Event processing"};
 
-    TRACCC_INFO("Throughput:" << throughput_wu << "\n" << throughput_pr);
+    TRACCC_INFO("Throughput:\n" << throughput_wu << "\n" << throughput_pr);
 
     // Print results to log file
     if (throughput_opts.log_file != "\0") {

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -36,8 +36,8 @@ full_chain_algorithm::full_chain_algorithm(
     const finding_algorithm::config_type& finding_config,
     const fitting_algorithm::config_type& fitting_config,
     const silicon_detector_description::host& det_descr,
-    host_detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
-    : messaging(logger->clone()),
+    host_detector_type* detector, std::unique_ptr<const traccc::Logger> log)
+    : messaging(log->clone()),
       m_host_mr(host_mr),
       m_stream(),
       m_device_mr(),
@@ -57,22 +57,22 @@ full_chain_algorithm::full_chain_algorithm(
                        m_stream, clustering_config),
       m_measurement_sorting(memory_resource{*m_cached_device_mr, &m_host_mr},
                             m_copy, m_stream,
-                            logger->cloneWithSuffix("MeasSortingAlg")),
+                            log->cloneWithSuffix("MeasSortingAlg")),
       m_spacepoint_formation(memory_resource{*m_cached_device_mr, &m_host_mr},
                              m_copy, m_stream,
-                             logger->cloneWithSuffix("SpFormationAlg")),
+                             log->cloneWithSuffix("SpFormationAlg")),
       m_seeding(finder_config, grid_config, filter_config,
                 memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                m_stream, logger->cloneWithSuffix("SeedingAlg")),
+                m_stream, log->cloneWithSuffix("SeedingAlg")),
       m_track_parameter_estimation(
           memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy, m_stream,
-          logger->cloneWithSuffix("TrackParEstAlg")),
+          log->cloneWithSuffix("TrackParEstAlg")),
       m_finding(finding_config,
                 memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                m_stream, logger->cloneWithSuffix("TrackFindingAlg")),
+                m_stream, log->cloneWithSuffix("TrackFindingAlg")),
       m_fitting(fitting_config,
                 memory_resource{*m_cached_device_mr, &m_host_mr}, m_copy,
-                m_stream, logger->cloneWithSuffix("TrackFittingAlg")),
+                m_stream, log->cloneWithSuffix("TrackFittingAlg")),
       m_clustering_config(clustering_config),
       m_finder_config(finder_config),
       m_grid_config(grid_config),
@@ -85,9 +85,10 @@ full_chain_algorithm::full_chain_algorithm(
     CUDA_ERROR_CHECK(cudaGetDevice(&device));
     cudaDeviceProp props;
     CUDA_ERROR_CHECK(cudaGetDeviceProperties(&props, device));
-    std::cout << "Using CUDA device: " << props.name << " [id: " << device
-              << ", bus: " << props.pciBusID
-              << ", device: " << props.pciDeviceID << "]" << std::endl;
+    TRACCC_INFO("Using CUDA device: " << props.name << " [id: " << device
+                                      << ", bus: " << props.pciBusID
+                                      << ", device: " << props.pciDeviceID
+                                      << "]");
 
     // Copy the detector (description) to the device.
     m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->ignore();

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -57,8 +57,8 @@ full_chain_algorithm::full_chain_algorithm(
     const finding_algorithm::config_type& finding_config,
     const fitting_algorithm::config_type& fitting_config,
     const silicon_detector_description::host& det_descr,
-    host_detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
-    : messaging(logger->clone()),
+    host_detector_type* detector, std::unique_ptr<const traccc::Logger> log)
+    : messaging(log->clone()),
       m_data(std::make_unique<details::full_chain_algorithm_data>(
           ::handle_async_error)),
       m_host_mr(host_mr),
@@ -77,29 +77,29 @@ full_chain_algorithm::full_chain_algorithm(
       m_device_detector{},
       m_clusterization{memory_resource{m_cached_device_mr, &(m_host_mr.get())},
                        m_copy, m_data->m_queue_wrapper, clustering_config,
-                       logger->clone("ClusteringAlg")},
+                       log->clone("ClusteringAlg")},
       m_measurement_sorting(
           memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-          m_data->m_queue_wrapper, logger->clone("MeasSortingAlg")),
+          m_data->m_queue_wrapper, log->clone("MeasSortingAlg")),
       m_spacepoint_formation{
           memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-          m_data->m_queue_wrapper, logger->clone("SpFormationAlg")},
+          m_data->m_queue_wrapper, log->clone("SpFormationAlg")},
       m_seeding{finder_config,
                 grid_config,
                 filter_config,
                 memory_resource{m_cached_device_mr, &(m_host_mr.get())},
                 m_copy,
                 m_data->m_queue_wrapper,
-                logger->clone("SeedingAlg")},
+                log->clone("SeedingAlg")},
       m_track_parameter_estimation{
           memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-          m_data->m_queue_wrapper, logger->clone("TrackParEstAlg")},
+          m_data->m_queue_wrapper, log->clone("TrackParEstAlg")},
       m_finding{finding_config,
                 memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-                m_data->m_queue_wrapper, logger->clone("TrackFindingAlg")},
+                m_data->m_queue_wrapper, log->clone("TrackFindingAlg")},
       m_fitting{fitting_config,
                 memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-                m_data->m_queue_wrapper, logger->clone("TrackFittingAlg")},
+                m_data->m_queue_wrapper, log->clone("TrackFittingAlg")},
       m_clustering_config(clustering_config),
       m_finder_config(finder_config),
       m_grid_config(grid_config),
@@ -108,10 +108,9 @@ full_chain_algorithm::full_chain_algorithm(
       m_fitting_config(fitting_config) {
 
     // Tell the user what device is being used.
-    std::cout
-        << "Using SYCL device: "
-        << m_data->m_queue.get_device().get_info<::sycl::info::device::name>()
-        << std::endl;
+    TRACCC_INFO(
+        "Using SYCL device: "
+        << m_data->m_queue.get_device().get_info<::sycl::info::device::name>());
 
     // Copy the detector (description) to the device.
     m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->wait();
@@ -161,10 +160,12 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
           m_data->m_queue_wrapper, parent.logger().clone("TrackParEstAlg")},
       m_finding{parent.m_finding_config,
                 memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-                m_data->m_queue_wrapper, parent.logger().clone("FindingAlg")},
+                m_data->m_queue_wrapper,
+                parent.logger().clone("TrackFindingAlg")},
       m_fitting{parent.m_fitting_config,
                 memory_resource{m_cached_device_mr, &(m_host_mr.get())}, m_copy,
-                m_data->m_queue_wrapper, parent.logger().clone("FittingAlg")},
+                m_data->m_queue_wrapper,
+                parent.logger().clone("TrackFittingAlg")},
       m_clustering_config(parent.m_clustering_config),
       m_finder_config(parent.m_finder_config),
       m_grid_config(parent.m_grid_config),


### PR DESCRIPTION
While working on #1007 and #1008, I was reminded that the outputs from the throughput applications could do with a bit of an improvement. After these updates, the applications output everything using `traccc::Logger` beside the few lines printed by Detray. Along the lines of:

```
[bash][Legolas]:build > ./bin/traccc_throughput_st_cuda
13:14:39    ThroughputExampleOptions      INFO      
13:14:39    ThroughputExampleOptions      INFO      Running Single-threaded CUDA GPU throughput tests
13:14:39    ThroughputExampleOptions      INFO      
13:14:39    ThroughputExampleOptions      INFO      Detector Options:
13:14:39    ThroughputExampleOptions      INFO      ├ Detector file:                          geometries/odd/odd-detray_geometry_detray.json
13:14:39    ThroughputExampleOptions      INFO      ├ Material file:                          geometries/odd/odd-detray_material_detray.json
13:14:39    ThroughputExampleOptions      INFO      ├ Surface grid file:                      geometries/odd/odd-detray_surface_grids_detray.json
13:14:39    ThroughputExampleOptions      INFO      ├ Use detray detector:                    true
13:14:39    ThroughputExampleOptions      INFO      └ Digitization file:                      geometries/odd/odd-digi-geometric-config.json
...
Detector check: OK
WARNING: No entries in volume finder

Detector check: OK
13:14:43    io::read_cells                WARNING   28 duplicate cells found in /data/ssd-1tb/projects/traccc/traccc/data/odd/geant4_10muon_10GeV/event000000000-cells.csv
13:14:43    FullChainAlg                  INFO      Using CUDA device: NVIDIA GeForce RTX 3080 [id: 0, bus: 1, device: 0]
Warm-up processing [==================================================] 100% [00m:00s]                                                                                                                     
Event processing   [==================================================] 100% [00m:00s]                                                                                                                     
01:14:45 PM ThroughputExample             INFO      Reconstructed track parameters: 18300
01:14:45 PM ThroughputExample             INFO      Time totals:
01:14:45 PM ThroughputExample             INFO                        File reading  4 ms
01:14:45 PM ThroughputExample             INFO                  Warm-up processing  205 ms
01:14:45 PM ThroughputExample             INFO                    Event processing  1823 ms
01:14:45 PM ThroughputExample             INFO      Throughput:
01:14:45 PM ThroughputExample             INFO                  Warm-up processing  20.5455 ms/event, 48.6724 events/s
01:14:45 PM ThroughputExample             INFO                    Event processing  18.2338 ms/event, 54.8432 events/s
[bash][Legolas]:build >
```

And:

```
[bash][Legolas]:build > ./bin/traccc_throughput_mt_sycl --cpu-threads=2
13:15:32    ThroughputExampleOptions      INFO      
13:15:32    ThroughputExampleOptions      INFO      Running Multi-threaded SYCL GPU throughput tests
13:15:32    ThroughputExampleOptions      INFO      
13:15:32    ThroughputExampleOptions      INFO      Detector Options:
13:15:32    ThroughputExampleOptions      INFO      ├ Detector file:                          geometries/odd/odd-detray_geometry_detray.json
13:15:32    ThroughputExampleOptions      INFO      ├ Material file:                          geometries/odd/odd-detray_material_detray.json
13:15:32    ThroughputExampleOptions      INFO      ├ Surface grid file:                      geometries/odd/odd-detray_surface_grids_detray.json
13:15:32    ThroughputExampleOptions      INFO      ├ Use detray detector:                    true
13:15:32    ThroughputExampleOptions      INFO      └ Digitization file:                      geometries/odd/odd-digi-geometric-config.json
...
Detector check: OK
WARNING: No entries in volume finder

Detector check: OK
13:15:36    io::read_cells                WARNING   28 duplicate cells found in /data/ssd-1tb/projects/traccc/traccc/data/odd/geant4_10muon_10GeV/event000000000-cells.csv
13:15:36    FullChainAlg0                 INFO      Using SYCL device: NVIDIA GeForce RTX 3080
13:15:36    FullChainAlg1                 INFO      Using SYCL device: NVIDIA GeForce RTX 3080
13:15:36    FullChainAlg2                 INFO      Using SYCL device: NVIDIA GeForce RTX 3080
Warm-up processing [==================================================] 100% [00m:00s]                                                                                                                     
Event processing   [==================================================] 100% [00m:00s]                                                                                                                     
01:15:37 PM ThroughputExample             INFO      Reconstructed track parameters: 18300
01:15:37 PM ThroughputExample             INFO      Time totals:
01:15:37 PM ThroughputExample             INFO                        File reading  5 ms
01:15:37 PM ThroughputExample             INFO                  Warm-up processing  111 ms
01:15:37 PM ThroughputExample             INFO                    Event processing  754 ms
01:15:37 PM ThroughputExample             INFO      Throughput:
01:15:37 PM ThroughputExample             INFO                  Warm-up processing  11.1279 ms/event, 89.8644 events/s
01:15:37 PM ThroughputExample             INFO                    Event processing  7.54076 ms/event, 132.613 events/s
[bash][Legolas]:build >
```

Note how the "non-cloned" `traccc::Logger` object in the `throughput_st(...)` and `throughput_mt(...)` functions uses a slightly different formatting at the end of the logs. :thinking: Which makes me think that [Acts::Logger::clone(...)](https://github.com/acts-project/acts/blob/main/Core/include/Acts/Utilities/Logger.hpp#L694) is not working correctly at the moment. :thinking: But that's not a burning issue right now...

Still, @paulgessinger, it may be worth a look at one point.