### PR TITLE
CKF Track Deduplication, main branch (2025.07.15.)

### DIFF
--- a/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
@@ -21,10 +21,12 @@
 #include "traccc/finding/details/combinatorial_kalman_filter_types.hpp"
 #include "traccc/finding/device/apply_interaction.hpp"
 #include "traccc/finding/device/build_tracks.hpp"
+#include "traccc/finding/device/fill_finding_duplicate_removal_sort_keys.hpp"
 #include "traccc/finding/device/fill_finding_propagation_sort_keys.hpp"
 #include "traccc/finding/device/find_tracks.hpp"
 #include "traccc/finding/device/make_barcode_sequence.hpp"
 #include "traccc/finding/device/propagate_to_next_surface.hpp"
+#include "traccc/finding/device/remove_duplicates.hpp"
 #include "traccc/finding/finding_config.hpp"
 #include "traccc/utils/logging.hpp"
 #include "traccc/utils/memory_resource.hpp"
@@ -105,8 +107,37 @@ struct find_tracks {
     }
 };
 
-/// Alpaka kernel functor for @c
-/// traccc::device::fill_finding_propagation_sort_keys
+/// Alpaka kernel functor for
+/// @c traccc::device::fill_finding_duplicate_removal_sort_keys
+struct fill_finding_duplicate_removal_sort_keys {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        const device::fill_finding_duplicate_removal_sort_keys_payload& payload)
+        const {
+
+        const device::global_index_t globalThreadIdx =
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
+        device::fill_finding_duplicate_removal_sort_keys(globalThreadIdx,
+                                                         payload);
+    }
+};
+
+/// Alpaka kernel functor for @c traccc::device::remove_duplicates
+struct remove_duplicates {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc, const finding_config& cfg,
+        const device::remove_duplicates_payload& payload) const {
+
+        const device::global_index_t globalThreadIdx =
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
+        device::remove_duplicates(globalThreadIdx, cfg, payload);
+    }
+};
+
+/// Alpaka kernel functor for
+/// @c traccc::device::fill_finding_propagation_sort_keys
 struct fill_finding_propagation_sort_keys {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(
@@ -408,6 +439,74 @@ combinatorial_kalman_filter(
                 step_to_link_idx_map[step + 1] - step_to_link_idx_map[step];
         }
 
+        /*
+         * On later steps, we can duplicate removal which will attempt to find
+         * tracks that are propagated multiple times and deduplicate them.
+         */
+        if (n_candidates > 0 &&
+            step >= config.duplicate_removal_minimum_length) {
+            vecmem::data::vector_buffer<unsigned int>
+                link_last_measurement_buffer(n_candidates, mr.main);
+            vecmem::data::vector_buffer<unsigned int> param_ids_buffer(
+                n_candidates, mr.main);
+
+            /*
+             * First, we sort the tracks by the index of their final
+             * measurement which is critical to ensure good performance.
+             */
+            {
+                const unsigned int nThreads = 256;
+                const unsigned int nBlocks =
+                    (n_candidates + nThreads - 1) / nThreads;
+                const auto workDiv = makeWorkDiv<Acc>(nBlocks, nThreads);
+
+                ::alpaka::exec<Acc>(
+                    queue, workDiv,
+                    kernels::fill_finding_duplicate_removal_sort_keys{},
+                    device::fill_finding_duplicate_removal_sort_keys_payload{
+                        .links_view = links_buffer,
+                        .param_liveness_view = param_liveness_buffer,
+                        .link_last_measurement_view =
+                            link_last_measurement_buffer,
+                        .param_ids_view = param_ids_buffer,
+                        .n_links = n_candidates,
+                        .curr_links_idx = step_to_link_idx_map[step],
+                        .n_measurements = n_measurements});
+                ::alpaka::wait(queue);
+            }
+
+            vecmem::device_vector<unsigned int> keys_device(
+                link_last_measurement_buffer);
+            vecmem::device_vector<unsigned int> param_ids_device(
+                param_ids_buffer);
+            thrust::sort_by_key(thrustExecPolicy, keys_device.begin(),
+                                keys_device.end(), param_ids_device.begin());
+
+            /*
+             * Then, we run the actual duplicate removal kernel.
+             */
+            {
+                const unsigned int nThreads = 256;
+                const unsigned int nBlocks =
+                    (n_candidates + nThreads - 1) / nThreads;
+                const auto workDiv = makeWorkDiv<Acc>(nBlocks, nThreads);
+
+                ::alpaka::exec<Acc>(
+                    queue, workDiv, kernels::remove_duplicates{}, config,
+                    device::remove_duplicates_payload{
+                        .links_view = links_buffer,
+                        .link_last_measurement_view =
+                            link_last_measurement_buffer,
+                        .param_ids_view = param_ids_buffer,
+                        .param_liveness_view = param_liveness_buffer,
+                        .n_links = n_candidates,
+                        .curr_links_idx = step_to_link_idx_map[step],
+                        .n_measurements = n_measurements,
+                        .step = step});
+                ::alpaka::wait(queue);
+            }
+        }
+
         if (step == config.max_track_candidates_per_track - 1) {
             break;
         }
@@ -566,3 +665,22 @@ struct BlockSharedMemDynSizeBytes<
 };
 
 }  // namespace alpaka::trait
