### PR TITLE
Switch CUDA B-field to use texture memory

### DIFF
--- a/device/cuda/src/utils/bfield.cuh
+++ b/device/cuda/src/utils/bfield.cuh
@@ -8,7 +8,6 @@
 #pragma once
 
 // Covfie include(s).
-#include <covfie/core/backend/primitive/constant.hpp>
 #include <covfie/core/backend/transformer/affine.hpp>
 #include <covfie/core/backend/transformer/clamp.hpp>
 #include <covfie/core/backend/transformer/linear.hpp>
@@ -16,15 +15,29 @@
 #include <covfie/core/field.hpp>
 #include <covfie/core/vector.hpp>
 #include <covfie/cuda/backend/primitive/cuda_device_array.hpp>
+#include <covfie/cuda/backend/primitive/cuda_texture.hpp>
 
 namespace traccc::cuda {
 
-/// Inhomogeneous B-field backend type for CUDA
+/// Inhomogeneous non-texture B-field backend type for CUDA
 template <typename scalar_t>
-using inhom_bfield_backend_t =
+using inhom_bfield_non_texture_backend_t =
     covfie::backend::affine<covfie::backend::linear<covfie::backend::clamp<
         covfie::backend::strided<covfie::vector::vector_d<std::size_t, 3>,
                                  covfie::backend::cuda_device_array<
                                      covfie::vector::vector_d<scalar_t, 3>>>>>>;
+
+/// Inhomogeneous texture B-field backend type for CUDA
+template <typename scalar_t>
+using inhom_bfield_texture_backend_t = covfie::backend::affine<
+    covfie::backend::cuda_texture<covfie::vector::vector_d<scalar_t, 3>,
+                                  covfie::vector::vector_d<scalar_t, 3>>>;
+
+/// Inhomogeneous B-field backend type for CUDA
+template <typename scalar_t>
+using inhom_bfield_backend_t =
+    std::conditional_t<std::is_same_v<scalar_t, float>,
+                       inhom_bfield_texture_backend_t<scalar_t>,
+                       inhom_bfield_non_texture_backend_t<scalar_t>>;
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/utils/make_bfield.cu
+++ b/device/cuda/src/utils/make_bfield.cu
@@ -23,8 +23,23 @@ bfield make_bfield(const bfield& field) {
         return bfield{covfie::field<const_bfield_backend_t<scalar>>{
             field.get_covfie_field<const_bfield_backend_t<scalar>>()}};
     } else if (field.is<traccc::inhom_bfield_backend_t<scalar>>()) {
-        return bfield{covfie::field<cuda::inhom_bfield_backend_t<scalar>>(
-            field.get_covfie_field<traccc::inhom_bfield_backend_t<scalar>>())};
+        const auto& in_field =
+            field.get_covfie_field<traccc::inhom_bfield_backend_t<scalar>>();
+
+        if constexpr (std::is_same_v<
+                          cuda::inhom_bfield_backend_t<scalar>,
+                          cuda::inhom_bfield_texture_backend_t<scalar>>) {
+            return bfield{covfie::field<cuda::inhom_bfield_backend_t<scalar>>(
+                covfie::make_parameter_pack(
+                    in_field.backend().get_configuration(),
+                    in_field.backend()
+                        .get_backend()
+                        .get_backend()
+                        .get_backend()))};
+        } else {
+            return bfield{
+                covfie::field<cuda::inhom_bfield_backend_t<scalar>>(in_field)};
+        }
     } else {
         throw std::invalid_argument("Unsupported b-field type received");
     }


### PR DESCRIPTION
This commit changes the CUDA magnetic field representation from a classical array-based field to a field in texture memory.