### PR TITLE
Add separate CKF cuts for 1D and 2D measurements

### DIFF
--- a/core/include/traccc/finding/candidate_link.hpp
+++ b/core/include/traccc/finding/candidate_link.hpp
@@ -31,6 +31,10 @@ struct candidate_link {
     // How many times it skipped a surface
     unsigned int n_skipped;
 
+    // How many measurements of given dimensionalities have been found
+    unsigned short n_1d;
+    unsigned short n_2d;
+
     // chi2
     traccc::scalar chi2;
 

--- a/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -196,6 +196,16 @@ combinatorial_kalman_filter(
                      ? 0
                      : links[step - 1][param_to_link[step - 1][in_param_id]]
                            .ndf_sum);
+            const unsigned short prev_n_1d =
+                (step == 0
+                     ? 0
+                     : links[step - 1][param_to_link[step - 1][in_param_id]]
+                           .n_1d);
+            const unsigned short prev_n_2d =
+                (step == 0
+                     ? 0
+                     : links[step - 1][param_to_link[step - 1][in_param_id]]
+                           .n_2d);
 
             TRACCC_VERBOSE("Processing input parameter "
                            << in_param_id + 1 << " / " << n_in_params << ": "
@@ -283,6 +293,16 @@ combinatorial_kalman_filter(
                           .meas_idx = item_id,
                           .seed_idx = orig_param_id,
                           .n_skipped = skip_counter,
+                          .n_1d = static_cast<unsigned short>(
+                              prev_n_1d +
+                              (trk_state.get_measurement().meas_dim == 1u
+                                   ? 1u
+                                   : 0u)),
+                          .n_2d = static_cast<unsigned short>(
+                              prev_n_2d +
+                              (trk_state.get_measurement().meas_dim == 2u
+                                   ? 1u
+                                   : 0u)),
                           .chi2 = chi2,
                           .chi2_sum = prev_chi2_sum + chi2,
                           .ndf_sum = prev_ndf_sum +
@@ -329,6 +349,8 @@ combinatorial_kalman_filter(
                      .meas_idx = std::numeric_limits<unsigned int>::max(),
                      .seed_idx = orig_param_id,
                      .n_skipped = skip_counter + 1,
+                     .n_1d = prev_n_1d,
+                     .n_2d = prev_n_2d,
                      .chi2 = std::numeric_limits<traccc::scalar>::max(),
                      .chi2_sum = prev_chi2_sum,
                      .ndf_sum = prev_ndf_sum});

--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -29,6 +29,15 @@ struct finding_config {
     unsigned int min_track_candidates_per_track = 3;
     unsigned int max_track_candidates_per_track = 100;
 
+    /// Min number of track candidates of a specific dimensionality
+    unsigned int min_1d_track_candidates_per_track = 0u;
+    unsigned int min_2d_track_candidates_per_track = 3u;
+
+    /// Enable strict ordering of 1D measurements after 2D measurements, i.e.
+    /// if this is set to true, the algorithm will assume that if it finds a
+    /// 1D measurement, it can never again find another 2D measurement.
+    bool strict_1d_after_2d_ordering = true;
+
     /// Maximum allowed number of skipped steps per candidate
     unsigned int max_num_skipping_per_cand = 3;
 

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -107,7 +107,9 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     } else {
         params_liveness[param_id] = 0u;
 
-        if (n_cands >= cfg.min_track_candidates_per_track) {
+        if (n_cands >= cfg.min_track_candidates_per_track &&
+            link.n_1d >= cfg.min_1d_track_candidates_per_track &&
+            link.n_2d >= cfg.min_2d_track_candidates_per_track) {
             auto tip_pos = tips.push_back(link_idx);
             tip_lengths.at(tip_pos) = n_cands;
         }


### PR DESCRIPTION
This commit adds additional cuts for the number of 1D and 2D measurements found (rather than the number of measurements found in total). A special case is implemented where all 2D measurements can be required before the 1D measurements, which will allow the cut to be applied earlier.