### PR TITLE
Select first rather than last smoothed parameter

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -351,6 +351,7 @@ class kalman_fitter {
         for (const auto& st : track_states) {
             if (st.is_smoothed) {
                 fit_res.fit_params = st.smoothed();
+                break;
             }
         }
 


### PR DESCRIPTION
The final step of the Kálmán fitter algorithm collects one of the smoothed parameters. It is supposed to collect the first one, but the current implementation collects the last one due to a missing break statement. This commit adds the missing statement, ensuring that we always pick the first smoothed state.