### PR TITLE
Enable flushing of subnormals to zero

### DIFF
--- a/cmake/traccc-compiler-options-cuda.cmake
+++ b/cmake/traccc-compiler-options-cuda.cmake
@@ -27,6 +27,9 @@ endif()
 # not marked with __device__.
 traccc_add_flag( CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr" )
 
+# Enable the flusing of subnormal floating point numbers to zero
+traccc_add_flag( CMAKE_CUDA_FLAGS "--ftz=true" )
+
 # Make CUDA generate debug symbols for the device code as well in a debug
 # build.
 traccc_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G --keep -src-in-ptx" )


### PR DESCRIPTION
We don't generally deal with subnormal numbers in traccc, so we can probably get away with flushing them to zero, which will speed up the code.