### PR TITLE
Implement visitor for polymorphic magnetic field

### DIFF
--- a/core/include/traccc/bfield/magnetic_field.hpp
+++ b/core/include/traccc/bfield/magnetic_field.hpp
@@ -13,6 +13,7 @@
 
 // System include(s).
 #include <any>
+#include <sstream>
 
 namespace traccc {
 
@@ -64,11 +65,54 @@ class magnetic_field {
     template <covfie::concepts::field_backend bfield_backend_t>
     const covfie::field<bfield_backend_t>& as_field() const;
 
+    /// @brief Return type information about the contained magnetic field.
+    const std::type_info& type() const { return m_field.type(); }
+
     private:
     /// The actualy covfie b-field object
     std::any m_field;
 
 };  // class magnetic_field
+
+/// @brief Helper function for `bfield_visitor`
+template <typename callable_t, typename bfield_t, typename... bfield_ts>
+auto magnetic_field_visitor_helper(const magnetic_field& bfield,
+                                   callable_t&& callable,
+                                   std::tuple<bfield_t, bfield_ts...>*)
+    requires(covfie::concepts::field_backend<bfield_t> &&
+             (covfie::concepts::field_backend<bfield_ts> && ...))
+{
+    if (bfield.is<bfield_t>()) {
+        return callable(bfield.as_view<bfield_t>());
+    } else {
+        if constexpr (sizeof...(bfield_ts) > 0) {
+            return magnetic_field_visitor_helper(
+                bfield, std::forward<callable_t>(callable),
+                static_cast<std::tuple<bfield_ts...>*>(nullptr));
+        } else {
+            std::stringstream exception_message;
+
+            exception_message
+                << "Invalid B-field type (" << bfield.type().name()
+                << ") received, but this type is not supported" << std::endl;
+
+            throw std::invalid_argument(exception_message.str());
+        }
+    }
+}
+
+/// @brief Visitor for polymorphic magnetic field types
+///
+/// This function takes a list of supported magnetic field types and checks
+/// if the provided field is one of them. If it is, it will call the provided
+/// callable on a view of it and otherwise it will throw an exception.
+template <typename bfield_list_t, typename callable_t>
+auto magnetic_field_visitor(const magnetic_field& bfield,
+                            callable_t&& callable) {
+    return magnetic_field_visitor_helper(bfield,
+                                         std::forward<callable_t>(callable),
+                                         static_cast<bfield_list_t*>(nullptr));
+}
 
 }  // namespace traccc
 

--- a/core/include/traccc/bfield/magnetic_field_types.hpp
+++ b/core/include/traccc/bfield/magnetic_field_types.hpp
@@ -49,5 +49,10 @@ using inhom_bfield_backend_t = covfie::backend::affine<
 static_assert(covfie::concepts::field_backend<inhom_bfield_backend_t<float>>,
               "inhom_bfield_backend_t is not a valid field backend type");
 
+/// @brief The standard list of host bfield types to support
+template <typename scalar_t>
+using bfield_type_list = std::tuple<const_bfield_backend_t<scalar_t>,
+                                    inhom_bfield_backend_t<scalar_t>>;
+
 }  // namespace host
 }  // namespace traccc

--- a/core/src/finding/combinatorial_kalman_filter_algorithm_default_detector.cpp
+++ b/core/src/finding/combinatorial_kalman_filter_algorithm_default_detector.cpp
@@ -22,19 +22,12 @@ combinatorial_kalman_filter_algorithm::operator()(
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
     // Perform the track finding using the appropriate templated implementation.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(), measurements,
-            seeds, m_config, m_mr.get(), logger());
-    } else if (bfield.is<host::inhom_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter(
-            det, bfield.as_view<host::inhom_bfield_backend_t<scalar>>(),
-            measurements, seeds, m_config, m_mr.get(), logger());
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::host::combinatorial_kalman_filter_algorithm");
-    }
+    return magnetic_field_visitor<bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::combinatorial_kalman_filter(
+                det, bfield_view, measurements, seeds, m_config, m_mr.get(),
+                logger());
+        });
 }
 
 }  // namespace traccc::host

