### PR TITLE
Inhomogeneous Magnetic Field Throughput Applications, main branch (2025.07.02.)

### DIFF
--- a/examples/run/alpaka/CMakeLists.txt
+++ b/examples/run/alpaka/CMakeLists.txt
@@ -36,7 +36,7 @@ add_library( traccc_examples_alpaka STATIC
    "full_chain_algorithm.cpp" )
 target_link_libraries( traccc_examples_alpaka
    PUBLIC vecmem::core detray::core detray::detectors
-   traccc::core traccc::device_common traccc::alpaka ${EXTRA_LIBS})
+   traccc::core traccc::device_common traccc::alpaka traccc_examples_common ${EXTRA_LIBS})
 
 traccc_add_executable( throughput_st_alpaka "throughput_st.cpp"
    LINK_LIBRARIES indicators::indicators ${LIBRARIES} ${DETRAY} traccc_examples_alpaka )

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -22,7 +22,7 @@ full_chain_algorithm::full_chain_algorithm(
     const seedfilter_config& filter_config,
     const finding_algorithm::config_type& finding_config,
     const fitting_algorithm::config_type& fitting_config,
-    const silicon_detector_description::host& det_descr,
+    const silicon_detector_description::host& det_descr, const bfield& field,
     host_detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
     : messaging(logger->clone()),
       m_queue(),
@@ -32,8 +32,7 @@ full_chain_algorithm::full_chain_algorithm(
           std::make_unique<::vecmem::binary_page_memory_resource>(
               m_vecmem_objects.device_mr())),
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
-      m_field(traccc::construct_const_bfield<host_detector_type::scalar_type>(
-          m_field_vec)),
+      m_field(field),
       m_det_descr(det_descr),
       m_device_det_descr(
           static_cast<silicon_detector_description::buffer::size_type>(

--- a/examples/run/alpaka/full_chain_algorithm.hpp
+++ b/examples/run/alpaka/full_chain_algorithm.hpp
@@ -83,7 +83,7 @@ class full_chain_algorithm
                          const finding_algorithm::config_type& finding_config,
                          const fitting_algorithm::config_type& fitting_config,
                          const silicon_detector_description::host& det_descr,
-                         host_detector_type* detector,
+                         const bfield& field, host_detector_type* detector,
                          std::unique_ptr<const traccc::Logger> logger);
 
     /// Copy constructor

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// Local include(s).
+#include "make_magnetic_field.hpp"
+
 // Project include(s)
 #include "traccc/geometry/detector.hpp"
 
@@ -14,6 +17,7 @@
 #include "traccc/options/clusterization.hpp"
 #include "traccc/options/detector.hpp"
 #include "traccc/options/input_data.hpp"
+#include "traccc/options/magnetic_field.hpp"
 #include "traccc/options/program_options.hpp"
 #include "traccc/options/threading.hpp"
 #include "traccc/options/throughput.hpp"
@@ -65,6 +69,7 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
 
     // Program options.
     opts::detector detector_opts;
+    opts::magnetic_field bfield_opts;
     opts::input_data input_opts;
     opts::clusterization clusterization_opts;
     opts::track_seeding seeding_opts;
@@ -75,9 +80,9 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
     opts::threading threading_opts;
     opts::program_options program_opts{
         description,
-        {detector_opts, input_opts, clusterization_opts, seeding_opts,
-         finding_opts, propagation_opts, fitting_opts, throughput_opts,
-         threading_opts},
+        {detector_opts, bfield_opts, input_opts, clusterization_opts,
+         seeding_opts, finding_opts, propagation_opts, fitting_opts,
+         throughput_opts, threading_opts},
         argc,
         argv,
         logger().cloneWithSuffix("Options")};
@@ -102,6 +107,9 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
             detector, uncached_host_mr, detector_opts.detector_file,
             detector_opts.material_file, detector_opts.grid_file);
     }
+
+    // Construct the magnetic field object.
+    traccc::bfield field{details::make_magnetic_field(bfield_opts)};
 
     // Read in all input events into memory.
     vecmem::vector<edm::silicon_cell_collection::host> input{&uncached_host_mr};
@@ -174,6 +182,7 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
              finding_cfg,
              fitting_cfg,
              det_descr,
+             field,
              (detector_opts.use_detray_detector ? &detector : nullptr),
              logger().clone()});
     }

