### PR TITLE
Optimize `remove_tracks` by skipping unnecessary iteration

### DIFF
--- a/device/common/include/traccc/ambiguity_resolution/device/count_removable_tracks.hpp
+++ b/device/common/include/traccc/ambiguity_resolution/device/count_removable_tracks.hpp
@@ -86,6 +86,11 @@ struct count_removable_tracks_payload {
      * @brief View object to thread id of measurements to remove
      */
     vecmem::data::vector_view<unsigned int> threads_view;
+
+    /**
+     * @brief The number of threads that can remove its corresponding track
+     */
+    unsigned int* n_valid_threads;
 };
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/ambiguity_resolution/device/remove_tracks.hpp
+++ b/device/common/include/traccc/ambiguity_resolution/device/remove_tracks.hpp
@@ -80,11 +80,6 @@ struct remove_tracks_payload {
     unsigned int* n_removable_tracks;
 
     /**
-     * @brief The number of measurements to remove
-     */
-    unsigned int* n_meas_to_remove;
-
-    /**
      * @brief View object to measurements to remove
      */
     vecmem::data::vector_view<measurement_id_type> meas_to_remove_view;
@@ -113,6 +108,11 @@ struct remove_tracks_payload {
      * @brief View object to the whether track id is updated
      */
     vecmem::data::vector_view<int> is_updated_view;
+
+    /**
+     * @brief The number of threads that can remove its corresponding track
+     */
+    unsigned int* n_valid_threads;
 };
 
 }  // namespace traccc::device

--- a/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
+++ b/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
@@ -375,6 +375,8 @@ greedy_ambiguity_resolution_algorithm::operator()(
         vecmem::make_unique_alloc<unsigned int>(m_mr.main);
     vecmem::unique_alloc_ptr<unsigned int> n_meas_to_remove_device =
         vecmem::make_unique_alloc<unsigned int>(m_mr.main);
+    vecmem::unique_alloc_ptr<unsigned int> n_valid_threads_device =
+        vecmem::make_unique_alloc<unsigned int>(m_mr.main);
 
     // Device objects
     int is_first_iteration = 1;
@@ -459,9 +461,10 @@ greedy_ambiguity_resolution_algorithm::operator()(
                 .n_removable_tracks = n_removable_tracks_device.get(),
                 .n_meas_to_remove = n_meas_to_remove_device.get(),
                 .meas_to_remove_view = meas_to_remove_buffer,
-                .threads_view = threads_buffer});
+                .threads_view = threads_buffer,
+                .n_valid_threads = n_valid_threads_device.get()});
 
-        kernels::remove_tracks<<<1, 1024, 0, stream>>>(
+        kernels::remove_tracks<<<1, 512, 0, stream>>>(
             device::remove_tracks_payload{
                 .sorted_ids_view = sorted_ids_buffer,
                 .n_accepted = n_accepted_device.get(),
@@ -476,13 +479,13 @@ greedy_ambiguity_resolution_algorithm::operator()(
                 .n_shared_view = n_shared_buffer,
                 .rel_shared_view = rel_shared_buffer,
                 .n_removable_tracks = n_removable_tracks_device.get(),
-                .n_meas_to_remove = n_meas_to_remove_device.get(),
                 .meas_to_remove_view = meas_to_remove_buffer,
                 .threads_view = threads_buffer,
                 .terminate = terminate_device.get(),
                 .n_updated_tracks = n_updated_tracks_device.get(),
                 .updated_tracks_view = updated_tracks_buffer,
-                .is_updated_view = is_updated_buffer});
+                .is_updated_view = is_updated_buffer,
+                .n_valid_threads = n_valid_threads_device.get()});
 
         // The seven kernels below are to keep sorted_ids sorted based on
         // the relative shared measurements and pvalues. This can be reduced


### PR DESCRIPTION
Depends on #1083.

It is difficult to trace the changes as this PR depends on #1083 but the key change is the following:

```diff
     if (is_valid_thread) {
-
         const auto id = sh_meas_ids[threadIndex];
-        is_duplicate = false;
-
-        for (unsigned int i = 0; i < threadIndex; ++i) {
-            if (sh_meas_ids[i] == id) {
-                is_duplicate = true;
-                break;
-            }
-        }
+        is_duplicate = (threadIndex > 0 && sh_meas_ids[threadIndex - 1] == id);
     }
```
This simplification is possible because the inputs to `sh_meas_ids` are already sorted in the previous kernel (`count_removable_tracks`)

The performance is improved by about 10%

Before
```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from CUDAStandard/CUDAGreedyResolutionCompareToCPU
[ RUN      ] CUDAStandard/CUDAGreedyResolutionCompareToCPU.Comparison/0
Event: 0 Seed: 42
 Time for the cpu method 471 ms
 Time for the cuda method 138 ms
Event: 1 Seed: 43
 Time for the cpu method 491 ms
 Time for the cuda method 97 ms
Event: 2 Seed: 44
 Time for the cpu method 464 ms
 Time for the cuda method 98 ms
Event: 3 Seed: 45
 Time for the cpu method 482 ms
 Time for the cuda method 101 ms
Event: 4 Seed: 46
 Time for the cpu method 482 ms
 Time for the cuda method 100 ms
```

After
```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from CUDAStandard/CUDAGreedyResolutionCompareToCPU
[ RUN      ] CUDAStandard/CUDAGreedyResolutionCompareToCPU.Comparison/0
Event: 0 Seed: 42
 Time for the cpu method 477 ms
 Time for the cuda method 139 ms
Event: 1 Seed: 43
 Time for the cpu method 466 ms
 Time for the cuda method 88 ms
Event: 2 Seed: 44
 Time for the cpu method 474 ms
 Time for the cuda method 89 ms
Event: 3 Seed: 45
 Time for the cpu method 486 ms
 Time for the cuda method 91 ms
Event: 4 Seed: 46
 Time for the cpu method 495 ms
 Time for the cuda method 91 ms
 ```