--- a/core/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.cpp
+++ b/core/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.cpp
@@ -22,19 +22,12 @@ combinatorial_kalman_filter_algorithm::operator()(
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
     // Perform the track finding using the appropriate templated implementation.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(), measurements,
-            seeds, m_config, m_mr.get(), logger());
-    } else if (bfield.is<host::inhom_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter(
-            det, bfield.as_view<host::inhom_bfield_backend_t<scalar>>(),
-            measurements, seeds, m_config, m_mr.get(), logger());
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::host::combinatorial_kalman_filter_algorithm");
-    }
+    return magnetic_field_visitor<bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::combinatorial_kalman_filter(
+                det, bfield_view, measurements, seeds, m_config, m_mr.get(),
+                logger());
+        });
 }
 
 }  // namespace traccc::host

--- a/core/src/fitting/kalman_fitting_algorithm_default_detector.cpp
+++ b/core/src/fitting/kalman_fitting_algorithm_default_detector.cpp
@@ -21,28 +21,15 @@ kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
     const edm::track_candidate_container<default_algebra>::const_view&
         track_candidates) const {
 
-    // Perform the track finding using the appropriate templated implementation.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        traccc::details::kalman_fitter_t<
-            default_detector::host,
-            covfie::field<const_bfield_backend_t<scalar>>::view_t>
-            fitter{det, bfield.as_view<const_bfield_backend_t<scalar>>(),
-                   m_config};
-        return details::kalman_fitting<default_algebra>(
-            fitter, track_candidates, m_mr.get(), m_copy.get());
-    } else if (bfield.is<host::inhom_bfield_backend_t<scalar>>()) {
-        traccc::details::kalman_fitter_t<
-            default_detector::host,
-            covfie::field<host::inhom_bfield_backend_t<scalar>>::view_t>
-            fitter{det, bfield.as_view<host::inhom_bfield_backend_t<scalar>>(),
-                   m_config};
-        return details::kalman_fitting<default_algebra>(
-            fitter, track_candidates, m_mr.get(), m_copy.get());
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::host::kalman_fitting_algorithm");
-    }
+    // Perform the track fitting using the appropriate templated implementation.
+    return magnetic_field_visitor<bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            traccc::details::kalman_fitter_t<default_detector::host,
+                                             bfield_view_t>
+                fitter{det, bfield_view, m_config};
+            return details::kalman_fitting<default_algebra>(
+                fitter, track_candidates, m_mr.get(), m_copy.get());
+        });
 }
 
 }  // namespace traccc::host

--- a/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.cpp
+++ b/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.cpp
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "../utils/get_queue.hpp"
+#include "../utils/magnetic_field_types.hpp"
 #include "combinatorial_kalman_filter.hpp"
 #include "traccc/alpaka/finding/combinatorial_kalman_filter_algorithm.hpp"
 
@@ -22,16 +23,13 @@ combinatorial_kalman_filter_algorithm::operator()(
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
     // Perform the track finding using the templated implementation.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter<telescope_detector::device>(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(), measurements,
-            seeds, m_config, m_mr, m_copy, logger(),
-            details::get_queue(m_queue.get()));
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::alpaka::combinatorial_kalman_filter_algorithm");
-    }
+    return magnetic_field_visitor<alpaka::bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::combinatorial_kalman_filter<
+                telescope_detector::device>(
+                det, bfield_view, measurements, seeds, m_config, m_mr, m_copy,
+                logger(), details::get_queue(m_queue.get()));
+        });
 }
 
 }  // namespace traccc::alpaka

--- a/device/alpaka/src/fitting/kalman_fitting_algorithm_default_detector.cpp
+++ b/device/alpaka/src/fitting/kalman_fitting_algorithm_default_detector.cpp
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "../utils/get_queue.hpp"
+#include "../utils/magnetic_field_types.hpp"
 #include "kalman_fitting.hpp"
 #include "traccc/alpaka/fitting/kalman_fitting_algorithm.hpp"
 
