### PR TITLE
Remove duplicate tracks in each CKF step

### DIFF
--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -53,6 +53,13 @@ struct finding_config {
     traccc::pdg_particle<traccc::scalar> ptc_hypothesis =
         traccc::muon<traccc::scalar>();
 
+    /// Minimum track length in order for a track to be a candidate for
+    /// duplicate removal.
+    ///
+    /// @warning This parameter should be greater than or equal to 3 under all
+    /// circumstances!
+    unsigned int duplicate_removal_minimum_length = 5u;
+
     /// @name Performance parameters
     /// These parameters impact only compute performance; any case in which a
     /// change in these parameters effects a change in _physics_ performance

--- a/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
@@ -434,7 +434,8 @@ combinatorial_kalman_filter(
                     queue, workDiv,
                     kernels::fill_finding_propagation_sort_keys{},
                     device::fill_finding_propagation_sort_keys_payload{
-                        in_params_buffer, keys_buffer, param_ids_buffer});
+                        in_params_buffer, param_liveness_buffer, keys_buffer,
+                        param_ids_buffer});
                 ::alpaka::wait(queue);
 
                 // Sort the key and values

--- a/device/common/include/traccc/finding/device/fill_finding_duplicate_removal_sort_keys.hpp
+++ b/device/common/include/traccc/finding/device/fill_finding_duplicate_removal_sort_keys.hpp
@@ -1,0 +1,109 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <vecmem/containers/data/vector_view.hpp>
+
+#include "traccc/device/global_index.hpp"
+#include "traccc/edm/device/sort_key.hpp"
+#include "traccc/edm/track_parameters.hpp"
+#include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/finding_config.hpp"
+
+namespace traccc::device {
+
+/**
+ * @brief Payload for the pre-duplicate-removal sorting key-filling kernel.
+ */
+struct fill_finding_duplicate_removal_sort_keys_payload {
+    /**
+     * @brief View to the vector of links.
+     */
+    const vecmem::data::vector_view<const candidate_link> links_view;
+
+    /**
+     * @brief View to the parameter liveness vector.
+     */
+    const vecmem::data::vector_view<const unsigned int> param_liveness_view;
+
+    /**
+     * @brief View to the array which is to be sorted as value.
+     */
+    vecmem::data::vector_view<unsigned int> link_last_measurement_view;
+
+    /**
+     * @brief View to the array which is to be sorted as key.
+     */
+    vecmem::data::vector_view<unsigned int> param_ids_view;
+
+    /**
+     * @brief The total number of links.
+     * TODO: Do we need this?
+     */
+    const unsigned int n_links;
+
+    /**
+     * @brief Starting index of the links for the current step.
+     */
+    const unsigned int curr_links_idx;
+
+    /**
+     * @brief The total number of measurements, used to find holes.
+     */
+    const unsigned int n_measurements;
+};
+
+/**
+ * @brief Function used to sort parameters before duplicate removal.
+ *
+ * The sorting here is on the last non-hole measurement of the track.
+ */
+TRACCC_HOST_DEVICE inline void fill_finding_duplicate_removal_sort_keys(
+    global_index_t gid,
+    const fill_finding_duplicate_removal_sort_keys_payload& payload) {
+    const vecmem::device_vector<const candidate_link> links(payload.links_view);
+    const vecmem::device_vector<const unsigned int> param_liveness(
+        payload.param_liveness_view);
+    vecmem::device_vector<unsigned int> link_last_measurement(
+        payload.link_last_measurement_view);
+    vecmem::device_vector<unsigned int> param_ids(payload.param_ids_view);
+
+    /*
+     * Obviously, no work is to be done if our index is greater than the
+     * number of links in the current CKF step.
+     */
+    if (gid < payload.n_links) {
+        param_ids.at(gid) = gid;
+
+        /*
+         * If the parameter is not live, we don't care much about it and we
+         * won't process it. For reasons of efficiency, we assign it a very
+         * large key so all invalid tracks are grouped together.
+         */
+        if (param_liveness.at(gid) == 0u) {
+            link_last_measurement.at(gid) =
+                std::numeric_limits<unsigned int>::max();
+        }
+        /*
+         * If the parameter is alive, we skip through all the hole links until
+         * we find a non-hole measurement and we use its identifier as the
+         * sort key.
+         */
+        else {
+            auto L = links.at(payload.curr_links_idx + gid);
+
+            while (L.meas_idx >= payload.n_measurements && L.step != 0u) {
+                L = links.at(L.previous_candidate_idx);
+            }
+
+            link_last_measurement.at(gid) = L.meas_idx;
+        }
+    }
+}
+
+}  // namespace traccc::device

