### PR TITLE
Reduce the block dimension for `count_removable_tracks` kernel

### DIFF
--- a/device/cuda/src/ambiguity_resolution/kernels/count_removable_tracks.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/count_removable_tracks.cu
@@ -67,9 +67,9 @@ __global__ void count_removable_tracks(
         return;
     }
 
-    __shared__ int shared_n_meas[1024];
-    __shared__ measurement_id_type sh_meas_ids[1024];
-    __shared__ unsigned int sh_threads[1024];
+    __shared__ int shared_n_meas[512];
+    __shared__ measurement_id_type sh_meas_ids[512];
+    __shared__ unsigned int sh_threads[512];
     __shared__ unsigned int n_meas_total;
     __shared__ unsigned int bound;
     __shared__ unsigned int n_tracks_to_iterate;

--- a/device/cuda/src/ambiguity_resolution/kernels/count_removable_tracks.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/count_removable_tracks.cu
@@ -52,7 +52,7 @@ __device__ void count_tracks(int tid, int* sh_n_meas, int n_tracks,
     __syncthreads();
 }
 
-__global__ void count_removable_tracks(
+__launch_bounds__(512) __global__ void count_removable_tracks(
     device::count_removable_tracks_payload payload) {
 
     if (threadIdx.x == 0) {


### PR DESCRIPTION
Currently 1024 threads of the `count_removable_tracks`, which is the bottleneck, is an over-allocation. It is OK if the number of threads is higher than `bound` variable in the kernel.

```c++
// in count_removable_tracks.cu
    if (threadIndex == 0) {
        *(payload.n_removable_tracks) = 0;
        *(payload.n_meas_to_remove) = 0;
        n_meas_total = 0;
        bound = 512; 
        N = 1;
        n_tracks_to_iterate = 0;
        min_thread = std::numeric_limits<unsigned int>::max();
        stop = false;
    }
```

This gives a small boost (3-4%) to the ambiguity resolution
