### PR TITLE
Seeding Throughput, main branch (2025.07.24.)

### DIFF
--- a/examples/options/include/traccc/options/throughput.hpp
+++ b/examples/options/include/traccc/options/throughput.hpp
@@ -23,6 +23,14 @@ class throughput : public interface {
     /// @name Options
     /// @{
 
+    /// "Reconstruction stage" to run
+    enum class stage {
+        seeding,  ///< Run until the end of seeding
+        full      ///< Run the full chain of reconstruction
+    };
+    /// The reconstruction stage to run
+    stage reco_stage = stage::full;
+
     /// The number of events to process during the job
     std::size_t processed_events = 100;
     /// The number of events to run "cold", i.e. run without accounting for
@@ -43,6 +51,13 @@ class throughput : public interface {
     throughput();
 
     std::unique_ptr<configuration_printable> as_printable() const override;
+
+    /// Read/process the command line options
+    ///
+    /// @param vm The command line options to interpret/read
+    ///
+    void read(const boost::program_options::variables_map& vm) override;
+
 };  // class throughput
 
 }  // namespace traccc::opts

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -200,4 +200,47 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     }
 }
 
+bound_track_parameters_collection_types::host full_chain_algorithm::seeding(
+    const edm::silicon_cell_collection::host& cells) const {
+
+    // Create device copy of input collections
+    edm::silicon_cell_collection::buffer cells_buffer(
+        static_cast<unsigned int>(cells.size()), *m_cached_device_mr);
+    m_vecmem_objects.async_copy()(::vecmem::get_data(cells), cells_buffer)
+        ->ignore();
+
+    // Run the clusterization (asynchronously).
+    const clusterization_algorithm::output_type measurements =
+        m_clusterization(cells_buffer, m_device_det_descr);
+    m_measurement_sorting(measurements);
+
+    // If we have a Detray detector, run the track finding and fitting.
+    if (m_detector != nullptr) {
+
+        // Run the seed-finding (asynchronously).
+        const spacepoint_formation_algorithm::output_type spacepoints =
+            m_spacepoint_formation(m_device_detector_view, measurements);
+        const track_params_estimation::output_type track_params =
+            m_track_parameter_estimation(measurements, spacepoints,
+                                         m_seeding(spacepoints), m_field_vec);
+
+        // Copy a limited amount of result data back to the host.
+        bound_track_parameters_collection_types::host result{&m_host_mr};
+        m_vecmem_objects.async_copy()(track_params, result)->wait();
+        return result;
+
+    }
+    // If not, copy the track parameters back to the host, and return a dummy
+    // object.
+    else {
+
+        // Copy the measurements back to the host.
+        measurement_collection_types::host measurements_host(&m_host_mr);
+        m_vecmem_objects.async_copy()(measurements, measurements_host)->wait();
+
+        // Return an empty object.
+        return {};
+    }
+}
+
 }  // namespace traccc::alpaka

--- a/examples/run/alpaka/full_chain_algorithm.hpp
+++ b/examples/run/alpaka/full_chain_algorithm.hpp
@@ -20,6 +20,7 @@
 #include "traccc/bfield/magnetic_field.hpp"
 #include "traccc/clusterization/clustering_config.hpp"
 #include "traccc/edm/silicon_cell_collection.hpp"
+#include "traccc/edm/track_parameters.hpp"
 #include "traccc/edm/track_state.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 #include "traccc/geometry/detector.hpp"
@@ -107,6 +108,14 @@ class full_chain_algorithm
     ///
     output_type operator()(
         const edm::silicon_cell_collection::host& cells) const override;
+
+    /// Reconstruct track seeds in the entire detector
+    ///
+    /// @param cells The cells for every detector module in the event
+    /// @return The track seeds reconstructed
+    ///
+    bound_track_parameters_collection_types::host seeding(
+        const edm::silicon_cell_collection::host& cells) const;
 
     private:
     /// Alpaka Queue

--- a/examples/run/cpu/full_chain_algorithm.cpp
+++ b/examples/run/cpu/full_chain_algorithm.cpp
@@ -90,4 +90,41 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     }
 }
 
+bound_track_parameters_collection_types::host full_chain_algorithm::seeding(
+    const edm::silicon_cell_collection::host& cells) const {
+
+    // Create a data object for the detector description.
+    const silicon_detector_description::const_data det_descr_data =
+        vecmem::get_data(m_det_descr.get());
+
+    // Run the clusterization.
+    auto cells_data = vecmem::get_data(cells);
+    const clustering_algorithm::output_type measurements =
+        m_clusterization(cells_data, det_descr_data);
+
+    // If we have a Detray detector, run the seeding track finding and fitting.
+    if (m_detector != nullptr) {
+
+        // Run the seed-finding.
+        const measurement_collection_types::const_view measurements_view =
+            vecmem::get_data(measurements);
+        const spacepoint_formation_algorithm::output_type spacepoints =
+            m_spacepoint_formation(*m_detector, measurements_view);
+        const edm::spacepoint_collection::const_data spacepoints_data =
+            vecmem::get_data(spacepoints);
+        const host::seeding_algorithm::output_type seeds =
+            m_seeding(spacepoints_data);
+        const edm::seed_collection::const_data seeds_data =
+            vecmem::get_data(seeds);
+        return m_track_parameter_estimation(measurements_view, spacepoints_data,
+                                            seeds_data, m_field_vec);
+    }
+    // If not, just return an empty object.
+    else {
+
+        // Return an empty object.
+        return {};
+    }
+}
+
 }  // namespace traccc

