### PR TITLE
Add truth finding cuts and efficiency output

### DIFF
--- a/examples/options/include/traccc/options/truth_finding.hpp
+++ b/examples/options/include/traccc/options/truth_finding.hpp
@@ -7,16 +7,29 @@
 
 #pragma once
 
+#include <boost/program_options.hpp>
+
 #include "traccc/definitions/common.hpp"
+#include "traccc/options/details/config_provider.hpp"
 #include "traccc/options/details/interface.hpp"
+#include "traccc/utils/truth_matching_config.hpp"
 
 namespace traccc::opts {
-class truth_finding : public interface {
+class truth_finding : public interface,
+                      public config_provider<truth_matching_config> {
 
     public:
-    float m_min_pt = 0.5f * unit<float>::GeV;
+    float m_pT_min = 0.5f * unit<float>::GeV;
+    float m_z_min = -500.f * unit<float>::mm;
+    float m_z_max = 500.f * unit<float>::mm;
+    float m_r_max = 200.f * unit<float>::mm;
+    float m_matching_ratio = 0.5f;
+    unsigned int m_min_track_candidates = 3;
+    bool m_double_matching = true;
 
     truth_finding();
+
+    operator truth_matching_config() const override;
 
     void read(const boost::program_options::variables_map &) override;
 

--- a/examples/options/src/truth_finding.cpp
+++ b/examples/options/src/truth_finding.cpp
@@ -17,19 +17,68 @@ namespace traccc::opts {
 truth_finding::truth_finding() : interface("Truth Track Finding Options") {
     m_desc.add_options()(
         "truth-finding-min-pt",
-        boost::program_options::value(&m_min_pt)->default_value(m_min_pt),
-        "Candidate particule pT cut [GeV]");
+        boost::program_options::value(&m_pT_min)->default_value(m_pT_min),
+        "Candidate particle pT cut [GeV]");
+    m_desc.add_options()(
+        "truth-finding-min-z",
+        boost::program_options::value(&m_z_min)->default_value(m_z_min),
+        "Candidate particle min z cut [mm]");
+    m_desc.add_options()(
+        "truth-finding-max-z",
+        boost::program_options::value(&m_z_max)->default_value(m_z_max),
+        "Candidate particle max z cut [mm]");
+    m_desc.add_options()(
+        "truth-finding-max-r",
+        boost::program_options::value(&m_r_max)->default_value(m_r_max),
+        "Candidate particle max r cut [mm]");
+    m_desc.add_options()("truth-finding-matching-ratio",
+                         boost::program_options::value(&m_matching_ratio)
+                             ->default_value(m_matching_ratio),
+                         "Minimum track state matching ratio");
+    m_desc.add_options()("truth-finding-min-track-candidates",
+                         boost::program_options::value(&m_min_track_candidates)
+                             ->default_value(m_min_track_candidates),
+                         "Minimum track candidates on track");
+    m_desc.add_options()("truth-finding-double-matching",
+                         boost::program_options::bool_switch(&m_double_matching)
+                             ->default_value(m_double_matching),
+                         "Enable double truth-reco matching");
 }
 
 void truth_finding::read(const boost::program_options::variables_map &) {
-    m_min_pt *= unit<float>::GeV;
+    m_pT_min *= unit<float>::GeV;
+    m_z_min *= unit<float>::mm;
+    m_z_max *= unit<float>::mm;
+    m_r_max *= unit<float>::mm;
+}
+
+truth_finding::operator truth_matching_config() const {
+    return truth_matching_config{.pT_min = m_pT_min,
+                                 .z_min = m_z_min,
+                                 .z_max = m_z_max,
+                                 .r_max = m_r_max,
+                                 .matching_ratio = m_matching_ratio,
+                                 .min_track_candidates = m_min_track_candidates,
+                                 .double_matching = m_double_matching};
 }
 
 std::unique_ptr<configuration_printable> truth_finding::as_printable() const {
     auto cat = std::make_unique<configuration_category>(m_description);
 
     cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Minimum pT", std::format("{} GeV", m_min_pt / unit<float>::GeV)));
+        "Minimum pT", std::format("{} GeV", m_pT_min / unit<float>::GeV)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Minimum z", std::format("{} mm", m_z_min / unit<float>::mm)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Maximum z", std::format("{} mm", m_z_max / unit<float>::mm)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Maximum r", std::format("{} mm", m_r_max / unit<float>::mm)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Matching ratio", std::format("{}", m_matching_ratio)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Minimum track candidates", std::format("{}", m_min_track_candidates)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Double matching", std::format("{}", m_double_matching)));
 
     return cat;
 }

--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -38,6 +38,7 @@
 #include "traccc/options/track_fitting.hpp"
 #include "traccc/options/track_propagation.hpp"
 #include "traccc/options/track_seeding.hpp"
+#include "traccc/options/truth_finding.hpp"
 #include "traccc/performance/collection_comparator.hpp"
 #include "traccc/performance/soa_comparator.hpp"
 #include "traccc/performance/timer.hpp"
@@ -63,6 +64,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             const traccc::opts::magnetic_field& bfield_opts,
             const traccc::opts::performance& performance_opts,
             const traccc::opts::accelerator& accelerator_opts,
+            const traccc::opts::truth_finding& truth_finding_opts,
             [[maybe_unused]] std::unique_ptr<const traccc::Logger> ilogger) {
     TRACCC_LOCAL_LOGGER(std::move(ilogger));
 
@@ -80,7 +82,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         traccc::seeding_performance_writer::config{},
         logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{},
+        traccc::finding_performance_writer::config{.truth_config =
+                                                       truth_finding_opts},
         logger().clone("FindingPerformanceWriter"));
     traccc::fitting_performance_writer fit_performance_writer(
         traccc::fitting_performance_writer::config{},
@@ -452,10 +455,12 @@ int main(int argc, char* argv[]) {
     traccc::opts::track_fitting fitting_opts;
     traccc::opts::performance performance_opts;
     traccc::opts::accelerator accelerator_opts;
+    traccc::opts::truth_finding truth_finding_opts;
     traccc::opts::program_options program_opts{
         "Full Tracking Chain Using Alpaka (without clusterization)",
         {detector_opts, bfield_opts, input_opts, seeding_opts, finding_opts,
-         propagation_opts, fitting_opts, performance_opts, accelerator_opts},
+         propagation_opts, fitting_opts, performance_opts, accelerator_opts,
+         truth_finding_opts},
         argc,
         argv,
         logger->cloneWithSuffix("Options")};
@@ -463,5 +468,5 @@ int main(int argc, char* argv[]) {
     // Run the application.
     return seq_run(seeding_opts, finding_opts, propagation_opts, fitting_opts,
                    input_opts, detector_opts, bfield_opts, performance_opts,
-                   accelerator_opts, logger->clone());
+                   accelerator_opts, truth_finding_opts, logger->clone());
 }

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -43,6 +43,7 @@
 #include "traccc/options/track_propagation.hpp"
 #include "traccc/options/track_resolution.hpp"
 #include "traccc/options/track_seeding.hpp"
