### PR TITLE
Reduce the number of smoothed parameter copies

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -348,10 +348,18 @@ class kalman_fitter {
 
         // Fit parameter = smoothed track parameter of the first smoothed track
         // state
-        for (const auto& st : track_states) {
-            if (st.is_smoothed) {
-                fit_res.fit_params = st.smoothed();
+        unsigned int final_state_id = std::numeric_limits<unsigned int>::max();
+
+        for (unsigned int i = 0; i < track_states.size(); ++i) {
+            if (track_states.at(i).is_smoothed) {
+                final_state_id = i;
             }
+        }
+
+        // TODO: It would seem that this condition failing should invoke some
+        // kind of error...
+        if (final_state_id < track_states.size()) {
+            fit_res.fit_params = track_states.at(final_state_id).smoothed();
         }
 
         for (const auto& trk_state : track_states) {


### PR DESCRIPTION
The Kálmán fitter algorithm finds the first smoothed track state by iterating over all of them and copying each of them. This invokes a lot of unnecessary copies. To alleviate this, this commit ensures that only one track parameter is copied.

Although this code is not particularly hot, this change might bring a small performance improvement.