--- a/device/common/include/traccc/finding/device/fill_finding_propagation_sort_keys.hpp
+++ b/device/common/include/traccc/finding/device/fill_finding_propagation_sort_keys.hpp
@@ -28,6 +28,12 @@ struct fill_finding_propagation_sort_keys_payload {
     bound_track_parameters_collection_types::const_view params_view;
 
     /**
+     * @brief View object to the vector of boolean-like integers describing the
+     * liveness of each parameter
+     */
+    vecmem::data::vector_view<const unsigned int> param_liveness_view;
+
+    /**
      * @brief View object to the vector of sort keys
      */
     vecmem::data::vector_view<device::sort_key> keys_view;

--- a/device/common/include/traccc/finding/device/remove_duplicates.hpp
+++ b/device/common/include/traccc/finding/device/remove_duplicates.hpp
@@ -1,0 +1,285 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <vecmem/containers/data/vector_view.hpp>
+
+#include "traccc/device/global_index.hpp"
+#include "traccc/edm/device/sort_key.hpp"
+#include "traccc/edm/track_parameters.hpp"
+#include "traccc/finding/candidate_link.hpp"
+#include "traccc/finding/finding_config.hpp"
+#include "traccc/utils/prob.hpp"
+
+namespace traccc::device {
+
+/**
+ * @brief Payload for the duplicate-removal kernel.
+ */
+struct remove_duplicates_payload {
+    /**
+     * @brief View of the links vector.
+     */
+    const vecmem::data::vector_view<const candidate_link> links_view;
+
+    /**
+     * @brief View of the last measurement in each link of the current step.
+     */
+    const vecmem::data::vector_view<const unsigned int>
+        link_last_measurement_view;
+
+    /**
+     * @brief View of the parameter IDs, sorted in order of last measurement
+     * index.
+     */
+    const vecmem::data::vector_view<const unsigned int> param_ids_view;
+
+    /**
+     * @brief View to the vector of parameter livenesses, which is used to
+     * remove duplicate tracks.
+     */
+    vecmem::data::vector_view<unsigned int> param_liveness_view;
+
+    /**
+     * @brief The total number of links in this step.
+     */
+    const unsigned int n_links;
+
+    /**
+     * @brief The starting index of the links belonging to this step.
+     */
+    const unsigned int curr_links_idx;
+
+    /**
+     * @brief The total number of measurements, used to find holes.
+     */
+    const unsigned int n_measurements;
+
+    /**
+     * @brief The current step.
+     */
+    const unsigned int step;
+};
+
+/**
+ * @brief The CKF duplicate removal kernel.
+ *
+ * This kernel is designed to remove duplicate tracks from the CKF algorithm.
+ * As a motivating example, consider a truth track consisting of spacepoints
+ * A, B, C, D, and E. During seed finding, we find seeds 1: (A, B, C) and
+ * 2: (A, B, D). Although the seeds are different, they will eventually end up
+ * with exactly the same spacepoints, and thus one of them can be removed.
+ *
+ * This kernel detects tracks with the same spacepoints and keeps only the one
+ * with the lowest $\chi^2$ score.
+ *
+ * @note For performance reasons, this kernel can only deduplicate tracks with
+ * the last measurement the same. Thus, while a track (A, B, C, D) might be
+ * able to replace a shorter track (A, B, C), this algorithm will not do so.
+ * This is not a large problem, however, as tracks with a different initial
+ * spacepoint are much more likely to have significantly different initial
+ * track parameters.
+ *
+ * @warning If this kernel is run very early in the CKF process, it might end
+ * up removing tracks that are the same before they begin the branch. The very
+ * minimum length at which tracks can be removed is 3 spacepoints, but the
+ * minimum length should be configured conform physics performance
+ * requirements. Intuitively, longer tracks with the same spacepoints have
+ * undergone more Kálmán gain to bring them closer together, and thus it is
+ * increasingly less likely that they will diverge afterwards.
+ */
+TRACCC_HOST_DEVICE inline void remove_duplicates(
+    global_index_t gid, const finding_config& cfg,
+    const remove_duplicates_payload& payload) {
+
+    const vecmem::device_vector<const candidate_link> links(payload.links_view);
+    vecmem::device_vector<unsigned int> param_liveness(
+        payload.param_liveness_view);
+    const vecmem::device_vector<const unsigned int> link_last_measurement(
+        payload.link_last_measurement_view);
+    const vecmem::device_vector<const unsigned int> param_ids(
+        payload.param_ids_view);
+
+    const unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    /*
+     * As is standard fare, we ignore tracks that are out of bounds or that
+     * have already been marked as "dead". Since this kernel contains no
+     * synchronization points, early returns are safe.
+     */
+    if (tid >= param_ids.size()) {
+        return;
+    }
+
+    const unsigned int this_param_id = param_ids.at(tid);
+
+    if (param_liveness.at(this_param_id) == 0u) {
+        return;
+    }
+
+    const unsigned int last_measurement = link_last_measurement.at(tid);
+
+    /*
+     * We will now gather the range of tracks with the same last measurement
+     * as the track belonging to this thread. Because the tracks are sorted by
+     * the last measurement, we can perform a simple linear search.
+     */
+    unsigned int min_tid = tid;
+    unsigned int max_tid = tid;
+
+    while (min_tid > 0 &&
+           link_last_measurement.at(min_tid - 1) == last_measurement) {
+        min_tid--;
+    }
+
+    while (max_tid < link_last_measurement.size() - 1 &&
+           link_last_measurement.at(max_tid + 1) == last_measurement) {
+        max_tid++;
+    }
+
+    /*
+     * Throughout this function, we refer to "this" as the track uniquely
+     * belonging to the executing thread and "that" as any other track
+     * considered.
+     */
+    const auto& Lthisbase =
+        links.at(payload.curr_links_idx + param_ids.at(tid));
+
+    /*
+     * A core design of this function is that a thread can only remove itself,
+     * and a track cannot be removed if it has too few measurements. Thus, we
+     * return early if the thread under study is too short.
+     */
+    if (payload.step + 1 - Lthisbase.n_skipped <=
+            cfg.duplicate_removal_minimum_length ||
+        Lthisbase.ndf_sum <= 5) {
+        return;
+    }
+
+    const scalar prob_this =
+        prob(Lthisbase.chi2_sum, static_cast<scalar>(Lthisbase.ndf_sum - 5));
+
+    /*
+     * We now compare the current track with every other track that has the
+     * same final measurement.
+     */
+    for (unsigned int i = min_tid; i <= max_tid; ++i) {
+        /*
+         * Obviously, a thread cannot be compared to itself.
+         */
+        if (i == tid)
+            continue;
+
+        /*
+         * We will consider a track dominated if every single one of its
+         * track states is also found in another track and the other way
+         * around.
+         */
+        bool this_is_dominated = true;
+
+        auto Lthis = Lthisbase;
+        auto Lthat = links.at(payload.curr_links_idx + param_ids.at(i));
+
+        if (payload.step + 1 - Lthat.n_skipped <=
+                cfg.duplicate_removal_minimum_length ||
+            Lthis.ndf_sum <= 5 || Lthat.ndf_sum <= 5) {
+            continue;
+        }
+
+        const scalar prob_that =
+            prob(Lthat.chi2_sum, static_cast<scalar>(Lthat.ndf_sum - 5));
+
+        /*
+         * This loop is the main workhorse of the algorithm, comparing the
+         * track states of the two tracks.
+         */
+        while (true) {
+            /*
+             * First, we eliminate any holes in either track, to ensure that
+             * we only compare actual measurements.
+             */
+            while (Lthis.meas_idx >= payload.n_measurements &&
+                   Lthis.step != 0u) {
+                Lthis = links.at(Lthis.previous_candidate_idx);
+            }
+
+            while (Lthat.meas_idx >= payload.n_measurements &&
+                   Lthat.step != 0u) {
+                Lthat = links.at(Lthat.previous_candidate_idx);
+            }
+
+            /*
+             * If the two measurements at the top of the recursively examined
+             * subtracks are the same, our search continues.
+             */
+            if (Lthis.meas_idx == Lthat.meas_idx) {
+                /*
+                 * If we have reached the last step in the "this" track, then
+                 * we know for certain that the tracks are the same and thus
+                 * we break out of the loop. Note that not setting the
+                 * domination flag to false leaves it true, thus marking this
+                 * track as dominated.
+                 */
+                if (Lthis.step == 0) {
+                    break;
+                }
+                /*
+                 * If, instead, the other track has run out then we know the
+                 * current track has a state that the other does not, so it is
+                 * definitionally not dominated.
+                 */
+                else if (Lthat.step == 0) {
+                    this_is_dominated = false;
+                    break;
+                }
+                /*
+                 * Finally, in all other cases we still have some track to go
+                 * and we recurse further.
+                 */
+                else {
+                    Lthis = links.at(Lthis.previous_candidate_idx);
+                    Lthat = links.at(Lthat.previous_candidate_idx);
+                }
+            }
+            /*
+             * If the two measurements at the top are different, we can be
+             * certain that the tracks are different, so the current track is
+             * _not_ dominated by the other.
+             */
+            else {
+                this_is_dominated = false;
+                break;
+            }
+        }
+
+        /*
+         * We now decide which of the tracks is better. Note that this block
+         * of code does nothing if the domination flag is false. If it is true
+         * it will remain true only if either the other track has a better
+         * p-value or, if the p-value is equal, if the other track has a lower
+         * identifier (this should be a very uncommon tie-breaker).
+         */
+        if (prob_this != prob_that) {
+            this_is_dominated &= prob_that >= prob_this;
+        } else {
+            this_is_dominated &= param_ids.at(i) < param_ids.at(tid);
+        }
+
+        /*
+         * Finally, if we determine the track to be dominated we mark it as
+         * such in global memory and we exit out of the main loop, thus
+         * exiting the kernel.
+         */
+        if (this_is_dominated) {
+            param_liveness.at(param_ids.at(tid)) = 0u;
+            break;
+        }
+    }
+}
+
+}  // namespace traccc::device

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -66,6 +66,8 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/finding/kernels/apply_interaction.hpp"
   "src/finding/kernels/fill_finding_propagation_sort_keys.cu"
   "src/finding/kernels/fill_finding_propagation_sort_keys.cuh"
+  "src/finding/kernels/fill_finding_duplicate_removal_sort_keys.cu"
+  "src/finding/kernels/remove_duplicates.cu"
   "src/finding/kernels/build_tracks.cu"
   "src/finding/kernels/build_tracks.cuh"
   "src/finding/kernels/find_tracks.cuh"

--- a/device/cuda/src/finding/kernels/fill_finding_duplicate_removal_sort_keys.cu
+++ b/device/cuda/src/finding/kernels/fill_finding_duplicate_removal_sort_keys.cu
@@ -1,0 +1,21 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "../../utils/global_index.hpp"
+#include "fill_finding_duplicate_removal_sort_keys.cuh"
+#include "traccc/finding/device/fill_finding_duplicate_removal_sort_keys.hpp"
+
+namespace traccc::cuda::kernels {
+
+__global__ void fill_finding_duplicate_removal_sort_keys(
+    device::fill_finding_duplicate_removal_sort_keys_payload payload) {
+
+    device::fill_finding_duplicate_removal_sort_keys(details::global_index1(),
+                                                     payload);
+}
+
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/finding/kernels/fill_finding_duplicate_removal_sort_keys.cuh
+++ b/device/cuda/src/finding/kernels/fill_finding_duplicate_removal_sort_keys.cuh
@@ -1,0 +1,16 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/finding/device/fill_finding_duplicate_removal_sort_keys.hpp"
+
+namespace traccc::cuda::kernels {
+
+__global__ void fill_finding_duplicate_removal_sort_keys(
+    device::fill_finding_duplicate_removal_sort_keys_payload payload);
+}

--- a/device/cuda/src/finding/kernels/remove_duplicates.cu
+++ b/device/cuda/src/finding/kernels/remove_duplicates.cu
@@ -1,0 +1,20 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "../../utils/global_index.hpp"
+#include "remove_duplicates.cuh"
+#include "traccc/finding/device/remove_duplicates.hpp"
+
+namespace traccc::cuda::kernels {
+
+__global__ void remove_duplicates(const finding_config cfg,
+                                  device::remove_duplicates_payload payload) {
+
+    device::remove_duplicates(details::global_index1(), cfg, payload);
+}
+
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/finding/kernels/remove_duplicates.cuh
+++ b/device/cuda/src/finding/kernels/remove_duplicates.cuh
@@ -1,0 +1,16 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/finding/device/remove_duplicates.hpp"
+
+namespace traccc::cuda::kernels {
+
+__global__ void remove_duplicates(const finding_config cfg,
+                                  device::remove_duplicates_payload payload);
+}

--- a/device/sycl/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/sycl/src/finding/combinatorial_kalman_filter.hpp
@@ -359,12 +359,15 @@ combinatorial_kalman_filter(
                                 kernel_t>>(
                             calculate1DimNdRange(n_candidates, 256),
                             [in_params = vecmem::get_data(in_params_buffer),
+                             param_liveness =
+                                 vecmem::get_data(param_liveness_buffer),
                              keys = vecmem::get_data(keys_buffer),
                              param_ids = vecmem::get_data(param_ids_buffer)](
                                 ::sycl::nd_item<1> item) {
                                 device::fill_finding_propagation_sort_keys(
                                     details::global_index(item),
-                                    {in_params, keys, param_ids});
+                                    {in_params, param_liveness, keys,
+                                     param_ids});
                             });
                     })
                     .wait_and_throw();

--- a/tests/cpu/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cpu/test_ckf_combinatorics_telescope.cpp
@@ -119,11 +119,13 @@ TEST_P(CpuCkfCombinatoricsTelescopeTests, Run) {
         std::numeric_limits<unsigned int>::max();
     cfg_no_limit.max_num_branches_per_surface = 10;
     cfg_no_limit.chi2_max = 30.f;
+    cfg_no_limit.duplicate_removal_minimum_length = 100u;
 
     traccc::finding_config cfg_limit;
     cfg_limit.max_num_branches_per_seed = 500;
     cfg_limit.max_num_branches_per_surface = 10;
     cfg_limit.chi2_max = 30.f;
+    cfg_limit.duplicate_removal_minimum_length = 100u;
 
     // Finding algorithm object
     traccc::host::combinatorial_kalman_filter_algorithm host_finding(

--- a/tests/cuda/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cuda/test_ckf_combinatorics_telescope.cpp
@@ -141,6 +141,7 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
     cfg_no_limit.max_num_branches_per_seed = 100000;
     cfg_no_limit.chi2_max = 30.f;
     cfg_no_limit.max_num_branches_per_surface = 10;
+    cfg_no_limit.duplicate_removal_minimum_length = 100u;
 
     typename traccc::cuda::combinatorial_kalman_filter_algorithm::config_type
         cfg_limit;
@@ -148,6 +149,7 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
     cfg_limit.max_num_branches_per_seed = 500;
     cfg_limit.chi2_max = 30.f;
     cfg_limit.max_num_branches_per_surface = 10;
+    cfg_limit.duplicate_removal_minimum_length = 100u;
 
     // Finding algorithm object
     traccc::cuda::combinatorial_kalman_filter_algorithm device_finding(

--- a/tests/sycl/test_ckf_combinatorics_telescope.cpp
+++ b/tests/sycl/test_ckf_combinatorics_telescope.cpp
@@ -143,12 +143,14 @@ TEST_P(CkfCombinatoricsTelescopeTests, Run) {
     cfg_no_limit.max_num_branches_per_seed = 100000;
     cfg_no_limit.chi2_max = 30.f;
     cfg_no_limit.max_num_branches_per_surface = 10;
+    cfg_no_limit.duplicate_removal_minimum_length = 100u;
 
     traccc::sycl::combinatorial_kalman_filter_algorithm::config_type cfg_limit;
     cfg_limit.ptc_hypothesis = ptc;
     cfg_limit.max_num_branches_per_seed = 500;
     cfg_limit.chi2_max = 30.f;
     cfg_limit.max_num_branches_per_surface = 10;
+    cfg_limit.duplicate_removal_minimum_length = 100u;
 
     // Finding algorithm object
     traccc::sycl::combinatorial_kalman_filter_algorithm device_finding{

--- a/tests/sycl/test_ckf_toy_detector.cpp
+++ b/tests/sycl/test_ckf_toy_detector.cpp
@@ -139,6 +139,7 @@ TEST_P(CkfToyDetectorTests, Run) {
     cfg.ptc_hypothesis = ptc;
     cfg.max_num_branches_per_seed = 500;
     cfg.propagation.navigation.search_window = search_window;
+    cfg.duplicate_removal_minimum_length = 100u;
 
     // Finding algorithm object
     traccc::host::combinatorial_kalman_filter_algorithm host_finding(cfg,


### PR DESCRIPTION
As it stands, it is possible for our CKF to propagate what is essentially the same track multiple times, which wastes expensive propagation cycles. This PR adds an experimental substep to the CKF algorithm which will check if any of the currently in-flight tracks are based on exactly the same measurements and, if so, remove them.