### PR TITLE
Switch from synchronized propagator to default

### DIFF
--- a/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -374,8 +374,7 @@ combinatorial_kalman_filter(
             }
 
             // Propagate to the next surface
-            propagator.propagate_sync(propagation,
-                                      detray::tie(s0, s1, s2, s3, s4));
+            propagator.propagate(propagation, detray::tie(s0, s1, s2, s3, s4));
 
             // If a surface found, add the parameter for the next
             // step

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -95,7 +95,7 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     }
 
     // Propagate to the next surface
-    propagator.propagate_sync(propagation, detray::tie(s0, s2, s3, s4, s5));
+    propagator.propagate(propagation, detray::tie(s0, s2, s3, s4, s5));
 
     // If a surface found, add the parameter for the next step
     if (s5.success) {


### PR DESCRIPTION
This commit switches our usage of the detray propagator from the synchronized version to the default version, which has some upcoming optimizations in detray and will yield higher propagation performance.