### PR TITLE
CMDL Options Improvements, main branch (2025.07.24.)

### DIFF
--- a/examples/options/include/traccc/options/track_seeding.hpp
+++ b/examples/options/include/traccc/options/track_seeding.hpp
@@ -30,13 +30,13 @@ class track_seeding : public interface,
     /// @{
 
     /// Configuration provider for the seed-finder
-    operator seedfinder_config() const override;
+    explicit operator seedfinder_config() const override;
     /// Configuration provider for the seed-filter
-    operator seedfilter_config() const override;
+    explicit operator seedfilter_config() const override;
     /// Configuration provider for the spacepoint grid
-    operator spacepoint_grid_config() const override;
+    explicit operator spacepoint_grid_config() const override;
     /// Configuration provider for the constant magnetic field assumed
-    operator vector3() const override;
+    explicit operator vector3() const override;
 
     /// @}
 

--- a/examples/options/include/traccc/options/track_seeding.hpp
+++ b/examples/options/include/traccc/options/track_seeding.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,32 +8,68 @@
 #pragma once
 
 // Project include(s).
+#include "traccc/options/details/config_provider.hpp"
 #include "traccc/options/details/interface.hpp"
+#include "traccc/options/details/value_array.hpp"
 #include "traccc/seeding/detail/seeding_config.hpp"
-
-// System include(s).
-#include <iosfwd>
 
 namespace traccc::opts {
 
 /// Command line options used to configure track seeding
-class track_seeding : public interface {
+class track_seeding : public interface,
+                      public config_provider<seedfinder_config>,
+                      public config_provider<seedfilter_config>,
+                      public config_provider<spacepoint_grid_config>,
+                      public config_provider<vector3> {
 
     public:
-    /// @name Options
-    /// @{
-
-    /// Configuration for the seed-finding
-    traccc::seedfinder_config seedfinder;
-    /// Configuration for the seed filtering
-    traccc::seedfilter_config seedfilter;
-
-    /// @}
-
     /// Constructor
     track_seeding();
 
+    /// @name Configuration conversion operators
+    /// @{
+
+    /// Configuration provider for the seed-finder
+    operator seedfinder_config() const override;
+    /// Configuration provider for the seed-filter
+    operator seedfilter_config() const override;
+    /// Configuration provider for the spacepoint grid
+    operator spacepoint_grid_config() const override;
+    /// Configuration provider for the constant magnetic field assumed
+    operator vector3() const override;
+
+    /// @}
+
+    /// Read/process the command line options
+    ///
+    /// @param vm The command line options to interpret/read
+    ///
+    void read(const boost::program_options::variables_map& vm) override;
+
+    /// Get a printable representation of the configuration
     std::unique_ptr<configuration_printable> as_printable() const override;
+
+    private:
+    /// Configuration for the seed-finding
+    seedfinder_config m_seedfinder;
+    /// Configuration for the seed filtering
+    seedfilter_config m_seedfilter;
+
+    /// Z range for the used spacepoints
+    opts::value_array<float, 2> m_z_range{m_seedfinder.zMin / unit<float>::mm,
+                                          m_seedfinder.zMax / unit<float>::mm};
+    /// R range for the used spacepoints
+    opts::value_array<float, 2> m_r_range{m_seedfinder.rMin / unit<float>::mm,
+                                          m_seedfinder.rMax / unit<float>::mm};
+    /// Z range for the collision region
+    opts::value_array<float, 2> m_vertex_range{
+        m_seedfinder.collisionRegionMin / unit<float>::mm,
+        m_seedfinder.collisionRegionMax / unit<float>::mm};
+    /// Delta R range for the used spacepoints
+    opts::value_array<float, 2> m_delta_r_range{
+        m_seedfinder.deltaRMin / unit<float>::mm,
+        m_seedfinder.deltaRMax / unit<float>::mm};
+
 };  // struct track_seeding
 
 }  // namespace traccc::opts

--- a/examples/options/src/track_propagation.cpp
+++ b/examples/options/src/track_propagation.cpp
@@ -52,11 +52,45 @@ track_propagation::track_propagation()
         "search-window",
         po::value(&m_search_window)->default_value(m_search_window),
         "Size of the grid surface search window");
-    m_desc.add_options()("rk-tolerance-mm [mm]",
+    m_desc.add_options()("rk-tolerance-mm",
                          po::value(&(m_config.stepping.rk_error_tol))
                              ->default_value(m_config.stepping.rk_error_tol /
                                              traccc::unit<float>::mm),
-                         "The Runge-Kutta stepper tolerance");
+                         "The Runge-Kutta stepper tolerance [mm]");
+    m_desc.add_options()("min-step-size-mm",
+                         po::value(&(m_config.stepping.min_stepsize))
+                             ->default_value(m_config.stepping.min_stepsize /
+                                             traccc::unit<float>::mm),
+                         "The minimum step size [mm]");
+    m_desc.add_options()("stepping-path-limit",
+                         po::value(&(m_config.stepping.path_limit))
+                             ->default_value(m_config.stepping.path_limit /
+                                             traccc::unit<float>::m),
+                         "The maximum path length for the stepper [m]");
+    m_desc.add_options()("max-rk-updates",
+                         po::value(&(m_config.stepping.max_rk_updates))
+                             ->default_value(m_config.stepping.max_rk_updates),
+                         "The maximum number of Runge-Kutta updates");
+    m_desc.add_options()("stepping-use-mean-loss",
+                         po::value(&(m_config.stepping.use_mean_loss))
+                             ->default_value(m_config.stepping.use_mean_loss),
+                         "Enable the Bethe energy loss model");
+
+    m_desc.add_options()(
+        "stepping-do-covariance-transport",
+        po::value(&(m_config.stepping.do_covariance_transport))
+            ->default_value(m_config.stepping.do_covariance_transport),
+        "Enable covariance transport in the stepper");
+    m_desc.add_options()(
+        "stepping-use-eloss-gradient",
+        po::value(&(m_config.stepping.use_eloss_gradient))
+            ->default_value(m_config.stepping.use_eloss_gradient),
+        "Enable the energy loss gradient in covariance transport");
+    m_desc.add_options()(
+        "stepping-use-field-gradient",
+        po::value(&(m_config.stepping.use_field_gradient))
+            ->default_value(m_config.stepping.use_field_gradient),
+        "Enable the B-field gradient in covariance transport");
 }
 
 void track_propagation::read(const po::variables_map &) {
@@ -67,6 +101,9 @@ void track_propagation::read(const po::variables_map &) {
     m_config.navigation.min_mask_tolerance *= traccc::unit<float>::mm;
     m_config.navigation.max_mask_tolerance *= traccc::unit<float>::mm;
     m_config.navigation.search_window = m_search_window;
+
+    m_config.stepping.min_stepsize *= traccc::unit<float>::mm;
+    m_config.stepping.path_limit *= traccc::unit<float>::m;
 }
 
 track_propagation::operator detray::propagation::config() const {
@@ -125,10 +162,6 @@ std::unique_ptr<configuration_printable> track_propagation::as_printable()
         "Path limit",
         std::to_string(m_config.stepping.path_limit / traccc::unit<float>::m) +
             " m"));
