### PR TITLE
Constant Detector, main branch (2025.08.15.)

### DIFF
--- a/benchmarks/cuda/toy_detector_cuda.cpp
+++ b/benchmarks/cuda/toy_detector_cuda.cpp
@@ -69,7 +69,7 @@ BENCHMARK_DEFINE_F(ToyDetectorBenchmark, CUDA)(benchmark::State& state) {
                                                           async_copy, stream);
 
     // Copy detector to device
-    auto det_buffer = detray::get_buffer(det, device_mr, copy);
+    const auto det_buffer = detray::get_buffer(det, device_mr, copy);
     // Detector view object
     auto det_view = detray::get_data(det_buffer);
 

--- a/core/include/traccc/geometry/detector.hpp
+++ b/core/include/traccc/geometry/detector.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,7 +16,34 @@
 #include <detray/detectors/telescope_metadata.hpp>
 #include <detray/detectors/toy_metadata.hpp>
 
+// VecMem include(s).
+#include <vecmem/containers/device_vector.hpp>
+
+// System include(s).
+#include <type_traits>
+
 namespace traccc {
+namespace details {
+
+/// Type used instead of @c detray::device_container_types
+///
+/// This is meant as a template for how @c detray::device_container_types should
+/// change. So that it would correctly reflect that all data access on a device
+/// is constant. Not modifying the detector's payload.
+///
+/// Also note that with all the types present in @c detray::container_types
+/// it's really only @c vector_type that is actually used by @c detray::detector
+/// at this point.
+///
+struct device_detector_container_types {
+
+    /// Vector type to use in device code
+    template <typename T>
+    using vector_type = vecmem::device_vector<std::add_const_t<T>>;
+
+};  // struct device_detector_container_types
+
+}  // namespace details
 
 /// Base struct for the different detector types supported by the project.
 template <typename metadata_t>
@@ -28,13 +55,11 @@ struct detector {
     /// Host type of the detector.
     using host = detray::detector<metadata_type, detray::host_container_types>;
     /// Device type of the detector.
-    using device =
-        detray::detector<metadata_type, detray::device_container_types>;
+    using device = detray::detector<metadata_type,
+                                    details::device_detector_container_types>;
 
     /// Non-const view of the detector.
-    using view = typename host::view_type;
-    /// Const view of the detector.
-    using const_view = typename host::const_view_type;
+    using view = typename host::const_view_type;
 
     /// Buffer for a detector's data.
     using buffer = typename host::buffer_type;

--- a/device/alpaka/include/traccc/alpaka/seeding/spacepoint_formation_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/seeding/spacepoint_formation_algorithm.hpp
@@ -33,7 +33,7 @@ namespace traccc::alpaka {
 template <typename detector_t>
 class spacepoint_formation_algorithm
     : public algorithm<edm::spacepoint_collection::buffer(
-          const typename detector_t::view_type&,
+          const typename detector_t::const_view_type&,
           const measurement_collection_types::const_view&)>,
       public messaging {
 
@@ -57,7 +57,7 @@ class spacepoint_formation_algorithm
     ///         measurement
     ///
     edm::spacepoint_collection::buffer operator()(
-        const typename detector_t::view_type& det_view,
+        const typename detector_t::const_view_type& det_view,
         const measurement_collection_types::const_view& measurements_view)
         const override;
 

--- a/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
@@ -198,7 +198,7 @@ struct build_tracks {
 template <typename detector_t, typename bfield_t>
 edm::track_candidate_collection<default_algebra>::buffer
 combinatorial_kalman_filter(
-    const typename detector_t::view_type& det, const bfield_t& field,
+    const typename detector_t::const_view_type& det, const bfield_t& field,
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds,
     const finding_config& config, const memory_resource& mr, vecmem::copy& copy,

--- a/device/alpaka/src/fitting/kalman_fitting.hpp
+++ b/device/alpaka/src/fitting/kalman_fitting.hpp
@@ -113,7 +113,8 @@ struct fit_backward {
 ///
 template <typename detector_t, typename bfield_t>
 track_state_container_types::buffer kalman_fitting(
-    const typename detector_t::view_type& det_view, const bfield_t& field_view,
+    const typename detector_t::const_view_type& det_view,
+    const bfield_t& field_view,
     const typename edm::track_candidate_container<
         typename detector_t::algebra_type>::const_view& track_candidates_view,
     const fitting_config& config, const memory_resource& mr, vecmem::copy& copy,

--- a/device/alpaka/src/seeding/spacepoint_formation_algorithm.cpp
+++ b/device/alpaka/src/seeding/spacepoint_formation_algorithm.cpp
@@ -22,7 +22,7 @@ template <typename detector_t>
 struct FormSpacepointsKernel {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(
-        TAcc const& acc, typename detector_t::view_type det_view,
+        TAcc const& acc, typename detector_t::const_view_type det_view,
         measurement_collection_types::const_view measurements_view,
         edm::spacepoint_collection::view spacepoints_view) const {
 
@@ -43,7 +43,7 @@ spacepoint_formation_algorithm<detector_t>::spacepoint_formation_algorithm(
 template <typename detector_t>
 edm::spacepoint_collection::buffer
 spacepoint_formation_algorithm<detector_t>::operator()(
-    const typename detector_t::view_type& det_view,
+    const typename detector_t::const_view_type& det_view,
     const measurement_collection_types::const_view& measurements_view) const {
 
     // Get a convenience variable for the queue that we'll be using.

--- a/device/common/include/traccc/finding/device/apply_interaction.hpp
+++ b/device/common/include/traccc/finding/device/apply_interaction.hpp
@@ -26,7 +26,7 @@ struct apply_interaction_payload {
     /**
      * @brief View object describing the tracking detector
      */
-    typename detector_t::view_type det_data;
+    typename detector_t::const_view_type det_data;
 
     /**
      * @brief Total number of input parameters (including non-live ones)

--- a/device/common/include/traccc/finding/device/find_tracks.hpp
+++ b/device/common/include/traccc/finding/device/find_tracks.hpp
@@ -34,7 +34,7 @@ struct find_tracks_payload {
     /**
      * @brief View object to the tracking detector description
      */
-    typename detector_t::view_type det_data;
+    typename detector_t::const_view_type det_data;
 
     /**
      * @brief View object to the vector of bound track parameters

--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -28,7 +28,7 @@ struct propagate_to_next_surface_payload {
     /**
      * @brief View object to the tracking detector description
      */
-    typename propagator_t::detector_type::view_type det_data;
+    typename propagator_t::detector_type::const_view_type det_data;
 
     /**
      * @brief View object to the magnetic field

--- a/device/common/include/traccc/fitting/device/fit.hpp
+++ b/device/common/include/traccc/fitting/device/fit.hpp
@@ -26,7 +26,7 @@ struct fit_payload {
     /**
      * @brief View object to the detector description
      */
-    typename fitter_t::detector_type::view_type det_data;
+    typename fitter_t::detector_type::const_view_type det_data;
 
     /**
      * @brief View object to the magnetic field description

--- a/device/common/include/traccc/seeding/device/form_spacepoints.hpp
+++ b/device/common/include/traccc/seeding/device/form_spacepoints.hpp
@@ -27,7 +27,7 @@ namespace traccc::device {
 ///
 template <typename detector_t>
 TRACCC_HOST_DEVICE inline void form_spacepoints(
-    global_index_t globalIndex, typename detector_t::view_type det_view,
+    global_index_t globalIndex, typename detector_t::const_view_type det_view,
     const measurement_collection_types::const_view& measurements_view,
     edm::spacepoint_collection::view spacepoints_view);
 

--- a/device/common/include/traccc/seeding/device/impl/form_spacepoints.ipp
+++ b/device/common/include/traccc/seeding/device/impl/form_spacepoints.ipp
@@ -17,7 +17,8 @@ namespace traccc::device {
 
 template <typename detector_t>
 TRACCC_HOST_DEVICE inline void form_spacepoints(
-    const global_index_t globalIndex, typename detector_t::view_type det_view,
+    const global_index_t globalIndex,
+    typename detector_t::const_view_type det_view,
     const measurement_collection_types::const_view& measurements_view,
     edm::spacepoint_collection::view spacepoints_view) {
 

--- a/device/cuda/include/traccc/cuda/seeding/spacepoint_formation_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/spacepoint_formation_algorithm.hpp
@@ -33,7 +33,7 @@ namespace traccc::cuda {
 template <typename detector_t>
 class spacepoint_formation_algorithm
     : public algorithm<edm::spacepoint_collection::buffer(
-          const typename detector_t::view_type&,
+          const typename detector_t::const_view_type&,
           const measurement_collection_types::const_view&)>,
       public messaging {
 
@@ -55,7 +55,7 @@ class spacepoint_formation_algorithm
     ///         measurement
     ///
     edm::spacepoint_collection::buffer operator()(
-        const typename detector_t::view_type& det_view,
+        const typename detector_t::const_view_type& det_view,
         const measurement_collection_types::const_view& measurements)
         const override;
 

--- a/device/cuda/src/finding/combinatorial_kalman_filter.cuh
+++ b/device/cuda/src/finding/combinatorial_kalman_filter.cuh
@@ -72,7 +72,7 @@ namespace traccc::cuda::details {
 template <typename detector_t, typename bfield_t>
 edm::track_candidate_collection<default_algebra>::buffer
 combinatorial_kalman_filter(
-    const typename detector_t::view_type& det, const bfield_t& field,
+    const typename detector_t::const_view_type& det, const bfield_t& field,
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds,
     const finding_config& config, const memory_resource& mr, vecmem::copy& copy,

--- a/device/cuda/src/fitting/kalman_fitting.cuh
+++ b/device/cuda/src/fitting/kalman_fitting.cuh
@@ -51,7 +51,8 @@ namespace traccc::cuda::details {
 ///
 template <typename detector_t, typename bfield_t>
 track_state_container_types::buffer kalman_fitting(
-    const typename detector_t::view_type& det_view, const bfield_t& field_view,
+    const typename detector_t::const_view_type& det_view,
+    const bfield_t& field_view,
     const typename edm::track_candidate_container<
         typename detector_t::algebra_type>::const_view& track_candidates_view,
     const fitting_config& config, const memory_resource& mr, vecmem::copy& copy,

--- a/device/cuda/src/seeding/spacepoint_formation_algorithm.cu
+++ b/device/cuda/src/seeding/spacepoint_formation_algorithm.cu
@@ -20,7 +20,7 @@ namespace kernels {
 
 template <typename detector_t>
 __global__ void __launch_bounds__(1024, 1)
-    form_spacepoints(typename detector_t::view_type det_view,
+    form_spacepoints(typename detector_t::const_view_type det_view,
                      measurement_collection_types::const_view measurements_view,
                      edm::spacepoint_collection::view spacepoints_view) {
 
@@ -39,7 +39,7 @@ spacepoint_formation_algorithm<detector_t>::spacepoint_formation_algorithm(
 template <typename detector_t>
 edm::spacepoint_collection::buffer
 spacepoint_formation_algorithm<detector_t>::operator()(
-    const typename detector_t::view_type& det_view,
+    const typename detector_t::const_view_type& det_view,
     const measurement_collection_types::const_view& measurements_view) const {
 
     // Get the number of measurements.

--- a/device/sycl/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/sycl/src/finding/combinatorial_kalman_filter.hpp
@@ -87,7 +87,7 @@ struct build_tracks {};
 template <typename kernel_t, typename detector_t, typename bfield_t>
 edm::track_candidate_collection<default_algebra>::buffer
 combinatorial_kalman_filter(
-    const typename detector_t::view_type& det, const bfield_t& field,
+    const typename detector_t::const_view_type& det, const bfield_t& field,
     const measurement_collection_types::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds,
     const finding_config& config, const memory_resource& mr, vecmem::copy& copy,

--- a/device/sycl/src/fitting/kalman_fitting.hpp
+++ b/device/sycl/src/fitting/kalman_fitting.hpp
@@ -65,7 +65,8 @@ namespace details {
 ///
 template <typename kernel_t, typename detector_t, typename bfield_t>
 track_state_container_types::buffer kalman_fitting(
-    const typename detector_t::view_type& det_view, const bfield_t& field_view,
+    const typename detector_t::const_view_type& det_view,
+    const bfield_t& field_view,
     const typename edm::track_candidate_container<
         typename detector_t::algebra_type>::const_view& track_candidates_view,
     const fitting_config& config, const memory_resource& mr, vecmem::copy& copy,

--- a/device/sycl/src/seeding/silicon_pixel_spacepoint_formation.hpp
+++ b/device/sycl/src/seeding/silicon_pixel_spacepoint_formation.hpp
@@ -39,7 +39,7 @@ namespace traccc::sycl::details {
 ///
 template <typename detector_t>
 edm::spacepoint_collection::buffer silicon_pixel_spacepoint_formation(
-    const typename detector_t::view_type& det_view,
+    const typename detector_t::const_view_type& det_view,
     const measurement_collection_types::const_view& measurements_view,
     vecmem::memory_resource& mr, vecmem::copy& copy, ::sycl::queue& queue) {
 

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -82,7 +82,8 @@ full_chain_algorithm::full_chain_algorithm(
         m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
                                                m_vecmem_objects.device_mr(),
                                                m_vecmem_objects.async_copy());
-        m_device_detector_view = detray::get_data(m_device_detector);
+        const auto& const_device_detector = m_device_detector;
+        m_device_detector_view = detray::get_data(const_device_detector);
     }
 }
 
@@ -143,7 +144,8 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
         m_device_detector = detray::get_buffer(detray::get_data(*m_detector),
                                                m_vecmem_objects.device_mr(),
                                                m_vecmem_objects.async_copy());
-        m_device_detector_view = detray::get_data(m_device_detector);
+        const auto& const_device_detector = m_device_detector;
+        m_device_detector_view = detray::get_data(const_device_detector);
     }
 }
 

--- a/examples/run/alpaka/full_chain_algorithm.hpp
+++ b/examples/run/alpaka/full_chain_algorithm.hpp
@@ -143,7 +143,7 @@ class full_chain_algorithm
     /// Buffer holding the detector's payload on the device
     host_detector_type::buffer_type m_device_detector;
     /// View of the detector's payload on the device
-    host_detector_type::view_type m_device_detector_view;
+    host_detector_type::const_view_type m_device_detector_view;
 
     /// @name Sub-algorithms used by this full-chain algorithm
     /// @{

--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -130,7 +130,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                               detector_opts.grid_file);
 
     // Detector view object
-    traccc::default_detector::view det_view = detray::get_data(host_det);
+    const traccc::default_detector::host& const_host_det = host_det;
+    traccc::default_detector::view det_view = detray::get_data(const_host_det);
 
     // Copy objects
     vecmem::copy host_copy;

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -105,7 +105,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
             detector_opts.material_file, detector_opts.grid_file);
         device_detector = detray::get_buffer(host_detector, device_mr, copy);
         queue.synchronize();
-        device_detector_view = detray::get_data(device_detector);
+        const auto& const_device_detector = device_detector;
+        device_detector_view = detray::get_data(const_device_detector);
     }
 
     // Output stats

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -97,7 +97,8 @@ full_chain_algorithm::full_chain_algorithm(
     if (m_detector != nullptr) {
         m_device_detector =
             detray::get_buffer(*m_detector, m_device_mr, m_copy);
-        m_device_detector_view = detray::get_data(m_device_detector);
+        const auto& const_device_detector = m_device_detector;
+        m_device_detector_view = detray::get_data(const_device_detector);
     }
 }
 
@@ -150,7 +151,8 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
     if (m_detector != nullptr) {
         m_device_detector =
             detray::get_buffer(*m_detector, m_device_mr, m_copy);
-        m_device_detector_view = detray::get_data(m_device_detector);
+        const auto& const_device_detector = m_device_detector;
+        m_device_detector_view = detray::get_data(const_device_detector);
     }
 }
 

--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -145,7 +145,7 @@ class full_chain_algorithm
     /// Buffer holding the detector's payload on the device
     host_detector_type::buffer_type m_device_detector;
     /// View of the detector's payload on the device
-    host_detector_type::view_type m_device_detector_view;
+    host_detector_type::const_view_type m_device_detector_view;
 
     /// @name Sub-algorithms used by this full-chain algorithm
     /// @{

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -139,7 +139,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                               detector_opts.grid_file);
 
     // Detector view object
-    traccc::default_detector::view det_view = detray::get_data(host_det);
+    const traccc::default_detector::host& const_host_det = host_det;
+    traccc::default_detector::view det_view = detray::get_data(const_host_det);
 
     // Copy objects
     vecmem::copy host_copy;

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -114,7 +114,9 @@ int seq_run(const traccc::opts::detector& detector_opts,
             detector_opts.material_file, detector_opts.grid_file);
         device_detector = detray::get_buffer(host_detector, device_mr, copy);
         stream.synchronize();
-        device_detector_view = detray::get_data(device_detector);
+        const traccc::default_detector::buffer& const_device_detector =
+            device_detector;
+        device_detector_view = detray::get_data(const_device_detector);
     }
 
     // Output stats

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -108,7 +108,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
                               detector_opts.grid_file);
 
     // Detector view object
-    traccc::default_detector::view det_view = detray::get_data(detector);
+    const traccc::default_detector::host& const_detector = detector;
+    traccc::default_detector::view det_view = detray::get_data(const_detector);
 
     /*****************************
      * Do the reconstruction

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -114,7 +114,7 @@ int main(int argc, char* argv[]) {
         reader_cfg.add_file(
             traccc::io::get_absolute_path(detector_opts.grid_file));
     }
-    auto [host_det, names] =
+    const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
 
     // Detector view object

--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -141,7 +141,7 @@ class full_chain_algorithm
     /// Buffer holding the detector's payload on the device
     host_detector_type::buffer_type m_device_detector;
     /// View of the detector's payload on the device
-    host_detector_type::view_type m_device_detector_view;
+    host_detector_type::const_view_type m_device_detector_view;
 
     /// @name Sub-algorithms used by this full-chain algorithm
     /// @{

--- a/examples/run/sycl/full_chain_algorithm.sycl
+++ b/examples/run/sycl/full_chain_algorithm.sycl
@@ -121,7 +121,8 @@ full_chain_algorithm::full_chain_algorithm(
     if (m_detector != nullptr) {
         m_device_detector =
             detray::get_buffer(*m_detector, m_device_mr, m_copy);
-        m_device_detector_view = detray::get_data(m_device_detector);
+        const auto& const_device_detector = m_device_detector;
+        m_device_detector_view = detray::get_data(const_device_detector);
     }
 }
 
@@ -180,7 +181,8 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
     if (m_detector != nullptr) {
         m_device_detector =
             detray::get_buffer(*m_detector, m_device_mr, m_copy);
-        m_device_detector_view = detray::get_data(m_device_detector);
+        const auto& const_device_detector = m_device_detector;
+        m_device_detector_view = detray::get_data(const_device_detector);
     }
 }
 

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -96,7 +96,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
             detector_opts.material_file, detector_opts.grid_file);
         device_det = detray::get_buffer(host_det, device_mr, copy);
         q.wait_and_throw();
-        device_det_view = detray::get_data(device_det);
+        const auto& const_device_det = device_det;
+        device_det_view = detray::get_data(const_device_det);
     }
 
     const traccc::vector3 field_vec(seeding_opts);

--- a/examples/run/sycl/seq_example_sycl.sycl
+++ b/examples/run/sycl/seq_example_sycl.sycl
@@ -142,7 +142,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
             detector_opts.material_file, detector_opts.grid_file);
         device_detector = detray::get_buffer(host_detector, device_mr, copy);
         q.wait_and_throw();
-        device_detector_view = detray::get_data(device_detector);
+        const auto& const_device_detector = device_detector;
+        device_detector_view = detray::get_data(const_device_detector);
     }
 
     // Output stats

--- a/tests/cuda/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cuda/test_ckf_combinatorics_telescope.cpp
@@ -71,7 +71,7 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
     reader_cfg.add_file(path + "telescope_detector_geometry.json")
         .add_file(path + "telescope_detector_homogeneous_material.json");
 
-    auto [host_det, names] =
+    const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
 
     const auto field = traccc::construct_const_bfield(std::get<13>(GetParam()));

--- a/tests/cuda/test_ckf_toy_detector.cpp
+++ b/tests/cuda/test_ckf_toy_detector.cpp
@@ -68,7 +68,7 @@ TEST_P(CkfToyDetectorTests, Run) {
         .add_file(path + "toy_detector_homogeneous_material.json")
         .add_file(path + "toy_detector_surface_grids.json");
 
-    auto [host_det, names] =
+    const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
 
     const auto field = traccc::construct_const_bfield(B);

--- a/tests/cuda/test_kalman_fitter_telescope.cpp
+++ b/tests/cuda/test_kalman_fitter_telescope.cpp
@@ -80,7 +80,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     detray::io::detector_reader_config reader_cfg{};
     reader_cfg.add_file(path + "telescope_detector_geometry.json")
         .add_file(path + "telescope_detector_homogeneous_material.json");
-    auto [host_det, names] =
+    const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(mng_mr, reader_cfg);
 
     // Detector view object

--- a/tests/cuda/test_spacepoint_formation.cpp
+++ b/tests/cuda/test_spacepoint_formation.cpp
@@ -53,7 +53,7 @@ TEST(CUDASpacepointFormation, cuda) {
     tel_cfg.pilot_track(traj);
 
     // Create telescope geometry
-    auto [det, name_map] = build_telescope_detector(mng_mr, tel_cfg);
+    const auto [det, name_map] = build_telescope_detector(mng_mr, tel_cfg);
     using device_detector_type = traccc::telescope_detector::device;
 
     // Surface lookup

--- a/tests/sycl/test_ckf_combinatorics_telescope.cpp
+++ b/tests/sycl/test_ckf_combinatorics_telescope.cpp
@@ -85,7 +85,8 @@ TEST_P(CkfCombinatoricsTelescopeTests, Run) {
     auto field = traccc::construct_const_bfield(std::get<13>(GetParam()));
 
     // Detector view object
-    auto det_view = detray::get_data(host_det);
+    const host_detector_type& const_host_det = host_det;
+    auto det_view = detray::get_data(const_host_det);
 
     /***************************
      * Generate simulation data

--- a/tests/sycl/test_ckf_toy_detector.cpp
+++ b/tests/sycl/test_ckf_toy_detector.cpp
@@ -81,7 +81,8 @@ TEST_P(CkfToyDetectorTests, Run) {
     const auto field = traccc::construct_const_bfield(B);
 
     // Detector view object
-    auto det_view = detray::get_data(host_det);
+    const host_detector_type& const_host_det = host_det;
+    auto det_view = detray::get_data(const_host_det);
 
     /***************************
      * Generate simulation data

--- a/tests/sycl/test_kalman_fitter_telescope.cpp
+++ b/tests/sycl/test_kalman_fitter_telescope.cpp
@@ -93,7 +93,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
     reader_cfg.add_file(path + "telescope_detector_geometry.json")
         .add_file(path + "telescope_detector_homogeneous_material.json");
 
-    auto [host_det, names] =
+    const auto [host_det, names] =
         detray::io::read_detector<host_detector_type>(shared_mr, reader_cfg);
     auto det_view = detray::get_data(host_det);
     const auto field = traccc::construct_const_bfield(std::get<13>(GetParam()));

--- a/tests/sycl/test_spacepoint_formation.cpp
+++ b/tests/sycl/test_spacepoint_formation.cpp
@@ -52,7 +52,7 @@ TEST(SYCLSpacepointFormation, sycl) {
     tel_cfg.pilot_track(traj);
 
     // Create telescope geometry
-    auto [det, name_map] = build_telescope_detector(shared_mr, tel_cfg);
+    const auto [det, name_map] = build_telescope_detector(shared_mr, tel_cfg);
 
     // Surface lookup
     auto surfaces = det.surfaces();


### PR DESCRIPTION
As @niermann999 reminded me earlier today, in all our algorithms we access the tracking geometry in device code with non-const pointers. Which is tangentially related to the non-cached access that @stephenswat floated recently.

As I discussed with Joana, right now [detray](https://github.com/acts-project/detray) doesn't actually provide a way to create a "device detector" object that would use const access. It provides typedefs for constant views, but those constant views can not be used in any shape or form with a device detector object with the existing infrastructure.

But as it turns out, one can create a "constant device detector" object with a relatively minimal amount of effort. See the `traccc::details::device_detector_container_types` type introduced by this PR! Using that, plus some relatively manageable amount of changes, the project should now be accessing the data held by Detray, using constant pointers.

Don't think that this will make any difference for the performance of the compiled code, but at least it should make the code a little safer vis-a-vis const correctness.

Of course some of this will need to find its way back into Detray. Since as we discussed with Joana, `detray::detector` should pretty much only ever offer constant versions of itself. As its API doesn't allow for any modification of an existing detector. Not on the host and even less on a device.