### PR TITLE
Various seeding performance writer improvements

### DIFF
--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -79,7 +79,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // Performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{},
+        traccc::seeding_performance_writer::config{.truth_config =
+                                                       truth_finding_opts},
         logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
         traccc::finding_performance_writer::config{.truth_config =

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -77,7 +77,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // Performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{},
+        traccc::seeding_performance_writer::config{.truth_config =
+                                                       truth_finding_opts},
         logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
         traccc::finding_performance_writer::config{.truth_config =

--- a/examples/run/cpu/seq_example.cpp
+++ b/examples/run/cpu/seq_example.cpp
@@ -158,7 +158,8 @@ int seq_run(const traccc::opts::input_data& input_opts,
 
     // performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{},
+        traccc::seeding_performance_writer::config{.truth_config =
+                                                       truth_finding_opts},
         logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
         traccc::finding_performance_writer::config{.truth_config =

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -83,7 +83,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
     // Performance writer
     traccc::seeding_performance_writer sd_performance_writer(
-        traccc::seeding_performance_writer::config{},
+        traccc::seeding_performance_writer::config{.truth_config =
+                                                       truth_finding_opts},
         logger().clone("SeedingPerformanceWriter"));
     traccc::finding_performance_writer find_performance_writer(
         traccc::finding_performance_writer::config{.truth_config =

--- a/extras/cut_optimiser/main.py
+++ b/extras/cut_optimiser/main.py
@@ -275,19 +275,23 @@ def main():
 
                 stdout = result.stdout.decode("utf-8")
 
-                if match := re.search(r"Total efficiency was (\d+(?:\.\d*)?)%", stdout):
+                if match := re.search(
+                    r"Total track efficiency was (\d+(?:\.\d*)?)%", stdout
+                ):
                     result_efficiency = float(match.group(1)) / 100.0
                 else:
                     raise ValueError("Efficiency could not be parsed from stdout!")
 
                 if match := re.search(
-                    r"Total duplicate rate was (\d+(?:\.\d*)?)", stdout
+                    r"Total track duplicate rate was (\d+(?:\.\d*)?)", stdout
                 ):
                     result_duplicate_rate = float(match.group(1))
                 else:
                     raise ValueError("Dupliacate rate could not be parsed from stdout!")
 
-                if match := re.search(r"Total fake rate was (\d+(?:\.\d*)?)", stdout):
+                if match := re.search(
+                    r"Total track fake rate was (\d+(?:\.\d*)?)", stdout
+                ):
                     result_fake_rate = float(match.group(1))
                 else:
                     raise ValueError("Fake rate could not be parsed from stdout!")

--- a/performance/include/traccc/efficiency/seeding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/seeding_performance_writer.hpp
@@ -10,6 +10,7 @@
 // Local include(s).
 #include "traccc/utils/helpers.hpp"
 #include "traccc/utils/messaging.hpp"
+#include "traccc/utils/truth_matching_config.hpp"
 
 // Project include(s).
 #include "traccc/edm/measurement.hpp"
@@ -51,11 +52,7 @@ class seeding_performance_writer : public messaging {
             {"Num", plot_helpers::binning("N", 30, -0.5f, 29.5f)}};
 
         /// Cut values
-        scalar pT_cut = 0.5f * traccc::unit<scalar>::GeV;
-        scalar z_min = -500.f * traccc::unit<scalar>::mm;
-        scalar z_max = 500.f * traccc::unit<scalar>::mm;
-        scalar r_max = 200.f * traccc::unit<scalar>::mm;
-        scalar matching_ratio = 0.5f;
+        truth_matching_config truth_config;
     };
 
     /// Construct from configuration and log level.

--- a/performance/src/efficiency/eff_plot_tool.hpp
+++ b/performance/src/efficiency/eff_plot_tool.hpp
@@ -63,18 +63,28 @@ class eff_plot_tool {
         (void)cache;
 
 #ifdef TRACCC_HAVE_ROOT
+        std::string header;
+
+        if (name == "finding") {
+            header = "Track finding efficiency";
+        } else if (name == "seeding") {
+            header = "Seed finding efficiency";
+        } else {
+            header = "Tracking efficiency";
+        }
+
         // efficiency vs pT
         cache.track_eff_vs_pT = plot_helpers::book_eff(
             TString(name) + "_trackeff_vs_pT",
-            "Tracking efficiency;Truth pT [GeV/c];Efficiency", b_pt);
+            header + ";Truth pT [GeV/c];Efficiency", b_pt);
         // efficiency vs eta
-        cache.track_eff_vs_eta = plot_helpers::book_eff(
-            TString(name) + "_trackeff_vs_eta",
-            "Tracking efficiency;Truth #eta;Efficiency", b_eta);
+        cache.track_eff_vs_eta =
+            plot_helpers::book_eff(TString(name) + "_trackeff_vs_eta",
+                                   header + ";Truth #eta;Efficiency", b_eta);
         // efficiency vs phi
-        cache.track_eff_vs_phi = plot_helpers::book_eff(
-            TString(name) + "_trackeff_vs_phi",
-            "Tracking efficiency;Truth #phi;Efficiency", b_phi);
+        cache.track_eff_vs_phi =
+            plot_helpers::book_eff(TString(name) + "_trackeff_vs_phi",
+                                   header + ";Truth #phi;Efficiency", b_phi);
 #endif  // TRACCC_HAVE_ROOT
     }
 

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -287,19 +287,19 @@ void finding_performance_writer::write_common(
     TRACCC_INFO("Total number of truth particles was "
                 << total_truth_particles);
     TRACCC_INFO("Total number of found tracks was " << n_tracks);
-    TRACCC_INFO("Total number of matched particles was "
+    TRACCC_INFO("Total number of track-matched particles was "
                 << total_matched_truth_particles);
     TRACCC_INFO("Total number of duplicated tracks was "
                 << total_duplicate_tracks);
     TRACCC_INFO("Total number of fake tracks was " << total_fake_tracks);
-    TRACCC_INFO("Total efficiency was "
+    TRACCC_INFO("Total track efficiency was "
                 << (100. * static_cast<double>(total_matched_truth_particles) /
                     static_cast<double>(total_truth_particles))
                 << "%");
-    TRACCC_INFO("Total duplicate rate was "
+    TRACCC_INFO("Total track duplicate rate was "
                 << (static_cast<double>(total_duplicate_tracks) /
                     static_cast<double>(total_matched_truth_particles)));
-    TRACCC_INFO("Total fake rate was "
+    TRACCC_INFO("Total track fake rate was "
                 << (static_cast<double>(total_fake_tracks) /
                     static_cast<double>(total_truth_particles)));
 }


### PR DESCRIPTION
This commit makes the following changes to the seeding performance writer (and some related code):

1. The class now accepts the same truth matching configuration as the finding efficiency writer.
2. Relevant example executables were updated to forward the aforementioned configuration to the efficiency writer.
3. ROOT plots outputted now have clearer names.
4. Printouts have been added of the seeding performance.
5. In tandem with point 4, the finding efficiency writer has had its printouts more clearly differentiated, and the cut optimiser has been updated accordingly.