### PR TITLE
Enable approximate square root computation

### DIFF
--- a/cmake/traccc-compiler-options-cuda.cmake
+++ b/cmake/traccc-compiler-options-cuda.cmake
@@ -27,6 +27,9 @@ endif()
 # not marked with __device__.
 traccc_add_flag( CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr" )
 
+# Enable approximate square root computation to increase performance
+traccc_add_flag( CMAKE_CUDA_FLAGS "--prec-sqrt=false" )
+
 # Make CUDA generate debug symbols for the device code as well in a debug
 # build.
 traccc_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G --keep -src-in-ptx" )


### PR DESCRIPTION
This is another flag that is enabled by the fast math flag, although this one inserts a software approximation method than an intrinsic.