+#include "traccc/options/truth_finding.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -64,6 +65,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             const traccc::opts::detector& detector_opts,
             const traccc::opts::magnetic_field& bfield_opts,
             const traccc::opts::performance& performance_opts,
+            const traccc::opts::truth_finding& truth_finding_opts,
             std::unique_ptr<const traccc::Logger> ilogger) {
     TRACCC_LOCAL_LOGGER(std::move(ilogger));
 
@@ -78,7 +80,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         traccc::seeding_performance_writer::config{},
         logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{},
+        traccc::finding_performance_writer::config{.truth_config =
+                                                       truth_finding_opts},
         logger().clone("FindingPerformanceWriter"));
     traccc::finding_performance_writer::config ar_writer_cfg;
     ar_writer_cfg.file_path = "performance_track_ambiguity_resolution.root";
@@ -282,10 +285,12 @@ int main(int argc, char* argv[]) {
     traccc::opts::track_resolution resolution_opts;
     traccc::opts::track_fitting fitting_opts;
     traccc::opts::performance performance_opts;
+    traccc::opts::truth_finding truth_finding_opts;
     traccc::opts::program_options program_opts{
         "Full Tracking Chain on the Host (without clusterization)",
         {detector_opts, bfield_opts, input_opts, seeding_opts, finding_opts,
-         propagation_opts, resolution_opts, fitting_opts, performance_opts},
+         propagation_opts, resolution_opts, fitting_opts, performance_opts,
+         truth_finding_opts},
         argc,
         argv,
         logger->cloneWithSuffix("Options")};
