### PR TITLE
Add fast math function library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,9 @@ option( TRACCC_BUILD_TESTING "Build the (unit) tests of traccc" TRUE )
 option( TRACCC_BUILD_BENCHMARKS "Build the benchmarks of traccc" TRUE )
 option( TRACCC_BUILD_EXAMPLES "Build the examples of traccc" TRUE )
 
+# Flags controlling aspects of the traccc build
+option( TRACCC_FORCE_SLOW_MATH "Enforce slow math functions" FALSE )
+
 # Flags controlling what traccc should use.
 option( TRACCC_USE_SYSTEM_LIBS "Use system libraries be default" FALSE )
 option( TRACCC_USE_SPACK_LIBS "Use Spack libraries by default" FALSE )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -143,3 +143,7 @@ target_compile_definitions( traccc_core
 # Set the algebra-plugins plugin to use.
 message(STATUS "Building with plugin type: " ${TRACCC_ALGEBRA_PLUGINS})
 target_compile_definitions(traccc_core PUBLIC ALGEBRA_PLUGINS_INCLUDE_${TRACCC_ALGEBRA_PLUGINS})
+
+if(TRACCC_FORCE_SLOW_MATH)
+  target_compile_definitions(traccc_core PUBLIC TRACCC_FORCE_SLOW_MATH)
+endif()

--- a/core/include/traccc/definitions/math.hpp
+++ b/core/include/traccc/definitions/math.hpp
@@ -12,16 +12,201 @@
 #include <sycl/sycl.hpp>
 #endif
 
+#include "traccc/definitions/qualifiers.hpp"
+
 // System include(s).
 #include <cmath>
+
+#ifdef __CUDA_ARCH__
+#define TRACCC_MATH_ALWAYS_INLINE __attribute__((always_inline))
+#else
+#define TRACCC_MATH_ALWAYS_INLINE
+#endif
 
 namespace traccc {
 
 /// Namespace to pick up math functions from
+namespace math {
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
-namespace math = ::sycl;
+using ::sycl::abs;
+using ::sycl::acos;
+using ::sycl::asin;
+using ::sycl::atan;
+using ::sycl::atan2;
+using ::sycl::cos;
+using ::sycl::exp;
+using ::sycl::fabs;
+using ::sycl::floor;
+using ::sycl::fmod;
+using ::sycl::log;
+using ::sycl::max;
+using ::sycl::min;
+using ::sycl::pow;
+using ::sycl::sin;
+using ::sycl::sqrt;
+using ::sycl::tan;
 #else
-namespace math = std;
+using std::abs;
+using std::acos;
+using std::asin;
+using std::atan;
+using std::atan2;
+using std::cos;
+using std::exp;
+using std::fabs;
+using std::floor;
+using std::fmod;
+using std::log;
+using std::max;
+using std::min;
+using std::pow;
+using std::sin;
+using std::sqrt;
+using std::tan;
 #endif  // SYCL
 
+namespace fast {
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline float sqrt(float v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return __fsqrt_rn(v);
+#else
+    return ::traccc::math::sqrt(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline double sqrt(double v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return __dsqrt_rn(v);
+#else
+    return ::traccc::math::sqrt(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline float sin(float v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return __sinf(v);
+#else
+    return ::traccc::math::sin(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline double sin(double v) {
+    return ::traccc::math::sin(v);
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline float asin(float v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return asinf(v);
+#else
+    return ::traccc::math::asin(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline double asin(double v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return asin(v);
+#else
+    return ::traccc::math::asin(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline float cos(float v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return __cosf(v);
+#else
+    return ::traccc::math::cos(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline double cos(double v) {
+    return ::traccc::math::cos(v);
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline float acos(float v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return acosf(v);
+#else
+    return ::traccc::math::acos(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline double acos(double v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return acos(v);
+#else
+    return ::traccc::math::acos(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline float tan(float v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return __tanf(v);
+#else
+    return ::traccc::math::tan(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline double tan(double v) {
+    return ::traccc::math::tan(v);
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline float atan(float v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return atanf(v);
+#else
+    return ::traccc::math::atan(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline double atan(double v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return atan(v);
+#else
+    return ::traccc::math::atan(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline float atan2(float y,
+                                                                float x) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return atan2f(y, x);
+#else
+    return ::traccc::math::atan2(y, x);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline double atan2(double y,
+                                                                 double x) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return atan2(y, x);
+#else
+    return ::traccc::math::atan2(y, x);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline float log(float v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return __logf(v);
+#else
+    return ::traccc::math::log(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline double log(double v) {
+    return ::traccc::math::log(v);
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline float exp(float v) {
+#if defined(__CUDA_ARCH__) && !defined(TRACCC_FORCE_SLOW_MATH)
+    return __expf(v);
+#else
+    return ::traccc::math::exp(v);
+#endif
+}
+
+TRACCC_HOST_DEVICE TRACCC_MATH_ALWAYS_INLINE inline double exp(double v) {
+    return ::traccc::math::exp(v);
+}
+}  // namespace fast
+}  // namespace math
 }  // namespace traccc

--- a/core/include/traccc/seeding/detail/seeding_config.hpp
+++ b/core/include/traccc/seeding/detail/seeding_config.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/definitions/common.hpp"
+#include "traccc/definitions/math.hpp"
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 
@@ -119,19 +120,19 @@ struct seedfinder_config {
     TRACCC_HOST_DEVICE
     void setup() {
         highland = 13.6f * traccc::unit<float>::MeV *
-                   std::sqrt(radLengthPerSeed) *
-                   (1.f + 0.038f * std::log(radLengthPerSeed));
+                   math::sqrt(radLengthPerSeed) *
+                   (1.f + 0.038f * math::log(radLengthPerSeed));
 
         float maxScatteringAngle = highland / minPt;
         maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
 
         pTPerHelixRadius = bFieldInZ;
-        minHelixDiameter2 = std::pow(minPt * 2.f / pTPerHelixRadius, 2.f);
-        minHelixRadius = std::sqrt(minHelixDiameter2) / 2.f;
+        minHelixDiameter2 = math::pow(minPt * 2.f / pTPerHelixRadius, 2.f);
+        minHelixRadius = math::sqrt(minHelixDiameter2) / 2.f;
 
         // @TODO: This is definitely a bug because highland / pTPerHelixRadius
         // is in length unit
-        pT2perRadius = std::pow(highland / pTPerHelixRadius, 2.f);
+        pT2perRadius = math::pow(highland / pTPerHelixRadius, 2.f);
     }
 };
 

--- a/core/include/traccc/seeding/doublet_finding_helper.hpp
+++ b/core/include/traccc/seeding/doublet_finding_helper.hpp
@@ -144,7 +144,7 @@ bool TRACCC_HOST_DEVICE doublet_finding_helper::isCompatible(
     scalar deltaX = sp2.x() - sp1.x();
     scalar deltaY = sp2.y() - sp1.y();
     scalar deltaXY2 = deltaX * deltaX + deltaY * deltaY;
-    scalar sagittaLength = math::sqrt(
+    scalar sagittaLength = math::fast::sqrt(
         config.minHelixRadius * config.minHelixRadius - deltaXY2 / 4.f);
 
     /*
@@ -174,7 +174,7 @@ bool TRACCC_HOST_DEVICE doublet_finding_helper::isCompatible(
      * mdY = q * sinTheta
      * ```
      */
-    scalar denom = math::sqrt((slope * slope + 1) / (slope * slope));
+    scalar denom = math::fast::sqrt((slope * slope + 1) / (slope * slope));
     scalar cosCentralAngle = 1.f / denom;
     scalar sinCentralAngle = -1.f / (slope * denom);
 

--- a/core/include/traccc/seeding/spacepoint_binning_helper.hpp
+++ b/core/include/traccc/seeding/spacepoint_binning_helper.hpp
@@ -38,8 +38,8 @@ inline std::pair<detray::axis2::circular<>, detray::axis2::regular<>> get_axes(
         }
         scalar maxR2 = grid_config.rMax * grid_config.rMax;
         scalar xOuter = maxR2 / (2 * minHelixRadius);
-        scalar yOuter = std::sqrt(maxR2 - xOuter * xOuter);
-        scalar outerAngle = std::atan(xOuter / yOuter);
+        scalar yOuter = math::fast::sqrt(maxR2 - xOuter * xOuter);
+        scalar outerAngle = math::fast::atan(xOuter / yOuter);
 
         // intersection of helix and max detector radius minus maximum R
         // distance from middle SP to top SP
@@ -50,15 +50,15 @@ inline std::pair<detray::axis2::circular<>, detray::axis2::regular<>> get_axes(
             scalar innerCircleR2 = (grid_config.rMax - grid_config.deltaRMax) *
                                    (grid_config.rMax - grid_config.deltaRMax);
             scalar xInner = innerCircleR2 / (2 * minHelixRadius);
-            scalar yInner = std::sqrt(innerCircleR2 - xInner * xInner);
-            innerAngle = std::atan(xInner / yInner);
+            scalar yInner = math::fast::sqrt(innerCircleR2 - xInner * xInner);
+            innerAngle = math::fast::atan(xInner / yInner);
         }
 
         // evaluating the azimutal deflection including the maximum impact
         // parameter
-        scalar deltaAngleWithMaxD0 =
-            math::fabs(std::asin(grid_config.impactMax / (rMin)) -
-                       std::asin(grid_config.impactMax / grid_config.rMax));
+        scalar deltaAngleWithMaxD0 = math::fabs(
+            math::fast::asin(grid_config.impactMax / (rMin)) -
+            math::fast::asin(grid_config.impactMax / grid_config.rMax));
 
         // evaluating delta Phi based on the inner and outer angle, and the
         // azimutal deflection including the maximum impact parameter Divide by
@@ -117,7 +117,7 @@ inline TRACCC_HOST_DEVICE bool is_valid_sp(const seedfinder_config& config,
     if (sp.z() > config.zMax || sp.z() < config.zMin) {
         return false;
     }
-    scalar spPhi = algebra::math::atan2(sp.y(), sp.x());
+    scalar spPhi = math::fast::atan2(sp.y(), sp.x());
     if (spPhi > config.phiMax || spPhi < config.phiMin) {
         return false;
     }

--- a/core/include/traccc/seeding/triplet_finding_helper.hpp
+++ b/core/include/traccc/seeding/triplet_finding_helper.hpp
@@ -64,7 +64,7 @@ bool TRACCC_HOST_DEVICE triplet_finding_helper::isCompatible(
     if (deltaCotTheta2 - error2 > 0) {
         deltaCotTheta = math::fabs(deltaCotTheta);
         // if deltaTheta larger than the scattering for the lower pT cut, skip
-        error = std::sqrt(error2);
+        error = math::fast::sqrt(error2);
         dCotThetaMinusError2 = deltaCotTheta2 + error2 -
                                static_cast<scalar>(2.) * deltaCotTheta * error;
         // avoid taking root of scatteringInRegion
@@ -101,8 +101,8 @@ bool TRACCC_HOST_DEVICE triplet_finding_helper::isCompatible(
         static_cast<scalar>(4.) * iHelixDiameter2 * config.pT2perRadius;
     // if pT > maxPtScattering, calculate allowed scattering angle using
     // maxPtScattering instead of pt.
-    scalar pT =
-        config.pTPerHelixRadius * std::sqrt(S2 / B2) / static_cast<scalar>(2.);
+    scalar pT = config.pTPerHelixRadius * math::fast::sqrt(S2 / B2) /
+                static_cast<scalar>(2.);
     if (pT > config.maxPtScattering) {
         scalar pTscatter = config.highland / config.maxPtScattering;
         pT2scatter = pTscatter * pTscatter;
@@ -118,7 +118,7 @@ bool TRACCC_HOST_DEVICE triplet_finding_helper::isCompatible(
     }
 
     // calculate curvature
-    curvature = B / std::sqrt(S2);
+    curvature = B / math::fast::sqrt(S2);
 
     // A and B allow calculation of impact params in U/V plane with linear
     // function

--- a/core/include/traccc/utils/prob.hpp
+++ b/core/include/traccc/utils/prob.hpp
@@ -196,11 +196,11 @@ TRACCC_HOST_DEVICE inline scalar_t igam_impl(const scalar_t a,
     scalar_t ans, ax, c, r;
 
     /* Compute  x**a * exp(-x) / gamma(a)  */
-    ax = a * math::log(x) - x - lgam(a);
+    ax = a * math::fast::log(x) - x - lgam(a);
     if (ax < -log_gamma<scalar_t>::kMAXLOG)
         return (0.0f);
 
-    ax = std::exp(ax);
+    ax = math::fast::exp(ax);
 
     /* power series */
     r = a;
@@ -242,11 +242,11 @@ TRACCC_HOST_DEVICE inline scalar_t igamc_impl(const scalar_t a,
     scalar_t ans, ax, c, yc, r, t, y, z;
     scalar_t pk, pkm1, pkm2, qk, qkm1, qkm2;
 
-    ax = a * std::log(x) - x - lgam(a);
+    ax = a * math::fast::log(x) - x - lgam(a);
     if (ax < -log_gamma<scalar_t>::kMAXLOG)
         return (0.0f);
 
-    ax = std::exp(ax);
+    ax = math::fast::exp(ax);
 
     /* continued fraction */
     y = 1.0f - a;
@@ -267,7 +267,7 @@ TRACCC_HOST_DEVICE inline scalar_t igamc_impl(const scalar_t a,
         qk = qkm1 * z - qkm2 * yc;
         if (qk != 0.f) {
             r = pk / qk;
-            t = std::abs((ans - r) / r);
+            t = math::abs((ans - r) / r);
             ans = r;
         } else {
             t = 1.0f;
@@ -276,7 +276,7 @@ TRACCC_HOST_DEVICE inline scalar_t igamc_impl(const scalar_t a,
         pkm1 = pk;
         qkm2 = qkm1;
         qkm1 = qk;
-        if (std::abs(pk) > log_gamma<scalar_t>::kBig) {
+        if (math::abs(pk) > log_gamma<scalar_t>::kBig) {
             pkm2 *= log_gamma<scalar_t>::kBiginv;
             pkm1 *= log_gamma<scalar_t>::kBiginv;
             qkm2 *= log_gamma<scalar_t>::kBiginv;
@@ -302,7 +302,7 @@ TRACCC_HOST_DEVICE inline scalar_t lgam(scalar_t x) {
 
         // For x > 34
         w = lgam_impl<scalar_t>(q);
-        p = std::floor(q);
+        p = math::floor(q);
         if (p == q)  //_unur_FP_same(p,q)
             return (std::numeric_limits<scalar_t>::infinity());
         i = static_cast<int>(p);
@@ -315,11 +315,11 @@ TRACCC_HOST_DEVICE inline scalar_t lgam(scalar_t x) {
             p += 1.0f;
             z = p - q;
         }
-        z = q * std::sin(constant<scalar_t>::pi * z);
+        z = q * math::fast::sin(constant<scalar_t>::pi * z);
         if (z == 0)
             return (std::numeric_limits<scalar_t>::infinity());
         /* z = log(ROOT::Math::Pi()) - log( z ) - w;*/
-        z = std::log(constant<scalar_t>::pi) - math::log(z) - w;
+        z = math::fast::log(constant<scalar_t>::pi) - math::fast::log(z) - w;
         return (z);
     }
 
@@ -345,11 +345,11 @@ TRACCC_HOST_DEVICE inline scalar_t lgam(scalar_t x) {
         } else
             sgngam = 1;
         if (u == static_cast<scalar_t>(2.0))
-            return (std::log(z));
+            return (math::fast::log(z));
         p -= 2.0f;
         x = x + p;
         p = x * Polynomialeval_B(x, 5) / Polynomialeval_C(x, 6);
-        return (std::log(z) + p);
+        return (math::fast::log(z) + p);
     }
 
     return lgam_impl<scalar_t>(x);
@@ -363,7 +363,7 @@ TRACCC_HOST_DEVICE inline scalar_t lgam_impl(scalar_t x) {
     if (x > log_gamma<scalar_t>::kMAXLGM)
         return (sgngam * std::numeric_limits<scalar_t>::infinity());
 
-    q = (x - 0.5f) * std::log(x) - x + log_gamma<scalar_t>::LS2PI;
+    q = (x - 0.5f) * math::fast::log(x) - x + log_gamma<scalar_t>::LS2PI;
     if (x > 1.0e8f)
         return (q);
 

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -178,7 +178,7 @@ inline void aggregate_cluster(
         out.diameter = std::max(delta0, delta1);
     } else if (cfg.diameter_strategy ==
                clustering_diameter_strategy::DIAGONAL) {
-        out.diameter = math::sqrt(delta0 * delta0 + delta1 * delta1);
+        out.diameter = math::fast::sqrt(delta0 * delta0 + delta1 * delta1);
     }
 }
 

--- a/performance/include/traccc/utils/ranges.hpp
+++ b/performance/include/traccc/utils/ranges.hpp
@@ -18,7 +18,7 @@ namespace traccc {
 
 template <typename scalar_t>
 TRACCC_HOST_DEVICE inline scalar_t eta_to_theta(const scalar_t eta) {
-    return 2.f * math::atan(std::exp(-eta));
+    return 2.f * math::atan(math::exp(-eta));
 }
 
 template <typename scalar_t>


### PR DESCRIPTION
This commit adds a new `math::fast` namespace alternative to `math` which will always attempt to use fast instrinsics when possible. This allows much finer control over what is and isn't using fast math to allow us to manage precision. Also migrate some `std` math functions to call into `math` or `math::fast` instead.