### PR TITLE
Add track purity and completeness to ROOT output

### DIFF
--- a/performance/include/traccc/resolution/stat_plot_tool_config.hpp
+++ b/performance/include/traccc/resolution/stat_plot_tool_config.hpp
@@ -25,7 +25,9 @@ struct stat_plot_tool_config {
         {"chi2", plot_helpers::binning("chi2", 100, 0.f, 50.f)},
         {"reduced_chi2", plot_helpers::binning("chi2/ndf", 100, 0.f, 10.f)},
         {"pval", plot_helpers::binning("pval", 50, 0.f, 1.f)},
-        {"chi2_local", plot_helpers::binning("chi2", 100, 0.f, 10.f)}};
+        {"chi2_local", plot_helpers::binning("chi2", 100, 0.f, 10.f)},
+        {"completeness", plot_helpers::binning("completeness", 20, 0.f, 1.f)},
+        {"purity", plot_helpers::binning("purity", 20, 0.f, 1.f)}};
 };
 
 }  // namespace traccc

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -205,14 +205,20 @@ void finding_performance_writer::write_common(
         // of the number of measurements
         assert(found_measurements.size() > 0u);
         assert(truth_measurements.size() > 0u);
+
+        const double purity = static_cast<double>(n_major_hits) /
+                              static_cast<double>(found_measurements.size());
+        const double completeness =
+            static_cast<double>(n_major_hits) /
+            static_cast<double>(truth_measurements.size());
+
         const bool reco_matched =
-            static_cast<double>(n_major_hits) /
-                static_cast<double>(found_measurements.size()) >
-            m_cfg.track_truth_config.matching_ratio;
+            purity > m_cfg.track_truth_config.matching_ratio;
         const bool truth_matched =
-            static_cast<double>(n_major_hits) /
-                static_cast<double>(truth_measurements.size()) >
-            m_cfg.track_truth_config.matching_ratio;
+            completeness > m_cfg.track_truth_config.matching_ratio;
+
+        m_data->m_stat_plot_tool.fill(m_data->m_stat_plot_cache, purity,
+                                      completeness);
 
         if ((!m_cfg.track_truth_config.double_matching && reco_matched) ||
             (m_cfg.track_truth_config.double_matching && reco_matched &&

--- a/performance/src/resolution/stat_plot_tool.cpp
+++ b/performance/src/resolution/stat_plot_tool.cpp
@@ -26,11 +26,16 @@ void stat_plot_tool::book(stat_plot_cache& cache) const {
     plot_helpers::binning b_reduced_chi2 = m_cfg.var_binning.at("reduced_chi2");
     plot_helpers::binning b_pval = m_cfg.var_binning.at("pval");
     plot_helpers::binning b_chi2_local = m_cfg.var_binning.at("chi2_local");
+    plot_helpers::binning b_purity = m_cfg.var_binning.at("purity");
+    plot_helpers::binning b_completeness = m_cfg.var_binning.at("completeness");
     cache.ndf_hist = plot_helpers::book_histo("ndf", "NDF", b_ndf);
     cache.chi2_hist = plot_helpers::book_histo("chi2", "Chi2", b_chi2);
     cache.reduced_chi2_hist =
         plot_helpers::book_histo("reduced_chi2", "Chi2/NDF", b_reduced_chi2);
     cache.pval_hist = plot_helpers::book_histo("pval", "p value", b_pval);
+    cache.purity_hist = plot_helpers::book_histo("purity", "Ratio", b_purity);
+    cache.completeness_hist =
+        plot_helpers::book_histo("completeness", "Ratio", b_completeness);
     for (unsigned int D = 1u; D <= 2u; D++) {
         cache.chi2_filtered_hist[D] = plot_helpers::book_histo(
             Form("chi2_%dD_filtered", D),
@@ -87,6 +92,20 @@ void stat_plot_tool::fill(
 #endif  // TRACCC_HAVE_ROOT
 }
 
+void stat_plot_tool::fill(stat_plot_cache& cache, double purity,
+                          double completeness) const {
+
+    // Avoid unused variable warnings when building the code without ROOT.
+    (void)cache;
+    (void)purity;
+    (void)completeness;
+
+#ifdef TRACCC_HAVE_ROOT
+    cache.purity_hist->Fill(purity);
+    cache.completeness_hist->Fill(completeness);
+#endif  // TRACCC_HAVE_ROOT
+}
+
 void stat_plot_tool::write(const stat_plot_cache& cache) const {
 
     // Avoid unused variable warnings when building the code without ROOT.
@@ -101,6 +120,8 @@ void stat_plot_tool::write(const stat_plot_cache& cache) const {
     cache.chi2_hist->Write();
     cache.reduced_chi2_hist->Write();
     cache.pval_hist->Write();
+    cache.purity_hist->Write();
+    cache.completeness_hist->Write();
 
     for (const auto& flt : cache.chi2_filtered_hist) {
         flt.second->Write();

--- a/performance/src/resolution/stat_plot_tool.hpp
+++ b/performance/src/resolution/stat_plot_tool.hpp
@@ -31,6 +31,10 @@ class stat_plot_tool {
         std::unique_ptr<TH1> reduced_chi2_hist;
         // Histogram for the pvalue
         std::unique_ptr<TH1> pval_hist;
+        // Histogram for the purity
+        std::unique_ptr<TH1> purity_hist;
+        // Histogram for the completeness
+        std::unique_ptr<TH1> completeness_hist;
         // Histogram for chi2 of filtered states
         std::map<unsigned int, std::unique_ptr<TH1>> chi2_filtered_hist;
         // Histogram for chi2 of smoothed states
@@ -73,6 +77,12 @@ class stat_plot_tool {
     /// @param trk_state track state at local measurements
     void fill(stat_plot_cache& cache,
               const track_state<traccc::default_algebra>& trk_state) const;
+
+    /// @brief fill the cache
+    /// @param cache the cache for statistics plots
+    /// @param purity the track purity
+    /// @param completeness the track completeness
+    void fill(stat_plot_cache& cache, double purity, double completeness) const;
 
     /// @brief write the statistics plots into ROOT
     ///

--- a/performance/src/resolution/stat_plot_tool.ipp
+++ b/performance/src/resolution/stat_plot_tool.ipp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "traccc/utils/prob.hpp"
+
 namespace traccc {
 
 template <typename T>
@@ -22,8 +24,8 @@ void stat_plot_tool::fill(stat_plot_cache& cache,
     const auto& chi2 = find_res.chi2();
     cache.ndf_hist->Fill(ndf);
     cache.chi2_hist->Fill(chi2);
+    cache.pval_hist->Fill(prob(chi2, ndf));
     cache.reduced_chi2_hist->Fill(chi2 / ndf);
-//    cache.pval_hist->Fill(ROOT::Math::chisquared_cdf_c(chi2, ndf));
 #endif  // TRACCC_HAVE_ROOT
 }
 


### PR DESCRIPTION
This commit adds the purity and completeness of tracks to our ROOT output in the form of a histogram. The purity is the number of true measurements on a track divided by the number of reconstructed measurements, while the completeness is divided by the number of true measurements.