### PR TITLE
Reset CKF parameters in toy detector tests

### DIFF
--- a/tests/cuda/test_ckf_toy_detector.cpp
+++ b/tests/cuda/test_ckf_toy_detector.cpp
@@ -136,6 +136,8 @@ TEST_P(CkfToyDetectorTests, Run) {
         cfg;
     cfg.ptc_hypothesis = ptc;
     cfg.max_num_branches_per_seed = 500;
+    cfg.max_num_branches_per_surface = 2;
+    cfg.chi2_max = 10.f;
     cfg.propagation.navigation.search_window = search_window;
 
     // Finding algorithm object

--- a/tests/sycl/test_ckf_toy_detector.cpp
+++ b/tests/sycl/test_ckf_toy_detector.cpp
@@ -137,6 +137,8 @@ TEST_P(CkfToyDetectorTests, Run) {
     traccc::sycl::combinatorial_kalman_filter_algorithm::config_type cfg;
     cfg.ptc_hypothesis = ptc;
     cfg.max_num_branches_per_seed = 500;
+    cfg.max_num_branches_per_surface = 2;
+    cfg.chi2_max = 10.f;
     cfg.propagation.navigation.search_window = search_window;
 
     // Finding algorithm object


### PR DESCRIPTION
This fixes the CI issues caused by #1118.