### PR TITLE
Device Cluster Reconstruction, main branch (2025.06.17.)

### DIFF
--- a/device/alpaka/src/clusterization/clusterization_algorithm.cpp
+++ b/device/alpaka/src/clusterization/clusterization_algorithm.cpp
@@ -34,7 +34,8 @@ struct CCLKernel {
         vecmem::data::vector_view<device::details::index_t> gf_backup_view,
         vecmem::data::vector_view<unsigned char> adjc_backup_view,
         vecmem::data::vector_view<device::details::index_t> adjv_backup_view,
-        uint32_t* backup_mutex_ptr,
+        uint32_t* backup_mutex_ptr, unsigned int* disjoint_set_ptr,
+        unsigned int* cluster_size_ptr,
         measurement_collection_types::view measurements_view,
         vecmem::data::vector_view<unsigned int> cell_links) const {
 
@@ -57,11 +58,11 @@ struct CCLKernel {
 
         alpaka::barrier<TAcc> barry_r(&acc);
 
-        device::ccl_kernel(cfg, thread_id, cells_view, det_descr_view,
-                           partition_start, partition_end, outi, f_view,
-                           gf_view, f_backup_view, gf_backup_view,
-                           adjc_backup_view, adjv_backup_view, backup_mutex,
-                           barry_r, measurements_view, cell_links);
+        device::ccl_kernel(
+            cfg, thread_id, cells_view, det_descr_view, partition_start,
+            partition_end, outi, f_view, gf_view, f_backup_view, gf_backup_view,
+            adjc_backup_view, adjv_backup_view, backup_mutex, disjoint_set_ptr,
+            cluster_size_ptr, barry_r, measurements_view, cell_links);
     }
 };
 
@@ -140,7 +141,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
         queue, workDiv, CCLKernel{}, m_config, cells, det_descr,
         vecmem::get_data(m_f_backup), vecmem::get_data(m_gf_backup),
         vecmem::get_data(m_adjc_backup), vecmem::get_data(m_adjv_backup),
-        m_backup_mutex.get(), vecmem::get_data(measurements),
+        m_backup_mutex.get(), nullptr, nullptr, vecmem::get_data(measurements),
         vecmem::get_data(cell_links));
     ::alpaka::wait(queue);
 