@@ -21,16 +22,12 @@ kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
         track_candidates) const {
 
     // Run the track fitting.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::kalman_fitting<default_detector::device>(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(),
-            track_candidates, m_config, m_mr, m_copy.get(),
-            details::get_queue(m_queue.get()));
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::alpaka::kalman_fitting_algorithm");
-    }
+    return magnetic_field_visitor<alpaka::bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::kalman_fitting<default_detector::device>(
+                det, bfield_view, track_candidates, m_config, m_mr,
+                m_copy.get(), details::get_queue(m_queue.get()));
+        });
 }
 
 }  // namespace traccc::alpaka

--- a/device/alpaka/src/utils/magnetic_field_types.hpp
+++ b/device/alpaka/src/utils/magnetic_field_types.hpp
@@ -1,0 +1,18 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/bfield/magnetic_field_types.hpp"
+
+namespace traccc::alpaka {
+
+/// @brief the standard list of Alpaka bfield types to support
+template <typename scalar_t>
+using bfield_type_list = std::tuple<const_bfield_backend_t<scalar_t> >;
+
+}  // namespace traccc::alpaka

--- a/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_default_detector.cu
+++ b/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_default_detector.cu
@@ -24,26 +24,14 @@ combinatorial_kalman_filter_algorithm::operator()(
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
-    // Perform the track finding using the templated implementation.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter<default_detector::device>(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(), measurements,
-            seeds, m_config, m_mr, m_copy, logger(), m_stream, m_warp_size);
-    } else if (bfield.is<cuda::inhom_global_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter<default_detector::device>(
-            det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
-            measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
-            m_warp_size);
-    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t>()) {
-        return details::combinatorial_kalman_filter<default_detector::device>(
-            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t>(),
-            measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
-            m_warp_size);
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::cuda::combinatorial_kalman_filter_algorithm");
-    }
+    // Perform the track finding using the appropriate templated implementation.
+    return magnetic_field_visitor<cuda::bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::combinatorial_kalman_filter<
+                default_detector::device>(det, bfield_view, measurements, seeds,
+                                          m_config, m_mr, m_copy, logger(),
+                                          m_stream, m_warp_size);
+        });
 }
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.cu
+++ b/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.cu
@@ -24,26 +24,14 @@ combinatorial_kalman_filter_algorithm::operator()(
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
-    // Perform the track finding using the templated implementation.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter<telescope_detector::device>(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(), measurements,
-            seeds, m_config, m_mr, m_copy, logger(), m_stream, m_warp_size);
-    } else if (bfield.is<cuda::inhom_global_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter<telescope_detector::device>(
-            det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
-            measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
-            m_warp_size);
-    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t>()) {
-        return details::combinatorial_kalman_filter<telescope_detector::device>(
-            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t>(),
-            measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
-            m_warp_size);
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::cuda::combinatorial_kalman_filter_algorithm");
-    }
+    // Perform the track finding using the appropriate templated implementation.
+    return magnetic_field_visitor<cuda::bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::combinatorial_kalman_filter<
+                telescope_detector::device>(det, bfield_view, measurements,
+                                            seeds, m_config, m_mr, m_copy,
+                                            logger(), m_stream, m_warp_size);
+        });
 }
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/fitting/kalman_fitting_algorithm_default_detector.cu
+++ b/device/cuda/src/fitting/kalman_fitting_algorithm_default_detector.cu
@@ -21,26 +21,12 @@ kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
         track_candidates) const {
 
     // Run the track fitting.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::kalman_fitting<default_detector::device>(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(),
-            track_candidates, m_config, m_mr, m_copy.get(), m_stream,
-            m_warp_size);
-    } else if (bfield.is<cuda::inhom_global_bfield_backend_t<scalar>>()) {
-        return details::kalman_fitting<default_detector::device>(
-            det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
-            track_candidates, m_config, m_mr, m_copy.get(), m_stream,
-            m_warp_size);
-    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t>()) {
-        return details::kalman_fitting<default_detector::device>(
-            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t>(),
-            track_candidates, m_config, m_mr, m_copy.get(), m_stream,
-            m_warp_size);
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::cuda::kalman_fitting_algorithm");
-    }
+    return magnetic_field_visitor<cuda::bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::kalman_fitting<default_detector::device>(
+                det, bfield_view, track_candidates, m_config, m_mr,
+                m_copy.get(), m_stream, m_warp_size);
+        });
 }
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/fitting/kalman_fitting_algorithm_telescope_detector.cu
+++ b/device/cuda/src/fitting/kalman_fitting_algorithm_telescope_detector.cu
@@ -21,26 +21,12 @@ kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
         track_candidates) const {
 
     // Run the track fitting.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::kalman_fitting<telescope_detector::device>(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(),
-            track_candidates, m_config, m_mr, m_copy.get(), m_stream,
-            m_warp_size);
-    } else if (bfield.is<cuda::inhom_global_bfield_backend_t<scalar>>()) {
-        return details::kalman_fitting<telescope_detector::device>(
-            det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
-            track_candidates, m_config, m_mr, m_copy.get(), m_stream,
-            m_warp_size);
-    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t>()) {
-        return details::kalman_fitting<telescope_detector::device>(
-            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t>(),
-            track_candidates, m_config, m_mr, m_copy.get(), m_stream,
-            m_warp_size);
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::cuda::kalman_fitting_algorithm");
-    }
+    return magnetic_field_visitor<cuda::bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::kalman_fitting<telescope_detector::device>(
+                det, bfield_view, track_candidates, m_config, m_mr,
+                m_copy.get(), m_stream, m_warp_size);
+        });
 }
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/utils/magnetic_field_types.hpp
+++ b/device/cuda/src/utils/magnetic_field_types.hpp
@@ -19,6 +19,8 @@
 #include <covfie/cuda/backend/primitive/cuda_device_array.hpp>
 #include <covfie/cuda/backend/primitive/cuda_texture.hpp>
 