--- a/examples/run/cpu/full_chain_algorithm.hpp
+++ b/examples/run/cpu/full_chain_algorithm.hpp
@@ -11,6 +11,7 @@
 #include "traccc/bfield/magnetic_field.hpp"
 #include "traccc/clusterization/clusterization_algorithm.hpp"
 #include "traccc/edm/silicon_cell_collection.hpp"
+#include "traccc/edm/track_parameters.hpp"
 #include "traccc/edm/track_state.hpp"
 #include "traccc/finding/combinatorial_kalman_filter_algorithm.hpp"
 #include "traccc/fitting/kalman_fitting_algorithm.hpp"
@@ -86,6 +87,14 @@ class full_chain_algorithm : public algorithm<track_state_container_types::host(
     ///
     output_type operator()(
         const edm::silicon_cell_collection::host& cells) const override;
+
+    /// Reconstruct track seeds in the entire detector
+    ///
+    /// @param cells The cells for every detector module in the event
+    /// @return The track seeds reconstructed
+    ///
+    bound_track_parameters_collection_types::host seeding(
+        const edm::silicon_cell_collection::host& cells) const;
 
     private:
     /// Vecmem copy object

--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -18,6 +18,7 @@
 #include "traccc/cuda/seeding/track_params_estimation.hpp"
 #include "traccc/cuda/utils/stream.hpp"
 #include "traccc/edm/silicon_cell_collection.hpp"
+#include "traccc/edm/track_parameters.hpp"
 #include "traccc/edm/track_state.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/silicon_detector_description.hpp"
@@ -108,6 +109,14 @@ class full_chain_algorithm
     ///
     output_type operator()(
         const edm::silicon_cell_collection::host& cells) const override;
+
+    /// Reconstruct track seeds in the entire detector
+    ///
+    /// @param cells The cells for every detector module in the event
+    /// @return The track seeds reconstructed
+    ///
+    bound_track_parameters_collection_types::host seeding(
+        const edm::silicon_cell_collection::host& cells) const;
 
     private:
     /// Host memory resource

--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/edm/silicon_cell_collection.hpp"
+#include "traccc/edm/track_parameters.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/silicon_detector_description.hpp"
 #include "traccc/sycl/clusterization/clusterization_algorithm.hpp"
@@ -104,6 +105,14 @@ class full_chain_algorithm
     ///
     output_type operator()(
         const edm::silicon_cell_collection::host& cells) const override;
+
+    /// Reconstruct track seeds in the entire detector
+    ///
+    /// @param cells The cells for every detector module in the event
+    /// @return The track seeds reconstructed
+    ///
+    bound_track_parameters_collection_types::host seeding(
+        const edm::silicon_cell_collection::host& cells) const;
 
     private:
     /// Private data object

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -238,4 +238,49 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     }
 }
 
+bound_track_parameters_collection_types::host full_chain_algorithm::seeding(
+    const edm::silicon_cell_collection::host& cells) const {
+
+    // Create device copy of input collections
+    edm::silicon_cell_collection::buffer cells_buffer{
+        static_cast<unsigned int>(cells.size()), m_cached_device_mr};
+    m_copy(vecmem::get_data(cells), cells_buffer)->wait();
+
+    // Execute the algorithms.
+    const clusterization_algorithm::output_type measurements =
+        m_clusterization(cells_buffer, m_device_det_descr);
+    m_measurement_sorting(measurements);
+
+    // If we have a Detray detector, run the seeding, track
+    // finding and fitting.
+    if (m_detector != nullptr) {
+
+        // Run the seed-finding.
+        const spacepoint_formation_algorithm::output_type spacepoints =
+            m_spacepoint_formation(m_device_detector_view, measurements);
+        const track_params_estimation::output_type track_params =
+            m_track_parameter_estimation(measurements, spacepoints,
+                                         m_seeding(spacepoints),
+                                         {0.f, 0.f, m_finder_config.bFieldInZ});
+
+        // Copy a limited amount of result data back to the host.
+        bound_track_parameters_collection_types::host result{
+            &(m_host_mr.get())};
+        m_copy(track_params, result)->wait();
+        return result;
+    }
+    // If not, copy the measurements back to the host, and return
+    // a dummy object.
+    else {
+
+        // Copy the measurements back to the host.
+        measurement_collection_types::host measurements_host(
+            &(m_host_mr.get()));
+        m_copy(measurements, measurements_host)->wait();
+
+        // Return an empty object.
+        return {};
+    }
+}
+
 }  // namespace traccc::sycl


### PR DESCRIPTION
In the same vain as #1088, to help with the throughput measurements that @flg is working on, this is to allow running throughput measurements just until the seed-finding stage.

While at this point using `traccc::algorithm` as the base class for the various `full_chain_algorithm` classes is a bit misleading, I didn't want to change things more than necessary. Though if we ever introduce even more variations on what we want to measure the throughput of, it will probably be better to make all of them be implemented as regular member functions.

But for now, with all its faults, I thought this could be good enough. :thinking: