### PR TITLE
Improve performance of triplet finding

### DIFF
--- a/device/common/include/traccc/edm/device/triplet_counter.hpp
+++ b/device/common/include/traccc/edm/device/triplet_counter.hpp
@@ -47,6 +47,9 @@ struct triplet_counter {
     /// The position in which these triplets will be added
     unsigned int posTriplets = 0;
 
+    /// Index of the bottom-middle doublet
+    unsigned int m_botMidIdx = 0;
+
 };  // struct triplet_counter
 
 /// Declare all triplet counter collection types

--- a/device/common/include/traccc/seeding/device/count_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/count_triplets.hpp
@@ -48,7 +48,9 @@ inline void count_triplets(
     const device_doublet_collection_types::const_view& mid_bot_doublet_view,
     const device_doublet_collection_types::const_view& mid_top_doublet_view,
     triplet_counter_spM_collection_types::view spM_tc,
-    triplet_counter_collection_types::view mb_tc);
+    triplet_counter_collection_types::view mb_tc,
+    vecmem::data::vector_view<const lin_circle> mid_bot_circles,
+    vecmem::data::vector_view<const lin_circle> mid_top_circles);
 
 }  // namespace traccc::device
 

--- a/device/common/include/traccc/seeding/device/find_triplets.hpp
+++ b/device/common/include/traccc/seeding/device/find_triplets.hpp
@@ -49,6 +49,8 @@ inline void find_triplets(
     const device_doublet_collection_types::const_view& mid_top_doublet_view,
     const triplet_counter_spM_collection_types::const_view& spM_tc_view,
     const triplet_counter_collection_types::const_view& tc_view,
+    vecmem::data::vector_view<const lin_circle> mid_bot_circle_view,
+    vecmem::data::vector_view<const lin_circle> mid_top_circle_view,
     device_triplet_collection_types::view triplet_view);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/make_mid_bot_lincircles.hpp
+++ b/device/common/include/traccc/seeding/device/make_mid_bot_lincircles.hpp
@@ -1,0 +1,48 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::device {
+/**
+ * @brief Kernel to create middle-bottom linearised circles.
+ */
+TRACCC_HOST_DEVICE
+inline void make_mid_bot_lincircles(
+    global_index_t tid,
+    device::device_doublet_collection_types::const_view mb_doublet_view,
+    device::doublet_counter_collection_types::const_view doublet_count_view,
+    edm::spacepoint_collection::const_view spacepoint_view,
+    traccc::details::spacepoint_grid_types::const_view sp_grid_view,
+    vecmem::data::vector_view<lin_circle> out_view) {
+
+    const device::device_doublet_collection_types::const_device doublets(
+        mb_doublet_view);
+    const device::doublet_counter_collection_types::const_device doublet_counts(
+        doublet_count_view);
+    const edm::spacepoint_collection::const_device spacepoints(spacepoint_view);
+    traccc::details::spacepoint_grid_types::const_device sp_grid(sp_grid_view);
+    vecmem::device_vector<lin_circle> out(out_view);
+
+    if (tid >= doublets.size()) {
+        return;
+    }
+
+    const device::device_doublet dub = doublets.at(tid);
+    const unsigned int counter_link = dub.counter_link;
+    const device::doublet_counter count = doublet_counts.at(counter_link);
+    const sp_location spM_loc = count.m_spM;
+    const edm::spacepoint_collection::const_device::const_proxy_type spM =
+        spacepoints.at(sp_grid.bin(spM_loc.bin_idx)[spM_loc.sp_idx]);
+    const sp_location spB_loc = dub.sp2;
+    const edm::spacepoint_collection::const_device::const_proxy_type spB =
+        spacepoints.at(sp_grid.bin(spB_loc.bin_idx)[spB_loc.sp_idx]);
+
+    out.at(tid) = doublet_finding_helper::transform_coordinates<
+        traccc::details::spacepoint_type::bottom>(spM, spB);
+}
+}  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/make_mid_top_lincircles.hpp
+++ b/device/common/include/traccc/seeding/device/make_mid_top_lincircles.hpp
@@ -1,0 +1,48 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::device {
+/**
+ * @brief Kernel to create middle-bottom linearised circles.
+ */
+TRACCC_HOST_DEVICE
+inline void make_mid_top_lincircles(
+    global_index_t tid,
+    device::device_doublet_collection_types::const_view mt_doublet_view,
+    device::doublet_counter_collection_types::const_view doublet_count_view,
+    edm::spacepoint_collection::const_view spacepoint_view,
+    traccc::details::spacepoint_grid_types::const_view sp_grid_view,
+    vecmem::data::vector_view<lin_circle> out_view) {
+
+    const device::device_doublet_collection_types::const_device doublets(
+        mt_doublet_view);
+    const device::doublet_counter_collection_types::const_device doublet_counts(
+        doublet_count_view);
+    const edm::spacepoint_collection::const_device spacepoints(spacepoint_view);
+    traccc::details::spacepoint_grid_types::const_device sp_grid(sp_grid_view);
+    vecmem::device_vector<lin_circle> out(out_view);
+
+    if (tid >= doublets.size()) {
+        return;
+    }
+
+    const device::device_doublet dub = doublets.at(tid);
+    const unsigned int counter_link = dub.counter_link;
+    const device::doublet_counter count = doublet_counts.at(counter_link);
+    const sp_location spM_loc = count.m_spM;
+    const edm::spacepoint_collection::const_device::const_proxy_type spM =
+        spacepoints.at(sp_grid.bin(spM_loc.bin_idx)[spM_loc.sp_idx]);
+    const sp_location spT_loc = dub.sp2;
+    const edm::spacepoint_collection::const_device::const_proxy_type spT =
+        spacepoints.at(sp_grid.bin(spT_loc.bin_idx)[spT_loc.sp_idx]);
+
+    out.at(tid) = doublet_finding_helper::transform_coordinates<
+        traccc::details::spacepoint_type::top>(spM, spT);
+}
+}  // namespace traccc::device

