### PR TITLE
Fix bugs in the greedy resolver

### DIFF
--- a/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
+++ b/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
@@ -233,7 +233,7 @@ greedy_ambiguity_resolution_algorithm::operator()(
 
     // Unique measurement ids
     vecmem::data::vector_buffer<measurement_id_type>
-        meas_id_to_unique_id_buffer{max_meas.measurement_id, m_mr.main};
+        meas_id_to_unique_id_buffer{max_meas.measurement_id + 1, m_mr.main};
 
     // Make meas_id to meas vector
     {

--- a/device/cuda/src/ambiguity_resolution/kernels/count_removable_tracks.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/count_removable_tracks.cu
@@ -36,8 +36,9 @@ __device__ void count_tracks(int tid, int* sh_n_meas, int n_tracks,
                 offset = sh_n_meas[count];
                 add = stride * 2;
             }
-            __syncthreads();
         }
+
+        __syncthreads();
     }
 
     if (tid == 0) {

--- a/device/cuda/src/ambiguity_resolution/kernels/remove_tracks.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/remove_tracks.cu
@@ -35,8 +35,13 @@ __global__ void remove_tracks(device::remove_tracks_payload payload) {
     __shared__ unsigned int shared_tids[1024];
     __shared__ measurement_id_type sh_meas_ids[1024];
     __shared__ unsigned int sh_threads[1024];
+    __shared__ unsigned int n_accepted_prev;
 
     auto threadIndex = threadIdx.x;
+
+    bool active = false;
+    bool active2 = false;
+    bool is_duplicate = true;
 
     shared_tids[threadIndex] = std::numeric_limits<unsigned int>::max();
 
@@ -62,112 +67,124 @@ __global__ void remove_tracks(device::remove_tracks_payload payload) {
         payload.meas_to_remove_view);
     vecmem::device_vector<unsigned int> threads(payload.threads_view);
 
-    auto n_accepted_prev = (*payload.n_accepted);
     if (threadIndex == 0) {
+        n_accepted_prev = *(payload.n_accepted);
         (*payload.n_accepted) -= *(payload.n_removable_tracks);
     }
+
+    __syncthreads();
 
     if (threadIndex < *(payload.n_meas_to_remove)) {
         sh_meas_ids[threadIndex] = meas_to_remove[threadIndex];
         sh_threads[threadIndex] = threads[threadIndex];
-    } else {
-        return;
+        active2 = true;
     }
-
-    const auto id = sh_meas_ids[threadIndex];
-
-    bool is_duplicate = false;
-    for (unsigned int i = 0; i < threadIndex; ++i) {
-        if (sh_meas_ids[i] == id) {
-            is_duplicate = true;
-            break;
-        }
-    }
-    if (is_duplicate) {
-        return;
-    }
-
-    const auto unique_meas_idx = meas_id_to_unique_id.at(id);
-
-    // If there is only one track associated with measurement, the
-    // number of shared measurement can be reduced by one
-    const auto& tracks = tracks_per_measurement[unique_meas_idx];
-    auto track_status = track_status_per_measurement[unique_meas_idx];
-
-    auto trk_id = sorted_ids[n_accepted_prev - 1 - sh_threads[threadIndex]];
-
-    unsigned int worst_idx =
-        thrust::find(thrust::seq, tracks.begin(), tracks.end(), trk_id) -
-        tracks.begin();
-
-    track_status[worst_idx] = 0;
-
-    int n_sharing_tracks = 1;
-    for (unsigned int i = threadIndex + 1; i < *(payload.n_meas_to_remove);
-         ++i) {
-
-        if (sh_meas_ids[i] == id && sh_threads[i] != sh_threads[i - 1]) {
-            n_sharing_tracks++;
-
-            trk_id = sorted_ids[n_accepted_prev - 1 - sh_threads[i]];
-
-            worst_idx = thrust::find(thrust::seq, tracks.begin(), tracks.end(),
-                                     trk_id) -
-                        tracks.begin();
-
-            track_status[worst_idx] = 0;
-
-        } else if (sh_meas_ids[i] != id) {
-            break;
-        }
-    }
-
-    vecmem::device_atomic_ref<unsigned int> n_accepted_per_meas(
-        n_accepted_tracks_per_measurement.at(
-            static_cast<unsigned int>(unique_meas_idx)));
-    const unsigned int N_A = n_accepted_per_meas.fetch_sub(n_sharing_tracks);
-
-    if (N_A != 1 + n_sharing_tracks) {
-        return;
-    }
-
-    const unsigned int alive_idx =
-        thrust::find(thrust::seq, track_status.begin(), track_status.end(), 1) -
-        track_status.begin();
-
-    shared_tids[threadIndex] = static_cast<unsigned int>(tracks[alive_idx]);
-
-    auto tid = shared_tids[threadIndex];
-
-    const auto m_count = static_cast<unsigned int>(thrust::count(
-        thrust::seq, meas_ids[tid].begin(), meas_ids[tid].end(), id));
-
-    const unsigned int N_S =
-        vecmem::device_atomic_ref<unsigned int>(n_shared.at(tid))
-            .fetch_sub(m_count);
 
     __syncthreads();
 
-    bool already_pushed = false;
-    for (unsigned int i = 0; i < threadIndex; ++i) {
-        if (shared_tids[i] == tid) {
-            already_pushed = true;
-            break;
+    if (active2) {
+
+        const auto id = sh_meas_ids[threadIndex];
+        is_duplicate = false;
+
+        for (unsigned int i = 0; i < threadIndex; ++i) {
+            if (sh_meas_ids[i] == id) {
+                is_duplicate = true;
+                break;
+            }
         }
     }
-    if (!already_pushed) {
 
-        // Write updated track IDs
-        vecmem::device_atomic_ref<unsigned int> num_updated_tracks(
-            *(payload.n_updated_tracks));
+    if (!is_duplicate && active2) {
 
-        const unsigned int pos = num_updated_tracks.fetch_add(1);
+        const auto id = sh_meas_ids[threadIndex];
+        const auto unique_meas_idx = meas_id_to_unique_id.at(id);
 
-        updated_tracks[pos] = tid;
-        is_updated[tid] = 1;
+        // If there is only one track associated with measurement, the
+        // number of shared measurement can be reduced by one
+        const auto& tracks = tracks_per_measurement[unique_meas_idx];
+        auto track_status = track_status_per_measurement[unique_meas_idx];
 
-        rel_shared.at(tid) = static_cast<traccc::scalar>(n_shared.at(tid)) /
-                             static_cast<traccc::scalar>(n_meas.at(tid));
+        auto trk_id = sorted_ids[n_accepted_prev - 1 - sh_threads[threadIndex]];
+
+        unsigned int worst_idx =
+            thrust::find(thrust::seq, tracks.begin(), tracks.end(), trk_id) -
+            tracks.begin();
+
+        track_status[worst_idx] = 0;
+
+        int n_sharing_tracks = 1;
+        for (unsigned int i = threadIndex + 1; i < *(payload.n_meas_to_remove);
+             ++i) {
+
+            if (sh_meas_ids[i] == id && sh_threads[i] != sh_threads[i - 1]) {
+                n_sharing_tracks++;
+
+                trk_id = sorted_ids[n_accepted_prev - 1 - sh_threads[i]];
+
+                worst_idx = thrust::find(thrust::seq, tracks.begin(),
+                                         tracks.end(), trk_id) -
+                            tracks.begin();
+
+                track_status[worst_idx] = 0;
+
+            } else if (sh_meas_ids[i] != id) {
+                break;
+            }
+        }
+
+        vecmem::device_atomic_ref<unsigned int> n_accepted_per_meas(
+            n_accepted_tracks_per_measurement.at(
+                static_cast<unsigned int>(unique_meas_idx)));
+        const unsigned int N_A =
+            n_accepted_per_meas.fetch_sub(n_sharing_tracks);
+
+        if (N_A == 1 + n_sharing_tracks) {
+            active = true;
+            const unsigned int alive_idx =
+                thrust::find(thrust::seq, track_status.begin(),
+                             track_status.end(), 1) -
+                track_status.begin();
+
+            shared_tids[threadIndex] =
+                static_cast<unsigned int>(tracks[alive_idx]);
+
+            auto tid = shared_tids[threadIndex];
+
+            const auto m_count = static_cast<unsigned int>(thrust::count(
+                thrust::seq, meas_ids[tid].begin(), meas_ids[tid].end(), id));
+
+            const unsigned int N_S =
+                vecmem::device_atomic_ref<unsigned int>(n_shared.at(tid))
+                    .fetch_sub(m_count);
+        }
+    }
+
+    __syncthreads();
+
+    if (active) {
+        auto tid = shared_tids[threadIndex];
+        bool already_pushed = false;
+        for (unsigned int i = 0; i < threadIndex; ++i) {
+            if (shared_tids[i] == tid) {
+                already_pushed = true;
+                break;
+            }
+        }
+        if (!already_pushed) {
+
+            // Write updated track IDs
+            vecmem::device_atomic_ref<unsigned int> num_updated_tracks(
+                *(payload.n_updated_tracks));
+
+            const unsigned int pos = num_updated_tracks.fetch_add(1);
+
+            updated_tracks[pos] = tid;
+            is_updated[tid] = 1;
+
+            rel_shared.at(tid) = static_cast<traccc::scalar>(n_shared.at(tid)) /
+                                 static_cast<traccc::scalar>(n_meas.at(tid));
+        }
     }
 }
 

--- a/tests/cuda/test_ambiguity_resolution.cpp
+++ b/tests/cuda/test_ambiguity_resolution.cpp
@@ -98,7 +98,7 @@ std::vector<measurement_id_type> get_pattern(
     return ret;
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest0) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest0) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -158,7 +158,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest0) {
     }
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest1) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest1) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -200,7 +200,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest1) {
                              {5, 14, 1, 11, 18, 16, 3}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest2) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest2) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -238,7 +238,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest2) {
         find_pattern(res_trk_cands, measurements_device, {3, 5, 6, 13}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest3) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest3) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -280,7 +280,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest3) {
         find_pattern(res_trk_cands, measurements_device, {13, 16, 2, 7, 11}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest5) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest5) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -318,7 +318,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest5) {
     ASSERT_TRUE(find_pattern(res_trk_cands, measurements_device, {6, 6, 6, 6}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest6) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest6) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -359,7 +359,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest6) {
                              {8, 9, 0, 8, 1, 4, 6}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest7) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest7) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -395,7 +395,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest7) {
     ASSERT_TRUE(find_pattern(res_trk_cands, measurements_device, {2, 8, 5, 4}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest8) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest8) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -435,7 +435,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest8) {
     ASSERT_TRUE(find_pattern(res_trk_cands, measurements_device, {1, 9, 3, 0}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest9) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest9) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -472,7 +472,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest9) {
         find_pattern(res_trk_cands, measurements_device, {0, 4, 8, 1, 1}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest10) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest10) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -515,7 +515,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest10) {
         find_pattern(res_trk_cands, measurements_device, {81, 22, 58, 54, 91}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest11) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest11) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -549,7 +549,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest11) {
     ASSERT_EQ(res_trk_cands.size(), 0u);
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest12) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest12) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -590,7 +590,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest12) {
         find_pattern(res_trk_cands, measurements_device, {54, 64, 49, 96, 40}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest13) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest13) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -636,7 +636,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest13) {
         find_pattern(res_trk_cands, measurements_device, {4, 85, 65, 14}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest14) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest14) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -674,7 +674,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest14) {
     ASSERT_TRUE(find_pattern(res_trk_cands, measurements_device, {1, 2, 5}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest15) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest15) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -712,7 +712,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest15) {
     ASSERT_TRUE(find_pattern(res_trk_cands, measurements_device, {8, 7, 1}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest16) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest16) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -756,7 +756,7 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest16) {
     ASSERT_TRUE(find_pattern(res_trk_cands, measurements_device, {80, 45, 94}));
 }
 
