### PR TITLE
CUDA Texture B-Field, main branch (2025.07.11.)

### DIFF
--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -78,8 +78,10 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/finding/kernels/specializations/apply_interaction_telescope_detector.cu"
   "src/finding/kernels/specializations/propagate_to_next_surface_constant_field_default_detector.cu"
   "src/finding/kernels/specializations/propagate_to_next_surface_constant_field_telescope_detector.cu"
-  "src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_field_default_detector.cu"
-  "src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_field_telescope_detector.cu"
+  "src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_global_field_default_detector.cu"
+  "src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_global_field_telescope_detector.cu"
+  "src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_texture_field_default_detector.cu"
+  "src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_texture_field_telescope_detector.cu"
   # Ambiguity resolution
   "include/traccc/cuda/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp"
   "src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu"
@@ -125,12 +127,16 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/fitting/kernels/fit_prelude.cu"
   "src/fitting/kernels/specializations/fit_forward_constant_field_default_detector.cu"
   "src/fitting/kernels/specializations/fit_forward_constant_field_telescope_detector.cu"
-  "src/fitting/kernels/specializations/fit_forward_inhomogeneous_field_default_detector.cu"
-  "src/fitting/kernels/specializations/fit_forward_inhomogeneous_field_telescope_detector.cu"
+  "src/fitting/kernels/specializations/fit_forward_inhomogeneous_global_field_default_detector.cu"
+  "src/fitting/kernels/specializations/fit_forward_inhomogeneous_global_field_telescope_detector.cu"
+  "src/fitting/kernels/specializations/fit_forward_inhomogeneous_texture_field_default_detector.cu"
+  "src/fitting/kernels/specializations/fit_forward_inhomogeneous_texture_field_telescope_detector.cu"
   "src/fitting/kernels/specializations/fit_backward_constant_field_default_detector.cu"
   "src/fitting/kernels/specializations/fit_backward_constant_field_telescope_detector.cu"
-  "src/fitting/kernels/specializations/fit_backward_inhomogeneous_field_default_detector.cu"
-  "src/fitting/kernels/specializations/fit_backward_inhomogeneous_field_telescope_detector.cu"
+  "src/fitting/kernels/specializations/fit_backward_inhomogeneous_global_field_default_detector.cu"
+  "src/fitting/kernels/specializations/fit_backward_inhomogeneous_global_field_telescope_detector.cu"
+  "src/fitting/kernels/specializations/fit_backward_inhomogeneous_texture_field_default_detector.cu"
+  "src/fitting/kernels/specializations/fit_backward_inhomogeneous_texture_field_telescope_detector.cu"
 )
 
 if(TRACCC_ENABLE_NVTX_PROFILING)