+#include "traccc/bfield/magnetic_field_types.hpp"
+
 namespace traccc::cuda {
 
 /// Inhomogeneous B-field backend type using CUDA global memory
@@ -41,5 +43,11 @@ using inhom_texture_bfield_backend_t = covfie::backend::affine<
 static_assert(
     covfie::concepts::field_backend<inhom_texture_bfield_backend_t>,
     "cuda::inhom_texture_bfield_backend_t is not a valid field backend type");
+
+/// @brief the standard list of CUDA bfield types to support
+template <typename scalar_t>
+using bfield_type_list = std::tuple<const_bfield_backend_t<scalar_t>,
+                                    inhom_global_bfield_backend_t<scalar_t>,
+                                    inhom_texture_bfield_backend_t>;
 
 }  // namespace traccc::cuda

--- a/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_default_detector.sycl
+++ b/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_default_detector.sycl
@@ -20,8 +20,8 @@
 
 namespace traccc::sycl {
 namespace kernels {
-struct ckf_constant_field_default_detector;
-struct ckf_inhomogeneous_field_default_detector;
+template <typename bfield_tag_t>
+struct ckf_default_detector;
 }  // namespace kernels
 
 combinatorial_kalman_filter_algorithm::output_type
@@ -31,24 +31,15 @@ combinatorial_kalman_filter_algorithm::operator()(
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
     // Perform the track finding using the templated implementation.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter<
-            kernels::ckf_constant_field_default_detector,
-            default_detector::device>(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(), measurements,
-            seeds, m_config, m_mr, m_copy, details::get_queue(m_queue));
-    } else if (bfield.is<sycl::inhom_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter<
-            kernels::ckf_inhomogeneous_field_default_detector,
-            default_detector::device>(
-            det, bfield.as_view<sycl::inhom_bfield_backend_t<scalar>>(),
-            measurements, seeds, m_config, m_mr, m_copy,
-            details::get_queue(m_queue));
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::sycl::combinatorial_kalman_filter_algorithm");
-    }
+    return magnetic_field_visitor<sycl::bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::combinatorial_kalman_filter<
+                kernels::ckf_default_detector<
+                    bfield_tag_selector_t<typename bfield_view_t::backend_t>>,
+                default_detector::device>(det, bfield_view, measurements, seeds,
+                                          m_config, m_mr, m_copy,
+                                          details::get_queue(m_queue));
+        });
 }
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.sycl
+++ b/device/sycl/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.sycl
@@ -20,8 +20,8 @@
 
 namespace traccc::sycl {
 namespace kernels {
-struct ckf_constant_field_telescope_detector;
-struct ckf_inhomogeneous_field_telescope_detector;
+template <typename bfield_tag_t>
+struct ckf_telescope_detector;
 }  // namespace kernels
 
 combinatorial_kalman_filter_algorithm::output_type
@@ -31,24 +31,15 @@ combinatorial_kalman_filter_algorithm::operator()(
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
     // Perform the track finding using the templated implementation.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter<
-            kernels::ckf_constant_field_telescope_detector,
-            telescope_detector::device>(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(), measurements,
-            seeds, m_config, m_mr, m_copy, details::get_queue(m_queue));
-    } else if (bfield.is<sycl::inhom_bfield_backend_t<scalar>>()) {
-        return details::combinatorial_kalman_filter<
-            kernels::ckf_inhomogeneous_field_telescope_detector,
-            telescope_detector::device>(
-            det, bfield.as_view<sycl::inhom_bfield_backend_t<scalar>>(),
-            measurements, seeds, m_config, m_mr, m_copy,
-            details::get_queue(m_queue));
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::sycl::combinatorial_kalman_filter_algorithm");
-    }
+    return magnetic_field_visitor<sycl::bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::combinatorial_kalman_filter<
+                kernels::ckf_telescope_detector<
+                    bfield_tag_selector_t<typename bfield_view_t::backend_t>>,
+                telescope_detector::device>(det, bfield_view, measurements,
+                                            seeds, m_config, m_mr, m_copy,
+                                            details::get_queue(m_queue));
+        });
 }
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/fitting/kalman_fitting_algorithm_default_detector.sycl
+++ b/device/sycl/src/fitting/kalman_fitting_algorithm_default_detector.sycl
@@ -16,8 +16,8 @@
 
 namespace traccc::sycl {
 namespace kernels {
-struct fit_tracks_constant_field_default_detector;
-struct fit_tracks_inhomogeneous_field_default_detector;
+template <typename bfield_tag_t>
+struct fit_tracks_default_detector;
 }  // namespace kernels
 
 kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
@@ -25,26 +25,16 @@ kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
     const edm::track_candidate_container<default_algebra>::const_view&
         track_candidates) const {
 
-    // Run the track fitting.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::kalman_fitting<
-            kernels::fit_tracks_constant_field_default_detector,
-            default_detector::device>(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(),
-            track_candidates, m_config, m_mr, m_copy.get(),
-            details::get_queue(m_queue));
-    } else if (bfield.is<sycl::inhom_bfield_backend_t<scalar>>()) {
-        return details::kalman_fitting<
-            kernels::fit_tracks_inhomogeneous_field_default_detector,
-            default_detector::device>(
-            det, bfield.as_view<sycl::inhom_bfield_backend_t<scalar>>(),
-            track_candidates, m_config, m_mr, m_copy.get(),
-            details::get_queue(m_queue));
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::sycl::kalman_fitting_algorithm");
-    }
+    // Perform the track fitting using the templated implementation.
+    return magnetic_field_visitor<sycl::bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::kalman_fitting<
+                kernels::fit_tracks_default_detector<
+                    bfield_tag_selector_t<typename bfield_view_t::backend_t>>,
+                default_detector::device>(det, bfield_view, track_candidates,
+                                          m_config, m_mr, m_copy.get(),
+                                          details::get_queue(m_queue));
+        });
 }
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/fitting/kalman_fitting_algorithm_telescope_detector.sycl
+++ b/device/sycl/src/fitting/kalman_fitting_algorithm_telescope_detector.sycl
@@ -16,8 +16,8 @@
 
 namespace traccc::sycl {
 namespace kernels {
-struct fit_tracks_constant_field_telescope_detector;
-struct fit_tracks_inhomogeneous_field_telescope_detector;
+template <typename bfield_tag_t>
+struct fit_tracks_telescope_detector;
 }  // namespace kernels
 
 kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
@@ -25,26 +25,16 @@ kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
     const edm::track_candidate_container<default_algebra>::const_view&
         track_candidates) const {
 
-    // Run the track fitting.
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return details::kalman_fitting<
-            kernels::fit_tracks_constant_field_telescope_detector,
-            telescope_detector::device>(
-            det, bfield.as_view<const_bfield_backend_t<scalar>>(),
-            track_candidates, m_config, m_mr, m_copy.get(),
-            details::get_queue(m_queue));
-    } else if (bfield.is<sycl::inhom_bfield_backend_t<scalar>>()) {
-        return details::kalman_fitting<
-            kernels::fit_tracks_inhomogeneous_field_telescope_detector,
-            telescope_detector::device>(
-            det, bfield.as_view<sycl::inhom_bfield_backend_t<scalar>>(),
-            track_candidates, m_config, m_mr, m_copy.get(),
-            details::get_queue(m_queue));
-    } else {
-        throw std::invalid_argument(
-            "Unsupported b-field type received in "
-            "traccc::sycl::kalman_fitting_algorithm");
-    }
+    // Perform the track fitting using the templated implementation.
+    return magnetic_field_visitor<sycl::bfield_type_list<scalar>>(
+        bfield, [&]<typename bfield_view_t>(const bfield_view_t& bfield_view) {
+            return details::kalman_fitting<
+                kernels::fit_tracks_telescope_detector<
+                    bfield_tag_selector_t<typename bfield_view_t::backend_t>>,
+                telescope_detector::device>(det, bfield_view, track_candidates,
+                                            m_config, m_mr, m_copy.get(),
+                                            details::get_queue(m_queue));
+        });
 }
 
 }  // namespace traccc::sycl