--- a/device/common/include/traccc/clusterization/device/aggregate_cluster.hpp
+++ b/device/common/include/traccc/clusterization/device/aggregate_cluster.hpp
@@ -30,6 +30,12 @@ namespace traccc::device {
 /// @param[in] end       partition end point this cell belongs to
 /// @param[in] cid       current cell id
 /// @param[out] out      cluster to fill
+/// @param[out] disjoint_set_ptr Pointer to an array of unsigned integers of
+///                      length $|cells|$ to which an integer is written
+///                      identifying the measurement index to which each cell
+///                      belongs.
+/// @param[out] cluster_size Optional integer which is filled with the size of
+///                      the measurement that is created.
 ///
 TRACCC_HOST_DEVICE
 inline void aggregate_cluster(
@@ -38,7 +44,9 @@ inline void aggregate_cluster(
     const silicon_detector_description::const_device& det_descr,
     const vecmem::device_vector<details::index_t>& f, unsigned int start,
     unsigned int end, unsigned short cid, measurement& out,
-    vecmem::data::vector_view<unsigned int> cell_links, unsigned int link);
+    vecmem::data::vector_view<unsigned int> cell_links, unsigned int link,
+    unsigned int* disjoint_set_ptr,
+    std::optional<std::reference_wrapper<unsigned int>> cluster_size);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/clusterization/device/aggregate_cluster.hpp
+++ b/device/common/include/traccc/clusterization/device/aggregate_cluster.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,7 +30,7 @@ namespace traccc::device {
 /// @param[in] end       partition end point this cell belongs to
 /// @param[in] cid       current cell id
 /// @param[out] out      cluster to fill
-/// @param[out] disjoint_set_ptr Pointer to an array of unsigned integers of
+/// @param[out] disjoint_set Array of unsigned integers of
 ///                      length $|cells|$ to which an integer is written
 ///                      identifying the measurement index to which each cell
 ///                      belongs.
@@ -45,7 +45,7 @@ inline void aggregate_cluster(
     const vecmem::device_vector<details::index_t>& f, unsigned int start,
     unsigned int end, unsigned short cid, measurement& out,
     vecmem::data::vector_view<unsigned int> cell_links, unsigned int link,
-    unsigned int* disjoint_set_ptr,
+    vecmem::device_vector<unsigned int>& disjoint_set,
     std::optional<std::reference_wrapper<unsigned int>> cluster_size);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
+++ b/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
@@ -49,6 +49,13 @@ namespace traccc::device {
 ///     matrix fragment storage
 /// @param backup_mutex mutex lock to mediate control over the backup global
 ///     memory data structures.
+/// @param[out] disjoint_set_ptr Pointer to array of unsigned integers of
+///     length $|cells|$ to which an integer is written identifying the
+///     measurement index to which each cell belongs.
+/// @param[out] cluster_size_ptr Pointer to an array of unsigned integers of
+///     length $|cells|$; the first $N$ elements - where $N$ is the number of
+///     output measurements - will have their value set to the size of the
+///     corresponding measurement.
 /// @param barrier  A generic object for block-wide synchronisation
 /// @param[out] measurements_view collection of measurements
 /// @param[out] cell_links    collection of links to measurements each cell is
@@ -66,7 +73,9 @@ TRACCC_DEVICE inline void ccl_kernel(
     vecmem::data::vector_view<details::index_t> gf_backup_view,
     vecmem::data::vector_view<unsigned char> adjc_backup_view,
     vecmem::data::vector_view<details::index_t> adjv_backup_view,
-    vecmem::device_atomic_ref<uint32_t> backup_mutex, const barrier_t& barrier,
+    vecmem::device_atomic_ref<uint32_t> backup_mutex,
+    unsigned int* disjoint_set_ptr, unsigned int* cluster_size_ptr,
+    const barrier_t& barrier,
     measurement_collection_types::view measurements_view,
     vecmem::data::vector_view<unsigned int> cell_links);
 

--- a/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
+++ b/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
@@ -49,11 +49,11 @@ namespace traccc::device {
 ///     matrix fragment storage
 /// @param backup_mutex mutex lock to mediate control over the backup global
 ///     memory data structures.
-/// @param[out] disjoint_set_ptr Pointer to array of unsigned integers of
+/// @param[out] disjoint_set_view Array of unsigned integers of
 ///     length $|cells|$ to which an integer is written identifying the
 ///     measurement index to which each cell belongs.
-/// @param[out] cluster_size_ptr Pointer to an array of unsigned integers of
-///     length $|cells|$; the first $N$ elements - where $N$ is the number of
+/// @param[out] cluster_size_view Array of unsigned integers of
+///     size $|cells|$; the first $N$ elements - where $N$ is the number of
 ///     output measurements - will have their value set to the size of the
 ///     corresponding measurement.
 /// @param barrier  A generic object for block-wide synchronisation
@@ -74,7 +74,8 @@ TRACCC_DEVICE inline void ccl_kernel(
     vecmem::data::vector_view<unsigned char> adjc_backup_view,
     vecmem::data::vector_view<details::index_t> adjv_backup_view,
     vecmem::device_atomic_ref<uint32_t> backup_mutex,
-    unsigned int* disjoint_set_ptr, unsigned int* cluster_size_ptr,
+    vecmem::data::vector_view<unsigned int> disjoint_set_view,
+    vecmem::data::vector_view<unsigned int> cluster_size_view,
     const barrier_t& barrier,
     measurement_collection_types::view measurements_view,
     vecmem::data::vector_view<unsigned int> cell_links);

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -20,7 +20,7 @@ inline void aggregate_cluster(
     const vecmem::device_vector<details::index_t>& f, const unsigned int start,
     const unsigned int end, const unsigned short cid, measurement& out,
     vecmem::data::vector_view<unsigned int> cell_links, const unsigned int link,
-    unsigned int* disjoint_set_ptr,
+    vecmem::device_vector<unsigned int>& disjoint_set,
     std::optional<std::reference_wrapper<unsigned int>> cluster_size) {
     vecmem::device_vector<unsigned int> cell_links_device(cell_links);
 
@@ -130,8 +130,8 @@ inline void aggregate_cluster(
 
             tmp_cluster_size++;
 
-            if (disjoint_set_ptr != nullptr) {
-                disjoint_set_ptr[pos] = link;
+            if (disjoint_set.capacity()) {
+                disjoint_set.at(pos) = link;
             }
         }
 

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -19,8 +19,9 @@ inline void aggregate_cluster(
     const silicon_detector_description::const_device& det_descr,
     const vecmem::device_vector<details::index_t>& f, const unsigned int start,
     const unsigned int end, const unsigned short cid, measurement& out,
-    vecmem::data::vector_view<unsigned int> cell_links,
-    const unsigned int link) {
+    vecmem::data::vector_view<unsigned int> cell_links, const unsigned int link,
+    unsigned int* disjoint_set_ptr,
+    std::optional<std::reference_wrapper<unsigned int>> cluster_size) {
     vecmem::device_vector<unsigned int> cell_links_device(cell_links);
 
     /*
@@ -63,6 +64,7 @@ inline void aggregate_cluster(
     const unsigned int module_idx = cells.module_index().at(cid + start);
     const auto module_descr = det_descr.at(module_idx);
     const auto partition_size = static_cast<unsigned short>(end - start);
+    unsigned int tmp_cluster_size = 0;
 
     bool first_processed = false;
 
@@ -125,6 +127,12 @@ inline void aggregate_cluster(
             }
 
             cell_links_device.at(pos) = link;
+
+            tmp_cluster_size++;
+
+            if (disjoint_set_ptr != nullptr) {
+                disjoint_set_ptr[pos] = link;
+            }
         }
 
         /*
@@ -133,6 +141,10 @@ inline void aggregate_cluster(
          */
         if (cell.channel1() > maxChannel1 + 1) {
             break;
+        }
+
+        if (cluster_size.has_value()) {
+            (*cluster_size).get() = tmp_cluster_size;
         }
     }
 

--- a/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
@@ -145,7 +145,8 @@ TRACCC_DEVICE inline void ccl_core(
     const edm::silicon_cell_collection::const_device& cells_device,
     const silicon_detector_description::const_device& det_descr,
     measurement_collection_types::device measurements_device,
-    const barrier_t& barrier) {
+    const barrier_t& barrier, unsigned int* disjoint_set_ptr,
+    unsigned int* cluster_size_ptr) {
     const auto size =
         static_cast<details::index_t>(partition_end - partition_start);
 
@@ -197,17 +198,23 @@ TRACCC_DEVICE inline void ccl_core(
     for (details::index_t tst = 0; tst < thread_cell_count; ++tst) {
         const auto cid = static_cast<details::index_t>(
             tst * thread_id.getBlockDimX() + thread_id.getLocalThreadIdX());
+
         if (f.at(cid) == cid) {
             // Add a new measurement to the output buffer. Remembering its
             // position inside of the container.
             const measurement_collection_types::device::size_type meas_pos =
                 measurements_device.push_back({});
             // Set up the measurement under the appropriate index.
-            aggregate_cluster(cfg, cells_device, det_descr, f,
-                              static_cast<unsigned int>(partition_start),
-                              static_cast<unsigned int>(partition_end), cid,
-                              measurements_device.at(meas_pos), cell_links,
-                              meas_pos);
+            aggregate_cluster(
+                cfg, cells_device, det_descr, f,
+                static_cast<unsigned int>(partition_start),
+                static_cast<unsigned int>(partition_end), cid,
+                measurements_device.at(meas_pos), cell_links, meas_pos,
+                disjoint_set_ptr,
+                cluster_size_ptr != nullptr
+                    ? cluster_size_ptr[meas_pos]
+                    : std::optional<std::reference_wrapper<unsigned int>>{
+                          std::nullopt});
         }
     }
 }
@@ -225,7 +232,9 @@ TRACCC_DEVICE inline void ccl_kernel(
     vecmem::data::vector_view<details::index_t> gf_backup_view,
     vecmem::data::vector_view<unsigned char> adjc_backup_view,
     vecmem::data::vector_view<details::index_t> adjv_backup_view,
-    vecmem::device_atomic_ref<uint32_t> backup_mutex, const barrier_t& barrier,
+    vecmem::device_atomic_ref<uint32_t> backup_mutex,
+    unsigned int* disjoint_set_ptr, unsigned int* cluster_size_ptr,
+    const barrier_t& barrier,
     measurement_collection_types::view measurements_view,
     vecmem::data::vector_view<unsigned int> cell_links) {
 
@@ -353,7 +362,8 @@ TRACCC_DEVICE inline void ccl_kernel(
     ccl_core(cfg, thread_id, partition_start, partition_end,
              use_scratch ? f_backup : f_primary,
              use_scratch ? gf_backup : gf_primary, cell_links, adjv, adjc,
-             cells_device, det_descr, measurements_device, barrier);
+             cells_device, det_descr, measurements_device, barrier,
+             disjoint_set_ptr, cluster_size_ptr);
 
     barrier.blockBarrier();
 }

--- a/device/common/include/traccc/clusterization/device/impl/reify_cluster_data.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/reify_cluster_data.ipp
@@ -1,0 +1,30 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::device {
+
+TRACCC_HOST_DEVICE inline void reify_cluster_data(
+    global_index_t thread_id,
+    vecmem::data::vector_view<const unsigned int> disjoint_set_view,
+    traccc::edm::silicon_cluster_collection::view cluster_view) {
+
+    // Create the device objects.
+    const vecmem::device_vector<const unsigned int> disjoint_set(
+        disjoint_set_view);
+    traccc::edm::silicon_cluster_collection::device clusters(cluster_view);
+
+    // Fill the output container.
+    if (thread_id < disjoint_set.size()) {
+        clusters.cell_indices()
+            .at(disjoint_set.at(thread_id))
+            .push_back(thread_id);
+    }
+}
+
+}  // namespace traccc::device

--- a/device/common/include/traccc/clusterization/device/reify_cluster_data.hpp
+++ b/device/common/include/traccc/clusterization/device/reify_cluster_data.hpp
@@ -5,19 +5,29 @@
  * Mozilla Public License Version 2.0
  */
 
-#include "traccc/definitions/qualifiers.hpp"
+#pragma once
+
+// Local include(s).
 #include "traccc/device/concepts/thread_id.hpp"
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/silicon_cluster_collection.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
 
 namespace traccc::device {
 template <device::concepts::thread_id1 thread_id_t>
 TRACCC_HOST_DEVICE void reify_cluster_data(
-    const thread_id_t& thread_id, unsigned int* disjoint_set_ptr,
-    unsigned int num_cells,
+    const thread_id_t& thread_id,
+    vecmem::data::vector_view<const unsigned int> disjoint_set_view,
     traccc::edm::silicon_cluster_collection::view cluster_view) {
+
+    vecmem::device_vector<const unsigned int> disjoint_set(disjoint_set_view);
     traccc::edm::silicon_cluster_collection::device clusters(cluster_view);
-    if (auto idx = thread_id.getGlobalThreadIdX(); idx < num_cells) {
-        clusters.cell_indices().at(disjoint_set_ptr[idx]).push_back(idx);
+    if (auto idx = thread_id.getGlobalThreadIdX(); idx < disjoint_set.size()) {
+        clusters.cell_indices().at(disjoint_set.at(idx)).push_back(idx);
     }
 }
 }  // namespace traccc::device

--- a/device/common/include/traccc/clusterization/device/reify_cluster_data.hpp
+++ b/device/common/include/traccc/clusterization/device/reify_cluster_data.hpp
@@ -1,0 +1,23 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/device/concepts/thread_id.hpp"
+#include "traccc/edm/silicon_cluster_collection.hpp"
+
+namespace traccc::device {
+template <device::concepts::thread_id1 thread_id_t>
+TRACCC_HOST_DEVICE void reify_cluster_data(
+    const thread_id_t& thread_id, unsigned int* disjoint_set_ptr,
+    unsigned int num_cells,
+    traccc::edm::silicon_cluster_collection::view cluster_view) {
+    traccc::edm::silicon_cluster_collection::device clusters(cluster_view);
+    if (auto idx = thread_id.getGlobalThreadIdX(); idx < num_cells) {
+        clusters.cell_indices().at(disjoint_set_ptr[idx]).push_back(idx);
+    }
+}
+}  // namespace traccc::device

--- a/device/common/include/traccc/clusterization/device/reify_cluster_data.hpp
+++ b/device/common/include/traccc/clusterization/device/reify_cluster_data.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Local include(s).
-#include "traccc/device/concepts/thread_id.hpp"
+#include "traccc/device/global_index.hpp"
 
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
@@ -18,16 +18,19 @@
 #include <vecmem/containers/data/vector_view.hpp>
 
 namespace traccc::device {
-template <device::concepts::thread_id1 thread_id_t>
-TRACCC_HOST_DEVICE void reify_cluster_data(
-    const thread_id_t& thread_id,
-    vecmem::data::vector_view<const unsigned int> disjoint_set_view,
-    traccc::edm::silicon_cluster_collection::view cluster_view) {
 
-    vecmem::device_vector<const unsigned int> disjoint_set(disjoint_set_view);
-    traccc::edm::silicon_cluster_collection::device clusters(cluster_view);
-    if (auto idx = thread_id.getGlobalThreadIdX(); idx < disjoint_set.size()) {
-        clusters.cell_indices().at(disjoint_set.at(idx)).push_back(idx);
-    }
-}
+/// Fill a cluster collection with the cell indices
+///
+/// @param thread_id The thread identifier
+/// @param disjoint_set_view The cluster/measurement index of each cell
+/// @param cluster_view The collection to fill
+///
+TRACCC_HOST_DEVICE inline void reify_cluster_data(
+    global_index_t thread_id,
+    vecmem::data::vector_view<const unsigned int> disjoint_set_view,
+    traccc::edm::silicon_cluster_collection::view cluster_view);
+
 }  // namespace traccc::device
+
+// Include the implementation.
+#include "traccc/clusterization/device/impl/reify_cluster_data.ipp"

--- a/device/common/include/traccc/clusterization/device/tags.hpp
+++ b/device/common/include/traccc/clusterization/device/tags.hpp
@@ -1,0 +1,29 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::device {
+/**
+ * @defgroup Clustering algorithm cluster retention parameters
+ *
+ * Optional parameters to clustering algorithms which convert directly from
+ * cells to measurements, determining whether to reconstruct the intermediate
+ * cluster data or not.
+ *
+ * @{
+ * @brief Explicitly discard cluster information.
+ */
+struct clustering_discard_disjoint_set {};
+/*
+ * @brief Explicitly reconstruct and return cluster information.
+ */
+struct clustering_keep_disjoint_set {};
+/*
+ * @}
+ */
+}  // namespace traccc::device

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -51,6 +51,7 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/clusterization/measurement_sorting_algorithm.cu"
   "src/clusterization/kernels/ccl_kernel.cu"
   "src/clusterization/kernels/ccl_kernel.cuh"
+  "src/clusterization/kernels/reify_cluster_data.cu"
   # Finding
   "include/traccc/cuda/finding/finding_algorithm.hpp"
   "src/finding/finding_algorithm.cu"

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -13,9 +13,11 @@
 #include "../utils/thread_id.hpp"
 #include "../utils/utils.hpp"
 #include "./kernels/ccl_kernel.cuh"
+#include "./kernels/reify_cluster_data.cuh"
 #include "traccc/clusterization/clustering_config.hpp"
 #include "traccc/clusterization/device/ccl_kernel_definitions.hpp"
 #include "traccc/cuda/clusterization/clusterization_algorithm.hpp"
+#include "traccc/edm/silicon_cluster_collection.hpp"
 #include "traccc/utils/projections.hpp"
 #include "traccc/utils/relations.hpp"
 
@@ -47,10 +49,39 @@ clusterization_algorithm::clusterization_algorithm(
         sizeof(std::remove_extent_t<decltype(m_backup_mutex)::element_type>)));
 }
 
-clusterization_algorithm::output_type clusterization_algorithm::operator()(
+measurement_collection_types::buffer clusterization_algorithm::operator()(
     const edm::silicon_cell_collection::const_view& cells,
     const silicon_detector_description::const_view& det_descr) const {
+    return this->operator()(cells, det_descr,
+                            device::clustering_discard_disjoint_set{});
+}
 
+measurement_collection_types::buffer clusterization_algorithm::operator()(
+    const edm::silicon_cell_collection::const_view& cells,
+    const silicon_detector_description::const_view& det_descr,
+    device::clustering_discard_disjoint_set&&) const {
+    auto [res, djs] = this->execute_impl(cells, det_descr, false);
+    assert(!djs.has_value());
+    return std::move(res);
+}
+
+std::pair<measurement_collection_types::buffer,
+          traccc::edm::silicon_cluster_collection::buffer>
+clusterization_algorithm::operator()(
+    const edm::silicon_cell_collection::const_view& cells,
+    const silicon_detector_description::const_view& det_descr,
+    device::clustering_keep_disjoint_set&&) const {
+    auto [res, djs] = this->execute_impl(cells, det_descr, true);
+    assert(djs.has_value());
+    return {std::move(res), std::move(*djs)};
+}
+
+std::pair<measurement_collection_types::buffer,
+          std::optional<traccc::edm::silicon_cluster_collection::buffer>>
+clusterization_algorithm::execute_impl(
+    const edm::silicon_cell_collection::const_view& cells,
+    const silicon_detector_description::const_view& det_descr,
+    bool keep_disjoint_set) const {
     // Get a convenience variable for the stream that we'll be using.
     cudaStream_t stream = details::get_stream(m_stream);
 
@@ -65,7 +96,8 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
 
     // If there are no cells, return right away.
     if (num_cells == 0) {
-        return measurements;
+        return {std::move(measurements),
+                traccc::edm::silicon_cluster_collection::buffer{}};
     }
 
     assert(is_contiguous_on<edm::silicon_cell_collection::const_device>(
@@ -92,16 +124,58 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
     assert(m_config.max_cells_per_thread <=
            device::details::CELLS_PER_THREAD_STACK_LIMIT);
 
+    vecmem::unique_alloc_ptr<unsigned int[]> disjoint_set;
+    vecmem::unique_alloc_ptr<unsigned int[]> cluster_sizes;
+
+    // If we are keeping the disjoint set data structure, allocate space for it.
+    if (keep_disjoint_set) {
+        disjoint_set =
+            vecmem::make_unique_alloc<unsigned int[]>(m_mr.main, num_cells);
+        cluster_sizes =
+            vecmem::make_unique_alloc<unsigned int[]>(m_mr.main, num_cells);
+    }
+
     kernels::ccl_kernel<<<num_blocks, m_config.threads_per_partition,
                           2 * m_config.max_partition_size() *
                               sizeof(device::details::index_t),
                           stream>>>(
         m_config, cells, det_descr, measurements, cell_links, m_f_backup,
-        m_gf_backup, m_adjc_backup, m_adjv_backup, m_backup_mutex.get());
+        m_gf_backup, m_adjc_backup, m_adjv_backup, m_backup_mutex.get(),
+        disjoint_set.get(), cluster_sizes.get());
+
     TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 
+    std::optional<traccc::edm::silicon_cluster_collection::buffer>
+        cluster_data = std::nullopt;
+
+    if (keep_disjoint_set) {
+        assert(m_mr.host != nullptr);
+
+        auto num_measurements = m_copy.get().get_size(measurements);
+
+        std::vector<unsigned int> cluster_sizes_host;
+        cluster_sizes_host.resize(num_measurements);
+
+        TRACCC_CUDA_ERROR_CHECK(cudaMemcpy(
+            cluster_sizes_host.data(), cluster_sizes.get(),
+            num_measurements * sizeof(unsigned int), cudaMemcpyDeviceToHost));
+
+        cluster_data.emplace(cluster_sizes_host, m_mr.main, m_mr.host,
+                             vecmem::data::buffer_type::resizable);
+        m_copy.get().setup(*cluster_data)->ignore();
+
+        const unsigned int num_threads = 512;
+        const unsigned int num_blocks =
+            (num_cells + num_threads - 1) / num_threads;
+
+        kernels::reify_cluster_data<<<num_blocks, num_threads, 0, stream>>>(
+            disjoint_set.get(), num_cells, *cluster_data);
+
+        TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+    }
+
     // Return the reconstructed measurements.
-    return measurements;
+    return {std::move(measurements), std::move(cluster_data)};
 }
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/clusterization/kernels/ccl_kernel.cu
+++ b/device/cuda/src/clusterization/kernels/ccl_kernel.cu
@@ -38,8 +38,9 @@ __global__ void ccl_kernel(
     vecmem::data::vector_view<device::details::index_t> gf_backup_view,
     vecmem::data::vector_view<unsigned char> adjc_backup_view,
     vecmem::data::vector_view<device::details::index_t> adjv_backup_view,
-    unsigned int* backup_mutex_ptr, unsigned int* disjoint_set_ptr,
-    unsigned int* cluster_size_ptr) {
+    unsigned int* backup_mutex_ptr,
+    vecmem::data::vector_view<unsigned int> disjoint_set_view,
+    vecmem::data::vector_view<unsigned int> cluster_size_view) {
 
     __shared__ std::size_t partition_start, partition_end;
     __shared__ std::size_t outi;
@@ -60,7 +61,7 @@ __global__ void ccl_kernel(
     device::ccl_kernel(
         cfg, thread_id, cells_view, det_descr_view, partition_start,
         partition_end, outi, f_view, gf_view, f_backup_view, gf_backup_view,
-        adjc_backup_view, adjv_backup_view, backup_mutex, disjoint_set_ptr,
-        cluster_size_ptr, barry_r, measurements_view, cell_links);
+        adjc_backup_view, adjv_backup_view, backup_mutex, disjoint_set_view,
+        cluster_size_view, barry_r, measurements_view, cell_links);
 }
 }  // namespace traccc::cuda::kernels

--- a/device/cuda/src/clusterization/kernels/ccl_kernel.cu
+++ b/device/cuda/src/clusterization/kernels/ccl_kernel.cu
@@ -38,7 +38,8 @@ __global__ void ccl_kernel(
     vecmem::data::vector_view<device::details::index_t> gf_backup_view,
     vecmem::data::vector_view<unsigned char> adjc_backup_view,
     vecmem::data::vector_view<device::details::index_t> adjv_backup_view,
-    unsigned int* backup_mutex_ptr) {
+    unsigned int* backup_mutex_ptr, unsigned int* disjoint_set_ptr,
+    unsigned int* cluster_size_ptr) {
 
     __shared__ std::size_t partition_start, partition_end;
     __shared__ std::size_t outi;
@@ -56,10 +57,10 @@ __global__ void ccl_kernel(
     traccc::cuda::barrier barry_r;
     const details::thread_id1 thread_id;
 
-    device::ccl_kernel(cfg, thread_id, cells_view, det_descr_view,
-                       partition_start, partition_end, outi, f_view, gf_view,
-                       f_backup_view, gf_backup_view, adjc_backup_view,
-                       adjv_backup_view, backup_mutex, barry_r,
-                       measurements_view, cell_links);
+    device::ccl_kernel(
+        cfg, thread_id, cells_view, det_descr_view, partition_start,
+        partition_end, outi, f_view, gf_view, f_backup_view, gf_backup_view,
+        adjc_backup_view, adjv_backup_view, backup_mutex, disjoint_set_ptr,
+        cluster_size_ptr, barry_r, measurements_view, cell_links);
 }
 }  // namespace traccc::cuda::kernels

--- a/device/cuda/src/clusterization/kernels/ccl_kernel.cuh
+++ b/device/cuda/src/clusterization/kernels/ccl_kernel.cuh
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -23,6 +23,7 @@ __global__ void ccl_kernel(
     vecmem::data::vector_view<device::details::index_t> gf_backup_view,
     vecmem::data::vector_view<unsigned char> adjc_backup_view,
     vecmem::data::vector_view<device::details::index_t> adjv_backup_view,
-    unsigned int* backup_mutex_ptr, unsigned int* disjoint_set_ptr,
-    unsigned int* cluster_size_ptr);
+    unsigned int* backup_mutex_ptr,
+    vecmem::data::vector_view<unsigned int> disjoint_set_view,
+    vecmem::data::vector_view<unsigned int> cluster_size_view);
 }

--- a/device/cuda/src/clusterization/kernels/ccl_kernel.cuh
+++ b/device/cuda/src/clusterization/kernels/ccl_kernel.cuh
@@ -23,5 +23,6 @@ __global__ void ccl_kernel(
     vecmem::data::vector_view<device::details::index_t> gf_backup_view,
     vecmem::data::vector_view<unsigned char> adjc_backup_view,
     vecmem::data::vector_view<device::details::index_t> adjv_backup_view,
-    unsigned int* backup_mutex_ptr);
+    unsigned int* backup_mutex_ptr, unsigned int* disjoint_set_ptr,
+    unsigned int* cluster_size_ptr);
 }

--- a/device/cuda/src/clusterization/kernels/reify_cluster_data.cu
+++ b/device/cuda/src/clusterization/kernels/reify_cluster_data.cu
@@ -11,11 +11,10 @@
 
 namespace traccc::cuda::kernels {
 __global__ void reify_cluster_data(
-    unsigned int* disjoint_set_ptr, unsigned int num_cells,
+    vecmem::data::vector_view<const unsigned int> disjoint_set_view,
     traccc::edm::silicon_cluster_collection::view cluster_view) {
     const details::thread_id1 thread_id;
 
-    device::reify_cluster_data(thread_id, disjoint_set_ptr, num_cells,
-                               cluster_view);
+    device::reify_cluster_data(thread_id, disjoint_set_view, cluster_view);
 }
 }  // namespace traccc::cuda::kernels

--- a/device/cuda/src/clusterization/kernels/reify_cluster_data.cu
+++ b/device/cuda/src/clusterization/kernels/reify_cluster_data.cu
@@ -1,0 +1,21 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "../../utils/thread_id.hpp"
+#include "reify_cluster_data.cuh"
+#include "traccc/clusterization/device/reify_cluster_data.hpp"
+
+namespace traccc::cuda::kernels {
+__global__ void reify_cluster_data(
+    unsigned int* disjoint_set_ptr, unsigned int num_cells,
+    traccc::edm::silicon_cluster_collection::view cluster_view) {
+    const details::thread_id1 thread_id;
+
+    device::reify_cluster_data(thread_id, disjoint_set_ptr, num_cells,
+                               cluster_view);
+}
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/clusterization/kernels/reify_cluster_data.cu
+++ b/device/cuda/src/clusterization/kernels/reify_cluster_data.cu
@@ -5,16 +5,19 @@
  * Mozilla Public License Version 2.0
  */
 
+// Local include(s).
 #include "../../utils/thread_id.hpp"
 #include "reify_cluster_data.cuh"
+
+// Project include(s).
 #include "traccc/clusterization/device/reify_cluster_data.hpp"
 
 namespace traccc::cuda::kernels {
 __global__ void reify_cluster_data(
     vecmem::data::vector_view<const unsigned int> disjoint_set_view,
     traccc::edm::silicon_cluster_collection::view cluster_view) {
-    const details::thread_id1 thread_id;
 
-    device::reify_cluster_data(thread_id, disjoint_set_view, cluster_view);
+    device::reify_cluster_data(details::thread_id1{}.getGlobalThreadId(),
+                               disjoint_set_view, cluster_view);
 }
 }  // namespace traccc::cuda::kernels

--- a/device/cuda/src/clusterization/kernels/reify_cluster_data.cuh
+++ b/device/cuda/src/clusterization/kernels/reify_cluster_data.cuh
@@ -1,0 +1,16 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/edm/silicon_cluster_collection.hpp"
+
+namespace traccc::cuda::kernels {
+__global__ void reify_cluster_data(
+    unsigned int* disjoint_set_ptr, unsigned int num_cells,
+    traccc::edm::silicon_cluster_collection::view cluster_view);
+}

--- a/device/cuda/src/clusterization/kernels/reify_cluster_data.cuh
+++ b/device/cuda/src/clusterization/kernels/reify_cluster_data.cuh
@@ -13,7 +13,14 @@
 // VecMem include(s).
 #include <vecmem/containers/data/vector_view.hpp>
 namespace traccc::cuda::kernels {
+
+/// Fill the cluster collection with the cell indices
+///
+/// @param disjoint_set_view The cluster/measurement index of each cell
+/// @param cluster_view The collection to fill
+///
 __global__ void reify_cluster_data(
     vecmem::data::vector_view<const unsigned int> disjoint_set_view,
     traccc::edm::silicon_cluster_collection::view cluster_view);
-}
+
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/clusterization/kernels/reify_cluster_data.cuh
+++ b/device/cuda/src/clusterization/kernels/reify_cluster_data.cuh
@@ -7,10 +7,13 @@
 
 #pragma once
 
+// Project include(s).
 #include "traccc/edm/silicon_cluster_collection.hpp"
 
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
 namespace traccc::cuda::kernels {
 __global__ void reify_cluster_data(
-    unsigned int* disjoint_set_ptr, unsigned int num_cells,
+    vecmem::data::vector_view<const unsigned int> disjoint_set_view,
     traccc::edm::silicon_cluster_collection::view cluster_view);
 }

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -159,12 +159,12 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
                     const details::thread_id thread_id{item};
 
                     // Run the algorithm for this thread.
-                    device::ccl_kernel(cfg, thread_id, cells_view, det_descr,
-                                       partition_start, partition_end, outi,
-                                       f_view, gf_view, f_backup_view,
-                                       gf_backup_view, adjc_backup_view,
-                                       adjv_backup_view, backup_mutex, barrier,
-                                       measurements_view, cell_links_view);
+                    device::ccl_kernel(
+                        cfg, thread_id, cells_view, det_descr, partition_start,
+                        partition_end, outi, f_view, gf_view, f_backup_view,
+                        gf_backup_view, adjc_backup_view, adjv_backup_view,
+                        backup_mutex, nullptr, nullptr, barrier,
+                        measurements_view, cell_links_view);
                 });
         })
         .wait_and_throw();

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -163,7 +163,7 @@ clusterization_algorithm::output_type clusterization_algorithm::operator()(
                         cfg, thread_id, cells_view, det_descr, partition_start,
                         partition_end, outi, f_view, gf_view, f_backup_view,
                         gf_backup_view, adjc_backup_view, adjv_backup_view,
-                        backup_mutex, nullptr, nullptr, barrier,
+                        backup_mutex, {0u, nullptr}, {0u, nullptr}, barrier,
                         measurements_view, cell_links_view);
                 });
         })

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -162,7 +162,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     m_copy(vecmem::get_data(cells), cells_buffer)->ignore();
 
     // Run the clusterization (asynchronously).
