### PR TITLE
Enable register spilling to shared memory

### DIFF
--- a/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
@@ -12,6 +12,7 @@
 
 // Local include(s).
 #include "../../../utils/barrier.hpp"
+#include "../../../utils/hints.hpp"
 #include "../../../utils/thread_id.hpp"
 
 // System include(s).
@@ -25,6 +26,7 @@ __global__ void find_tracks(
     const __grid_constant__ finding_config cfg,
     const __grid_constant__ typename detector_t::const_view_type det,
     const __grid_constant__ device::find_tracks_payload payload) {
+    TRACCC_CUDA_SPILL_TO_SHARED_MEMORY;
 
     __shared__ unsigned int shared_num_out_params;
     __shared__ unsigned int shared_candidates_size;

--- a/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
@@ -9,6 +9,7 @@
 
 // Local include(s).
 #include "../../../utils/global_index.hpp"
+#include "../../../utils/hints.hpp"
 #include "../propagate_to_next_surface.hpp"
 
 // Project include(s).
@@ -24,6 +25,7 @@ __global__ __launch_bounds__(128) void propagate_to_next_surface(
     typename propagator_t::detector_type::const_view_type det_data,
     const __grid_constant__ bfield_t field_data,
     const __grid_constant__ device::propagate_to_next_surface_payload payload) {
+    TRACCC_CUDA_SPILL_TO_SHARED_MEMORY;
 
     device::propagate_to_next_surface<propagator_t>(
         details::global_index1(), cfg, det_data, field_data, payload);

--- a/device/cuda/src/utils/hints.hpp
+++ b/device/cuda/src/utils/hints.hpp
@@ -1,0 +1,20 @@
+/**
+ * TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#if defined(__CUDA_ARCH__) && CUDART_VERSION >= 13000
+#define TRACCC_CUDA_SPILL_TO_SHARED_MEMORY        \
+    do {                                          \
+        asm(".pragma \"enable_smem_spilling\";"); \
+    } while (0)
+#else
+#define TRACCC_CUDA_SPILL_TO_SHARED_MEMORY \
+    do {                                   \
+    } while (0)
+#endif


### PR DESCRIPTION
CUDA 13.0 enables the PTX assembler to spill registers to shared memory instead of local memory, which should both be much faster, and also reduce the local memory usage of our fitting and finding kernels which are currently bottlenecking our throughput.