### PR TITLE
Remove unnecessary reset of `is_updated_buffer`

### DIFF
--- a/device/common/include/traccc/ambiguity_resolution/device/find_max_shared.hpp
+++ b/device/common/include/traccc/ambiguity_resolution/device/find_max_shared.hpp
@@ -40,11 +40,6 @@ struct find_max_shared_payload {
      * @brief The number of max shared
      */
     unsigned int* max_shared;
-
-    /**
-     * @brief View object to the whether track id is updated
-     */
-    vecmem::data::vector_view<int> is_updated_view;
 };
 
 }  // namespace traccc::device

--- a/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
+++ b/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
@@ -477,8 +477,7 @@ greedy_ambiguity_resolution_algorithm::operator()(
                 .n_accepted = n_accepted_device.get(),
                 .n_shared_view = n_shared_buffer,
                 .terminate = terminate_device.get(),
-                .max_shared = max_shared_device.get(),
-                .is_updated_view = is_updated_buffer});
+                .max_shared = max_shared_device.get()});
 
         kernels::remove_tracks<<<1, 512, 0, stream>>>(
             device::remove_tracks_payload{

--- a/device/cuda/src/ambiguity_resolution/kernels/find_max_shared.cu
+++ b/device/cuda/src/ambiguity_resolution/kernels/find_max_shared.cu
@@ -26,11 +26,6 @@ __global__ void find_max_shared(device::find_max_shared_payload payload) {
     vecmem::device_vector<const unsigned int> sorted_ids(
         payload.sorted_ids_view);
     vecmem::device_vector<const unsigned int> n_shared(payload.n_shared_view);
-    vecmem::device_vector<int> is_updated(payload.is_updated_view);
-
-    if (globalIndex < is_updated.size()) {
-        is_updated[globalIndex] = 0;
-    }
 
     if (globalIndex >= *payload.n_accepted) {
         return;


### PR DESCRIPTION
`is_updated_buffer` is already reset in `gather_tracks` so removing the overlapping parts