### PR TITLE
Synchronize threads to update shared measurements correctly

### DIFF
--- a/device/cuda/src/ambiguity_resolution/kernels/remove_tracks.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/remove_tracks.cu
@@ -140,8 +140,6 @@ __global__ void remove_tracks(device::remove_tracks_payload payload) {
 
     shared_tids[threadIndex] = static_cast<unsigned int>(tracks[alive_idx]);
 
-    __syncthreads();
-
     auto tid = shared_tids[threadIndex];
 
     const auto m_count = static_cast<unsigned int>(thrust::count(
@@ -150,6 +148,8 @@ __global__ void remove_tracks(device::remove_tracks_payload payload) {
     const unsigned int N_S =
         vecmem::device_atomic_ref<unsigned int>(n_shared.at(tid))
             .fetch_sub(m_count);
+
+    __syncthreads();
 
     bool already_pushed = false;
     for (unsigned int i = 0; i < threadIndex; ++i) {

--- a/tests/cuda/test_ambiguity_resolution.cpp
+++ b/tests/cuda/test_ambiguity_resolution.cpp
@@ -943,6 +943,15 @@ INSTANTIATE_TEST_SUITE_P(
                                       100u, false)));
 
 INSTANTIATE_TEST_SUITE_P(
+    Long, GreedyResolutionCompareToCPU,
+    ::testing::Values(std::make_tuple(3u, 10000u,
+                                      std::array<std::size_t, 2u>{3u, 500u},
+                                      10000u, true),
+                      std::make_tuple(3u, 10000u,
+                                      std::array<std::size_t, 2u>{3u, 500u},
+                                      10000u, false)));
+
+INSTANTIATE_TEST_SUITE_P(
     Simple, GreedyResolutionCompareToCPU,
     ::testing::Values(
         std::make_tuple(3u, 5u, std::array<std::size_t, 2u>{3u, 5u}, 10u, true),


### PR DESCRIPTION
Currently `n_shared` array in `remove_tracks.cu` is not synchronized correctly, resulting into a wrong (and non-deterministic) calculation of relative shared measurements 

Before

```
Number of resolved track candidates: 5860 (host), 5858 (device)
  Matching rate(s):
    - 99.8805% at 0.01% uncertainty
    - 99.8805% at 0.1% uncertainty
    - 99.8805% at 1% uncertainty
    - 99.8805% at 5% uncertainty
```

After

```
Number of resolved track candidates: 5860 (host), 5860 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
```

Also added tests which can catch the current bug