--- a/examples/run/cpu/full_chain_algorithm.cpp
+++ b/examples/run/cpu/full_chain_algorithm.cpp
@@ -17,14 +17,12 @@ full_chain_algorithm::full_chain_algorithm(
     const seedfilter_config& filter_config,
     const finding_algorithm::config_type& finding_config,
     const fitting_algorithm::config_type& fitting_config,
-    const silicon_detector_description::host& det_descr,
+    const silicon_detector_description::host& det_descr, const bfield& field,
     detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
     : messaging(logger->clone()),
       m_copy{std::make_unique<vecmem::copy>()},
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
-      m_field(
-          traccc::construct_const_bfield<typename detector_type::scalar_type>(
-              m_field_vec)),
+      m_field(field),
       m_det_descr(det_descr),
       m_detector(detector),
       m_clusterization(mr, logger->cloneWithSuffix("ClusteringAlg")),

--- a/examples/run/cpu/full_chain_algorithm.hpp
+++ b/examples/run/cpu/full_chain_algorithm.hpp
@@ -76,7 +76,7 @@ class full_chain_algorithm : public algorithm<track_state_container_types::host(
                          const finding_algorithm::config_type& finding_config,
                          const fitting_algorithm::config_type& fitting_config,
                          const silicon_detector_description::host& det_descr,
-                         detector_type* detector,
+                         const bfield& field, detector_type* detector,
                          std::unique_ptr<const traccc::Logger> logger);
 
     /// Reconstruct track parameters in the entire detector

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -8,6 +8,9 @@
 // Local include(s).
 #include "full_chain_algorithm.hpp"
 
+// Project include(s).
+#include "traccc/cuda/utils/make_bfield.hpp"
+
 // CUDA include(s).
 #include <cuda_runtime_api.h>
 
@@ -35,7 +38,7 @@ full_chain_algorithm::full_chain_algorithm(
     const seedfilter_config& filter_config,
     const finding_algorithm::config_type& finding_config,
     const fitting_algorithm::config_type& fitting_config,
-    const silicon_detector_description::host& det_descr,
+    const silicon_detector_description::host& det_descr, const bfield& field,
     host_detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
     : messaging(logger->clone()),
       m_host_mr(host_mr),
@@ -45,8 +48,7 @@ full_chain_algorithm::full_chain_algorithm(
           std::make_unique<vecmem::binary_page_memory_resource>(m_device_mr)),
       m_copy(m_stream.cudaStream()),
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
-      m_field(traccc::construct_const_bfield<host_detector_type::scalar_type>(
-          m_field_vec)),
+      m_field(make_bfield(field)),
       m_det_descr(det_descr),
       m_device_det_descr(
           static_cast<silicon_detector_description::buffer::size_type>(

--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -84,7 +84,7 @@ class full_chain_algorithm
                          const finding_algorithm::config_type& finding_config,
                          const fitting_algorithm::config_type& fitting_config,
                          const silicon_detector_description::host& det_descr,
-                         host_detector_type* detector,
+                         const bfield& field, host_detector_type* detector,
                          std::unique_ptr<const traccc::Logger> logger);
 
     /// Copy constructor

--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -80,7 +80,7 @@ class full_chain_algorithm
                          const finding_algorithm::config_type& finding_config,
                          const fitting_algorithm::config_type& fitting_config,
                          const silicon_detector_description::host& det_descr,
-                         host_detector_type* detector,
+                         const bfield& field, host_detector_type* detector,
                          std::unique_ptr<const traccc::Logger> logger);
 
     /// Copy constructor

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -8,6 +8,9 @@
 // Local include(s).
 #include "full_chain_algorithm.hpp"
 
+// Project include(s).
+#include "traccc/sycl/utils/make_bfield.hpp"
+
 // SYCL include(s).
 #include <sycl/sycl.hpp>
 
@@ -56,7 +59,7 @@ full_chain_algorithm::full_chain_algorithm(
     const seedfilter_config& filter_config,
     const finding_algorithm::config_type& finding_config,
     const fitting_algorithm::config_type& fitting_config,
-    const silicon_detector_description::host& det_descr,
+    const silicon_detector_description::host& det_descr, const bfield& field,
     host_detector_type* detector, std::unique_ptr<const traccc::Logger> logger)
     : messaging(logger->clone()),
       m_data(std::make_unique<details::full_chain_algorithm_data>(
@@ -66,8 +69,7 @@ full_chain_algorithm::full_chain_algorithm(
       m_cached_device_mr{m_device_mr},
       m_copy{&(m_data->m_queue)},
       m_field_vec{0.f, 0.f, finder_config.bFieldInZ},
-      m_field{traccc::construct_const_bfield<host_detector_type::scalar_type>(
-          m_field_vec)},
+      m_field{make_bfield(field, m_data->m_queue_wrapper)},
       m_det_descr(det_descr),
       m_device_det_descr{
           static_cast<silicon_detector_description::buffer::size_type>(


### PR DESCRIPTION
Made magnetic fields configurable for the throughput applications. After #1049, they should now work "reliably". :thinking: Though if asking for a non-homogeneous field in the Alpaka applications, they will fail. Since in #1033 no real Alpaka support was added yet.

The inhomogeneous field is not for free though. :frowning: On my private GPU I see:
  - Constant field:

```
[bash][Legolas]:traccc > ./out/build/full-native-fp32/bin/traccc_throughput_mt_cuda --input-directory /data/hdd-4tb-1/acts_data/odd-20240509/geant4_ttbar_mu200 --input-events=50 --cpu-threads=3
15:53:45    ThroughputExampleOptions      INFO      
15:53:45    ThroughputExampleOptions      INFO      Running Multi-threaded CUDA GPU throughput tests
15:53:45    ThroughputExampleOptions      INFO      
15:53:45    ThroughputExampleOptions      INFO      Detector Options:
15:53:45    ThroughputExampleOptions      INFO      ├ Detector file:                          geometries/odd/odd-detray_geometry_detray.json
15:53:45    ThroughputExampleOptions      INFO      ├ Material file:                          geometries/odd/odd-detray_material_detray.json
15:53:45    ThroughputExampleOptions      INFO      ├ Surface grid file:                      geometries/odd/odd-detray_surface_grids_detray.json
15:53:45    ThroughputExampleOptions      INFO      ├ Use detray detector:                    true
15:53:45    ThroughputExampleOptions      INFO      └ Digitization file:                      geometries/odd/odd-digi-geometric-config.json
15:53:45    ThroughputExampleOptions      INFO      Magnetic Field Options:
15:53:45    ThroughputExampleOptions      INFO      ├ Read magnetic field from file:          false
15:53:45    ThroughputExampleOptions      INFO      ├ Magnetic field file:                    geometries/odd/odd-bfield.cvf
15:53:45    ThroughputExampleOptions      INFO      ├ Magnetic field file format:             binary
15:53:45    ThroughputExampleOptions      INFO      └ Magnetic field value:                   2 T
...
Using CUDA device: NVIDIA GeForce RTX 3080 [id: 0, bus: 1, device: 0]
Warm-up processing [==================================================] 100% [00m:00s]                                                                                                                                                                                                                                                                                                                                               
Event processing   [==================================================] 100% [00m:00s]                                                                                                                                                                                                                                                                                                                                               
03:54:16 PM ThroughputExample             INFO      Reconstructed track parameters: 6551133
03:54:16 PM ThroughputExample             INFO      Time totals:                   File reading  2646 ms
03:54:16 PM ThroughputExample             INFO                  Warm-up processing  2161 ms
03:54:16 PM ThroughputExample             INFO                    Event processing  22570 ms
03:54:16 PM ThroughputExample             INFO      Throughput:            Warm-up processing  216.11 ms/event, 4.62728 events/s
03:54:16 PM ThroughputExample             INFO                    Event processing  225.704 ms/event, 4.43058 events/s
[bash][Legolas]:traccc >
```

  - Inhomogeneous field:

```
[bash][Legolas]:traccc > ./out/build/full-native-fp32/bin/traccc_throughput_mt_cuda --read-bfield-from-file --input-directory /data/hdd-4tb-1/acts_data/odd-20240509/geant4_ttbar_mu200 --input-events=50 --cpu-threads=3
15:54:59    ThroughputExampleOptions      INFO      
15:54:59    ThroughputExampleOptions      INFO      Running Multi-threaded CUDA GPU throughput tests
15:54:59    ThroughputExampleOptions      INFO      
15:54:59    ThroughputExampleOptions      INFO      Detector Options:
15:54:59    ThroughputExampleOptions      INFO      ├ Detector file:                          geometries/odd/odd-detray_geometry_detray.json
15:54:59    ThroughputExampleOptions      INFO      ├ Material file:                          geometries/odd/odd-detray_material_detray.json
15:54:59    ThroughputExampleOptions      INFO      ├ Surface grid file:                      geometries/odd/odd-detray_surface_grids_detray.json
15:54:59    ThroughputExampleOptions      INFO      ├ Use detray detector:                    true
15:54:59    ThroughputExampleOptions      INFO      └ Digitization file:                      geometries/odd/odd-digi-geometric-config.json
15:54:59    ThroughputExampleOptions      INFO      Magnetic Field Options:
15:54:59    ThroughputExampleOptions      INFO      ├ Read magnetic field from file:          true
15:54:59    ThroughputExampleOptions      INFO      ├ Magnetic field file:                    geometries/odd/odd-bfield.cvf
15:54:59    ThroughputExampleOptions      INFO      ├ Magnetic field file format:             binary
15:54:59    ThroughputExampleOptions      INFO      └ Magnetic field value:                   2 T
...
Using CUDA device: NVIDIA GeForce RTX 3080 [id: 0, bus: 1, device: 0]
Warm-up processing [==================================================] 100% [00m:00s]                                                                                                                                                                                                                                                                                                                                               
Event processing   [==================================================] 100% [00m:00s]                                                                                                                                                                                                                                                                                                                                               
03:55:33 PM ThroughputExample             INFO      Reconstructed track parameters: 6500850
03:55:33 PM ThroughputExample             INFO      Time totals:                   File reading  2637 ms
03:55:33 PM ThroughputExample             INFO                  Warm-up processing  2653 ms
03:55:33 PM ThroughputExample             INFO                    Event processing  24549 ms
03:55:33 PM ThroughputExample             INFO      Throughput:            Warm-up processing  265.358 ms/event, 3.76849 events/s
03:55:33 PM ThroughputExample             INFO                    Event processing  245.498 ms/event, 4.07335 events/s
[bash][Legolas]:traccc >
```

Let's see what @stephenswat's tests will say in #1044... :thinking: