### PR TITLE
Add additional information to candidate links

### DIFF
--- a/core/include/traccc/finding/candidate_link.hpp
+++ b/core/include/traccc/finding/candidate_link.hpp
@@ -33,6 +33,12 @@ struct candidate_link {
 
     // chi2
     traccc::scalar chi2;
+
+    // chi2 sum
+    traccc::scalar chi2_sum;
+
+    // degrees of freedom
+    unsigned int ndf_sum;
 };
 
 }  // namespace traccc

--- a/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -186,6 +186,16 @@ combinatorial_kalman_filter(
                      ? 0
                      : links[step - 1][param_to_link[step - 1][in_param_id]]
                            .n_skipped);
+            const scalar prev_chi2_sum =
+                (step == 0
+                     ? 0.f
+                     : links[step - 1][param_to_link[step - 1][in_param_id]]
+                           .chi2_sum);
+            const unsigned int prev_ndf_sum =
+                (step == 0
+                     ? 0
+                     : links[step - 1][param_to_link[step - 1][in_param_id]]
+                           .ndf_sum);
 
             TRACCC_VERBOSE("Processing input parameter "
                            << in_param_id + 1 << " / " << n_in_params << ": "
@@ -273,7 +283,10 @@ combinatorial_kalman_filter(
                           .meas_idx = item_id,
                           .seed_idx = orig_param_id,
                           .n_skipped = skip_counter,
-                          .chi2 = chi2},
+                          .chi2 = chi2,
+                          .chi2_sum = prev_chi2_sum + chi2,
+                          .ndf_sum = prev_ndf_sum +
+                                     trk_state.get_measurement().meas_dim},
                          trk_state});
                 }
             }
@@ -316,7 +329,9 @@ combinatorial_kalman_filter(
                      .meas_idx = std::numeric_limits<unsigned int>::max(),
                      .seed_idx = orig_param_id,
                      .n_skipped = skip_counter + 1,
-                     .chi2 = std::numeric_limits<traccc::scalar>::max()});
+                     .chi2 = std::numeric_limits<traccc::scalar>::max(),
+                     .chi2_sum = prev_chi2_sum,
+                     .ndf_sum = prev_ndf_sum});
 
                 updated_params.push_back(in_param);
                 TRACCC_VERBOSE("updated_params["


### PR DESCRIPTION
This commit augments the candidate link type to store two additional member variables: the number of degrees of freedom along the track so far and the sum of the $\chi^2$ values along the track.

A small performance degredation is expected, but this is a prerequisite for future optimisations. See #1041.