-    const clusterization_algorithm::output_type measurements =
+    const measurement_collection_types::buffer measurements =
         m_clusterization(cells_buffer, m_device_det_descr);
     m_measurement_sorting(measurements);
 

--- a/tests/common/tests/cca_test.hpp
+++ b/tests/common/tests/cca_test.hpp
@@ -12,7 +12,9 @@
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/measurement.hpp"
 #include "traccc/edm/silicon_cell_collection.hpp"
+#include "traccc/edm/silicon_cluster_collection.hpp"
 #include "traccc/geometry/silicon_detector_description.hpp"
+#include "traccc/io/csv/make_cell_reader.hpp"
 #include "traccc/io/read_cells.hpp"
 
 // Test include(s).
@@ -36,10 +38,11 @@
 #include <sstream>
 #include <string>
 
-using cca_function_t = std::function<
-    std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>>(
-        const traccc::edm::silicon_cell_collection::host &,
-        const traccc::silicon_detector_description::host &)>;
+using cca_function_t = std::function<std::pair<
+    std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>>,
+    std::optional<traccc::edm::silicon_cluster_collection::host>>(
+    const traccc::edm::silicon_cell_collection::host &,
+    const traccc::silicon_detector_description::host &)>;
 
 inline traccc::clustering_config default_ccl_test_config() {
     traccc::clustering_config rv;
@@ -160,8 +163,7 @@ class ConnectedComponentAnalysisTests
         traccc::io::read_cells(cells, file_hits,
                                traccc::getDummyLogger().clone(), &dd);
 
-        std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>>
-            result = f(cells, dd);
+        auto [result, cluster_data] = f(cells, dd);
 
         std::size_t total_truth = 0, total_found = 0;
 
@@ -202,5 +204,17 @@ class ConnectedComponentAnalysisTests
         }
 
         EXPECT_EQ(total_truth, total_found);
