### PR TITLE
Initialize `is_updated` buffer to zero vector correctly

### DIFF
--- a/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
+++ b/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
@@ -369,6 +369,7 @@ greedy_ambiguity_resolution_algorithm::operator()(
     // Whether track id is updated after an iteration
     vecmem::data::vector_buffer<int> is_updated_buffer{n_tracks, m_mr.main};
     m_copy.get().setup(inverted_ids_buffer)->ignore();
+    m_copy.get().memset(is_updated_buffer, 0)->ignore();
 
     // Count track id apperance during removal process
     vecmem::data::vector_buffer<int> track_count_buffer{n_tracks, m_mr.main};

--- a/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
+++ b/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
@@ -368,7 +368,7 @@ greedy_ambiguity_resolution_algorithm::operator()(
 
     // Whether track id is updated after an iteration
     vecmem::data::vector_buffer<int> is_updated_buffer{n_tracks, m_mr.main};
-    m_copy.get().setup(inverted_ids_buffer)->ignore();
+    m_copy.get().setup(is_updated_buffer)->ignore();
     m_copy.get().memset(is_updated_buffer, 0)->ignore();
 
     // Count track id apperance during removal process


### PR DESCRIPTION
I found that the ODD example was crashing after #1123 where the elements of `is_updated buffer` is not initialized to zero at the beginning.

This PR is simply fixing it by using `memset`


```
byeo@hermes:/mnt/nvme0n1/byeo/projects/traccc/traccc_build$     ./bin/traccc_seq_example_cuda \
    --digitization-file=geometries/odd/odd-digi-geometric-config.json \
    --detector-file=geometries/odd/odd-detray_geometry_detray.json \
    --material-file=geometries/odd/odd-detray_material_detray.json \
    --grid-file=geometries/odd/odd-detray_surface_grids_detray.json \
    --use-acts-geom-source=true \
    --input-directory=odd/odd-simulations-20240509/geant4_ttbar_mu200/ \
    --input-events=10
19:29:16    CudaSeqExampleOptions         INFO      
19:29:16    CudaSeqExampleOptions         INFO      Running Full Tracking Chain Using CUDA
19:29:16    CudaSeqExampleOptions         INFO      
19:29:16    CudaSeqExampleOptions         INFO      Detector Options:
19:29:16    CudaSeqExampleOptions         INFO      ├ Detector file:                              geometries/odd/odd-detray_geometry_detray.json
19:29:16    CudaSeqExampleOptions         INFO      ├ Material file:                              geometries/odd/odd-detray_material_detray.json
19:29:16    CudaSeqExampleOptions         INFO      ├ Surface grid file:                          geometries/odd/odd-detray_surface_grids_detray.json
19:29:16    CudaSeqExampleOptions         INFO      └ Digitization file:                          geometries/odd/odd-digi-geometric-config.json
19:29:16    CudaSeqExampleOptions         INFO      Magnetic Field Options:
19:29:16    CudaSeqExampleOptions         INFO      ├ Read magnetic field from file:              false
19:29:16    CudaSeqExampleOptions         INFO      ├ Magnetic field file:                        geometries/odd/odd-bfield.cvf
19:29:16    CudaSeqExampleOptions         INFO      ├ Magnetic field file format:                 binary
19:29:16    CudaSeqExampleOptions         INFO      └ Magnetic field value:                       2 T
19:29:16    CudaSeqExampleOptions         INFO      Input Data Options:
19:29:16    CudaSeqExampleOptions         INFO      ├ Use ACTS geometry source:                   true
19:29:16    CudaSeqExampleOptions         INFO      ├ Input data format:                          csv
19:29:16    CudaSeqExampleOptions         INFO      ├ Input directory:                            odd/odd-simulations-20240509/geant4_ttbar_mu200/
19:29:16    CudaSeqExampleOptions         INFO      ├ Number of input events:                     10
19:29:16    CudaSeqExampleOptions         INFO      └ Number of skipped events:                   0
19:29:16    CudaSeqExampleOptions         INFO      Clusterization Options:
19:29:16    CudaSeqExampleOptions         INFO      ├ Threads per partition:                      256
19:29:16    CudaSeqExampleOptions         INFO      ├ Target cells per thread:                    8
19:29:16    CudaSeqExampleOptions         INFO      ├ Max cells per thread:                       16
19:29:16    CudaSeqExampleOptions         INFO      └ Scratch space multiplier:                   256
19:29:16    CudaSeqExampleOptions         INFO      Track Seeding Options:
19:29:16    CudaSeqExampleOptions         INFO      ├ Spacepoint Z range:                         [-2000.0 - 2000.0] mm
19:29:16    CudaSeqExampleOptions         INFO      ├ Spacepoint R range:                         [33.00 - 200.00] mm
19:29:16    CudaSeqExampleOptions         INFO      ├ Vertex Z range:                             [-250.00 - 250.00] mm
19:29:16    CudaSeqExampleOptions         INFO      ├ Minimum track momentum:                     0.50 GeV
19:29:16    CudaSeqExampleOptions         INFO      ├ Maximum cotangent of theta angle:           27.2845 (eta = 4.00)
19:29:16    CudaSeqExampleOptions         INFO      ├ Radial distance between measurements:       [20.00 - 80.00] mm
19:29:16    CudaSeqExampleOptions         INFO      ├ Maximum impact parameter:                   10.00 mm
19:29:16    CudaSeqExampleOptions         INFO      ├ Scattering angle sigma:                     3.00
19:29:16    CudaSeqExampleOptions         INFO      ├ Upper pT limit for scattering:              10.00 GeV
19:29:16    CudaSeqExampleOptions         INFO      ├ Maximum seeds per middle space point:       5
19:29:16    CudaSeqExampleOptions         INFO      ├ B-field in Z direction:                     2.00 T
19:29:16    CudaSeqExampleOptions         INFO      ├ Inverted radius delta for compatible seeds: 0.00003 mm^-1
19:29:16    CudaSeqExampleOptions         INFO      ├ Weight factor for impact parameter:         1.00
19:29:16    CudaSeqExampleOptions         INFO      ├ Weight per compatible seed:                 200.00
19:29:16    CudaSeqExampleOptions         INFO      └ Maximum weighted compatible seed:           2
19:29:16    CudaSeqExampleOptions         INFO      Track Finding Options:
19:29:16    CudaSeqExampleOptions         INFO      ├ Max branches per seed:                      10
19:29:16    CudaSeqExampleOptions         INFO      ├ Max branches at surface:                    1
19:29:16    CudaSeqExampleOptions         INFO      ├ Track candidate range:                      3:100
19:29:16    CudaSeqExampleOptions         INFO      ├ Min step length to next surface:            1.200000 mm
19:29:16    CudaSeqExampleOptions         INFO      ├ Max step count to next surface:             100
19:29:16    CudaSeqExampleOptions         INFO      ├ Max Chi2:                                   100.000000
19:29:16    CudaSeqExampleOptions         INFO      ├ Max holes per candidate:                    3
19:29:16    CudaSeqExampleOptions         INFO      ├ Min track length for deduplication:         5
19:29:16    CudaSeqExampleOptions         INFO      ├ PDG number:                                 13
19:29:16    CudaSeqExampleOptions         INFO      ├ Minimum pT:                                 0.6 GeV
19:29:16    CudaSeqExampleOptions         INFO      └ Minimum p:                                  0.1 GeV
19:29:16    CudaSeqExampleOptions         INFO      Track Propagation Options:
19:29:16    CudaSeqExampleOptions         INFO      ├ Navigation:
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Min mask tolerance:                       0.000010 mm
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Max mask tolerance:                       3.000000 mm
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Mask tolerance scalar:                    0.050000
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Path tolerance:                           1.000000 um
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Overstep tolerance:                       -999.999939 um
19:29:16    CudaSeqExampleOptions         INFO      │ └ Search window:                            0 x 0
19:29:16    CudaSeqExampleOptions         INFO      ├ Transport:
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Min step size:                            0.000100 mm
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Runge-Kutta tolerance:                    0.000100 mm
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Max step updates:                         10000
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Step size constraint:                     340282346638528859811704183484516925440.000000 mm
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Path limit:                               5.000000 m
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Enable Bethe energy loss:                 true
19:29:16    CudaSeqExampleOptions         INFO      │ ├ Enable covariance transport:              true
19:29:16    CudaSeqExampleOptions         INFO      │ └ Covariance transport:
19:29:16    CudaSeqExampleOptions         INFO      │   ├ Enable energy loss gradient:            false
19:29:16    CudaSeqExampleOptions         INFO      │   └ Enable B-field gradient:                false
19:29:16    CudaSeqExampleOptions         INFO      └ Geometry context:
19:29:16    CudaSeqExampleOptions         INFO      Track Ambiguity Resolution Options:
19:29:16    CudaSeqExampleOptions         INFO      ├ Min number of measurements per track:       3
19:29:16    CudaSeqExampleOptions         INFO      ├ Max iteration to remove the bad tracks:     4294967295
19:29:16    CudaSeqExampleOptions         INFO      └ Max shared meas to break the iteration:     1
19:29:16    CudaSeqExampleOptions         INFO      Performance Measurement Options:
19:29:16    CudaSeqExampleOptions         INFO      └ Run performance checks:                     false
19:29:16    CudaSeqExampleOptions         INFO      Track Fitting Options:
19:29:16    CudaSeqExampleOptions         INFO      ├ Number of iterations:                       1
19:29:16    CudaSeqExampleOptions         INFO      ├ Particle hypothesis PDG:                    13
19:29:16    CudaSeqExampleOptions         INFO      ├ Covariance inflation factor:                1000.000000
19:29:16    CudaSeqExampleOptions         INFO      ├ Barcode sequence size factor:               5
19:29:16    CudaSeqExampleOptions         INFO      ├ Minimum capacity of barcode sequence:       100
19:29:16    CudaSeqExampleOptions         INFO      └ Mask tolerance for the backward filter:     5.000000
19:29:16    CudaSeqExampleOptions         INFO      Accelerator Options:
19:29:16    CudaSeqExampleOptions         INFO      ├ Compare with CPU output:                    false
19:29:16    CudaSeqExampleOptions         INFO      └ Use GPU texture memory:                     false
19:29:16    CudaSeqExampleOptions         INFO      
INFO: Reading detector files... Done
INFO: Building detector: Cylindrical detector from DD4hep blueprint... Done
INFO: Checking detector consistency...
WARNING: No material in detector
WARNING: No entries in volume finder
INFO: Consistency check: OK
INFO: Host detector construction complete
INFO: Reading detector files... Done
INFO: Building detector: Cylindrical detector from DD4hep blueprint... Done
INFO: Checking detector consistency...
WARNING: No entries in volume finder
INFO: Consistency check: OK
INFO: Host detector construction complete
19:29:23    CudaSeqExample                WARNING   18943 duplicate cells found in /mnt/nvme0n1/byeo/projects/traccc/traccc/data/odd/odd-simulations-20240509/geant4_ttbar_mu200/event000000000-cells.csv
19:29:24    CudaSeqExample                WARNING   16264 duplicate cells found in /mnt/nvme0n1/byeo/projects/traccc/traccc/data/odd/odd-simulations-20240509/geant4_ttbar_mu200/event000000001-cells.csv
19:29:25    CudaSeqExample                WARNING   16881 duplicate cells found in /mnt/nvme0n1/byeo/projects/traccc/traccc/data/odd/odd-simulations-20240509/geant4_ttbar_mu200/event000000002-cells.csv
19:29:27    CudaSeqExample                WARNING   18654 duplicate cells found in /mnt/nvme0n1/byeo/projects/traccc/traccc/data/odd/odd-simulations-20240509/geant4_ttbar_mu200/event000000003-cells.csv
19:29:28    CudaSeqExample                WARNING   19031 duplicate cells found in /mnt/nvme0n1/byeo/projects/traccc/traccc/data/odd/odd-simulations-20240509/geant4_ttbar_mu200/event000000004-cells.csv
19:29:30    CudaSeqExample                WARNING   17082 duplicate cells found in /mnt/nvme0n1/byeo/projects/traccc/traccc/data/odd/odd-simulations-20240509/geant4_ttbar_mu200/event000000005-cells.csv
19:29:31    CudaSeqExample                WARNING   18367 duplicate cells found in /mnt/nvme0n1/byeo/projects/traccc/traccc/data/odd/odd-simulations-20240509/geant4_ttbar_mu200/event000000006-cells.csv
19:29:32    CudaSeqExample                WARNING   17965 duplicate cells found in /mnt/nvme0n1/byeo/projects/traccc/traccc/data/odd/odd-simulations-20240509/geant4_ttbar_mu200/event000000007-cells.csv
19:29:33    CudaSeqExample                WARNING   16623 duplicate cells found in /mnt/nvme0n1/byeo/projects/traccc/traccc/data/odd/odd-simulations-20240509/geant4_ttbar_mu200/event000000008-cells.csv
19:29:35    CudaSeqExample                WARNING   19889 duplicate cells found in /mnt/nvme0n1/byeo/projects/traccc/traccc/data/odd/odd-simulations-20240509/geant4_ttbar_mu200/event000000009-cells.csv
19:29:36    CudaSeqExample                INFO      ==> Statistics ... 
19:29:36    CudaSeqExample                INFO      - read    3790687 cells
19:29:36    CudaSeqExample                INFO      - created (cpu)  0 measurements     
19:29:36    CudaSeqExample                INFO      - created (cuda)  1042450 measurements     
19:29:36    CudaSeqExample                INFO      - created (cpu)  0 spacepoints     
19:29:36    CudaSeqExample                INFO      - created (cuda) 823334 spacepoints     
19:29:36    CudaSeqExample                INFO      - created  (cpu) 0 seeds
19:29:36    CudaSeqExample                INFO      - created (cuda) 349163 seeds
19:29:36    CudaSeqExample                INFO      - found (cpu)    0 tracks
19:29:36    CudaSeqExample                INFO      - found (cuda)   188479 tracks
19:29:36    CudaSeqExample                INFO      - resolved (cpu)    0 tracks
19:29:36    CudaSeqExample                INFO      - resolved (cuda)   123508 tracks
19:29:36    CudaSeqExample                INFO      - fitted (cpu)   0 tracks
19:29:36    CudaSeqExample                INFO      - fitted (cuda)  123508 tracks
19:29:36    CudaSeqExample                INFO      ==>Elapsed times...            File reading  (cpu)  7883 ms
19:29:36    CudaSeqExample                INFO               Clusterization (cuda)  62 ms
19:29:36    CudaSeqExample                INFO         Spacepoint formation (cuda)  2 ms
19:29:36    CudaSeqExample                INFO                      Seeding (cuda)  68 ms
19:29:36    CudaSeqExample                INFO                 Track params (cuda)  5 ms
19:29:36    CudaSeqExample                INFO                Track finding (cuda)  548 ms
19:29:36    CudaSeqExample                INFO         Ambiguity resolution (cuda)  372 ms
19:29:36    CudaSeqExample                INFO                Track fitting (cuda)  321 ms
19:29:36    CudaSeqExample                INFO                           Wall time  9283 ms
```