--- a/device/sycl/src/seeding/seed_finding.sycl
+++ b/device/sycl/src/seeding/seed_finding.sycl
@@ -23,6 +23,8 @@
 #include "traccc/seeding/device/count_triplets.hpp"
 #include "traccc/seeding/device/find_doublets.hpp"
 #include "traccc/seeding/device/find_triplets.hpp"
+#include "traccc/seeding/device/make_mid_bot_lincircles.hpp"
+#include "traccc/seeding/device/make_mid_top_lincircles.hpp"
 #include "traccc/seeding/device/reduce_triplet_counts.hpp"
 #include "traccc/seeding/device/select_seeds.hpp"
 #include "traccc/seeding/device/update_triplet_weights.hpp"
@@ -41,6 +43,14 @@ class count_doublets;
 
 /// Class identifying the kernel running @c traccc::device::find_doublets
 class find_doublets;
+
+/// Class identifying the kernel running @c
+/// traccc::device::make_mid_bot_lincircles
+class make_mid_bot_lincircles;
+
+/// Class identifying the kernel running @c
+/// traccc::device::make_mid_top_lincircles
+class make_mid_top_lincircles;
 
 /// Class identifying the kernel running @c traccc::device::count_triplets
 class count_triplets;
@@ -181,6 +191,55 @@ edm::seed_collection::buffer seed_finding::operator()(
                 });
         });
 
