### PR TITLE
Disable combinatorics in CKF by default

### DIFF
--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -23,7 +23,7 @@ struct finding_config {
     unsigned int max_num_branches_per_seed = 10;
 
     /// Maximum number of branches per surface
-    unsigned int max_num_branches_per_surface = 2;
+    unsigned int max_num_branches_per_surface = 1;
 
     /// Min/Max number of track candidates per track
     unsigned int min_track_candidates_per_track = 3;
@@ -40,7 +40,7 @@ struct finding_config {
     unsigned int max_step_counts_for_next_surface = 100;
 
     /// Maximum Chi-square that is allowed for branching
-    float chi2_max = 10.f;
+    float chi2_max = 100.f;
 
     /// Propagation configuration
     detray::propagation::config propagation{};


### PR DESCRIPTION
Turns out that for our ODD-tuned default parameters, we can now get away with non-combinatorial Kálmán filtering. This commit disables the combinatorics and increases the $\chi^2$ cut to compensate. This brings our cuts more in line with the ACTS cuts.