### PR TITLE
fix: Refined hole counting in KF

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -25,6 +25,9 @@
 #include "traccc/utils/prob.hpp"
 #include "traccc/utils/propagation.hpp"
 
+// detray include(s)
+#include <detray/definitions/navigation.hpp>
+
 // vecmem include(s)
 #include <type_traits>
 #include <vecmem/containers/device_vector.hpp>


### PR DESCRIPTION
If the navigation in the forward KF missed a surface, advance the track state iterator correctly (for example if the propagation config between CKF and KF is different or we are running truth fitting). This is only needed for navigators that are not "guided" or "direct". 
It also adds an option to the KF to do the full hole count, which is only possible if the propagation starts at the IP and continues through the whole detector, otherwise the first and last holes are missed and the hole count remains an underestimation. Since this will not help in increasing the fit accuracy, but eat more compute resources it will remain optional.