### PR TITLE
Add pre-commit check for duplicate CUDA files

### DIFF
--- a/.github/check_duplicate_cu_files.sh
+++ b/.github/check_duplicate_cu_files.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+! [[ $(find device tests -name "*\.cu" | xargs -I {} basename {} | sort | uniq -d) ]]
+exit $?

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,11 @@ repos:
         name: Check taboo code patterns
         language: system
         entry: .github/check_taboos.sh
+
+  - repo: local
+    hooks:
+      - id: check_duplicate_cu_files
+        name: Check duplicate .cu file names
+        language: system
+        entry: .github/check_duplicate_cu_files.sh
+        pass_filenames: false


### PR DESCRIPTION
For reasons of CUDA being CUDA, we currently cannot reliable compile the project in debug mode if there are multiple CUDA files with the same base name. This causes a race condition during compilation. In order to relieve this issue, this commit adds a pre-commit check that verifies that all CUDA file base names are unique.