### PR TITLE
Change measurment id type from std::size_t to unsigned int

### DIFF
--- a/core/include/traccc/definitions/primitives.hpp
+++ b/core/include/traccc/definitions/primitives.hpp
@@ -27,7 +27,7 @@
 
 namespace traccc {
 
-using measurement_id = std::uint64_t;
+using measurement_id_type = unsigned int;
 using particle_id = std::uint64_t;
 using geometry_id = std::uint64_t;
 using channel_id = unsigned int;

--- a/core/include/traccc/edm/measurement.hpp
+++ b/core/include/traccc/edm/measurement.hpp
@@ -44,7 +44,7 @@ struct measurement {
     scalar time = 0.f;
 
     // Unique measurement ID
-    std::size_t measurement_id = 0;
+    measurement_id_type measurement_id = 0;
 
     /// Measurement dimension
     unsigned int meas_dim = 2u;

--- a/device/common/include/traccc/ambiguity_resolution/device/count_removable_tracks.hpp
+++ b/device/common/include/traccc/ambiguity_resolution/device/count_removable_tracks.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/definitions/primitives.hpp"
 #include "traccc/utils/pair.hpp"
 
 // VecMem include(s).
@@ -43,17 +44,17 @@ struct count_removable_tracks_payload {
     /**
      * @brief View object to the vector of measured ids per track
      */
-    vecmem::data::jagged_vector_view<const std::size_t> meas_ids_view;
+    vecmem::data::jagged_vector_view<const measurement_id_type> meas_ids_view;
 
     /**
      * @brief View object to the vector of number of measurements
      */
-    vecmem::data::vector_view<const std::size_t> n_meas_view;
+    vecmem::data::vector_view<const unsigned int> n_meas_view;
 
     /**
      * @brief View object to the unique measurement ids
      */
-    vecmem::data::vector_view<const std::size_t> unique_meas_view;
+    vecmem::data::vector_view<const measurement_id_type> unique_meas_view;
 
     /**
      * @brief View object to the number of accepted tracks per measurement
@@ -74,7 +75,7 @@ struct count_removable_tracks_payload {
     /**
      * @brief View object to measurements to remove
      */
-    vecmem::data::vector_view<std::size_t> meas_to_remove_view;
+    vecmem::data::vector_view<measurement_id_type> meas_to_remove_view;
 
     /**
      * @brief View object to thread id of measurements to remove

--- a/device/common/include/traccc/ambiguity_resolution/device/count_shared_measurements.hpp
+++ b/device/common/include/traccc/ambiguity_resolution/device/count_shared_measurements.hpp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// Project include(s).
+#include "traccc/definitions/primitives.hpp"
+
 // VecMem include(s).
 #include <vecmem/containers/data/jagged_vector_view.hpp>
 #include <vecmem/containers/data/vector_view.hpp>
@@ -25,12 +28,12 @@ struct count_shared_measurements_payload {
     /**
      * @brief View object to the vector of measured ids per track
      */
-    vecmem::data::jagged_vector_view<const std::size_t> meas_ids_view;
+    vecmem::data::jagged_vector_view<const measurement_id_type> meas_ids_view;
 
     /**
      * @brief View object to the unique measurement ids
      */
-    vecmem::data::vector_view<const std::size_t> unique_meas_view;
+    vecmem::data::vector_view<const measurement_id_type> unique_meas_view;
 
     /**
      * @brief View object to the tracks per measurement

--- a/device/common/include/traccc/ambiguity_resolution/device/exclusive_scan.hpp
+++ b/device/common/include/traccc/ambiguity_resolution/device/exclusive_scan.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/definitions/primitives.hpp"
 #include "traccc/utils/pair.hpp"
 
 // VecMem include(s).
@@ -37,7 +38,7 @@ struct exclusive_scan_payload {
     /**
      * @brief View object to measurements to remove
      */
-    vecmem::data::vector_view<std::size_t> meas_to_remove_view;
+    vecmem::data::vector_view<measurement_id_type> meas_to_remove_view;
 
     /**
      * @brief View object to thread id of measurements to remove

--- a/device/common/include/traccc/ambiguity_resolution/device/fill_tracks_per_measurement.hpp
+++ b/device/common/include/traccc/ambiguity_resolution/device/fill_tracks_per_measurement.hpp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// Project include(s).
+#include "traccc/definitions/primitives.hpp"
+
 // VecMem include(s).
 #include <vecmem/containers/data/jagged_vector_view.hpp>
 #include <vecmem/containers/data/vector_view.hpp>
@@ -28,17 +31,17 @@ struct fill_tracks_per_measurement_payload {
     /**
      * @brief View object to the vector of measured ids per track
      */
-    vecmem::data::jagged_vector_view<const std::size_t> meas_ids_view;
+    vecmem::data::jagged_vector_view<const measurement_id_type> meas_ids_view;
 
     /**
      * @brief View object to the unique measurement ids
      */
-    vecmem::data::vector_view<const std::size_t> unique_meas_view;
+    vecmem::data::vector_view<const measurement_id_type> unique_meas_view;
 
     /**
      * @brief View object to the tracks per measurement
      */
-    vecmem::data::jagged_vector_view<std::size_t> tracks_per_measurement_view;
+    vecmem::data::jagged_vector_view<unsigned int> tracks_per_measurement_view;
 
     /**
      * @brief View object to the track status per measurement

--- a/device/common/include/traccc/ambiguity_resolution/device/fill_vectors.hpp
+++ b/device/common/include/traccc/ambiguity_resolution/device/fill_vectors.hpp
@@ -30,12 +30,12 @@ struct fill_vectors_payload {
     /**
      * @brief View object to the vector of measured ids per track
      */
-    vecmem::data::jagged_vector_view<std::size_t> meas_ids_view;
+    vecmem::data::jagged_vector_view<measurement_id_type> meas_ids_view;
 
     /**
      * @brief View object to the measurement ids in flat vector
      */
-    vecmem::data::vector_view<std::size_t> flat_meas_ids_view;
+    vecmem::data::vector_view<measurement_id_type> flat_meas_ids_view;
 
     /**
      * @brief View object to the vector of pvalues
@@ -45,7 +45,7 @@ struct fill_vectors_payload {
     /**
      * @brief View object to the number of measurements per track
      */
-    vecmem::data::vector_view<std::size_t> n_meas_view;
+    vecmem::data::vector_view<unsigned int> n_meas_view;
 
     /**
      * @brief View object to the status of track acceptance

--- a/device/common/include/traccc/ambiguity_resolution/device/remove_tracks.hpp
+++ b/device/common/include/traccc/ambiguity_resolution/device/remove_tracks.hpp
@@ -34,22 +34,22 @@ struct remove_tracks_payload {
     /**
      * @brief View object to the vector of measured ids per track
      */
-    vecmem::data::jagged_vector_view<const std::size_t> meas_ids_view;
+    vecmem::data::jagged_vector_view<const measurement_id_type> meas_ids_view;
 
     /**
      * @brief View object to the vector of number of measurements
      */
-    vecmem::data::vector_view<const std::size_t> n_meas_view;
+    vecmem::data::vector_view<const unsigned int> n_meas_view;
 
     /**
      * @brief View object to the unique measurement ids
      */
-    vecmem::data::vector_view<const std::size_t> unique_meas_view;
+    vecmem::data::vector_view<const measurement_id_type> unique_meas_view;
 
     /**
      * @brief View object to the tracks per measurement
      */
-    vecmem::data::jagged_vector_view<const std::size_t>
+    vecmem::data::jagged_vector_view<const unsigned int>
         tracks_per_measurement_view;
 
     /**
@@ -87,7 +87,7 @@ struct remove_tracks_payload {
     /**
      * @brief View object to measurements to remove
      */
-    vecmem::data::vector_view<std::size_t> meas_to_remove_view;
+    vecmem::data::vector_view<measurement_id_type> meas_to_remove_view;
 
     /**
      * @brief View object to thread id of measurements to remove

--- a/device/cuda/src/ambiguity_resolution/kernels/count_removable_tracks.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/count_removable_tracks.cu
@@ -68,7 +68,7 @@ __global__ void count_removable_tracks(
     }
 
     __shared__ int shared_n_meas[1024];
-    __shared__ std::size_t sh_meas_ids[1024];
+    __shared__ measurement_id_type sh_meas_ids[1024];
     __shared__ unsigned int sh_threads[1024];
     __shared__ unsigned int n_meas_total;
     __shared__ unsigned int bound;
@@ -79,13 +79,13 @@ __global__ void count_removable_tracks(
 
     vecmem::device_vector<const unsigned int> sorted_ids(
         payload.sorted_ids_view);
-    vecmem::jagged_device_vector<const std::size_t> meas_ids(
+    vecmem::jagged_device_vector<const measurement_id_type> meas_ids(
         payload.meas_ids_view);
-    vecmem::device_vector<const std::size_t> n_meas(payload.n_meas_view);
-    vecmem::device_vector<std::size_t> meas_to_remove(
+    vecmem::device_vector<const unsigned int> n_meas(payload.n_meas_view);
+    vecmem::device_vector<measurement_id_type> meas_to_remove(
         payload.meas_to_remove_view);
     vecmem::device_vector<unsigned int> threads(payload.threads_view);
-    vecmem::device_vector<const std::size_t> unique_meas(
+    vecmem::device_vector<const measurement_id_type> unique_meas(
         payload.unique_meas_view);
     vecmem::device_vector<const unsigned int> n_accepted_tracks_per_measurement(
         payload.n_accepted_tracks_per_measurement_view);
@@ -94,7 +94,7 @@ __global__ void count_removable_tracks(
 
     int gid = static_cast<int>(*payload.n_accepted) - 1 - threadIndex;
     shared_n_meas[threadIndex] = 0;
-    sh_meas_ids[threadIndex] = std::numeric_limits<std::size_t>::max();
+    sh_meas_ids[threadIndex] = std::numeric_limits<measurement_id_type>::max();
     sh_threads[threadIndex] = std::numeric_limits<unsigned int>::max();
 
     if (threadIndex == 0) {

--- a/device/cuda/src/ambiguity_resolution/kernels/count_shared_measurements.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/count_shared_measurements.cu
@@ -31,9 +31,9 @@ __global__ void count_shared_measurements(
         return;
     }
 
-    vecmem::jagged_device_vector<const std::size_t> meas_ids(
+    vecmem::jagged_device_vector<const measurement_id_type> meas_ids(
         payload.meas_ids_view);
-    vecmem::device_vector<const std::size_t> unique_meas(
+    vecmem::device_vector<const measurement_id_type> unique_meas(
         payload.unique_meas_view);
     vecmem::device_vector<const unsigned int> n_accepted_tracks_per_measurement(
         payload.n_accepted_tracks_per_measurement_view);

--- a/device/cuda/src/ambiguity_resolution/kernels/exclusive_scan.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/exclusive_scan.cu
@@ -21,7 +21,7 @@ __global__ void exclusive_scan(device::exclusive_scan_payload payload) {
     }
 
     __shared__ int prefix[1024];
-    __shared__ std::size_t sh_meas_ids[1024];
+    __shared__ measurement_id_type sh_meas_ids[1024];
     __shared__ unsigned int sh_threads[1024];
 
     auto threadIndex = threadIdx.x;
@@ -30,7 +30,7 @@ __global__ void exclusive_scan(device::exclusive_scan_payload payload) {
         return;
     }
 
-    vecmem::device_vector<std::size_t> meas_to_remove(
+    vecmem::device_vector<measurement_id_type> meas_to_remove(
         payload.meas_to_remove_view);
     vecmem::device_vector<unsigned int> threads(payload.threads_view);
 

--- a/device/cuda/src/ambiguity_resolution/kernels/fill_tracks_per_measurement.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/fill_tracks_per_measurement.cu
@@ -31,11 +31,11 @@ __global__ void fill_tracks_per_measurement(
         return;
     }
 
-    vecmem::jagged_device_vector<const std::size_t> meas_ids(
+    vecmem::jagged_device_vector<const measurement_id_type> meas_ids(
         payload.meas_ids_view);
-    vecmem::device_vector<const std::size_t> unique_meas(
+    vecmem::device_vector<const measurement_id_type> unique_meas(
         payload.unique_meas_view);
-    vecmem::jagged_device_vector<std::size_t> tracks_per_measurement(
+    vecmem::jagged_device_vector<unsigned int> tracks_per_measurement(
         payload.tracks_per_measurement_view);
     vecmem::jagged_device_vector<int> track_status_per_measurement(
         payload.track_status_per_measurement_view);

--- a/device/cuda/src/ambiguity_resolution/kernels/fill_vectors.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/fill_vectors.cu
@@ -33,11 +33,12 @@ __global__ void fill_vectors(const ambiguity_resolution_config cfg,
         payload.track_candidates_view.measurements);
     const auto track = track_candidates.at(globalIndex);
 
-    vecmem::jagged_device_vector<std::size_t> meas_ids(payload.meas_ids_view);
-    vecmem::device_vector<std::size_t> flat_meas_ids(
+    vecmem::jagged_device_vector<measurement_id_type> meas_ids(
+        payload.meas_ids_view);
+    vecmem::device_vector<measurement_id_type> flat_meas_ids(
         payload.flat_meas_ids_view);
     vecmem::device_vector<traccc::scalar> pvals(payload.pvals_view);
-    vecmem::device_vector<std::size_t> n_meas(payload.n_meas_view);
+    vecmem::device_vector<unsigned int> n_meas(payload.n_meas_view);
     vecmem::device_vector<int> status(payload.status_view);
 
     pvals.at(globalIndex) = track.pval();

--- a/device/cuda/src/ambiguity_resolution/kernels/remove_tracks.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/remove_tracks.cu
@@ -33,7 +33,7 @@ __global__ void remove_tracks(device::remove_tracks_payload payload) {
     }
 
     __shared__ unsigned int shared_tids[1024];
-    __shared__ std::size_t sh_meas_ids[1024];
+    __shared__ measurement_id_type sh_meas_ids[1024];
     __shared__ unsigned int sh_threads[1024];
 
     auto threadIndex = threadIdx.x;
@@ -42,12 +42,12 @@ __global__ void remove_tracks(device::remove_tracks_payload payload) {
 
     vecmem::device_vector<const unsigned int> sorted_ids(
         payload.sorted_ids_view);
-    vecmem::jagged_device_vector<const std::size_t> meas_ids(
+    vecmem::jagged_device_vector<const measurement_id_type> meas_ids(
         payload.meas_ids_view);
-    vecmem::device_vector<const std::size_t> n_meas(payload.n_meas_view);
-    vecmem::device_vector<const std::size_t> unique_meas(
+    vecmem::device_vector<const unsigned int> n_meas(payload.n_meas_view);
+    vecmem::device_vector<const measurement_id_type> unique_meas(
         payload.unique_meas_view);
-    vecmem::jagged_device_vector<const std::size_t> tracks_per_measurement(
+    vecmem::jagged_device_vector<const unsigned int> tracks_per_measurement(
         payload.tracks_per_measurement_view);
     vecmem::jagged_device_vector<int> track_status_per_measurement(
         payload.track_status_per_measurement_view);
@@ -58,7 +58,7 @@ __global__ void remove_tracks(device::remove_tracks_payload payload) {
     vecmem::device_vector<unsigned int> updated_tracks(
         payload.updated_tracks_view);
     vecmem::device_vector<int> is_updated(payload.is_updated_view);
-    vecmem::device_vector<std::size_t> meas_to_remove(
+    vecmem::device_vector<measurement_id_type> meas_to_remove(
         payload.meas_to_remove_view);
     vecmem::device_vector<unsigned int> threads(payload.threads_view);
 

--- a/io/include/traccc/io/read_measurements.hpp
+++ b/io/include/traccc/io/read_measurements.hpp
@@ -32,7 +32,7 @@ namespace traccc::io {
 /// @param[in]  detector  detray detector
 /// @param[in]  format    The format of the measurement data files (to read)
 ///
-std::vector<std::size_t> read_measurements(
+std::vector<measurement_id_type> read_measurements(
     measurement_collection_types::host& measurements, std::size_t event,
     std::string_view directory,
     const traccc::default_detector::host* detector = nullptr,
@@ -47,7 +47,7 @@ std::vector<std::size_t> read_measurements(
 /// @param[in]  detector  detray detector
 /// @param[in]  format   The format of the measurement data files (to read)
 ///
-std::vector<std::size_t> read_measurements(
+std::vector<measurement_id_type> read_measurements(
     measurement_collection_types::host& measurements, std::string_view filename,
     const traccc::default_detector::host* detector = nullptr,
     const bool sort_measurements = true, data_format format = data_format::csv);

--- a/io/src/csv/read_measurements.hpp
+++ b/io/src/csv/read_measurements.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/geometry/detector.hpp"
 
@@ -24,7 +25,7 @@ namespace traccc::io::csv {
 /// @param[in]  detector  detray detector
 /// @param[in]  do_sort      Whether to sort the measurements or not
 ///
-std::vector<std::size_t> read_measurements(
+std::vector<measurement_id_type> read_measurements(
     measurement_collection_types::host& measurements, std::string_view filename,
     const traccc::default_detector::host* detector = nullptr,
     const bool do_sort = true);

--- a/io/src/csv/read_particles.cpp
+++ b/io/src/csv/read_particles.cpp
@@ -61,11 +61,11 @@ void read_particles(particle_container_types::host& particles,
 
     // Read in all measurements, into a temporary collection.
     measurement_collection_types::host temp_measurements{&mr};
-    const std::vector<std::size_t> new_idx_map = read_measurements(
+    const std::vector<measurement_id_type> new_idx_map = read_measurements(
         temp_measurements, measurements_file, detector, sort_measurements);
 
     // Make a hit to measurement map.
-    std::unordered_map<std::size_t, std::size_t> hit_to_measurement;
+    std::unordered_map<std::size_t, measurement_id_type> hit_to_measurement;
     measurement_hit_id mhid;
     while (measurement_hit_id_reader.read(mhid)) {
         if (sort_measurements) {

--- a/io/src/csv/read_spacepoints.cpp
+++ b/io/src/csv/read_spacepoints.cpp
@@ -12,6 +12,9 @@
 #include "traccc/io/csv/make_hit_reader.hpp"
 #include "traccc/io/csv/make_measurement_hit_id_reader.hpp"
 
+// Project include(s).
+#include "traccc/definitions/primitives.hpp"
+
 // System include(s).
 #include <ranges>
 #include <stdexcept>
@@ -27,7 +30,7 @@ void read_spacepoints(edm::spacepoint_collection::host& spacepoints,
                       const bool sort_measurements) {
 
     // Read all measurements.
-    const std::vector<std::size_t> new_idx_map = read_measurements(
+    const std::vector<measurement_id_type> new_idx_map = read_measurements(
         measurements, meas_filename, detector, sort_measurements);
 
     // Measurement hit id reader

--- a/io/src/read_measurements.cpp
+++ b/io/src/read_measurements.cpp
@@ -17,7 +17,7 @@
 
 namespace traccc::io {
 
-std::vector<std::size_t> read_measurements(
+std::vector<measurement_id_type> read_measurements(
     measurement_collection_types::host& measurements, std::size_t event,
     std::string_view directory, const traccc::default_detector::host* detector,
     const bool sort_measurements, data_format format) {
@@ -47,7 +47,7 @@ std::vector<std::size_t> read_measurements(
     }
 }
 
-std::vector<std::size_t> read_measurements(
+std::vector<measurement_id_type> read_measurements(
     measurement_collection_types::host& measurements, std::string_view filename,
     const traccc::default_detector::host* detector,
     const bool sort_measurements, data_format format) {

--- a/performance/include/traccc/utils/event_data.hpp
+++ b/performance/include/traccc/utils/event_data.hpp
@@ -83,7 +83,7 @@ struct event_data {
         float pt_cut = 0.f);
 
     // Measurement map
-    std::map<measurement_id, measurement> m_measurement_map;
+    std::map<measurement_id_type, measurement> m_measurement_map;
     // Particle map
     std::map<particle_id, particle> m_particle_map;
     // Measurement to the contributing particle map

--- a/performance/src/utils/event_data.cpp
+++ b/performance/src/utils/event_data.cpp
@@ -181,7 +181,13 @@ void event_data::setup_csv(bool use_acts_geom_source, const detector_type* det,
             meas.time = iohit.tt;
         }
 
-        m_measurement_map[iomeas.measurement_id] = meas;
+        if (iomeas.measurement_id <=
+            std::numeric_limits<measurement_id_type>::max()) {
+            m_measurement_map[static_cast<measurement_id_type>(
+                iomeas.measurement_id)] = meas;
+        } else {
+            throw std::runtime_error("Measurement ID exceeds the bound");
+        }
     }
 
     // Particle map
@@ -213,7 +219,14 @@ void event_data::setup_csv(bool use_acts_geom_source, const detector_type* det,
             auto hid = csv_meas_hit_ids[meas_id].hit_id;
             const auto& iohit = csv_hits[hid];
 
-            const auto meas = m_measurement_map.at(meas_id);
+            traccc::measurement meas;
+            if (meas_id <= std::numeric_limits<measurement_id_type>::max()) {
+                meas = m_measurement_map.at(
+                    static_cast<measurement_id_type>(meas_id));
+            } else {
+                throw std::runtime_error("Measurement ID exceeds the bound");
+            }
+
             meas_to_cluster_map[meas].push_back(iocell);
 
             const auto& ptc = m_particle_map.at(iohit.particle_id);
@@ -243,8 +256,14 @@ void event_data::setup_csv(bool use_acts_geom_source, const detector_type* det,
         const auto& ptc = m_particle_map.at(iohit.particle_id);
 
         // Construct the measurement object.
-        const traccc::measurement& meas =
-            m_measurement_map.at(iomeas.measurement_id);
+        traccc::measurement meas;
+        if (iomeas.measurement_id <=
+            std::numeric_limits<measurement_id_type>::max()) {
+            meas = m_measurement_map.at(
+                static_cast<measurement_id_type>(iomeas.measurement_id));
+        } else {
+            throw std::runtime_error("Measurement ID exceeds the bound");
+        }
 
         // Fill measurement to truth global position and momentum map
         m_meas_to_param_map[meas] = std::make_pair(global_pos, global_mom);
@@ -341,8 +360,14 @@ void event_data::fill_cca_result(
                              });
 
         const auto& meas_id = pr->first;
-        m_found_meas_to_param_map[ms] =
-            m_meas_to_param_map[m_measurement_map[meas_id]];
+
+        if (meas_id <= std::numeric_limits<measurement_id_type>::max()) {
+            m_found_meas_to_param_map[ms] = m_meas_to_param_map
+                [m_measurement_map[static_cast<measurement_id_type>(meas_id)]];
+
+        } else {
+            throw std::runtime_error("Measurement ID exceeds the bound");
+        }
     }
 }
 

--- a/tests/common/tests/cca_test.hpp
+++ b/tests/common/tests/cca_test.hpp
@@ -70,7 +70,7 @@ class ConnectedComponentAnalysisTests
     public:
     struct cca_truth_hit {
         uint64_t geometry_id = 0;
-        uint64_t measurement_id = 0;
+        traccc::measurement_id_type measurement_id = 0;
         uint64_t num_cells = 0;
         traccc::scalar channel0 = 0;
         traccc::scalar channel1 = 0;

--- a/tests/cpu/test_ambiguity_resolution.cpp
+++ b/tests/cpu/test_ambiguity_resolution.cpp
@@ -28,7 +28,8 @@ vecmem::host_memory_resource host_mr;
 
 void fill_pattern(
     edm::track_candidate_container<default_algebra>::host& track_candidates,
-    const traccc::scalar pval, const std::vector<std::size_t>& pattern) {
+    const traccc::scalar pval,
+    const std::vector<measurement_id_type>& pattern) {
 
     track_candidates.tracks.resize(track_candidates.tracks.size() + 1u);
     track_candidates.tracks.pval().back() = pval;
@@ -255,15 +256,16 @@ TEST(AmbiguitySolverTests, GreedyResolverTest4) {
     for (std::size_t i = 0; i < 10000u; i++) {
 
         std::uniform_int_distribution<std::size_t> track_length_dist(1, 20);
-        std::uniform_int_distribution<std::size_t> meas_id_dist(0, 10000);
+        std::uniform_int_distribution<measurement_id_type> meas_id_dist(0,
+                                                                        10000);
         std::uniform_real_distribution<traccc::scalar> pval_dist(0.0f, 1.0f);
 
         const std::size_t track_length = track_length_dist(gen);
         const traccc::scalar pval = pval_dist(gen);
-        std::vector<std::size_t> pattern;
+        std::vector<measurement_id_type> pattern;
         while (pattern.size() < track_length) {
 
-            const std::size_t meas_id = meas_id_dist(gen);
+            const measurement_id_type meas_id = meas_id_dist(gen);
             if (std::find(pattern.begin(), pattern.end(), meas_id) ==
                 pattern.end()) {
                 pattern.push_back(meas_id);


### PR DESCRIPTION
I couldn't help testing the ambiguity resolution performance with unsigned int
Even though the measurement with `seq_example_cuda` is quite noisy, it seems the algorithm gets faster slightly

Before

```
14:28:51    CudaSeqExample                INFO      ==>Elapsed times...            File reading  (cpu)  883 ms
14:28:51    CudaSeqExample                INFO               Clusterization (cuda)  9 ms
14:28:51    CudaSeqExample                INFO         Spacepoint formation (cuda)  0 ms
14:28:51    CudaSeqExample                INFO                      Seeding (cuda)  52 ms
14:28:51    CudaSeqExample                INFO                 Track params (cuda)  0 ms
14:28:51    CudaSeqExample                INFO                Track finding (cuda)  228 ms
14:28:51    CudaSeqExample                INFO         Ambiguity resolution (cuda)  340 ms
14:28:51    CudaSeqExample                INFO                Track fitting (cuda)  65 ms
14:28:51    CudaSeqExample                INFO                           Wall time  1583 ms
```

After

```
14:22:45    CudaSeqExample                INFO      ==>Elapsed times...            File reading  (cpu)  892 ms
14:22:45    CudaSeqExample                INFO               Clusterization (cuda)  3 ms
14:22:45    CudaSeqExample                INFO         Spacepoint formation (cuda)  0 ms
14:22:45    CudaSeqExample                INFO                      Seeding (cuda)  53 ms
14:22:45    CudaSeqExample                INFO                 Track params (cuda)  0 ms
14:22:45    CudaSeqExample                INFO                Track finding (cuda)  217 ms
14:22:45    CudaSeqExample                INFO         Ambiguity resolution (cuda)  320 ms
14:22:45    CudaSeqExample                INFO                Track fitting (cuda)  66 ms
14:22:45    CudaSeqExample                INFO                           Wall time  1557 ms
```