-    cat_tsp->add_child(std::make_unique<configuration_kv_pair>(
-        "Min step size", std::to_string(m_config.stepping.min_stepsize /
-                                        traccc::unit<float>::mm) +
-                             " mm"));
     cat_tsp->add_child(std::make_unique<configuration_kv_pair>(
         "Enable Bethe energy loss",
         std::format("{}", m_config.stepping.use_mean_loss)));

--- a/examples/options/src/track_propagation.cpp
+++ b/examples/options/src/track_propagation.cpp
@@ -57,7 +57,7 @@ track_propagation::track_propagation()
                              ->default_value(m_config.stepping.rk_error_tol /
                                              traccc::unit<float>::mm),
                          "The Runge-Kutta stepper tolerance [mm]");
-    m_desc.add_options()("min-step-size-mm",
+    m_desc.add_options()("stepping-min-stepsize",
                          po::value(&(m_config.stepping.min_stepsize))
                              ->default_value(m_config.stepping.min_stepsize /
                                              traccc::unit<float>::mm),
@@ -67,7 +67,7 @@ track_propagation::track_propagation()
                              ->default_value(m_config.stepping.path_limit /
                                              traccc::unit<float>::m),
                          "The maximum path length for the stepper [m]");
-    m_desc.add_options()("max-rk-updates",
+    m_desc.add_options()("stepping-max-rk-updates",
                          po::value(&(m_config.stepping.max_rk_updates))
                              ->default_value(m_config.stepping.max_rk_updates),
                          "The maximum number of Runge-Kutta updates");

--- a/examples/options/src/track_seeding.cpp
+++ b/examples/options/src/track_seeding.cpp
@@ -110,6 +110,8 @@ void track_seeding::read(const po::variables_map&) {
     m_seedfinder.impactMax *= unit<float>::mm;
     m_seedfinder.maxPtScattering *= unit<float>::GeV;
     m_seedfinder.bFieldInZ *= unit<float>::T;
+
+    m_seedfinder.setup();
 }
 
 std::unique_ptr<configuration_printable> track_seeding::as_printable() const {

--- a/examples/options/src/track_seeding.cpp
+++ b/examples/options/src/track_seeding.cpp
@@ -10,12 +10,154 @@
 
 #include "traccc/examples/utils/printable.hpp"
 
+// System include(s).
+#include <format>
+
 namespace traccc::opts {
 
-track_seeding::track_seeding() : interface("Track Seeding Options") {}
+/// Convenience namespace shorthand
+namespace po = boost::program_options;
+
+track_seeding::track_seeding() : interface("Track Seeding Options") {
+
+    m_desc.add_options()(
+        "seedfinder-z-range",
+        po::value(&m_z_range)->value_name("MIN:MAX")->default_value(m_z_range),
+        "Spacepoint Z range [mm]");
+    m_desc.add_options()(
+        "seedfinder-r-range",
+        po::value(&m_r_range)->value_name("MIN:MAX")->default_value(m_r_range),
+        "Spacepoint R range [mm]");
+    m_desc.add_options()("seedfinder-vertex-range",
+                         po::value(&m_vertex_range)
+                             ->value_name("MIN:MAX")
+                             ->default_value(m_vertex_range),
+                         "Vertex Z range [mm]");
+
+    m_desc.add_options()(
+        "seedfinder-minPt",
+        po::value(&m_seedfinder.minPt)
+            ->default_value(m_seedfinder.minPt / unit<float>::GeV),
+        "Minimum track momentum [GeV]");
+
+    m_desc.add_options()("seedfinder-cotThetaMax",
+                         po::value(&m_seedfinder.cotThetaMax)
+                             ->default_value(m_seedfinder.cotThetaMax),
+                         "Maximum cotangent of theta angle [unitless]");
+    m_desc.add_options()(
+        "seedfinder-deltaR-range",
+        po::value(&m_delta_r_range)->default_value(m_delta_r_range),
+        "Distance range in radious between measurements within one seed [mm]");
+
+    m_desc.add_options()(
+        "seedfinder-impactMax",
+        po::value(&m_seedfinder.impactMax)
+            ->default_value(m_seedfinder.impactMax / unit<float>::mm),
+        "Maximum impact parameter [mm]");
+    m_desc.add_options()("seedfinder-sigmaScattering",
+                         po::value(&m_seedfinder.sigmaScattering)
+                             ->default_value(m_seedfinder.sigmaScattering),
+                         "Scattering angle sigma [unitless]");
+    m_desc.add_options()(
+        "seedfinder-maxPtScattering",
+        po::value(&m_seedfinder.maxPtScattering)
+            ->default_value(m_seedfinder.maxPtScattering / unit<float>::GeV),
+        "Upper pt limit for scattering calculation [GeV]");
+
+    m_desc.add_options()("seedfinder-maxSeedsPerSpM",
+                         po::value(&m_seedfinder.maxSeedsPerSpM)
+                             ->default_value(m_seedfinder.maxSeedsPerSpM),
+                         "Maximum number of seeds per middle space point");
+    m_desc.add_options()(
+        "seedfinder-bFieldInZ",
+        po::value(&m_seedfinder.bFieldInZ)
+            ->default_value(m_seedfinder.bFieldInZ / unit<float>::T),
+        "B-field in Z direction [T]");
+}
+
+track_seeding::operator seedfinder_config() const {
+
+    return m_seedfinder;
+}
+
+track_seeding::operator seedfilter_config() const {
+
+    return m_seedfilter;
+}
+
+track_seeding::operator spacepoint_grid_config() const {
+
+    return {m_seedfinder};
+}
+
+track_seeding::operator vector3() const {
+
+    return {0.f, 0.f, m_seedfinder.bFieldInZ};
+}
+
+void track_seeding::read(const po::variables_map&) {
+
+    m_seedfinder.zMin = m_z_range[0] * unit<float>::mm;
+    m_seedfinder.zMax = m_z_range[1] * unit<float>::mm;
+    m_seedfinder.rMin = m_r_range[0] * unit<float>::mm;
+    m_seedfinder.rMax = m_r_range[1] * unit<float>::mm;
+    m_seedfinder.collisionRegionMin = m_vertex_range[0] * unit<float>::mm;
+    m_seedfinder.collisionRegionMax = m_vertex_range[1] * unit<float>::mm;
+    m_seedfinder.deltaRMin = m_delta_r_range[0] * unit<float>::mm;
+    m_seedfinder.deltaRMax = m_delta_r_range[1] * unit<float>::mm;
+
+    m_seedfinder.minPt *= unit<float>::GeV;
+    m_seedfinder.impactMax *= unit<float>::mm;
+    m_seedfinder.maxPtScattering *= unit<float>::GeV;
+    m_seedfinder.bFieldInZ *= unit<float>::T;
+}
 
 std::unique_ptr<configuration_printable> track_seeding::as_printable() const {
+
     auto cat = std::make_unique<configuration_category>(m_description);
+
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Spacepoint Z range",
+        std::format("[{:.1f} - {:.1f}] mm", m_seedfinder.zMin / unit<float>::mm,
+                    m_seedfinder.zMax / unit<float>::mm)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Spacepoint R range",
+        std::format("[{:.2f} - {:.2f}] mm", m_seedfinder.rMin / unit<float>::mm,
+                    m_seedfinder.rMax / unit<float>::mm)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Vertex Z range",
+        std::format("[{:.2f} - {:.2f}] mm",
+                    m_seedfinder.collisionRegionMin / unit<float>::mm,
+                    m_seedfinder.collisionRegionMax / unit<float>::mm)));
+
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Minimum track momentum",
+        std::format("{:.2f} GeV", m_seedfinder.minPt / unit<float>::GeV)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Maximum cotangent of theta angle",
+        std::format("{:.4f}", m_seedfinder.cotThetaMax)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Distance range in radious between measurements within one seed",
+        std::format("[{:.2f} - {:.2f}] mm",
+                    m_seedfinder.deltaRMin / unit<float>::mm,
+                    m_seedfinder.deltaRMax / unit<float>::mm)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Maximum impact parameter",
+        std::format("{:.2f} mm", m_seedfinder.impactMax / unit<float>::mm)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Scattering angle sigma",
+        std::format("{:.2f}", m_seedfinder.sigmaScattering)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Upper pt limit for scattering calculation",
+        std::format("{:.2f} GeV",
+                    m_seedfinder.maxPtScattering / unit<float>::GeV)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Maximum seeds per middle space point",
+        std::to_string(m_seedfinder.maxSeedsPerSpM)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "B-field in Z direction",
+        std::format("{:.2f} T", m_seedfinder.bFieldInZ / unit<float>::T)));
+
     return cat;
 }
 }  // namespace traccc::opts

