### PR TITLE
Enable fast math library in CUDA compilation

### DIFF
--- a/cmake/traccc-compiler-options-cuda.cmake
+++ b/cmake/traccc-compiler-options-cuda.cmake
@@ -25,7 +25,7 @@ endif()
 
 # Allow to use functions in device code that are constexpr, even if they are
 # not marked with __device__.
-traccc_add_flag( CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr" )
+traccc_add_flag( CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr --use_fast_math" )
 
 # Make CUDA generate debug symbols for the device code as well in a debug
 # build.


### PR DESCRIPTION
One of the biggest performance bottlenecks of our code right now are the math functions we use from the standard library. To illustrate the problem, these functions have the problem that they contain a _lot_ of edge case handling code for NaN values, infinities, etc. which are not necessary for our use case. This causes an incredible amount of code to be added and causes a huge amount of instruction cache misses when though CUDA contains native intrinsics of high accurary which model the same behaviour. This PR serves to illustrate the massive performance gain that we can achieve by using intrinsic math rather than the math provided by the C++ standard library.