+
+        if (cluster_data.has_value()) {
+            ASSERT_EQ(cluster_data->size(), total_found);
+
+            std::size_t total_cluster_size = 0;
+
+            for (std::size_t i = 0; i < cluster_data->size(); ++i) {
+                total_cluster_size += cluster_data->cell_indices().at(i).size();
+            }
+
+            ASSERT_EQ(cells.size(), total_cluster_size);
+        }
     }
 };

--- a/tests/cpu/test_cca.cpp
+++ b/tests/cpu/test_cca.cpp
@@ -15,6 +15,7 @@
 #include "tests/cca_test.hpp"
 
 // VecMem include(s).
+#include <optional>
 #include <vecmem/memory/host_memory_resource.hpp>
 
 // GTest include(s).
@@ -25,23 +26,31 @@
 
 namespace {
 vecmem::host_memory_resource resource;
-traccc::host::clusterization_algorithm ca(resource);
+traccc::host::sparse_ccl_algorithm cc(resource);
+traccc::host::measurement_creation_algorithm mc(resource);
 
 cca_function_t f = [](const traccc::edm::silicon_cell_collection::host& cells,
-                      const traccc::silicon_detector_description::host& dd) {
+                      const traccc::silicon_detector_description::host& dd)
+    -> std::pair<
+        std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>>,
+        std::optional<traccc::edm::silicon_cluster_collection::host>> {
     std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>> result;
 
     const traccc::edm::silicon_cell_collection::const_data cells_data =
         vecmem::get_data(cells);
     const traccc::silicon_detector_description::const_data dd_data =
         vecmem::get_data(dd);
-    auto measurements = ca(cells_data, dd_data);
+
+    const auto clusters = cc(cells_data);
+    const auto clusters_data = vecmem::get_data(clusters);
+    auto measurements = mc(cells_data, clusters_data, dd_data);
+
     for (std::size_t i = 0; i < measurements.size(); i++) {
         result[measurements.at(i).surface_link.value()].push_back(
             measurements.at(i));
     }
 
-    return result;
+    return {std::move(result), std::nullopt};
 };
 }  // namespace
 