@@ -293,5 +298,6 @@ int main(int argc, char* argv[]) {
     // Run the application.
     return seq_run(seeding_opts, finding_opts, propagation_opts,
                    resolution_opts, fitting_opts, input_opts, detector_opts,
-                   bfield_opts, performance_opts, logger->clone());
+                   bfield_opts, performance_opts, truth_finding_opts,
+                   logger->clone());
 }

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -45,6 +45,7 @@
 #include "traccc/options/track_propagation.hpp"
 #include "traccc/options/track_resolution.hpp"
 #include "traccc/options/track_seeding.hpp"
+#include "traccc/options/truth_finding.hpp"
 
 // examples
 #include "../common/make_magnetic_field.hpp"
@@ -72,6 +73,7 @@ int seq_run(const traccc::opts::input_data& input_opts,
             const traccc::opts::track_resolution& resolution_opts,
             const traccc::opts::track_fitting& fitting_opts,
             const traccc::opts::performance& performance_opts,
+            const traccc::opts::truth_finding& truth_finding_opts,
             std::unique_ptr<const traccc::Logger> ilogger) {
     TRACCC_LOCAL_LOGGER(std::move(ilogger));
 
@@ -156,7 +158,8 @@ int seq_run(const traccc::opts::input_data& input_opts,
         traccc::seeding_performance_writer::config{},
         logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{},
+        traccc::finding_performance_writer::config{.truth_config =
+                                                       truth_finding_opts},
         logger().clone("FindingPerformanceWriter"));
     traccc::finding_performance_writer::config ar_writer_cfg;
     ar_writer_cfg.file_path = "performance_track_ambiguity_resolution.root";
@@ -386,11 +389,12 @@ int main(int argc, char* argv[]) {
     traccc::opts::track_resolution resolution_opts;
     traccc::opts::track_fitting fitting_opts;
     traccc::opts::performance performance_opts;
+    traccc::opts::truth_finding truth_finding_opts;
     traccc::opts::program_options program_opts{
         "Full Tracking Chain on the Host",
         {detector_opts, bfield_opts, input_opts, output_opts,
          clusterization_opts, seeding_opts, finding_opts, resolution_opts,
-         fitting_opts, propagation_opts, performance_opts},
+         fitting_opts, propagation_opts, performance_opts, truth_finding_opts},
         argc,
         argv,
         logger->cloneWithSuffix("Options")};
@@ -399,5 +403,5 @@ int main(int argc, char* argv[]) {
     return seq_run(input_opts, output_opts, detector_opts, bfield_opts,
                    clusterization_opts, seeding_opts, finding_opts,
                    propagation_opts, resolution_opts, fitting_opts,
-                   performance_opts, logger->clone());
+                   performance_opts, truth_finding_opts, logger->clone());
 }

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -61,7 +61,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
     // Performance writer
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{},
+        traccc::finding_performance_writer::config{.truth_config =
+                                                       truth_finding_opts},
         logger().clone("FindingPerformanceWriter"));
     traccc::fitting_performance_writer fit_performance_writer(
         traccc::fitting_performance_writer::config{},
@@ -128,7 +129,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
         traccc::edm::track_candidate_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
         evt_data.generate_truth_candidates(truth_track_candidates, sg, host_mr,
-                                           truth_finding_opts.m_min_pt);
+                                           truth_finding_opts.m_pT_min);
 
         // Prepare truth seeds
         traccc::bound_track_parameters_collection_types::host seeds(&host_mr);

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -37,6 +37,7 @@
 #include "traccc/options/track_fitting.hpp"
 #include "traccc/options/track_propagation.hpp"
 #include "traccc/options/track_seeding.hpp"
+#include "traccc/options/truth_finding.hpp"
 #include "traccc/performance/collection_comparator.hpp"
 #include "traccc/performance/soa_comparator.hpp"
 #include "traccc/performance/timer.hpp"
@@ -69,6 +70,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             const traccc::opts::magnetic_field& bfield_opts,
             const traccc::opts::performance& performance_opts,
             const traccc::opts::accelerator& accelerator_opts,
