### PR TITLE
Add clamping to magnetic field types

### DIFF
--- a/core/include/traccc/utils/bfield.hpp
+++ b/core/include/traccc/utils/bfield.hpp
@@ -13,6 +13,7 @@
 // Covfie include(s).
 #include <covfie/core/backend/primitive/constant.hpp>
 #include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/clamp.hpp>
 #include <covfie/core/backend/transformer/linear.hpp>
 #include <covfie/core/backend/transformer/strided.hpp>
 #include <covfie/core/field.hpp>
@@ -93,12 +94,19 @@ using const_bfield_backend_t =
     ::covfie::backend::constant<::covfie::vector::vector_d<scalar_t, 3>,
                                 ::covfie::vector::vector_d<scalar_t, 3>>;
 
-/// Inhomogeneous magnetic field backend type
+/// Inhomogeneous magnetic field used for IO
 template <typename scalar_t>
-using inhom_bfield_backend_t =
+using inhom_io_bfield_backend_t =
     covfie::backend::affine<covfie::backend::linear<covfie::backend::strided<
         covfie::vector::vector_d<std::size_t, 3>,
         covfie::backend::array<covfie::vector::vector_d<scalar_t, 3>>>>>;
+
+/// Inhomogeneous magnetic field backend type
+template <typename scalar_t>
+using inhom_bfield_backend_t = covfie::backend::affine<
+    covfie::backend::linear<covfie::backend::clamp<covfie::backend::strided<
+        covfie::vector::vector_d<std::size_t, 3>,
+        covfie::backend::array<covfie::vector::vector_d<scalar_t, 3>>>>>>;
 
 /// Construct a constant magnetic field object
 template <typename scalar_t>

--- a/device/cuda/src/utils/bfield.cuh
+++ b/device/cuda/src/utils/bfield.cuh
@@ -10,6 +10,7 @@
 // Covfie include(s).
 #include <covfie/core/backend/primitive/constant.hpp>
 #include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/clamp.hpp>
 #include <covfie/core/backend/transformer/linear.hpp>
 #include <covfie/core/backend/transformer/strided.hpp>
 #include <covfie/core/field.hpp>
@@ -20,9 +21,10 @@ namespace traccc::cuda {
 
 /// Inhomogeneous B-field backend type for CUDA
 template <typename scalar_t>
-using inhom_bfield_backend_t = covfie::backend::affine<covfie::backend::linear<
-    covfie::backend::strided<covfie::vector::vector_d<std::size_t, 3>,
-                             covfie::backend::cuda_device_array<
-                                 covfie::vector::vector_d<scalar_t, 3>>>>>;
+using inhom_bfield_backend_t =
+    covfie::backend::affine<covfie::backend::linear<covfie::backend::clamp<
+        covfie::backend::strided<covfie::vector::vector_d<std::size_t, 3>,
+                                 covfie::backend::cuda_device_array<
+                                     covfie::vector::vector_d<scalar_t, 3>>>>>>;
 
 }  // namespace traccc::cuda

--- a/device/sycl/src/utils/bfield.hpp
+++ b/device/sycl/src/utils/bfield.hpp
@@ -10,6 +10,7 @@
 // Covfie include(s).
 #include <covfie/core/backend/primitive/constant.hpp>
 #include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/clamp.hpp>
 #include <covfie/core/backend/transformer/linear.hpp>
 #include <covfie/core/backend/transformer/strided.hpp>
 #include <covfie/core/field.hpp>
@@ -20,9 +21,10 @@ namespace traccc::sycl {
 
 /// Inhomogeneous B-field backend type for CUDA
 template <typename scalar_t>
-using inhom_bfield_backend_t = covfie::backend::affine<covfie::backend::linear<
-    covfie::backend::strided<covfie::vector::vector_d<std::size_t, 3>,
-                             covfie::backend::sycl_device_array<
-                                 covfie::vector::vector_d<scalar_t, 3>>>>>;
+using inhom_bfield_backend_t =
+    covfie::backend::affine<covfie::backend::linear<covfie::backend::clamp<
+        covfie::backend::strided<covfie::vector::vector_d<std::size_t, 3>,
+                                 covfie::backend::sycl_device_array<
+                                     covfie::vector::vector_d<scalar_t, 3>>>>>>;
 
 }  // namespace traccc::sycl

--- a/extern/covfie/CMakeLists.txt
+++ b/extern/covfie/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Fetching covfie as part of the traccc project" )
 
 # Declare where to get covfie from.
 set( TRACCC_COVFIE_SOURCE
-   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.13.0.tar.gz;URL_MD5;9dbff64d68a9d8c88acff12e8f99584a"
+   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.15.1.tar.gz;URL_MD5;aa54f7e7e1a83edd02660e2778d29109"
    CACHE STRING "Source for covfie, when built as part of this project" )
 mark_as_advanced( TRACCC_COVFIE_SOURCE )
 FetchContent_Declare( covfie SYSTEM ${TRACCC_COVFIE_SOURCE} )

--- a/io/src/read_bfield.cpp
+++ b/io/src/read_bfield.cpp
@@ -35,7 +35,8 @@ void read_bfield(covfie::field<inhom_bfield_backend_t<traccc::scalar>>& field,
 
     // Construct/fill the magnetic field from the file.
     TRACCC_INFO("Reading magnetic field from file: " << filename);
-    field = covfie::field<inhom_bfield_backend_t<traccc::scalar>>(ifile);
+    field = covfie::field<inhom_bfield_backend_t<traccc::scalar>>(
+        covfie::field<inhom_io_bfield_backend_t<traccc::scalar>>(ifile));
 }
 
 }  // namespace binary


### PR DESCRIPTION
Currently, our magnetic field types are unclamped which means that an out-of-bounds access can yield a segmentation fault. Although we never really should go OOB, it does sometimes happen due to numerical instability. This commit adds a clamping transformer to our magnetic field backends to ensure that we never access invalid memory.