### PR TITLE
Increase the shared memory allocation

### DIFF
--- a/device/cuda/src/ambiguity_resolution/kernels/count_removable_tracks.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/count_removable_tracks.cu
@@ -67,10 +67,10 @@ __launch_bounds__(512) __global__ void count_removable_tracks(
         return;
     }
 
-    __shared__ int shared_n_meas[512];
-    __shared__ measurement_id_type sh_meas_ids[512];
-    __shared__ unsigned int sh_threads[512];
-    __shared__ int prefix[512];
+    __shared__ int shared_n_meas[1024];
+    __shared__ measurement_id_type sh_meas_ids[1024];
+    __shared__ unsigned int sh_threads[1024];
+    __shared__ int prefix[1024];
     __shared__ unsigned int n_meas_total;
     __shared__ unsigned int bound;
     __shared__ unsigned int n_tracks_to_iterate;


### PR DESCRIPTION
After the update of #1076, the following test fails, which is probably due to the insufficient memory allocation.

```
INSTANTIATE_TEST_SUITE_P(
    Dense, GreedyResolutionCompareToCPU,
    ::testing::Values(std::make_tuple(3u, 5000u,
                                      std::array<std::size_t, 2u>{3u, 10u},
                                      100u, true),
                      std::make_tuple(3u, 5000u,
                                      std::array<std::size_t, 2u>{3u, 10u},
                                      100u, false)));
```

This PR increases the size enough to avoid the failure.
I also found that the tests of ambiguity resolution is not included in the gitlab CI. Anyone has a clue on it?