--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -133,17 +133,17 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         track_state_d2h{mr, copy, logger().clone("TrackStateD2HCopyAlg")};
 
     // Seeding algorithms
-    traccc::host::seeding_algorithm sa(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, host_mr, logger().clone("HostSeedingAlg"));
+    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
+                                       host_mr,
+                                       logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
 
     // Alpaka Algorithms
     traccc::alpaka::seeding_algorithm sa_alpaka{
-        seeding_opts.seedfinder,
-        {seeding_opts.seedfinder},
-        seeding_opts.seedfilter,
+        seeding_opts,
+        seeding_opts,
+        seeding_opts,
         mr,
         async_copy,
         queue,
@@ -266,10 +266,9 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             {
                 traccc::performance::timer t("Track params (alpaka)",
                                              elapsedTimes);
-                params_alpaka_buffer =
-                    tp_alpaka(measurements_alpaka_buffer,
-                              spacepoints_alpaka_buffer, seeds_alpaka_buffer,
-                              {0.f, 0.f, seeding_opts.seedfinder.bFieldInZ});
+                params_alpaka_buffer = tp_alpaka(
+                    measurements_alpaka_buffer, spacepoints_alpaka_buffer,
+                    seeds_alpaka_buffer, seeding_opts);
                 queue.synchronize();
             }  // stop measuring track params alpaka timer
 
@@ -279,8 +278,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                                              elapsedTimes);
                 params = tp(vecmem::get_data(measurements_per_event),
                             vecmem::get_data(spacepoints_per_event),
-                            vecmem::get_data(seeds),
-                            {0.f, 0.f, seeding_opts.seedfinder.bFieldInZ});
+                            vecmem::get_data(seeds), seeding_opts);
             }  // stop measuring track params cpu timer
 
             /*------------------------

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -146,17 +146,16 @@ int seq_run(const traccc::opts::detector& detector_opts,
     fitting_cfg.propagation = propagation_config;
 
     // Constant B field for the track finding and fitting
-    const traccc::vector3 field_vec = {0.f, 0.f,
-                                       seeding_opts.seedfinder.bFieldInZ};
+    const traccc::vector3 field_vec = seeding_opts;
     const auto field = traccc::details::make_magnetic_field(bfield_opts);
 
     traccc::host::clusterization_algorithm ca(
         host_mr, logger().clone("HostClusteringAlg"));
     host_spacepoint_formation_algorithm sf(
         host_mr, logger().clone("HostSpFormationAlg"));
-    traccc::host::seeding_algorithm sa(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, host_mr, logger().clone("HostSeedingAlg"));
+    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
+                                       host_mr,
+                                       logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
     host_finding_algorithm finding_alg(finding_cfg, host_mr,
@@ -172,8 +171,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
     device_spacepoint_formation_algorithm sf_alpaka(
         mr, copy, queue, logger().clone("AlpakaSpFormationAlg"));
     traccc::alpaka::seeding_algorithm sa_alpaka(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, mr, copy, queue,
+        seeding_opts, seeding_opts, seeding_opts, mr, copy, queue,
         logger().clone("AlpakaSeedingAlg"));
     traccc::alpaka::track_params_estimation tp_alpaka(
         mr, copy, queue, logger().clone("AlpakaTrackParEstAlg"));

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -151,10 +151,12 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
         }
     }
 
+    // Algorithm configuration(s).
     typename FULL_CHAIN_ALG::clustering_algorithm::config_type clustering_cfg(
         clusterization_opts);
-
-    // Algorithm configuration(s).
+    const traccc::seedfinder_config seedfinder_config(seeding_opts);
+    const traccc::seedfilter_config seedfilter_config(seeding_opts);
+    const traccc::spacepoint_grid_config spacepoint_grid_config(seeding_opts);
     detray::propagation::config propagation_config(propagation_opts);
     typename FULL_CHAIN_ALG::finding_algorithm::config_type finding_cfg(
         finding_opts);
@@ -175,8 +177,9 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
                       *(cached_host_mrs.at(i)))
                 : static_cast<vecmem::memory_resource&>(uncached_host_mr);
         algs.push_back(
-            {alg_host_mr, clustering_cfg, seeding_opts, seeding_opts,
-             seeding_opts, finding_cfg, fitting_cfg, det_descr, field,
+            {alg_host_mr, clustering_cfg, seedfinder_config,
+             spacepoint_grid_config, seedfilter_config, finding_cfg,
+             fitting_cfg, det_descr, field,
              (detector_opts.use_detray_detector ? &detector : nullptr),
              logger().clone()});
     }

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -175,15 +175,8 @@ int throughput_mt(std::string_view description, int argc, char* argv[],
                       *(cached_host_mrs.at(i)))
                 : static_cast<vecmem::memory_resource&>(uncached_host_mr);
         algs.push_back(
-            {alg_host_mr,
-             clustering_cfg,
-             seeding_opts.seedfinder,
-             {seeding_opts.seedfinder},
-             seeding_opts.seedfilter,
-             finding_cfg,
-             fitting_cfg,
-             det_descr,
-             field,
+            {alg_host_mr, clustering_cfg, seeding_opts, seeding_opts,
+             seeding_opts, finding_cfg, fitting_cfg, det_descr, field,
              (detector_opts.use_detray_detector ? &detector : nullptr),
              logger().clone()});
     }

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -139,9 +139,8 @@ int throughput_st(std::string_view description, int argc, char* argv[],
 
     // Set up the full-chain algorithm.
     std::unique_ptr<FULL_CHAIN_ALG> alg = std::make_unique<FULL_CHAIN_ALG>(
-        alg_host_mr, clustering_cfg, seeding_opts.seedfinder,
-        spacepoint_grid_config{seeding_opts.seedfinder},
-        seeding_opts.seedfilter, finding_cfg, fitting_cfg, det_descr, field,
+        alg_host_mr, clustering_cfg, seeding_opts, seeding_opts, seeding_opts,
+        finding_cfg, fitting_cfg, det_descr, field,
         (detector_opts.use_detray_detector ? &detector : nullptr),
         logger->clone("FullChainAlg"));
 

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -129,6 +129,10 @@ int throughput_st(std::string_view description, int argc, char* argv[],
     typename FULL_CHAIN_ALG::clustering_algorithm::config_type clustering_cfg(
         clusterization_opts);
 
+    const traccc::seedfinder_config seedfinder_config(seeding_opts);
+    const traccc::seedfilter_config seedfilter_config(seeding_opts);
+    const traccc::spacepoint_grid_config spacepoint_grid_config(seeding_opts);
+
     typename FULL_CHAIN_ALG::finding_algorithm::config_type finding_cfg(
         finding_opts);
     finding_cfg.propagation = propagation_config;
@@ -139,8 +143,8 @@ int throughput_st(std::string_view description, int argc, char* argv[],
 
     // Set up the full-chain algorithm.
     std::unique_ptr<FULL_CHAIN_ALG> alg = std::make_unique<FULL_CHAIN_ALG>(
-        alg_host_mr, clustering_cfg, seeding_opts, seeding_opts, seeding_opts,
-        finding_cfg, fitting_cfg, det_descr, field,
+        alg_host_mr, clustering_cfg, seedfinder_config, spacepoint_grid_config,
+        seedfilter_config, finding_cfg, fitting_cfg, det_descr, field,
         (detector_opts.use_detray_detector ? &detector : nullptr),
         logger->clone("FullChainAlg"));
 

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -106,6 +106,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // B field value
     const auto field = traccc::details::make_magnetic_field(bfield_opts);
+    const traccc::vector3 field_vec(seeding_opts);
 
     // Construct a Detray detector object, if supported by the configuration.
     traccc::default_detector::host detector{host_mr};
@@ -115,8 +116,12 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                               detector_opts.grid_file);
 
     // Seeding algorithm
-    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
-                                       host_mr, logger().clone("SeedingAlg"));
+    const traccc::seedfinder_config seedfinder_config(seeding_opts);
+    const traccc::seedfilter_config seedfilter_config(seeding_opts);
+    const traccc::spacepoint_grid_config spacepoint_grid_config(seeding_opts);
+    traccc::host::seeding_algorithm sa(
+        seedfinder_config, spacepoint_grid_config, seedfilter_config, host_mr,
+        logger().clone("SeedingAlg"));
     traccc::host::track_params_estimation tp(host_mr,
                                              logger().clone("TrackParEstAlg"));
 
@@ -171,7 +176,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
         auto params = tp(vecmem::get_data(measurements_per_event),
                          vecmem::get_data(spacepoints_per_event),
-                         vecmem::get_data(seeds), seeding_opts);
+                         vecmem::get_data(seeds), field_vec);
 
         // Run CKF and KF if we are using a detray geometry
         traccc::edm::track_candidate_collection<traccc::default_algebra>::host

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -115,9 +115,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                               detector_opts.grid_file);
 
     // Seeding algorithm
-    traccc::host::seeding_algorithm sa(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, host_mr, logger().clone("SeedingAlg"));
+    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
+                                       host_mr, logger().clone("SeedingAlg"));
     traccc::host::track_params_estimation tp(host_mr,
                                              logger().clone("TrackParEstAlg"));
 
@@ -170,10 +169,9 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
            Track Parameter Estimation
           ----------------------------*/
 
