### PR TITLE
Rework the maximum branch per seed cut

### DIFF
--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -79,6 +79,12 @@ struct propagate_to_next_surface_payload {
      * @brief Vector to hold the number of track states per tip
      */
     vecmem::data::vector_view<unsigned int> tip_lengths_view;
+
+    /**
+     * @brief View object to the vector of the number of tracks per initial
+     * input seed
+     */
+    vecmem::data::vector_view<unsigned int> n_tracks_per_seed_view;
 };
 
 /// Function for propagating the kalman-updated tracks to the next surface

--- a/device/cuda/src/finding/combinatorial_kalman_filter.cuh
+++ b/device/cuda/src/finding/combinatorial_kalman_filter.cuh
@@ -166,6 +166,7 @@ combinatorial_kalman_filter(
     vecmem::data::vector_buffer<unsigned int> n_tracks_per_seed_buffer(n_seeds,
                                                                        mr.main);
     copy.setup(n_tracks_per_seed_buffer)->ignore();
+    copy.memset(n_tracks_per_seed_buffer, 0)->ignore();
 
     // Create a buffer for links
     unsigned int link_buffer_capacity = config.initial_links_per_seed * n_seeds;
@@ -227,9 +228,6 @@ combinatorial_kalman_filter(
         vecmem::data::vector_buffer<unsigned int> updated_liveness_buffer(
             n_max_candidates, mr.main);
         copy.setup(updated_liveness_buffer)->ignore();
-
-        // Reset the number of tracks per seed
-        copy.memset(n_tracks_per_seed_buffer, 0)->ignore();
 
         const unsigned int links_size = copy.get_size(links_buffer);
 
@@ -434,7 +432,8 @@ combinatorial_kalman_filter(
                     .step = step,
                     .n_in_params = n_candidates,
                     .tips_view = tips_buffer,
-                    .tip_lengths_view = tip_length_buffer};
+                    .tip_lengths_view = tip_length_buffer,
+                    .n_tracks_per_seed_view = n_tracks_per_seed_buffer};
 
                 const unsigned int nThreads = warp_size * 4;
                 const unsigned int nBlocks =

--- a/device/sycl/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/sycl/src/finding/combinatorial_kalman_filter.hpp
@@ -175,6 +175,7 @@ combinatorial_kalman_filter(
     vecmem::data::vector_buffer<unsigned int> n_tracks_per_seed_buffer(n_seeds,
                                                                        mr.main);
     copy.setup(n_tracks_per_seed_buffer)->wait();
+    copy.memset(n_tracks_per_seed_buffer, 0)->wait();
 
     // Create a buffer for links
     unsigned int link_buffer_capacity = config.initial_links_per_seed * n_seeds;
@@ -236,9 +237,6 @@ combinatorial_kalman_filter(
         vecmem::data::vector_buffer<unsigned int> updated_liveness_buffer(
             n_max_candidates, mr.main);
         copy.setup(updated_liveness_buffer)->wait();
-
-        // Reset the number of tracks per seed
-        copy.memset(n_tracks_per_seed_buffer, 0)->wait();
 
         const unsigned int links_size = copy.get_size(links_buffer);
 


### PR DESCRIPTION
This commit reworks the CKF cut on the maximum number of branches per initial seed. The current implementation makes little sense as it resets its internal counter in every step, which means that we can actually create far more tracks than the cut would suggest. This is therefore a borderline bugfix.