### PR TITLE
Add parameter for HS truth particle selection

### DIFF
--- a/examples/options/include/traccc/options/truth_finding.hpp
+++ b/examples/options/include/traccc/options/truth_finding.hpp
@@ -23,6 +23,8 @@ class truth_finding : public interface,
     float m_z_min = -500.f * unit<float>::mm;
     float m_z_max = 500.f * unit<float>::mm;
     float m_r_max = 200.f * unit<float>::mm;
+    float m_eta_max = 3.f;
+    int m_process_id = 0;
     unsigned int m_min_track_candidates = 3;
 
     truth_finding();

--- a/examples/options/src/truth_finding.cpp
+++ b/examples/options/src/truth_finding.cpp
@@ -31,6 +31,14 @@ truth_finding::truth_finding() : interface("Truth Track Finding Options") {
         "truth-finding-max-r",
         boost::program_options::value(&m_r_max)->default_value(m_r_max),
         "Candidate particle max r cut [mm]");
+    m_desc.add_options()(
+        "truth-finding-max-eta",
+        boost::program_options::value(&m_eta_max)->default_value(m_eta_max),
+        "Candidate particle max eta cut");
+    m_desc.add_options()("truth-finding-process-id",
+                         boost::program_options::value(&m_process_id)
+                             ->default_value(m_process_id),
+                         "Candidate particle is from a selected process");
     m_desc.add_options()("truth-finding-min-track-candidates",
                          boost::program_options::value(&m_min_track_candidates)
                              ->default_value(m_min_track_candidates),
@@ -50,6 +58,8 @@ truth_finding::operator truth_matching_config() const {
         .z_min = m_z_min,
         .z_max = m_z_max,
         .r_max = m_r_max,
+        .eta_max = m_eta_max,
+        .process_id = m_process_id,
         .min_track_candidates = m_min_track_candidates};
 }
 
@@ -64,6 +74,10 @@ std::unique_ptr<configuration_printable> truth_finding::as_printable() const {
         "Maximum z", std::format("{} mm", m_z_max / unit<float>::mm)));
     cat->add_child(std::make_unique<configuration_kv_pair>(
         "Maximum r", std::format("{} mm", m_r_max / unit<float>::mm)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Maximum eta", std::format("{}", m_eta_max)));
+    cat->add_child(std::make_unique<configuration_kv_pair>(
+        "Process ID", std::format("{}", m_process_id)));
     cat->add_child(std::make_unique<configuration_kv_pair>(
         "Minimum track candidates", std::format("{}", m_min_track_candidates)));
 

--- a/performance/include/traccc/utils/truth_matching_config.hpp
+++ b/performance/include/traccc/utils/truth_matching_config.hpp
@@ -16,8 +16,9 @@ struct truth_matching_config {
 
     float z_min = -500.f * traccc::unit<float>::mm;
     float z_max = 500.f * traccc::unit<float>::mm;
-
     float r_max = 200.f * traccc::unit<float>::mm;
+    float eta_max = 3.f;
+    int process_id = -1;
 
     unsigned int min_track_candidates = 3;
 };

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -264,6 +264,9 @@ void finding_performance_writer::write_common(
             ptc.vertex[2] < m_cfg.truth_config.z_min ||
             ptc.vertex[2] > m_cfg.truth_config.z_max ||
             vector::perp(ptc.vertex) > m_cfg.truth_config.r_max ||
+            std::abs(vector::eta(ptc.momentum)) > m_cfg.truth_config.eta_max ||
+            (m_cfg.truth_config.process_id >= 0 &&
+             m_cfg.truth_config.process_id != ptc.process) ||
             num_measurements < m_cfg.truth_config.min_track_candidates) {
             continue;
         }

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -176,6 +176,9 @@ void seeding_performance_writer::write(
             ptc.vertex[2] < m_cfg.truth_config.z_min ||
             ptc.vertex[2] > m_cfg.truth_config.z_max ||
             vector::perp(ptc.vertex) > m_cfg.truth_config.r_max ||
+            std::abs(vector::eta(ptc.momentum)) > m_cfg.truth_config.eta_max ||
+            (m_cfg.truth_config.process_id >= 0 &&
+             m_cfg.truth_config.process_id != ptc.process) ||
             num_measurements < m_cfg.truth_config.min_track_candidates) {
             continue;
         }


### PR DESCRIPTION
Hello! I have encapsulated "comes from HS process and is stable particle" into a `is_HS` truth parameter selection to have a coherent selection of truth particles between Athena and Traccc. This is currently read from the `process` value in the input "particles-initial" csv file. Happy to discuss if it should be renamed, placed somewhere else etc. 