### PR TITLE
Fix CUDA kernel launch parameter bug in fitter

### DIFF
--- a/device/cuda/src/fitting/kernels/fill_sort_keys.cu
+++ b/device/cuda/src/fitting/kernels/fill_sort_keys.cu
@@ -35,7 +35,7 @@ void fill_sort_keys(const dim3& grid_size, const dim3& block_size,
                     vecmem::data::vector_view<device::sort_key> keys_view,
                     vecmem::data::vector_view<unsigned int> ids_view) {
 
-    kernels::fill_sort_keys<<<block_size, grid_size, 0, stream>>>(
+    kernels::fill_sort_keys<<<grid_size, block_size, 0, stream>>>(
         track_candidates_view, keys_view, ids_view);
     TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 }


### PR DESCRIPTION
This commit fixes a bug introduced in #1029 where the block size and grid size for a kernel were incorrectly swapped around, leading to an invalid launch configuration error.