### PR TITLE
VecMem 1.19.0, main branch (2025.08.12.)

### DIFF
--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.18.0.tar.gz;URL_MD5;288ec7bb30e209ab5cc2e7f4a209c7ac"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.19.0.tar.gz;URL_MD5;ea817079a9ffd8c858a5933eb8a9cb2e"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem SYSTEM ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Upgraded to [VecMem 1.19.0](https://github.com/acts-project/vecmem/releases/tag/v1.19.0).

The new version has one important fix in it (https://github.com/acts-project/vecmem/pull/337), which is needed for #1112.