+            const traccc::opts::truth_finding& truth_finding_opts,
             std::unique_ptr<const traccc::Logger> ilogger) {
     TRACCC_LOCAL_LOGGER(std::move(ilogger));
 
@@ -84,7 +86,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         traccc::seeding_performance_writer::config{},
         logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{},
+        traccc::finding_performance_writer::config{.truth_config =
+                                                       truth_finding_opts},
         logger().clone("FindingPerformanceWriter"));
     traccc::fitting_performance_writer fit_performance_writer(
         traccc::fitting_performance_writer::config{},
@@ -474,10 +477,12 @@ int main(int argc, char* argv[]) {
     traccc::opts::track_fitting fitting_opts;
     traccc::opts::performance performance_opts;
     traccc::opts::accelerator accelerator_opts;
+    traccc::opts::truth_finding truth_finding_opts;
     traccc::opts::program_options program_opts{
         "Full Tracking Chain Using CUDA (without clusterization)",
         {detector_opts, bfield_opts, input_opts, seeding_opts, finding_opts,
-         propagation_opts, fitting_opts, performance_opts, accelerator_opts},
+         propagation_opts, fitting_opts, performance_opts, accelerator_opts,
+         truth_finding_opts},
         argc,
         argv,
         logger->cloneWithSuffix("Options")};
@@ -485,5 +490,5 @@ int main(int argc, char* argv[]) {
     // Run the application.
     return seq_run(seeding_opts, finding_opts, propagation_opts, fitting_opts,
                    input_opts, detector_opts, bfield_opts, performance_opts,
-                   accelerator_opts, logger->clone());
+                   accelerator_opts, truth_finding_opts, logger->clone());
 }

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -76,7 +76,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
 
     // Performance writer
     traccc::finding_performance_writer find_performance_writer(
-        traccc::finding_performance_writer::config{},
+        traccc::finding_performance_writer::config{.truth_config =
+                                                       truth_finding_opts},
         logger().clone("FindingPerformanceWriter"));
     traccc::fitting_performance_writer fit_performance_writer(
         traccc::fitting_performance_writer::config{},
@@ -169,7 +170,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
         traccc::edm::track_candidate_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
         evt_data.generate_truth_candidates(truth_track_candidates, sg, host_mr,
-                                           truth_finding_opts.m_min_pt);
+                                           truth_finding_opts.m_pT_min);
 
         // Prepare truth seeds
         traccc::bound_track_parameters_collection_types::host seeds(mr.host);

--- a/performance/include/traccc/efficiency/finding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/finding_performance_writer.hpp
@@ -11,6 +11,7 @@
 #include "traccc/resolution/stat_plot_tool_config.hpp"
 #include "traccc/utils/helpers.hpp"
 #include "traccc/utils/messaging.hpp"
+#include "traccc/utils/truth_matching_config.hpp"
 
 // Project include(s).
 #include "traccc/edm/track_candidate_collection.hpp"
@@ -52,15 +53,9 @@ class finding_performance_writer : public messaging {
             {"Pt", plot_helpers::binning("p_{T} [GeV/c]", 40, 0.f, 100.f)},
             {"Num", plot_helpers::binning("N", 30, -0.5f, 29.5f)}};
 
-        /// Cut values
-        scalar pT_cut = 0.5f * traccc::unit<scalar>::GeV;
-        scalar z_min = -500.f * traccc::unit<scalar>::mm;
-        scalar z_max = 500.f * traccc::unit<scalar>::mm;
-        scalar r_max = 200.f * traccc::unit<scalar>::mm;
-        scalar matching_ratio = 0.5f;
-        bool double_matching = true;
+        truth_matching_config truth_config;
 
-        stat_plot_tool_config stat_config;
+        stat_plot_tool_config stat_config{};
     };
 
     /// Construct from configuration and log level.

--- a/performance/include/traccc/utils/truth_matching_config.hpp
+++ b/performance/include/traccc/utils/truth_matching_config.hpp
@@ -1,0 +1,29 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/definitions/common.hpp"
+
+namespace traccc {
+
+struct truth_matching_config {
+    float pT_min = 0.5f * traccc::unit<float>::GeV;
+
+    float z_min = -500.f * traccc::unit<float>::mm;
+    float z_max = 500.f * traccc::unit<float>::mm;
+
+    float r_max = 200.f * traccc::unit<float>::mm;
+
+    float matching_ratio = 0.5f;
+
+    unsigned int min_track_candidates = 3;
+
+    bool double_matching = true;
+};
+
+}  // namespace traccc


### PR DESCRIPTION
This commit updates the truth matching code to have additional cuts on r, z, and the number of measurements on the track. It also adds some printouts to the finding efficiency writer to give the overall efficiency, fake rate, etc. without the need to use ROOT.