--- a/tests/sycl/test_cca.cpp
+++ b/tests/sycl/test_cca.cpp
@@ -24,49 +24,55 @@
 namespace {
 
 cca_function_t get_f_with(traccc::clustering_config cfg) {
-    return [cfg](const traccc::edm::silicon_cell_collection::host& cells,
-                 const traccc::silicon_detector_description::host& dd) {
-        std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>>
-            result;
+    return
+        [cfg](const traccc::edm::silicon_cell_collection::host& cells,
+              const traccc::silicon_detector_description::host& dd)
+            -> std::pair<
+                std::map<traccc::geometry_id,
+                         vecmem::vector<traccc::measurement>>,
+                std::optional<traccc::edm::silicon_cluster_collection::host>> {
+            std::map<traccc::geometry_id, vecmem::vector<traccc::measurement>>
+                result;
 
-        vecmem::sycl::queue_wrapper vecmem_queue;
-        traccc::sycl::queue_wrapper traccc_queue{vecmem_queue.queue()};
-        vecmem::host_memory_resource host_mr;
-        vecmem::sycl::device_memory_resource device_mr{vecmem_queue};
-        vecmem::sycl::async_copy copy{vecmem_queue};
+            vecmem::sycl::queue_wrapper vecmem_queue;
+            traccc::sycl::queue_wrapper traccc_queue{vecmem_queue.queue()};
+            vecmem::host_memory_resource host_mr;
+            vecmem::sycl::device_memory_resource device_mr{vecmem_queue};
+            vecmem::sycl::async_copy copy{vecmem_queue};
 
-        traccc::sycl::clusterization_algorithm cc({device_mr, &host_mr}, copy,
-                                                  traccc_queue, cfg);
+            traccc::sycl::clusterization_algorithm cc({device_mr, &host_mr},
+                                                      copy, traccc_queue, cfg);
 
-        traccc::silicon_detector_description::buffer dd_buffer{
-            static_cast<
-                traccc::silicon_detector_description::buffer::size_type>(
-                dd.size()),
-            device_mr};
-        copy.setup(dd_buffer)->ignore();
-        copy(vecmem::get_data(dd), dd_buffer,
-             vecmem::copy::type::host_to_device)
-            ->wait();
+            traccc::silicon_detector_description::buffer dd_buffer{
+                static_cast<
+                    traccc::silicon_detector_description::buffer::size_type>(
+                    dd.size()),
+                device_mr};
+            copy.setup(dd_buffer)->ignore();
+            copy(vecmem::get_data(dd), dd_buffer,
+                 vecmem::copy::type::host_to_device)
+                ->wait();
 
-        traccc::edm::silicon_cell_collection::buffer cells_buffer{
-            static_cast<
-                traccc::edm::silicon_cell_collection::buffer::size_type>(
-                cells.size()),
-            device_mr};
-        copy.setup(cells_buffer)->wait();
-        copy(vecmem::get_data(cells), cells_buffer)->wait();
+            traccc::edm::silicon_cell_collection::buffer cells_buffer{
+                static_cast<
+                    traccc::edm::silicon_cell_collection::buffer::size_type>(
+                    cells.size()),
+                device_mr};
+            copy.setup(cells_buffer)->wait();
+            copy(vecmem::get_data(cells), cells_buffer)->wait();
 
-        auto measurements_buffer = cc(cells_buffer, dd_buffer);
-        traccc::measurement_collection_types::host measurements{&host_mr};
-        copy(measurements_buffer, measurements)->wait();
+            auto measurements_buffer = cc(cells_buffer, dd_buffer);
+            traccc::measurement_collection_types::host measurements{&host_mr};
+            copy(measurements_buffer, measurements)->wait();
 
-        for (std::size_t i = 0; i < measurements.size(); i++) {
-            result[measurements.at(i).surface_link.value()].push_back(
-                measurements.at(i));
-        }
+            for (std::size_t i = 0; i < measurements.size(); i++) {
+                result[measurements.at(i).surface_link.value()].push_back(
+                    measurements.at(i));
+            }
 
-        return result;
-    };
+            // TODO: Output a real disjoint set here.
+            return {result, std::nullopt};
+        };
 }
 }  // namespace
 


### PR DESCRIPTION
It's time to re-open some old wounds...

This is an attempt at bringing #930 over the finish line, as we really-really need this code for the EFTracking report. :thinking:

The main things:
  - I left the `std::optional` in `traccc::device::aggregate_cluster`. As API-wise probably this is the most descriptive in the end for what argument the function should be receiving.
  - I switched all new arguments to vecmem views/types. So that their sizes would be less implicit. Making the code a bit easier to debug later on hopefully.

Based on ideas I gathered from the EDM updates, I now have some slightly different ideas for what the final algorithm API should be, but didn't want to slow things down with that in this PR. I'll leave that to a follow-up PR, in which I'll teach the Alpaka and SYCL algorithms as well how to output cluster collections.