### PR TITLE
CUDA Fix, main branch (2025.06.24.)

### DIFF
--- a/device/cuda/src/finding/combinatorial_kalman_filter.cuh
+++ b/device/cuda/src/finding/combinatorial_kalman_filter.cuh
@@ -289,7 +289,7 @@ combinatorial_kalman_filter(
             const unsigned int nBlocks =
                 (n_in_params + nThreads - 1) / nThreads;
             const std::size_t shared_size =
-                nThreads * sizeof(unsigned int) +
+                nThreads * sizeof(unsigned long long int) +
                 2 * nThreads * sizeof(std::pair<unsigned int, unsigned int>);
 
             // Run the kernel.


### PR DESCRIPTION
This is the CUDA equivalent of #1034. For some reason I only ran into these issues on my trusty old RTX 2060. I did not see such issues on newer GPUs for some reason. 😕

The way that dynamic shared memory is used in `traccc::device::find_tracks(...)` is a bit too complicated unfortunately. 😦 It took me a moment to understand how much memory is really needed.

I think all this broke in #929. But I have a hard time understanding how it was unnoticed so far. 😕 I should run more tests on this RTX 2060...