### PR TITLE
Fix oneDPL Usage, main branch (2025.06.13.)

### DIFF
--- a/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
+++ b/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
@@ -17,6 +17,9 @@
 #pragma clang diagnostic ignored "-Wsign-conversion"
 #pragma clang diagnostic ignored "-Wimplicit-int-conversion"
 #pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wunused-variable"
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
 #pragma clang diagnostic pop

--- a/device/sycl/src/finding/find_tracks.hpp
+++ b/device/sycl/src/finding/find_tracks.hpp
@@ -44,6 +44,9 @@
 #pragma clang diagnostic ignored "-Wimplicit-int-conversion"
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
 #pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wunused-variable"
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
 #pragma clang diagnostic pop

--- a/device/sycl/src/fitting/fit_tracks.hpp
+++ b/device/sycl/src/fitting/fit_tracks.hpp
@@ -35,6 +35,9 @@
 #pragma clang diagnostic ignored "-Wimplicit-int-conversion"
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
 #pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wunused-variable"
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
 #pragma clang diagnostic pop

--- a/extern/dpl/CMakeLists.txt
+++ b/extern/dpl/CMakeLists.txt
@@ -16,7 +16,9 @@ set( TRACCC_DPL_SOURCE
    "URL;https://github.com/oneapi-src/oneDPL/archive/refs/tags/oneDPL-2022.7.1-release.tar.gz;URL_MD5;21d45dc27ba3133bfb282ec7383177f4"
    CACHE STRING "Source for DPL, when built as part of this project" )
 mark_as_advanced( TRACCC_DPL_SOURCE )
-FetchContent_Declare( DPL SYSTEM ${TRACCC_DPL_SOURCE} )
+# Must not use SYSTEM here, as the oneAPI compiler then ignores this version
+# of oneDPL.
+FetchContent_Declare( DPL ${TRACCC_DPL_SOURCE} )
 
 # Set the default oneDPL threading backend.
 set( ONEDPL_BACKEND "dpcpp" CACHE STRING "oneDPL threading backend" )

--- a/tests/sycl/test_dpl.sycl
+++ b/tests/sycl/test_dpl.sycl
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,6 +15,9 @@
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
 #pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
 #pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wunused-variable"
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
 #pragma clang diagnostic pop


### PR DESCRIPTION
It turns out / I was reminded once again, that we can't use `SYSTEM` with the oneDPL external. :cry: It's because the oneAPI compiler makes use of its own oneDPL headers when we provide our own oneDPL headers using `-isystem`.

I noticed this through the following errors when trying to build the project using the latest, 2025.1.3 version of oneAPI.

```
[build] In file included from /home/krasznaa/ATLAS/projects/traccc/traccc/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl:21:
[build] In file included from /home/krasznaa/software/intel/oneapi-2025.1.3/dpl/2022.8/include/oneapi/dpl/execution:34:
[build] In file included from /home/krasznaa/software/intel/oneapi-2025.1.3/dpl/2022.8/include/oneapi/dpl/pstl/glue_algorithm_impl.h:27:
[build] In file included from /home/krasznaa/software/intel/oneapi-2025.1.3/dpl/2022.8/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h:22:
[build] In file included from /home/krasznaa/software/intel/oneapi-2025.1.3/dpl/2022.8/include/oneapi/dpl/pstl/hetero/../parallel_backend.h:32:
[build] In file included from /home/krasznaa/software/intel/oneapi-2025.1.3/dpl/2022.8/include/oneapi/dpl/pstl/hetero/../hetero/dpcpp/parallel_backend_sycl.h:41:
[build] /home/krasznaa/software/intel/oneapi-2025.1.3/dpl/2022.8/include/oneapi/dpl/pstl/hetero/../hetero/dpcpp/parallel_backend_sycl_merge.h:182:99: error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
[build]   182 |             __rng3[__rng3_idx] = (!__rng1_idx_less_n1 || __rng1_idx_less_n1 && __rng2_idx_less_n2 &&
[build]       |                                                       ~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
[build]   183 |                                                              __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
[build]       |                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[build] /home/krasznaa/software/intel/oneapi-2025.1.3/dpl/2022.8/include/oneapi/dpl/pstl/hetero/../hetero/dpcpp/parallel_backend_sycl_merge.h:182:99: note: place parentheses around the '&&' expression to silence this warning
[build]   182 |             __rng3[__rng3_idx] = (!__rng1_idx_less_n1 || __rng1_idx_less_n1 && __rng2_idx_less_n2 &&
[build]       |                                                                                                   ^
[build]       |                                                          (
[build]   183 |                                                              __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
```

(Notice how the messages refer to headers coming with oneAPI itself.)

So I had to do this mess. :frowning: Switching back to using `-I` with the oneDPL includes, and adding yet some more warnings that the compiler should ignore. :cry:

I also reached out to Intel about this, as this is really not great...