-        auto params =
-            tp(vecmem::get_data(measurements_per_event),
-               vecmem::get_data(spacepoints_per_event), vecmem::get_data(seeds),
-               {0.f, 0.f, seeding_opts.seedfinder.bFieldInZ});
+        auto params = tp(vecmem::get_data(measurements_per_event),
+                         vecmem::get_data(spacepoints_per_event),
+                         vecmem::get_data(seeds), seeding_opts);
 
         // Run CKF and KF if we are using a detray geometry
         traccc::edm::track_candidate_collection<traccc::default_algebra>::host

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -117,11 +117,15 @@ int seq_run(const traccc::opts::input_data& input_opts,
     using fitting_algorithm = traccc::host::kalman_fitting_algorithm;
 
     // Constant B field for the track finding and fitting
-    const traccc::vector3 field_vec = seeding_opts;
+    const traccc::vector3 field_vec(seeding_opts);
     const auto field = traccc::details::make_magnetic_field(bfield_opts);
 
     // Algorithm configuration(s).
     detray::propagation::config propagation_config(propagation_opts);
+
+    const traccc::seedfinder_config seedfinder_config(seeding_opts);
+    const traccc::seedfilter_config seedfilter_config(seeding_opts);
+    const traccc::spacepoint_grid_config spacepoint_grid_config(seeding_opts);
 
     finding_algorithm::config_type finding_cfg(finding_opts);
     finding_cfg.propagation = propagation_config;
@@ -139,8 +143,9 @@ int seq_run(const traccc::opts::input_data& input_opts,
         host_mr, logger().clone("MeasCreationAlg"));
     spacepoint_formation_algorithm sf(host_mr,
                                       logger().clone("SpFormationAlg"));
-    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
-                                       host_mr, logger().clone("SeedingAlg"));
+    traccc::host::seeding_algorithm sa(
+        seedfinder_config, spacepoint_grid_config, seedfilter_config, host_mr,
+        logger().clone("SeedingAlg"));
     traccc::host::track_params_estimation tp(host_mr,
                                              logger().clone("TrackParEstAlg"));
 

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -117,8 +117,7 @@ int seq_run(const traccc::opts::input_data& input_opts,
     using fitting_algorithm = traccc::host::kalman_fitting_algorithm;
 
     // Constant B field for the track finding and fitting
-    const traccc::vector3 field_vec = {0.f, 0.f,
-                                       seeding_opts.seedfinder.bFieldInZ};
+    const traccc::vector3 field_vec = seeding_opts;
     const auto field = traccc::details::make_magnetic_field(bfield_opts);
 
     // Algorithm configuration(s).
@@ -140,9 +139,8 @@ int seq_run(const traccc::opts::input_data& input_opts,
         host_mr, logger().clone("MeasCreationAlg"));
     spacepoint_formation_algorithm sf(host_mr,
                                       logger().clone("SpFormationAlg"));
-    traccc::host::seeding_algorithm sa(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, host_mr, logger().clone("SeedingAlg"));
+    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
+                                       host_mr, logger().clone("SeedingAlg"));
     traccc::host::track_params_estimation tp(host_mr,
                                              logger().clone("TrackParEstAlg"));
 

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -141,9 +141,9 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         track_state_d2h{mr, copy, logger().clone("TrackStateD2HCopyAlg")};
 
     // Seeding algorithm
