### PR TITLE
Update algebra plugins to v0.28.0

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -100,13 +100,14 @@ struct gain_matrix_updater {
             getter::element(V, 1u, 1u) = 1.f;
         }
 
-        const matrix_type<D, D> M =
-            H * predicted_cov * matrix::transpose(H) + V;
+        const matrix_type<e_bound_size, D> projected_cov =
+            algebra::matrix::transposed_product<false, true>(predicted_cov, H);
+
+        const matrix_type<D, D> M = H * projected_cov + V;
 
         // Kalman gain matrix
         assert(matrix::determinant(M) != 0.f);
-        const matrix_type<6, D> K =
-            predicted_cov * matrix::transpose(H) * matrix::inverse(M);
+        const matrix_type<6, D> K = projected_cov * matrix::inverse(M);
 
         // Calculate the filtered track parameters
         const matrix_type<6, 1> filtered_vec =
@@ -119,7 +120,9 @@ struct gain_matrix_updater {
         // Calculate the chi square
         const matrix_type<D, D> R = (I_m - H * K) * V;
         const matrix_type<1, 1> chi2 =
-            matrix::transpose(residual) * matrix::inverse(R) * residual;
+            algebra::matrix::transposed_product<true, false>(
+                residual, matrix::inverse(R)) *
+            residual;
 
         // Return false if track is parallel to z-axis or phi is not finite
         const scalar theta = bound_params.theta();

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Algebra Plugins as part of the TRACCC project" )
 
 # Declare where to get Algebra Plugins from.
 set( TRACCC_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.27.0.tar.gz;URL_MD5;d59270836aba4cebc27369acea6a995f"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.28.0.tar.gz;URL_MD5;24fa671f564a332858599df60fb2228f"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced( TRACCC_ALGEBRA_PLUGINS_SOURCE )
 FetchContent_Declare( AlgebraPlugins SYSTEM ${TRACCC_ALGEBRA_PLUGINS_SOURCE} )


### PR DESCRIPTION
This commit updates the algebra plugins external to v0.28.0 and uses its new transposed product function in the Kálmán filter code.