### PR TITLE
Shrink ODD seeding delta-r cut

### DIFF
--- a/core/include/traccc/seeding/detail/seeding_config.hpp
+++ b/core/include/traccc/seeding/detail/seeding_config.hpp
@@ -43,7 +43,7 @@ struct seedfinder_config {
     // minimum distance in mm in r between two measurements within one seed
     float deltaRMin = 20 * unit<float>::mm;
     // maximum distance in mm in r between two measurements within one seed
-    float deltaRMax = 280 * unit<float>::mm;
+    float deltaRMax = 80 * unit<float>::mm;
 
     // FIXME: this is not used yet
     //        float upperPtResolutionPerSeed = 20* Acts::GeV;


### PR DESCRIPTION
The delta-r cut we have currently is set to 280mm, which is insanely huge; this commit reduces this cut to 80mm which is more in line with the ODD geometry.