-TEST(CudaAmbiguitySolverTests, GreedyResolverTest17) {
+TEST(CUDAAmbiguitySolverTests, GreedyResolverTest17) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -797,12 +797,12 @@ TEST(CudaAmbiguitySolverTests, GreedyResolverTest17) {
 // Test class for the ambiguity resolution comparison with CPU implementation
 // Input tuple: < n_event, n_tracks, track_length_range , max_meas_id,
 // allow_duplicate >
-class GreedyResolutionCompareToCPU
+class CUDAGreedyResolutionCompareToCPU
     : public ::testing::TestWithParam<
           std::tuple<std::size_t, std::size_t, std::array<std::size_t, 2u>,
                      measurement_id_type, bool>> {};
 
-TEST_P(GreedyResolutionCompareToCPU, Comparison) {
+TEST_P(CUDAGreedyResolutionCompareToCPU, Comparison) {
 
     const std::size_t n_events = std::get<0>(GetParam());
     const std::size_t n_tracks = std::get<1>(GetParam());
@@ -938,7 +938,7 @@ TEST_P(GreedyResolutionCompareToCPU, Comparison) {
 };
 
 INSTANTIATE_TEST_SUITE_P(
-    Standard, GreedyResolutionCompareToCPU,
+    Standard, CUDAGreedyResolutionCompareToCPU,
     ::testing::Values(std::make_tuple(5u, 50000u,
                                       std::array<std::size_t, 2u>{1u, 10u},
                                       20000u, true),
@@ -947,7 +947,7 @@ INSTANTIATE_TEST_SUITE_P(
                                       20000u, false)));
 
 INSTANTIATE_TEST_SUITE_P(
-    Sparse, GreedyResolutionCompareToCPU,
+    Sparse, CUDAGreedyResolutionCompareToCPU,
     ::testing::Values(std::make_tuple(3u, 5000u,
                                       std::array<std::size_t, 2u>{3u, 10u},
                                       1000000u, true),
@@ -956,7 +956,7 @@ INSTANTIATE_TEST_SUITE_P(
                                       1000000u, false)));
 
 INSTANTIATE_TEST_SUITE_P(
-    Dense, GreedyResolutionCompareToCPU,
+    Dense, CUDAGreedyResolutionCompareToCPU,
     ::testing::Values(std::make_tuple(3u, 5000u,
                                       std::array<std::size_t, 2u>{3u, 10u},
                                       100u, true),
@@ -965,7 +965,7 @@ INSTANTIATE_TEST_SUITE_P(
                                       100u, false)));
 
 INSTANTIATE_TEST_SUITE_P(
-    Long, GreedyResolutionCompareToCPU,
+    Long, CUDAGreedyResolutionCompareToCPU,
     ::testing::Values(std::make_tuple(3u, 10000u,
                                       std::array<std::size_t, 2u>{3u, 500u},
                                       10000u, true),
@@ -974,7 +974,7 @@ INSTANTIATE_TEST_SUITE_P(
                                       10000u, false)));
 
 INSTANTIATE_TEST_SUITE_P(
-    Simple, GreedyResolutionCompareToCPU,
+    Simple, CUDAGreedyResolutionCompareToCPU,
     ::testing::Values(
         std::make_tuple(3u, 5u, std::array<std::size_t, 2u>{3u, 5u}, 10u, true),
         std::make_tuple(3u, 5u, std::array<std::size_t, 2u>{3u, 5u}, 10u,


### PR DESCRIPTION
There were a couple of bugs which cause the crash reported in #1079:

1. `meas_id_to_unique_id_buffer` is under-allocated => Fixed the size
2. The global variable `n_accepted_prev` in `remove_tracks.cu` is not synchronized by `syncthreads()` => Use the shared memory instead
3. There were some deadlocks caused by `syncthreads()` after thread-dependent condition statements and returns => Took  `syncthreds()` out of the condition statement and removed the thread-dependent returns.

Also changed the test name from Cuda to CUDA to register in the CI run.

Now all tests pass with debug build and `compute_sanitizer`:
```
byeo@hermes:/mnt/nvme0n1/byeo/projects/traccc/traccc_build$ compute-sanitizer ./bin/traccc_test_cuda --gtest_filter=*Greedy*
========= COMPUTE-SANITIZER
Note: Google Test filter = *Greedy*
[==========] Running 27 tests from 6 test suites.
[----------] Global test environment set-up.
[----------] 17 tests from CudaAmbiguitySolverTests
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest0
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest0 (2918 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest1
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest1 (309 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest2
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest2 (302 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest3
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest3 (312 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest5
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest5 (308 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest6
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest6 (310 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest7
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest7 (300 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest8
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest8 (301 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest9
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest9 (301 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest10
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest10 (303 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest11
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest11 (12 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest12
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest12 (303 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest13
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest13 (315 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest14
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest14 (311 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest15
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest15 (308 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest16
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest16 (304 ms)
[ RUN      ] CudaAmbiguitySolverTests.GreedyResolverTest17
[       OK ] CudaAmbiguitySolverTests.GreedyResolverTest17 (310 ms)
[----------] 17 tests from CudaAmbiguitySolverTests (7535 ms total)

[----------] 2 tests from Standard/GreedyResolutionCompareToCPU
[ RUN      ] Standard/GreedyResolutionCompareToCPU.Comparison/0
Event: 0 Seed: 42
 Time for the cpu method 36997 ms
 Time for the cuda method 26080 ms
Event: 1 Seed: 43
 Time for the cpu method 36478 ms
 Time for the cuda method 23068 ms
Event: 2 Seed: 44
 Time for the cpu method 36257 ms
 Time for the cuda method 23125 ms
Event: 3 Seed: 45
 Time for the cpu method 36616 ms
 Time for the cuda method 23853 ms
Event: 4 Seed: 46
 Time for the cpu method 36537 ms
 Time for the cuda method 23634 ms
[       OK ] Standard/GreedyResolutionCompareToCPU.Comparison/0 (308503 ms)
[ RUN      ] Standard/GreedyResolutionCompareToCPU.Comparison/1
Event: 0 Seed: 42
 Time for the cpu method 37048 ms
 Time for the cuda method 23488 ms
Event: 1 Seed: 43
 Time for the cpu method 36678 ms
 Time for the cuda method 23569 ms
Event: 2 Seed: 44
 Time for the cpu method 36289 ms
 Time for the cuda method 24105 ms
Event: 3 Seed: 45
 Time for the cpu method 36531 ms
 Time for the cuda method 23938 ms
Event: 4 Seed: 46
 Time for the cpu method 36497 ms
 Time for the cuda method 23760 ms
[       OK ] Standard/GreedyResolutionCompareToCPU.Comparison/1 (307889 ms)
[----------] 2 tests from Standard/GreedyResolutionCompareToCPU (616392 ms total)

[----------] 2 tests from Sparse/GreedyResolutionCompareToCPU
[ RUN      ] Sparse/GreedyResolutionCompareToCPU.Comparison/0
Event: 0 Seed: 42
 Time for the cpu method 242 ms
 Time for the cuda method 2481 ms
Event: 1 Seed: 43
 Time for the cpu method 239 ms
 Time for the cuda method 2355 ms
Event: 2 Seed: 44
 Time for the cpu method 240 ms
 Time for the cuda method 2503 ms
[       OK ] Sparse/GreedyResolutionCompareToCPU.Comparison/0 (30969 ms)
[ RUN      ] Sparse/GreedyResolutionCompareToCPU.Comparison/1
Event: 0 Seed: 42
 Time for the cpu method 242 ms
 Time for the cuda method 2541 ms
Event: 1 Seed: 43
 Time for the cpu method 239 ms
 Time for the cuda method 2352 ms
Event: 2 Seed: 44
 Time for the cpu method 240 ms
 Time for the cuda method 2532 ms
[       OK ] Sparse/GreedyResolutionCompareToCPU.Comparison/1 (31095 ms)
[----------] 2 tests from Sparse/GreedyResolutionCompareToCPU (62065 ms total)

[----------] 2 tests from Dense/GreedyResolutionCompareToCPU
[ RUN      ] Dense/GreedyResolutionCompareToCPU.Comparison/0
Event: 0 Seed: 42
 Time for the cpu method 652 ms
 Time for the cuda method 40350 ms
Event: 1 Seed: 43
 Time for the cpu method 650 ms
 Time for the cuda method 40543 ms
Event: 2 Seed: 44
 Time for the cpu method 648 ms
 Time for the cuda method 41279 ms
[       OK ] Dense/GreedyResolutionCompareToCPU.Comparison/0 (124294 ms)
[ RUN      ] Dense/GreedyResolutionCompareToCPU.Comparison/1
Event: 0 Seed: 42
 Time for the cpu method 650 ms
 Time for the cuda method 41709 ms
Event: 1 Seed: 43
 Time for the cpu method 649 ms
 Time for the cuda method 42731 ms
Event: 2 Seed: 44
 Time for the cpu method 648 ms
 Time for the cuda method 41824 ms
[       OK ] Dense/GreedyResolutionCompareToCPU.Comparison/1 (128392 ms)
[----------] 2 tests from Dense/GreedyResolutionCompareToCPU (252687 ms total)

[----------] 2 tests from Long/GreedyResolutionCompareToCPU
[ RUN      ] Long/GreedyResolutionCompareToCPU.Comparison/0
Event: 0 Seed: 42
 Time for the cpu method 9316 ms
 Time for the cuda method 585361 ms
Event: 1 Seed: 43
 Time for the cpu method 9280 ms
 Time for the cuda method 581621 ms
Event: 2 Seed: 44
 Time for the cpu method 9320 ms
 Time for the cuda method 580365 ms
[       OK ] Long/GreedyResolutionCompareToCPU.Comparison/0 (1779816 ms)
[ RUN      ] Long/GreedyResolutionCompareToCPU.Comparison/1
Event: 0 Seed: 42
 Time for the cpu method 9407 ms
 Time for the cuda method 568198 ms
Event: 1 Seed: 43
 Time for the cpu method 9436 ms
^[[A Time for the cuda method 572291 ms
Event: 2 Seed: 44
 Time for the cpu method 9432 ms
 Time for the cuda method 570329 ms
[       OK ] Long/GreedyResolutionCompareToCPU.Comparison/1 (1750405 ms)
[----------] 2 tests from Long/GreedyResolutionCompareToCPU (3530222 ms total)

[----------] 2 tests from Simple/GreedyResolutionCompareToCPU
[ RUN      ] Simple/GreedyResolutionCompareToCPU.Comparison/0
Event: 0 Seed: 42
 Time for the cpu method 0 ms
 Time for the cuda method 385 ms
Event: 1 Seed: 43
 Time for the cpu method 0 ms
 Time for the cuda method 334 ms
Event: 2 Seed: 44
 Time for the cpu method 0 ms
 Time for the cuda method 336 ms
[       OK ] Simple/GreedyResolutionCompareToCPU.Comparison/0 (1062 ms)
[ RUN      ] Simple/GreedyResolutionCompareToCPU.Comparison/1
Event: 0 Seed: 42
 Time for the cpu method 0 ms
 Time for the cuda method 335 ms
Event: 1 Seed: 43
 Time for the cpu method 0 ms
 Time for the cuda method 333 ms
Event: 2 Seed: 44
 Time for the cpu method 0 ms
 Time for the cuda method 336 ms
[       OK ] Simple/GreedyResolutionCompareToCPU.Comparison/1 (1011 ms)
[----------] 2 tests from Simple/GreedyResolutionCompareToCPU (2074 ms total)

[----------] Global test environment tear-down
[==========] 27 tests from 6 test suites ran. (4470977 ms total)
[  PASSED  ] 27 tests.
========= ERROR SUMMARY: 0 errors
```