### PR TITLE
Switch Kálmán filters to use Joseph form

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
@@ -222,7 +222,10 @@ struct two_filters_smoother {
         // Calculate the filtered track parameters
         const matrix_type<6, 1> filtered_vec =
             predicted_vec + K * (meas_local - H * predicted_vec);
-        const matrix_type<6, 6> filtered_cov = (I66 - K * H) * predicted_cov;
+        const matrix_type<6, 6> i_minus_kh = I66 - K * H;
+        const matrix_type<6, 6> filtered_cov =
+            i_minus_kh * predicted_cov * matrix::transpose(i_minus_kh) +
+            K * V * matrix::transpose(K);
 
         // Update the bound track parameters
         bound_params.set_vector(filtered_vec);


### PR DESCRIPTION
This commit switches the Kálmán filters to use the Joseph form covariance update which is known to be usable for any gain matrix $K$ even if the gain matrix is distorted by numerical imprecision. Empirically, this seems to resolve quite a few issues with our filtering algorithms.