+
+namespace alpaka {
+
+/// Convince Alpaka that
+/// @c traccc::device::fill_finding_duplicate_removal_sort_keys_payload
+/// is trivially copyable
+template <>
+struct IsKernelArgumentTriviallyCopyable<
+    traccc::device::fill_finding_duplicate_removal_sort_keys_payload, void>
+    : std::true_type {};
+
+/// Convince Alpaka that
+/// @c traccc::device::remove_duplicates_payload
+/// is trivially copyable
+template <>
+struct IsKernelArgumentTriviallyCopyable<
+    traccc::device::remove_duplicates_payload, void> : std::true_type {};
+
+}  // namespace alpaka

--- a/device/common/include/traccc/finding/device/remove_duplicates.hpp
+++ b/device/common/include/traccc/finding/device/remove_duplicates.hpp
@@ -94,7 +94,7 @@ struct remove_duplicates_payload {
  * increasingly less likely that they will diverge afterwards.
  */
 TRACCC_HOST_DEVICE inline void remove_duplicates(
-    global_index_t gid, const finding_config& cfg,
+    global_index_t tid, const finding_config& cfg,
     const remove_duplicates_payload& payload) {
 
     const vecmem::device_vector<const candidate_link> links(payload.links_view);
@@ -104,8 +104,6 @@ TRACCC_HOST_DEVICE inline void remove_duplicates(
         payload.link_last_measurement_view);
     const vecmem::device_vector<const unsigned int> param_ids(
         payload.param_ids_view);
-
-    const unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
 
     /*
      * As is standard fare, we ignore tracks that are out of bounds or that

--- a/tests/sycl/test_ckf_toy_detector.cpp
+++ b/tests/sycl/test_ckf_toy_detector.cpp
@@ -138,7 +138,6 @@ TEST_P(CkfToyDetectorTests, Run) {
     cfg.ptc_hypothesis = ptc;
     cfg.max_num_branches_per_seed = 500;
     cfg.propagation.navigation.search_window = search_window;
-    cfg.duplicate_removal_minimum_length = 100u;
 
     // Finding algorithm object
     traccc::host::combinatorial_kalman_filter_algorithm host_finding(cfg,


### PR DESCRIPTION
As @flg found it just yesterday, the SYCL track finding is currently not in sync with how the CUDA track finding behaves. And neither is the Alpaka variant. 😦 

The updates added in #1041 were not implemented for SYCL or Alpaka so far, leading to SYCL and Alpaka finding more tracks than CUDA. (~~Or the host algorithm, but that is another can of worms that I will only want to come back to later on.~~ Turns out that #1041 did update the host code.)

With these changes I see SYCL and (CUDA aided) Alpaka finding the same number of tracks with the ODD ttbar samples.

Pinging @paradajzblond as well.