+    // Wait here for the find_doublets kernel to finish
+    find_doublets_kernel.wait_and_throw();
+
+    // Create buffers to compute lin circles into
+    vecmem::data::vector_buffer<lin_circle> midBotLinCircles{
+        globalCounter_host->m_nMidBot, m_mr.main};
+    m_copy.setup(midBotLinCircles)->wait();
+    vecmem::data::vector_buffer<lin_circle> midTopLinCircles{
+        globalCounter_host->m_nMidTop, m_mr.main};
+    m_copy.setup(midBotLinCircles)->wait();
+
+    ::sycl::event makeMidBotLinCirclesKernel, makeMidTopLinCirclesKernel;
+
+    {
+        const unsigned int nThreads = 128;
+        const auto midBotRange = details::calculate1DimNdRange(
+            globalCounter_host->m_nMidBot, nThreads);
+        const auto midTopRange = details::calculate1DimNdRange(
+            globalCounter_host->m_nMidBot, nThreads);
+
+        makeMidBotLinCirclesKernel =
+            details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+                h.parallel_for<kernels::make_mid_bot_lincircles>(
+                    midBotRange,
+                    [spacepoints_view, g2_view, doublet_counter_view, mb_view,
+                     mid_bot_circles_view = vecmem::get_data(midBotLinCircles)](
+                        ::sycl::nd_item<1> item) {
+                        device::make_mid_bot_lincircles(
+                            details::global_index(item), mb_view,
+                            doublet_counter_view, spacepoints_view, g2_view,
+                            mid_bot_circles_view);
+                    });
+            });
+
+        makeMidTopLinCirclesKernel =
+            details::get_queue(m_queue).submit([&](::sycl::handler& h) {
+                h.parallel_for<kernels::make_mid_top_lincircles>(
+                    midTopRange,
+                    [spacepoints_view, g2_view, doublet_counter_view, mt_view,
+                     mid_top_circles_view = vecmem::get_data(midTopLinCircles)](
+                        ::sycl::nd_item<1> item) {
+                        device::make_mid_bot_lincircles(
+                            details::global_index(item), mt_view,
+                            doublet_counter_view, spacepoints_view, g2_view,
+                            mid_top_circles_view);
+                    });
+            });
+    }
+
     // Set up the triplet counter buffers and their views
     device::triplet_counter_spM_collection_types::buffer
         triplet_counter_spM_buffer = {doublet_counter_buffer_size, m_mr.main};
@@ -202,8 +261,8 @@ edm::seed_collection::buffer seed_finding::operator()(
     const auto tripletCountRange = details::calculate1DimNdRange(
         globalCounter_host->m_nMidBot, tripletCountLocalSize);
 
-    // Wait here for the find_doublets kernel to finish
-    find_doublets_kernel.wait_and_throw();
+    makeMidBotLinCirclesKernel.wait_and_throw();
+    makeMidTopLinCirclesKernel.wait_and_throw();
 
     // Count the number of triplets that we need to produce.
     auto count_triplets_kernel =
@@ -212,12 +271,15 @@ edm::seed_collection::buffer seed_finding::operator()(
                 tripletCountRange,
                 [config = m_seedfinder_config, spacepoints_view, g2_view,
                  doublet_counter_view, mb_view, mt_view,
-                 triplet_counter_spM_view,
-                 triplet_counter_midBot_view](::sycl::nd_item<1> item) {
+                 triplet_counter_spM_view, triplet_counter_midBot_view,
+                 mid_bot_circles_view = vecmem::get_data(midBotLinCircles),
+                 mid_top_circles_view = vecmem::get_data(midTopLinCircles)](
+                    ::sycl::nd_item<1> item) {
                     device::count_triplets(
                         details::global_index(item), config, spacepoints_view,
                         g2_view, doublet_counter_view, mb_view, mt_view,
-                        triplet_counter_spM_view, triplet_counter_midBot_view);
+                        triplet_counter_spM_view, triplet_counter_midBot_view,
+                        mid_bot_circles_view, mid_top_circles_view);
                 });
         });
 
@@ -272,13 +334,16 @@ edm::seed_collection::buffer seed_finding::operator()(
                 [config = m_seedfinder_config,
                  filter_config = m_seedfilter_config, spacepoints_view, g2_view,
                  doublet_counter_view, mt_view, triplet_counter_spM_view,
-                 triplet_counter_midBot_view,
-                 triplet_view](::sycl::nd_item<1> item) {
+                 triplet_counter_midBot_view, triplet_view,
+                 mid_bot_circles_view = vecmem::get_data(midBotLinCircles),
+                 mid_top_circles_view = vecmem::get_data(midTopLinCircles)](
+                    ::sycl::nd_item<1> item) {
                     device::find_triplets(
                         details::global_index(item), config, filter_config,
                         spacepoints_view, g2_view, doublet_counter_view,
                         mt_view, triplet_counter_spM_view,
-                        triplet_counter_midBot_view, triplet_view);
+                        triplet_counter_midBot_view, mid_bot_circles_view,
+                        mid_top_circles_view, triplet_view);
                 });
         });
 


### PR DESCRIPTION
This commit improves the performance of our seed finding by computing the linear circles for the doublets only once rather than computing them multiple times. Also tweaks launch parameters to improve occupancy.