-    traccc::host::seeding_algorithm sa(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, host_mr, logger().clone("HostSeedingAlg"));
+    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
+                                       host_mr,
+                                       logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
 
@@ -151,9 +151,9 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     vecmem::cuda::async_copy async_copy{stream.cudaStream()};
 
-    traccc::cuda::seeding_algorithm sa_cuda{seeding_opts.seedfinder,
-                                            {seeding_opts.seedfinder},
-                                            seeding_opts.seedfilter,
+    traccc::cuda::seeding_algorithm sa_cuda{seeding_opts,
+                                            seeding_opts,
+                                            seeding_opts,
                                             mr,
                                             async_copy,
                                             stream,
@@ -278,8 +278,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                                              elapsedTimes);
                 params_cuda_buffer =
                     tp_cuda(measurements_cuda_buffer, spacepoints_cuda_buffer,
-                            seeds_cuda_buffer,
-                            {0.f, 0.f, seeding_opts.seedfinder.bFieldInZ});
+                            seeds_cuda_buffer, seeding_opts);
                 stream.synchronize();
             }  // stop measuring track params cuda timer
 
@@ -289,8 +288,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                                              elapsedTimes);
                 params = tp(vecmem::get_data(measurements_per_event),
                             vecmem::get_data(spacepoints_per_event),
-                            vecmem::get_data(seeds),
-                            {0.f, 0.f, seeding_opts.seedfinder.bFieldInZ});
+                            vecmem::get_data(seeds), seeding_opts);
             }  // stop measuring track params cpu timer
 
             /*------------------------

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -150,6 +150,10 @@ int seq_run(const traccc::opts::detector& detector_opts,
     // Algorithm configuration(s).
     detray::propagation::config propagation_config(propagation_opts);
 
+    const traccc::seedfinder_config seedfinder_config(seeding_opts);
+    const traccc::seedfilter_config seedfilter_config(seeding_opts);
+    const traccc::spacepoint_grid_config spacepoint_grid_config(seeding_opts);
+
     traccc::finding_config finding_cfg(finding_opts);
     finding_cfg.propagation = propagation_config;
 
@@ -160,7 +164,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
     fitting_cfg.propagation = propagation_config;
 
     // Constant B field for the track finding and fitting
-    const traccc::vector3 field_vec = seeding_opts;
+    const traccc::vector3 field_vec(seeding_opts);
     const auto host_field = traccc::details::make_magnetic_field(bfield_opts);
     const auto device_field = traccc::cuda::make_magnetic_field(
         host_field,
@@ -172,9 +176,9 @@ int seq_run(const traccc::opts::detector& detector_opts,
         host_mr, logger().clone("HostClusteringAlg"));
     host_spacepoint_formation_algorithm sf(
         host_mr, logger().clone("HostSpFormationAlg"));
-    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
-                                       host_mr,
-                                       logger().clone("HostSeedingAlg"));
+    traccc::host::seeding_algorithm sa(
+        seedfinder_config, spacepoint_grid_config, seedfilter_config, host_mr,
+        logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
     host_finding_algorithm finding_alg(finding_cfg, host_mr,
@@ -192,9 +196,9 @@ int seq_run(const traccc::opts::detector& detector_opts,
         mr, copy, stream, logger().clone("CudaMeasSortingAlg"));
     device_spacepoint_formation_algorithm sf_cuda(
         mr, copy, stream, logger().clone("CudaSpFormationAlg"));
-    traccc::cuda::seeding_algorithm sa_cuda(seeding_opts, seeding_opts,
-                                            seeding_opts, mr, copy, stream,
-                                            logger().clone("CudaSeedingAlg"));
+    traccc::cuda::seeding_algorithm sa_cuda(
+        seedfinder_config, spacepoint_grid_config, seedfilter_config, mr, copy,
+        stream, logger().clone("CudaSeedingAlg"));
     traccc::cuda::track_params_estimation tp_cuda(
         mr, copy, stream, logger().clone("CudaTrackParEstAlg"));
     device_finding_algorithm finding_alg_cuda(finding_cfg, mr, copy, stream,

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -160,8 +160,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
     fitting_cfg.propagation = propagation_config;
 
     // Constant B field for the track finding and fitting
-    const traccc::vector3 field_vec = {0.f, 0.f,
-                                       seeding_opts.seedfinder.bFieldInZ};
+    const traccc::vector3 field_vec = seeding_opts;
     const auto host_field = traccc::details::make_magnetic_field(bfield_opts);
     const auto device_field = traccc::cuda::make_magnetic_field(
         host_field,
@@ -173,9 +172,9 @@ int seq_run(const traccc::opts::detector& detector_opts,
         host_mr, logger().clone("HostClusteringAlg"));
     host_spacepoint_formation_algorithm sf(
         host_mr, logger().clone("HostSpFormationAlg"));
-    traccc::host::seeding_algorithm sa(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, host_mr, logger().clone("HostSeedingAlg"));
+    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
+                                       host_mr,
+                                       logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
     host_finding_algorithm finding_alg(finding_cfg, host_mr,
@@ -193,10 +192,9 @@ int seq_run(const traccc::opts::detector& detector_opts,
         mr, copy, stream, logger().clone("CudaMeasSortingAlg"));
     device_spacepoint_formation_algorithm sf_cuda(
         mr, copy, stream, logger().clone("CudaSpFormationAlg"));
-    traccc::cuda::seeding_algorithm sa_cuda(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, mr, copy, stream,
-        logger().clone("CudaSeedingAlg"));
+    traccc::cuda::seeding_algorithm sa_cuda(seeding_opts, seeding_opts,
+                                            seeding_opts, mr, copy, stream,
+                                            logger().clone("CudaSeedingAlg"));
     traccc::cuda::track_params_estimation tp_cuda(
         mr, copy, stream, logger().clone("CudaTrackParEstAlg"));
     device_finding_algorithm finding_alg_cuda(finding_cfg, mr, copy, stream,

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -59,9 +59,9 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                               detector_opts.material_file,
                               detector_opts.grid_file);
 
-    traccc::host::seeding_algorithm sa(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, host_mr, logger().clone("HostSeedingAlg"));
+    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
+                                       host_mr,
+                                       logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
 
@@ -72,8 +72,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // KOKKOS Spacepoint Binning
     traccc::kokkos::details::spacepoint_binning m_spacepoint_binning(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder}, mr,
-        logger().clone("KokkosBinningAlg"));
+        seeding_opts, seeding_opts, mr, logger().clone("KokkosBinningAlg"));
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
@@ -137,8 +136,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                                              elapsedTimes);
                 params = tp(vecmem::get_data(measurements_per_event),
                             vecmem::get_data(spacepoints_per_event),
-                            vecmem::get_data(seeds),
-                            {0.f, 0.f, seeding_opts.seedfinder.bFieldInZ});
+                            vecmem::get_data(seeds), seeding_opts);
             }  // stop measuring track params cpu timer
 
         }  // Stop measuring wall time

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -59,9 +59,14 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                               detector_opts.material_file,
                               detector_opts.grid_file);
 
-    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
-                                       host_mr,
-                                       logger().clone("HostSeedingAlg"));
+    const traccc::vector3 field_vec(seeding_opts);
+
+    const traccc::seedfinder_config seedfinder_config(seeding_opts);
+    const traccc::seedfilter_config seedfilter_config(seeding_opts);
+    const traccc::spacepoint_grid_config spacepoint_grid_config(seeding_opts);
+    traccc::host::seeding_algorithm sa(
+        seedfinder_config, spacepoint_grid_config, seedfilter_config, host_mr,
+        logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
 
@@ -72,7 +77,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // KOKKOS Spacepoint Binning
     traccc::kokkos::details::spacepoint_binning m_spacepoint_binning(
-        seeding_opts, seeding_opts, mr, logger().clone("KokkosBinningAlg"));
+        seedfinder_config, spacepoint_grid_config, mr,
+        logger().clone("KokkosBinningAlg"));
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
@@ -136,7 +142,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                                              elapsedTimes);
                 params = tp(vecmem::get_data(measurements_per_event),
                             vecmem::get_data(spacepoints_per_event),
-                            vecmem::get_data(seeds), seeding_opts);
+                            vecmem::get_data(seeds), field_vec);
             }  // stop measuring track params cpu timer
 
         }  // Stop measuring wall time

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -99,16 +99,21 @@ int seq_run(const traccc::opts::detector& detector_opts,
         device_det_view = detray::get_data(device_det);
     }
 
+    const traccc::vector3 field_vec(seeding_opts);
+
     // Seeding algorithm
-    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
-                                       host_mr,
-                                       logger().clone("HostSeedingAlg"));
+    const traccc::seedfinder_config seedfinder_config(seeding_opts);
+    const traccc::seedfilter_config seedfilter_config(seeding_opts);
+    const traccc::spacepoint_grid_config spacepoint_grid_config(seeding_opts);
+    traccc::host::seeding_algorithm sa(
+        seedfinder_config, spacepoint_grid_config, seedfilter_config, host_mr,
+        logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
 
-    traccc::sycl::seeding_algorithm sa_sycl{seeding_opts,
-                                            seeding_opts,
-                                            seeding_opts,
+    traccc::sycl::seeding_algorithm sa_sycl{seedfinder_config,
+                                            spacepoint_grid_config,
+                                            seedfilter_config,
                                             mr,
                                             copy,
                                             &q,
@@ -199,7 +204,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
                                              elapsedTimes);
                 params_sycl_buffer =
                     tp_sycl(measurements_sycl_buffer, spacepoints_sycl_buffer,
-                            seeds_sycl_buffer, seeding_opts);
+                            seeds_sycl_buffer, field_vec);
             }  // stop measuring track params sycl timer
 
             // CPU
@@ -208,7 +213,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
                                              elapsedTimes);
                 params = tp(vecmem::get_data(measurements_per_event),
                             vecmem::get_data(spacepoints_per_event),
-                            vecmem::get_data(seeds), seeding_opts);
+                            vecmem::get_data(seeds), field_vec);
             }  // stop measuring track params cpu timer
 
         }  // Stop measuring wall time

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -100,15 +100,15 @@ int seq_run(const traccc::opts::detector& detector_opts,
     }
 
     // Seeding algorithm
-    traccc::host::seeding_algorithm sa(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, host_mr, logger().clone("HostSeedingAlg"));
+    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
+                                       host_mr,
+                                       logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
 
-    traccc::sycl::seeding_algorithm sa_sycl{seeding_opts.seedfinder,
-                                            {seeding_opts.seedfinder},
-                                            seeding_opts.seedfilter,
+    traccc::sycl::seeding_algorithm sa_sycl{seeding_opts,
+                                            seeding_opts,
+                                            seeding_opts,
                                             mr,
                                             copy,
                                             &q,
@@ -199,8 +199,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
                                              elapsedTimes);
                 params_sycl_buffer =
                     tp_sycl(measurements_sycl_buffer, spacepoints_sycl_buffer,
-                            seeds_sycl_buffer,
-                            {0.f, 0.f, seeding_opts.seedfinder.bFieldInZ});
+                            seeds_sycl_buffer, seeding_opts);
             }  // stop measuring track params sycl timer
 
             // CPU
@@ -209,8 +208,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
                                              elapsedTimes);
                 params = tp(vecmem::get_data(measurements_per_event),
                             vecmem::get_data(spacepoints_per_event),
-                            vecmem::get_data(seeds),
-                            {0.f, 0.f, seeding_opts.seedfinder.bFieldInZ});
+                            vecmem::get_data(seeds), seeding_opts);
             }  // stop measuring track params cpu timer
 
         }  // Stop measuring wall time

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -157,8 +157,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
     uint64_t n_found_tracks_sycl = 0;
 
     // Constant B field for the track finding and fitting
-    const traccc::vector3 field_vec = {0.f, 0.f,
-                                       seeding_opts.seedfinder.bFieldInZ};
+    const traccc::vector3 field_vec = seeding_opts;
     const auto host_field = traccc::details::make_magnetic_field(bfield_opts);
     const auto device_field =
         traccc::sycl::make_magnetic_field(host_field, queue);
@@ -174,9 +173,9 @@ int seq_run(const traccc::opts::detector& detector_opts,
         host_mr, logger().clone("HostClusteringAlg"));
     traccc::host::silicon_pixel_spacepoint_formation_algorithm sf(
         host_mr, logger().clone("HostSpFormationAlg"));
-    traccc::host::seeding_algorithm sa(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, host_mr, logger().clone("HostSeedingAlg"));
+    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
+                                       host_mr,
+                                       logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
     traccc::host::combinatorial_kalman_filter_algorithm finding_alg{
@@ -189,10 +188,9 @@ int seq_run(const traccc::opts::detector& detector_opts,
         mr, copy, queue, logger().clone("SyclMeasSortingAlg"));
     traccc::sycl::silicon_pixel_spacepoint_formation_algorithm sf_sycl(
         mr, copy, queue, logger().clone("SyclSpFormationAlg"));
-    traccc::sycl::seeding_algorithm sa_sycl(
-        seeding_opts.seedfinder, {seeding_opts.seedfinder},
-        seeding_opts.seedfilter, mr, copy, &q,
-        logger().clone("SyclSeedingAlg"));
+    traccc::sycl::seeding_algorithm sa_sycl(seeding_opts, seeding_opts,
+                                            seeding_opts, mr, copy, &q,
+                                            logger().clone("SyclSeedingAlg"));
     traccc::sycl::track_params_estimation tp_sycl(
         mr, copy, &q, logger().clone("SyclTrackParEstAlg"));
     traccc::sycl::combinatorial_kalman_filter_algorithm finding_alg_sycl{

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -157,12 +157,16 @@ int seq_run(const traccc::opts::detector& detector_opts,
     uint64_t n_found_tracks_sycl = 0;
 
     // Constant B field for the track finding and fitting
-    const traccc::vector3 field_vec = seeding_opts;
+    const traccc::vector3 field_vec(seeding_opts);
     const auto host_field = traccc::details::make_magnetic_field(bfield_opts);
     const auto device_field =
         traccc::sycl::make_magnetic_field(host_field, queue);
 
     // Algorithm configuration(s).
+    const traccc::seedfinder_config seedfinder_config(seeding_opts);
+    const traccc::seedfilter_config seedfilter_config(seeding_opts);
+    const traccc::spacepoint_grid_config spacepoint_grid_config(seeding_opts);
+
     detray::propagation::config propagation_config(propagation_opts);
 
     traccc::finding_config finding_cfg(finding_opts);
@@ -173,9 +177,9 @@ int seq_run(const traccc::opts::detector& detector_opts,
         host_mr, logger().clone("HostClusteringAlg"));
     traccc::host::silicon_pixel_spacepoint_formation_algorithm sf(
         host_mr, logger().clone("HostSpFormationAlg"));
-    traccc::host::seeding_algorithm sa(seeding_opts, seeding_opts, seeding_opts,
-                                       host_mr,
-                                       logger().clone("HostSeedingAlg"));
+    traccc::host::seeding_algorithm sa(
+        seedfinder_config, spacepoint_grid_config, seedfilter_config, host_mr,
+        logger().clone("HostSeedingAlg"));
     traccc::host::track_params_estimation tp(
         host_mr, logger().clone("HostTrackParEstAlg"));
     traccc::host::combinatorial_kalman_filter_algorithm finding_alg{
@@ -188,9 +192,9 @@ int seq_run(const traccc::opts::detector& detector_opts,
         mr, copy, queue, logger().clone("SyclMeasSortingAlg"));
     traccc::sycl::silicon_pixel_spacepoint_formation_algorithm sf_sycl(
         mr, copy, queue, logger().clone("SyclSpFormationAlg"));
-    traccc::sycl::seeding_algorithm sa_sycl(seeding_opts, seeding_opts,
-                                            seeding_opts, mr, copy, &q,
-                                            logger().clone("SyclSeedingAlg"));
+    traccc::sycl::seeding_algorithm sa_sycl(
+        seedfinder_config, spacepoint_grid_config, seedfilter_config, mr, copy,
+        &q, logger().clone("SyclSeedingAlg"));
     traccc::sycl::track_params_estimation tp_sycl(
         mr, copy, &q, logger().clone("SyclTrackParEstAlg"));
     traccc::sycl::combinatorial_kalman_filter_algorithm finding_alg_sycl{


### PR DESCRIPTION
Added command line options for all of the configuration flags that are being overridden from their default values in the EFTracking code. Took the changes implemented by @flg in his fork as a guide for all this.

This finally adds at least some configurable options for track seeding. For which I also changed the API of `traccc::opts::track_seeding` to be more in line with all the other options classes. So that it would provide the underlying configuration objects through conversion operators, which ended up simplifying the code using `traccc::opts::track_seeding` a little. (Though I do fear that the usage of the class may have become a bit more opaque like this. :frowning:)

Plus added some additional flags to `traccc::opts::track_propagation`. Again, just ones that were missing for EFTracking's benefit.