### PR TITLE
Fix incorrectly loose final triplet cut

### DIFF
--- a/core/include/traccc/seeding/seed_selecting_helper.hpp
+++ b/core/include/traccc/seeding/seed_selecting_helper.hpp
@@ -79,7 +79,7 @@ struct seed_selecting_helper {
         const edm::spacepoint_collection::const_device::const_proxy_type spB =
             spacepoints.at(grid.bin(seed.sp1.bin_idx)[seed.sp1.sp_idx]);
 
-        return (seed.weight > filter_config.seed_min_weight ||
+        return (seed.weight > filter_config.seed_min_weight &&
                 spB.radius() > filter_config.spB_min_radius);
     }
 };


### PR DESCRIPTION
This commit fixes a bug in the seed finding in which the final cut we apply on the triplets is incorrectly a disjunctive cut rather than a conjunctive cut.