### PR TITLE
Reduce type unrolling scope to reduce divergence

### DIFF
--- a/core/include/traccc/finding/details/find_tracks.hpp
+++ b/core/include/traccc/finding/details/find_tracks.hpp
@@ -15,6 +15,7 @@
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/finding/finding_config.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
+#include "traccc/fitting/kalman_filter/is_line_visitor.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/sanity/contiguous_on.hpp"
 #include "traccc/utils/logging.hpp"
@@ -268,10 +269,12 @@ find_tracks(
 
                 track_state<algebra_type> trk_state(meas);
 
+                const bool is_line = sf.template visit_mask<is_line_visitor>();
+
                 // Run the Kalman update on a copy of the track parameters
                 const kalman_fitter_status res =
-                    sf.template visit_mask<gain_matrix_updater<algebra_type>>(
-                        trk_state, in_param);
+                    gain_matrix_updater<algebra_type>{}(trk_state, in_param,
+                                                        is_line);
 
                 const traccc::scalar chi2 = trk_state.filtered_chi2();
 

--- a/core/include/traccc/fitting/kalman_filter/is_line_visitor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/is_line_visitor.hpp
@@ -1,0 +1,26 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <detray/geometry/shapes/line.hpp>
+
+#include "traccc/definitions/qualifiers.hpp"
+
+namespace traccc {
+
+struct is_line_visitor {
+    template <typename mask_group_t, typename index_t>
+    [[nodiscard]] TRACCC_HOST_DEVICE inline bool operator()(
+        const mask_group_t& /*mask_group*/, const index_t& /*index*/) const {
+        using shape_type = typename mask_group_t::value_type::shape;
+        return std::is_same_v<shape_type, detray::line<true>> ||
+               std::is_same_v<shape_type, detray::line<false>>;
+    }
+};
+
+}  // namespace traccc

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -359,8 +359,7 @@ class kalman_fitter {
 
             const detray::tracking_surface sf{m_detector,
                                               trk_state.surface_link()};
-            sf.template visit_mask<statistics_updater<algebra_type>>(fit_res,
-                                                                     trk_state);
+            statistics_updater<algebra_type>{}(fit_res, trk_state);
         }
 
         // Track quality

--- a/core/include/traccc/fitting/kalman_filter/statistics_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/statistics_updater.hpp
@@ -26,9 +26,7 @@ struct statistics_updater {
     /// @param index mask index of the current surface
     /// @param fit_res fitting information such as NDoF or Chi2
     /// @param trk_state track state of the current surface
-    template <typename mask_group_t, typename index_t>
     TRACCC_HOST_DEVICE inline void operator()(
-        const mask_group_t& /*mask_group*/, const index_t& /*index*/,
         fitting_result<algebra_t>& fit_res,
         const track_state<algebra_t>& trk_state) {
 

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -22,6 +22,7 @@
 
 // Project include(s).
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
+#include "traccc/fitting/kalman_filter/is_line_visitor.hpp"
 #include "traccc/fitting/status_codes.hpp"
 
 // Detray include(s)
@@ -248,10 +249,12 @@ TRACCC_HOST_DEVICE inline void find_tracks(
                 track_state<typename detector_t::algebra_type> trk_state(meas);
                 const detray::tracking_surface sf{det, in_par.surface_link()};
 
+                const bool is_line = sf.template visit_mask<is_line_visitor>();
+
                 // Run the Kalman update
-                const kalman_fitter_status res = sf.template visit_mask<
-                    gain_matrix_updater<typename detector_t::algebra_type>>(
-                    trk_state, in_par);
+                const kalman_fitter_status res =
+                    gain_matrix_updater<typename detector_t::algebra_type>{}(
+                        trk_state, in_par, is_line);
 
                 /*
                  * The $\chi^2$ value from the Kalman update should be less than


### PR DESCRIPTION
This experimental PR reduces the scope of the type unrolling using `visit_mask` in the Kálmán filter to decrease thread divergence and improve performance.