--- a/device/sycl/src/utils/magnetic_field_types.hpp
+++ b/device/sycl/src/utils/magnetic_field_types.hpp
@@ -18,6 +18,10 @@
 #include <covfie/core/vector.hpp>
 #include <covfie/sycl/backend/primitive/sycl_device_array.hpp>
 
+#include "traccc/bfield/magnetic_field.hpp"
+#include "traccc/bfield/magnetic_field_types.hpp"
+#include "traccc/definitions/primitives.hpp"
+
 namespace traccc::sycl {
 
 /// Inhomogeneous B-field backend type for CUDA
@@ -30,5 +34,49 @@ using inhom_bfield_backend_t =
 // Test that the type is a valid backend for a field
 static_assert(covfie::concepts::field_backend<inhom_bfield_backend_t<float>>,
               "sycl::inhom_bfield_backend_t is not a valid field backend type");
+
+/// @brief the standard list of SYCL bfield types to support
+template <typename scalar_t>
+using bfield_type_list = std::tuple<const_bfield_backend_t<scalar_t>,
+                                    inhom_bfield_backend_t<scalar_t>>;
+
+/*
+ * SYCL requires a little bit of extra massaging to make the kernel tags
+ * work...
+ */
+struct const_bfield_kernel_tag {};
+struct inhom_bfield_kernel_tag {};
+
+template <typename T>
+struct bfield_tag_selector {};
+
+template <typename scalar_t>
+struct bfield_tag_selector<const_bfield_backend_t<scalar_t>> {
+    using type = const_bfield_kernel_tag;
+};
+
+template <typename scalar_t>
+struct bfield_tag_selector<inhom_bfield_backend_t<scalar_t>> {
+    using type = inhom_bfield_kernel_tag;
+};
+
+template <typename T>
+using bfield_tag_selector_t = typename bfield_tag_selector<T>::type;
+
+template <typename T>
+concept bfield_tag_exists_for_backend =
+    requires { typename bfield_tag_selector_t<T>; };
+
+template <typename>
+struct bfield_tag_existance_validator {};
+
+template <typename... Ts>
+struct bfield_tag_existance_validator<std::tuple<Ts...>> {
+    static constexpr bool value = (bfield_tag_exists_for_backend<Ts> && ...);
+};
+
+static_assert(
+    bfield_tag_existance_validator<bfield_type_list<scalar>>::value,
+    "Not all B-field types registered for SYCL have an accompanying tag");
 
 }  // namespace traccc::sycl


### PR DESCRIPTION
This commit implements the visitor logic that I proposed for #1033, drastically reducing the amount of boilerplate we need to handle different magnetic field types and increasing the maintainability of the code significantly. This also paves the way for polymorphic detector types which we will need in the future.