--- a/device/cuda/include/traccc/cuda/utils/make_magnetic_field.hpp
+++ b/device/cuda/include/traccc/cuda/utils/make_magnetic_field.hpp
@@ -12,12 +12,21 @@
 
 namespace traccc::cuda {
 
+/// Storage method for inhomogeneous magnetic fields
+enum class magnetic_field_storage {
+    global_memory,  ///< Store the magnetic field in global device memory
+    texture_memory  ///< Store the magnetic field in texture device memory
+};
+
 /// Create a magnetic field usable on the active CUDA device
 ///
 /// @param bfield The magnetic field to be copied
+/// @param storage The storage method to use for the magnetic field
 /// @return A copy of the magnetic field that can be used on the active CUDA
 ///         device
 ///
-magnetic_field make_magnetic_field(const magnetic_field& bfield);
+magnetic_field make_magnetic_field(
+    const magnetic_field& bfield,
+    magnetic_field_storage storage = magnetic_field_storage::global_memory);
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_default_detector.cu
+++ b/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_default_detector.cu
@@ -29,9 +29,14 @@ combinatorial_kalman_filter_algorithm::operator()(
         return details::combinatorial_kalman_filter<default_detector::device>(
             det, bfield.as_view<const_bfield_backend_t<scalar>>(), measurements,
             seeds, m_config, m_mr, m_copy, logger(), m_stream, m_warp_size);
-    } else if (bfield.is<cuda::inhom_bfield_backend_t<scalar>>()) {
+    } else if (bfield.is<cuda::inhom_global_bfield_backend_t<scalar>>()) {
         return details::combinatorial_kalman_filter<default_detector::device>(
-            det, bfield.as_view<cuda::inhom_bfield_backend_t<scalar>>(),
+            det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
+            measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
+            m_warp_size);
+    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t<float>>()) {
+        return details::combinatorial_kalman_filter<default_detector::device>(
+            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t<float>>(),
             measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
             m_warp_size);
     } else {

--- a/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_default_detector.cu
+++ b/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_default_detector.cu
@@ -34,9 +34,9 @@ combinatorial_kalman_filter_algorithm::operator()(
             det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
             measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
             m_warp_size);
-    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t<float>>()) {
+    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t>()) {
         return details::combinatorial_kalman_filter<default_detector::device>(
-            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t<float>>(),
+            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t>(),
             measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
             m_warp_size);
     } else {

--- a/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.cu
+++ b/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.cu
@@ -34,9 +34,9 @@ combinatorial_kalman_filter_algorithm::operator()(
             det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
             measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
             m_warp_size);
-    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t<float>>()) {
+    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t>()) {
         return details::combinatorial_kalman_filter<telescope_detector::device>(
-            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t<float>>(),
+            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t>(),
             measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
             m_warp_size);
     } else {

--- a/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.cu
+++ b/device/cuda/src/finding/combinatorial_kalman_filter_algorithm_telescope_detector.cu
@@ -29,9 +29,14 @@ combinatorial_kalman_filter_algorithm::operator()(
         return details::combinatorial_kalman_filter<telescope_detector::device>(
             det, bfield.as_view<const_bfield_backend_t<scalar>>(), measurements,
             seeds, m_config, m_mr, m_copy, logger(), m_stream, m_warp_size);
-    } else if (bfield.is<cuda::inhom_bfield_backend_t<scalar>>()) {
+    } else if (bfield.is<cuda::inhom_global_bfield_backend_t<scalar>>()) {
         return details::combinatorial_kalman_filter<telescope_detector::device>(
-            det, bfield.as_view<cuda::inhom_bfield_backend_t<scalar>>(),
+            det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
+            measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
+            m_warp_size);
+    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t<float>>()) {
+        return details::combinatorial_kalman_filter<telescope_detector::device>(
+            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t<float>>(),
             measurements, seeds, m_config, m_mr, m_copy, logger(), m_stream,
             m_warp_size);
     } else {

--- a/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_global_field_default_detector.cu
+++ b/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_global_field_default_detector.cu
@@ -18,9 +18,10 @@
 
 namespace traccc::cuda {
 
-using bfield_t = covfie::field<cuda::inhom_bfield_backend_t<scalar>>::view_t;
+using bfield_t =
+    covfie::field<cuda::inhom_global_bfield_backend_t<scalar>>::view_t;
 using propagator_t =
-    traccc::details::ckf_propagator_t<telescope_detector::device, bfield_t>;
+    traccc::details::ckf_propagator_t<default_detector::device, bfield_t>;
 
 template void propagate_to_next_surface<propagator_t, bfield_t>(
     const dim3& grid_size, const dim3& block_size, std::size_t shared_mem_size,

--- a/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_global_field_telescope_detector.cu
+++ b/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_global_field_telescope_detector.cu
@@ -1,0 +1,31 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../../../utils/magnetic_field_types.hpp"
+#include "propagate_to_next_surface_src.cuh"
+
+// Project include(s).
+#include "traccc/finding/details/combinatorial_kalman_filter_types.hpp"
+#include "traccc/geometry/detector.hpp"
+
+// Covfie include(s).
+#include <covfie/core/field.hpp>
+
+namespace traccc::cuda {
+
+using bfield_t =
+    covfie::field<cuda::inhom_global_bfield_backend_t<scalar>>::view_t;
+using propagator_t =
+    traccc::details::ckf_propagator_t<telescope_detector::device, bfield_t>;
+
+template void propagate_to_next_surface<propagator_t, bfield_t>(
+    const dim3& grid_size, const dim3& block_size, std::size_t shared_mem_size,
+    const cudaStream_t& stream, const finding_config,
+    device::propagate_to_next_surface_payload<propagator_t, bfield_t>);
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_texture_field_default_detector.cu
+++ b/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_texture_field_default_detector.cu
@@ -18,8 +18,7 @@
 
 namespace traccc::cuda {
 
-using bfield_t =
-    covfie::field<cuda::inhom_texture_bfield_backend_t<float>>::view_t;
+using bfield_t = covfie::field<cuda::inhom_texture_bfield_backend_t>::view_t;
 using propagator_t =
     traccc::details::ckf_propagator_t<default_detector::device, bfield_t>;
 

--- a/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_texture_field_default_detector.cu
+++ b/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_texture_field_default_detector.cu
@@ -18,7 +18,8 @@
 
 namespace traccc::cuda {
 
-using bfield_t = covfie::field<cuda::inhom_bfield_backend_t<scalar>>::view_t;
+using bfield_t =
+    covfie::field<cuda::inhom_texture_bfield_backend_t<float>>::view_t;
 using propagator_t =
     traccc::details::ckf_propagator_t<default_detector::device, bfield_t>;
 

--- a/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_texture_field_telescope_detector.cu
+++ b/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_texture_field_telescope_detector.cu
@@ -1,0 +1,31 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../../../utils/magnetic_field_types.hpp"
+#include "propagate_to_next_surface_src.cuh"
+
+// Project include(s).
+#include "traccc/finding/details/combinatorial_kalman_filter_types.hpp"
+#include "traccc/geometry/detector.hpp"
+
+// Covfie include(s).
+#include <covfie/core/field.hpp>
+
+namespace traccc::cuda {
+
+using bfield_t =
+    covfie::field<cuda::inhom_texture_bfield_backend_t<float>>::view_t;
+using propagator_t =
+    traccc::details::ckf_propagator_t<telescope_detector::device, bfield_t>;
+
+template void propagate_to_next_surface<propagator_t, bfield_t>(
+    const dim3& grid_size, const dim3& block_size, std::size_t shared_mem_size,
+    const cudaStream_t& stream, const finding_config,
+    device::propagate_to_next_surface_payload<propagator_t, bfield_t>);
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_texture_field_telescope_detector.cu
+++ b/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_inhomogeneous_texture_field_telescope_detector.cu
@@ -18,8 +18,7 @@
 
 namespace traccc::cuda {
 
-using bfield_t =
-    covfie::field<cuda::inhom_texture_bfield_backend_t<float>>::view_t;
+using bfield_t = covfie::field<cuda::inhom_texture_bfield_backend_t>::view_t;
 using propagator_t =
     traccc::details::ckf_propagator_t<telescope_detector::device, bfield_t>;
 

--- a/device/cuda/src/fitting/kalman_fitting_algorithm_default_detector.cu
+++ b/device/cuda/src/fitting/kalman_fitting_algorithm_default_detector.cu
@@ -26,9 +26,14 @@ kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
             det, bfield.as_view<const_bfield_backend_t<scalar>>(),
             track_candidates, m_config, m_mr, m_copy.get(), m_stream,
             m_warp_size);
-    } else if (bfield.is<cuda::inhom_bfield_backend_t<scalar>>()) {
+    } else if (bfield.is<cuda::inhom_global_bfield_backend_t<scalar>>()) {
         return details::kalman_fitting<default_detector::device>(
-            det, bfield.as_view<cuda::inhom_bfield_backend_t<scalar>>(),
+            det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
+            track_candidates, m_config, m_mr, m_copy.get(), m_stream,
+            m_warp_size);
+    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t<float>>()) {
+        return details::kalman_fitting<default_detector::device>(
+            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t<float>>(),
             track_candidates, m_config, m_mr, m_copy.get(), m_stream,
             m_warp_size);
     } else {

--- a/device/cuda/src/fitting/kalman_fitting_algorithm_default_detector.cu
+++ b/device/cuda/src/fitting/kalman_fitting_algorithm_default_detector.cu
@@ -31,9 +31,9 @@ kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
             det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
             track_candidates, m_config, m_mr, m_copy.get(), m_stream,
             m_warp_size);
-    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t<float>>()) {
+    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t>()) {
         return details::kalman_fitting<default_detector::device>(
-            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t<float>>(),
+            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t>(),
             track_candidates, m_config, m_mr, m_copy.get(), m_stream,
             m_warp_size);
     } else {

--- a/device/cuda/src/fitting/kalman_fitting_algorithm_telescope_detector.cu
+++ b/device/cuda/src/fitting/kalman_fitting_algorithm_telescope_detector.cu
@@ -31,9 +31,9 @@ kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
             det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
             track_candidates, m_config, m_mr, m_copy.get(), m_stream,
             m_warp_size);
-    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t<float>>()) {
+    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t>()) {
         return details::kalman_fitting<telescope_detector::device>(
-            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t<float>>(),
+            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t>(),
             track_candidates, m_config, m_mr, m_copy.get(), m_stream,
             m_warp_size);
     } else {

--- a/device/cuda/src/fitting/kalman_fitting_algorithm_telescope_detector.cu
+++ b/device/cuda/src/fitting/kalman_fitting_algorithm_telescope_detector.cu
@@ -26,9 +26,14 @@ kalman_fitting_algorithm::output_type kalman_fitting_algorithm::operator()(
             det, bfield.as_view<const_bfield_backend_t<scalar>>(),
             track_candidates, m_config, m_mr, m_copy.get(), m_stream,
             m_warp_size);
-    } else if (bfield.is<cuda::inhom_bfield_backend_t<scalar>>()) {
+    } else if (bfield.is<cuda::inhom_global_bfield_backend_t<scalar>>()) {
         return details::kalman_fitting<telescope_detector::device>(
-            det, bfield.as_view<cuda::inhom_bfield_backend_t<scalar>>(),
+            det, bfield.as_view<cuda::inhom_global_bfield_backend_t<scalar>>(),
+            track_candidates, m_config, m_mr, m_copy.get(), m_stream,
+            m_warp_size);
+    } else if (bfield.is<cuda::inhom_texture_bfield_backend_t<float>>()) {
+        return details::kalman_fitting<telescope_detector::device>(
+            det, bfield.as_view<cuda::inhom_texture_bfield_backend_t<float>>(),
             track_candidates, m_config, m_mr, m_copy.get(), m_stream,
             m_warp_size);
     } else {

--- a/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_global_field_default_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_global_field_default_detector.cu
@@ -18,9 +18,9 @@
 
 namespace traccc::cuda {
 using fitter = traccc::details::kalman_fitter_t<
-    telescope_detector::device,
-    covfie::field<traccc::cuda::inhom_bfield_backend_t<
-        telescope_detector::device::scalar_type>>::view_t>;
+    default_detector::device,
+    covfie::field<traccc::cuda::inhom_global_bfield_backend_t<
+        default_detector::device::scalar_type>>::view_t>;
 
 template void fit_backward<fitter>(const dim3& grid_size,
                                    const dim3& block_size,

--- a/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_global_field_telescope_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_global_field_telescope_detector.cu
@@ -1,0 +1,32 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../../../utils/magnetic_field_types.hpp"
+#include "fit_backward_src.cuh"
+
+// Project include(s).
+#include "traccc/fitting/details/kalman_fitting_types.hpp"
+#include "traccc/geometry/detector.hpp"
+
+// Covfie include(s).
+#include <covfie/core/field.hpp>
+
+namespace traccc::cuda {
+using fitter = traccc::details::kalman_fitter_t<
+    telescope_detector::device,
+    covfie::field<traccc::cuda::inhom_global_bfield_backend_t<
+        telescope_detector::device::scalar_type>>::view_t>;
+
+template void fit_backward<fitter>(const dim3& grid_size,
+                                   const dim3& block_size,
+                                   std::size_t shared_mem_size,
+                                   const cudaStream_t& stream,
+                                   const fitting_config& cfg,
+                                   const device::fit_payload<fitter>& payload);
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_texture_field_default_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_texture_field_default_detector.cu
@@ -7,7 +7,7 @@
 
 // Local include(s).
 #include "../../../utils/magnetic_field_types.hpp"
-#include "fit_forward_src.cuh"
+#include "fit_backward_src.cuh"
 
 // Project include(s).
 #include "traccc/fitting/details/kalman_fitting_types.hpp"
@@ -19,13 +19,13 @@
 namespace traccc::cuda {
 using fitter = traccc::details::kalman_fitter_t<
     default_detector::device,
-    covfie::field<traccc::cuda::inhom_bfield_backend_t<
-        default_detector::device::scalar_type>>::view_t>;
+    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t<float>>::view_t>;
 
-template void fit_forward<fitter>(const dim3& grid_size, const dim3& block_size,
-                                  std::size_t shared_mem_size,
-                                  const cudaStream_t& stream,
-                                  const fitting_config& cfg,
-                                  const device::fit_payload<fitter>& payload);
+template void fit_backward<fitter>(const dim3& grid_size,
+                                   const dim3& block_size,
+                                   std::size_t shared_mem_size,
+                                   const cudaStream_t& stream,
+                                   const fitting_config& cfg,
+                                   const device::fit_payload<fitter>& payload);
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_texture_field_default_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_texture_field_default_detector.cu
@@ -19,7 +19,7 @@
 namespace traccc::cuda {
 using fitter = traccc::details::kalman_fitter_t<
     default_detector::device,
-    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t<float>>::view_t>;
+    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t>::view_t>;
 
 template void fit_backward<fitter>(const dim3& grid_size,
                                    const dim3& block_size,

--- a/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_texture_field_telescope_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_texture_field_telescope_detector.cu
@@ -19,7 +19,7 @@
 namespace traccc::cuda {
 using fitter = traccc::details::kalman_fitter_t<
     telescope_detector::device,
-    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t<float>>::view_t>;
+    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t>::view_t>;
 
 template void fit_backward<fitter>(const dim3& grid_size,
                                    const dim3& block_size,

--- a/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_texture_field_telescope_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_backward_inhomogeneous_texture_field_telescope_detector.cu
@@ -1,0 +1,31 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../../../utils/magnetic_field_types.hpp"
+#include "fit_backward_src.cuh"
+
+// Project include(s).
+#include "traccc/fitting/details/kalman_fitting_types.hpp"
+#include "traccc/geometry/detector.hpp"
+
+// Covfie include(s).
+#include <covfie/core/field.hpp>
+
+namespace traccc::cuda {
+using fitter = traccc::details::kalman_fitter_t<
+    telescope_detector::device,
+    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t<float>>::view_t>;
+
+template void fit_backward<fitter>(const dim3& grid_size,
+                                   const dim3& block_size,
+                                   std::size_t shared_mem_size,
+                                   const cudaStream_t& stream,
+                                   const fitting_config& cfg,
+                                   const device::fit_payload<fitter>& payload);
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_global_field_default_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_global_field_default_detector.cu
@@ -18,9 +18,9 @@
 
 namespace traccc::cuda {
 using fitter = traccc::details::kalman_fitter_t<
-    telescope_detector::device,
-    covfie::field<traccc::cuda::inhom_bfield_backend_t<
-        telescope_detector::device::scalar_type>>::view_t>;
+    default_detector::device,
+    covfie::field<traccc::cuda::inhom_global_bfield_backend_t<
+        default_detector::device::scalar_type>>::view_t>;
 
 template void fit_forward<fitter>(const dim3& grid_size, const dim3& block_size,
                                   std::size_t shared_mem_size,

--- a/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_global_field_telescope_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_global_field_telescope_detector.cu
@@ -1,0 +1,31 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../../../utils/magnetic_field_types.hpp"
+#include "fit_forward_src.cuh"
+
+// Project include(s).
+#include "traccc/fitting/details/kalman_fitting_types.hpp"
+#include "traccc/geometry/detector.hpp"
+
+// Covfie include(s).
+#include <covfie/core/field.hpp>
+
+namespace traccc::cuda {
+using fitter = traccc::details::kalman_fitter_t<
+    telescope_detector::device,
+    covfie::field<traccc::cuda::inhom_global_bfield_backend_t<
+        telescope_detector::device::scalar_type>>::view_t>;
+
+template void fit_forward<fitter>(const dim3& grid_size, const dim3& block_size,
+                                  std::size_t shared_mem_size,
+                                  const cudaStream_t& stream,
+                                  const fitting_config& cfg,
+                                  const device::fit_payload<fitter>& payload);
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_texture_field_default_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_texture_field_default_detector.cu
@@ -19,7 +19,7 @@
 namespace traccc::cuda {
 using fitter = traccc::details::kalman_fitter_t<
     default_detector::device,
-    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t<float>>::view_t>;
+    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t>::view_t>;
 
 template void fit_forward<fitter>(const dim3& grid_size, const dim3& block_size,
                                   std::size_t shared_mem_size,

--- a/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_texture_field_default_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_texture_field_default_detector.cu
@@ -7,7 +7,7 @@
 
 // Local include(s).
 #include "../../../utils/magnetic_field_types.hpp"
-#include "fit_backward_src.cuh"
+#include "fit_forward_src.cuh"
 
 // Project include(s).
 #include "traccc/fitting/details/kalman_fitting_types.hpp"
@@ -19,14 +19,12 @@
 namespace traccc::cuda {
 using fitter = traccc::details::kalman_fitter_t<
     default_detector::device,
-    covfie::field<traccc::cuda::inhom_bfield_backend_t<
-        default_detector::device::scalar_type>>::view_t>;
+    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t<float>>::view_t>;
 
-template void fit_backward<fitter>(const dim3& grid_size,
-                                   const dim3& block_size,
-                                   std::size_t shared_mem_size,
-                                   const cudaStream_t& stream,
-                                   const fitting_config& cfg,
-                                   const device::fit_payload<fitter>& payload);
+template void fit_forward<fitter>(const dim3& grid_size, const dim3& block_size,
+                                  std::size_t shared_mem_size,
+                                  const cudaStream_t& stream,
+                                  const fitting_config& cfg,
+                                  const device::fit_payload<fitter>& payload);
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_texture_field_telescope_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_texture_field_telescope_detector.cu
@@ -1,0 +1,30 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../../../utils/magnetic_field_types.hpp"
+#include "fit_forward_src.cuh"
+
+// Project include(s).
+#include "traccc/fitting/details/kalman_fitting_types.hpp"
+#include "traccc/geometry/detector.hpp"
+
+// Covfie include(s).
+#include <covfie/core/field.hpp>
+
+namespace traccc::cuda {
+using fitter = traccc::details::kalman_fitter_t<
+    telescope_detector::device,
+    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t<float>>::view_t>;
+
+template void fit_forward<fitter>(const dim3& grid_size, const dim3& block_size,
+                                  std::size_t shared_mem_size,
+                                  const cudaStream_t& stream,
+                                  const fitting_config& cfg,
+                                  const device::fit_payload<fitter>& payload);
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_texture_field_telescope_detector.cu
+++ b/device/cuda/src/fitting/kernels/specializations/fit_forward_inhomogeneous_texture_field_telescope_detector.cu
@@ -19,7 +19,7 @@
 namespace traccc::cuda {
 using fitter = traccc::details::kalman_fitter_t<
     telescope_detector::device,
-    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t<float>>::view_t>;
+    covfie::field<traccc::cuda::inhom_texture_bfield_backend_t>::view_t>;
 
 template void fit_forward<fitter>(const dim3& grid_size, const dim3& block_size,
                                   std::size_t shared_mem_size,

--- a/device/cuda/src/utils/magnetic_field_types.hpp
+++ b/device/cuda/src/utils/magnetic_field_types.hpp
@@ -17,18 +17,30 @@
 #include <covfie/core/field.hpp>
 #include <covfie/core/vector.hpp>
 #include <covfie/cuda/backend/primitive/cuda_device_array.hpp>
+#include <covfie/cuda/backend/primitive/cuda_texture.hpp>
 
 namespace traccc::cuda {
 
-/// Inhomogeneous B-field backend type for CUDA
+/// Inhomogeneous B-field backend type using CUDA global memory
 template <typename scalar_t>
-using inhom_bfield_backend_t =
+using inhom_global_bfield_backend_t =
     covfie::backend::affine<covfie::backend::linear<covfie::backend::clamp<
         covfie::backend::strided<covfie::vector::vector_d<std::size_t, 3>,
                                  covfie::backend::cuda_device_array<
                                      covfie::vector::vector_d<scalar_t, 3>>>>>>;
 // Test that the type is a valid backend for a field
-static_assert(covfie::concepts::field_backend<inhom_bfield_backend_t<float>>,
-              "cuda::inhom_bfield_backend_t is not a valid field backend type");
+static_assert(
+    covfie::concepts::field_backend<inhom_global_bfield_backend_t<float>>,
+    "cuda::inhom_global_bfield_backend_t is not a valid field backend type");
+
+/// Inhomogeneous B-field backend type using CUDA texture memory
+template <typename scalar_t>
+using inhom_texture_bfield_backend_t = covfie::backend::affine<
+    covfie::backend::cuda_texture<covfie::vector::vector_d<scalar_t, 3>,
+                                  covfie::vector::vector_d<scalar_t, 3>>>;
+// Test that the type is a valid backend for a field
+static_assert(
+    covfie::concepts::field_backend<inhom_texture_bfield_backend_t<float>>,
+    "cuda::inhom_texture_bfield_backend_t is not a valid field backend type");
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/utils/magnetic_field_types.hpp
+++ b/device/cuda/src/utils/magnetic_field_types.hpp
@@ -34,13 +34,12 @@ static_assert(
     "cuda::inhom_global_bfield_backend_t is not a valid field backend type");
 
 /// Inhomogeneous B-field backend type using CUDA texture memory
-template <typename scalar_t>
 using inhom_texture_bfield_backend_t = covfie::backend::affine<
-    covfie::backend::cuda_texture<covfie::vector::vector_d<scalar_t, 3>,
-                                  covfie::vector::vector_d<scalar_t, 3>>>;
+    covfie::backend::cuda_texture<covfie::vector::vector_d<float, 3>,
+                                  covfie::vector::vector_d<float, 3>>>;
 // Test that the type is a valid backend for a field
 static_assert(
-    covfie::concepts::field_backend<inhom_texture_bfield_backend_t<float>>,
+    covfie::concepts::field_backend<inhom_texture_bfield_backend_t>,
     "cuda::inhom_texture_bfield_backend_t is not a valid field backend type");
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/utils/make_magnetic_field.cpp
+++ b/device/cuda/src/utils/make_magnetic_field.cpp
@@ -38,7 +38,7 @@ magnetic_field make_magnetic_field(const magnetic_field& bfield,
                     in_field)};
         } else if (storage == magnetic_field_storage::texture_memory) {
             return magnetic_field{
-                covfie::field<cuda::inhom_texture_bfield_backend_t<float>>(
+                covfie::field<cuda::inhom_texture_bfield_backend_t>(
                     covfie::make_parameter_pack(
                         in_field.backend().get_configuration(),
                         in_field.backend()

--- a/device/cuda/src/utils/make_magnetic_field.cpp
+++ b/device/cuda/src/utils/make_magnetic_field.cpp
@@ -12,22 +12,53 @@
 
 // Project include(s).
 #include "traccc/bfield/magnetic_field_types.hpp"
-#include "traccc/definitions/common.hpp"
 
 // System include(s).
 #include <stdexcept>
 
 namespace traccc::cuda {
 
-magnetic_field make_magnetic_field(const magnetic_field& bfield) {
+magnetic_field make_magnetic_field(const magnetic_field& bfield,
+                                   const magnetic_field_storage storage) {
 
-    if (bfield.is<const_bfield_backend_t<scalar>>()) {
-        return magnetic_field{covfie::field<const_bfield_backend_t<scalar>>{
-            bfield.as_field<const_bfield_backend_t<scalar>>()}};
-    } else if (bfield.is<host::inhom_bfield_backend_t<scalar>>()) {
-        return magnetic_field{
-            covfie::field<cuda::inhom_bfield_backend_t<scalar>>(
-                bfield.as_field<host::inhom_bfield_backend_t<scalar>>())};
+    if (bfield.is<const_bfield_backend_t<float>>()) {
+        return magnetic_field{covfie::field<const_bfield_backend_t<float>>{
+            bfield.as_field<const_bfield_backend_t<float>>()}};
+    } else if (bfield.is<const_bfield_backend_t<double>>()) {
+        return magnetic_field{covfie::field<const_bfield_backend_t<double>>{
+            bfield.as_field<const_bfield_backend_t<double>>()}};
+    } else if (bfield.is<host::inhom_bfield_backend_t<float>>()) {
+        // Convenience access to the Covfie field object.
+        const auto& in_field =
+            bfield.as_field<host::inhom_bfield_backend_t<float>>();
+        // At single precision we can use either global or texture memory.
+        if (storage == magnetic_field_storage::global_memory) {
+            return magnetic_field{
+                covfie::field<cuda::inhom_global_bfield_backend_t<float>>(
+                    in_field)};
+        } else if (storage == magnetic_field_storage::texture_memory) {
+            return magnetic_field{
+                covfie::field<cuda::inhom_texture_bfield_backend_t<float>>(
+                    covfie::make_parameter_pack(
+                        in_field.backend().get_configuration(),
+                        in_field.backend()
+                            .get_backend()
+                            .get_backend()
+                            .get_backend()))};
+        } else {
+            throw std::invalid_argument(
+                "Unsupported storage method chosen for inhomogeneous b-field");
+        }
+    } else if (bfield.is<host::inhom_bfield_backend_t<double>>()) {
+        // At double precision we can only use global memory.
+        if (storage == magnetic_field_storage::global_memory) {
+            return magnetic_field{
+                covfie::field<cuda::inhom_global_bfield_backend_t<double>>(
+                    bfield.as_field<host::inhom_bfield_backend_t<double>>())};
+        } else {
+            throw std::invalid_argument(
+                "Unsupported storage method chosen for inhomogeneous b-field");
+        }
     } else {
         throw std::invalid_argument("Unsupported b-field type received");
     }

--- a/examples/options/include/traccc/options/accelerator.hpp
+++ b/examples/options/include/traccc/options/accelerator.hpp
@@ -21,6 +21,8 @@ class accelerator : public interface {
 
     /// Whether to compare the accelerator code's output with that of the CPU
     bool compare_with_cpu = false;
+    /// Whether GPU texture memory should be used
+    bool use_gpu_texture_memory = false;
 
     /// @}
 

--- a/examples/options/src/accelerator.cpp
+++ b/examples/options/src/accelerator.cpp
@@ -20,6 +20,10 @@ accelerator::accelerator() : interface("Accelerator Options") {
     m_desc.add_options()("compare-with-cpu",
                          boost::program_options::bool_switch(&compare_with_cpu),
                          "Compare accelerator output with that of the CPU");
+    m_desc.add_options()(
+        "use-gpu-texture-memory",
+        boost::program_options::bool_switch(&use_gpu_texture_memory),
+        "Use GPU texture memory on the accelerator");
 }
 
 std::unique_ptr<configuration_printable> accelerator::as_printable() const {
@@ -27,6 +31,8 @@ std::unique_ptr<configuration_printable> accelerator::as_printable() const {
 
     cat->add_child(std::make_unique<configuration_kv_pair>(
         "Compare with CPU output", std::format("{}", compare_with_cpu)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Use GPU texture memory", std::format("{}", use_gpu_texture_memory)));
 
     return cat;
 }

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -115,7 +115,11 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // B field value
     const auto host_field = traccc::details::make_magnetic_field(bfield_opts);
-    const auto device_field = traccc::cuda::make_magnetic_field(host_field);
+    const auto device_field = traccc::cuda::make_magnetic_field(
+        host_field,
+        (accelerator_opts.use_gpu_texture_memory
+             ? traccc::cuda::magnetic_field_storage::texture_memory
+             : traccc::cuda::magnetic_field_storage::global_memory));
 
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host host_det{mng_mr};

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -163,7 +163,11 @@ int seq_run(const traccc::opts::detector& detector_opts,
     const traccc::vector3 field_vec = {0.f, 0.f,
                                        seeding_opts.seedfinder.bFieldInZ};
     const auto host_field = traccc::details::make_magnetic_field(bfield_opts);
-    const auto device_field = traccc::cuda::make_magnetic_field(host_field);
+    const auto device_field = traccc::cuda::make_magnetic_field(
+        host_field,
+        (accelerator_opts.use_gpu_texture_memory
+             ? traccc::cuda::magnetic_field_storage::texture_memory
+             : traccc::cuda::magnetic_field_storage::global_memory));
 
     traccc::host::clusterization_algorithm ca(
         host_mr, logger().clone("HostClusteringAlg"));


### PR DESCRIPTION
As I wrote in #1055, I wanted to set up a more general way for the support of CUDA texture memory in the code. This is it.

Basically I want to support the usage of both "regular" and texture memory with FP32, and just "regular" memory with FP64. Which I tried to do in a way that would show I think we'll be able to organize floating point precision matters in our code in the long run. 🤔

Basically, I added a second argument to `traccc::cuda::make_magnetic_field(...)` that specifies what sort of CUDA memory the magnetic field should live in. And then implemented the function without any use of `traccc::scalar`. Instead, explicitly implementing the appropriate logic for `float` and `double` at the same time. I believe we will be able to organize our code something like this with the detector geometry and algebras as well. That we would just build single- and double-precision code in a single build, and the client would choose which version of the code would run, based on what precision they created the magnetic field and the tracking geometry with.