### PR TITLE
Avoid async size copies into pageable memory

### DIFF
--- a/device/cuda/src/seeding/spacepoint_binning.cu
+++ b/device/cuda/src/seeding/spacepoint_binning.cu
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "../utils/cuda_error_handling.hpp"
+#include "../utils/get_size.hpp"
 #include "../utils/global_index.hpp"
 #include "../utils/utils.hpp"
 #include "traccc/cuda/seeding/details/spacepoint_binning.hpp"
@@ -64,8 +65,13 @@ traccc::details::spacepoint_grid_types::buffer spacepoint_binning::operator()(
     // Get a convenience variable for the stream that we'll be using.
     cudaStream_t stream = details::get_stream(m_stream);
 
+    // Staging area for copying sizes from device to host
+    vecmem::unique_alloc_ptr<unsigned int> size_staging_ptr =
+        vecmem::make_unique_alloc<unsigned int>(*(m_mr.host));
+
     // Get the spacepoint sizes from the view
-    const auto sp_size = m_copy.get_size(spacepoints_view);
+    const auto sp_size =
+        get_size(spacepoints_view, size_staging_ptr.get(), stream);
 
     if (sp_size == 0) {
         return {m_axes.first, m_axes.second, {}, m_mr.main, m_mr.host};

--- a/device/cuda/src/seeding/track_params_estimation.cu
+++ b/device/cuda/src/seeding/track_params_estimation.cu
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "../utils/cuda_error_handling.hpp"
+#include "../utils/get_size.hpp"
 #include "../utils/global_index.hpp"
 #include "../utils/utils.hpp"
 #include "traccc/cuda/seeding/track_params_estimation.hpp"
@@ -52,8 +53,13 @@ track_params_estimation::output_type track_params_estimation::operator()(
     // Get a convenience variable for the stream that we'll be using.
     cudaStream_t stream = details::get_stream(m_stream);
 
+    // Staging area for copying sizes from device to host
+    vecmem::unique_alloc_ptr<unsigned int> size_staging_ptr =
+        vecmem::make_unique_alloc<unsigned int>(*(m_mr.host));
+
     // Get the size of the seeds view
-    const unsigned int seeds_size = m_copy.get_size(seeds_view);
+    const unsigned int seeds_size =
+        get_size(seeds_view, size_staging_ptr.get(), stream);
 
     // Create device buffer for the parameters
     bound_track_parameters_collection_types::buffer params_buffer(seeds_size,

--- a/device/cuda/src/utils/get_size.hpp
+++ b/device/cuda/src/utils/get_size.hpp
@@ -1,0 +1,60 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "../utils/cuda_error_handling.hpp"
+
+namespace traccc::cuda {
+
+namespace detail {
+template <typename T>
+concept container_has_size_ptr = requires(const T& t) {
+    { t.size_ptr() };
+};
+
+template <typename T>
+concept container_has_size = requires(const T& t) {
+    { t.size().ptr() };
+};
+}  // namespace detail
+
+/**
+ * @brief Helper function to efficiently get the size of a vecmem container,
+ * as the default vecmem copy logic goes through pageable memory which can
+ * greatly slow down the application.
+ */
+template <typename T>
+typename T::size_type get_size(const T& data, typename T::size_type* staging,
+                               cudaStream_t& stream) {
+    static_assert(detail::container_has_size_ptr<T> ||
+                  detail::container_has_size<T>);
+
+    if constexpr (detail::container_has_size_ptr<T>) {
+        if (data.size_ptr() == nullptr) {
+            return data.capacity();
+        } else {
+            TRACCC_CUDA_ERROR_CHECK(cudaMemcpyAsync(
+                staging, data.size_ptr(), sizeof(typename T::size_type),
+                cudaMemcpyDeviceToHost, stream));
+            TRACCC_CUDA_ERROR_CHECK(cudaStreamSynchronize(stream));
+            return *staging;
+        }
+    } else {
+        if (data.size().ptr() == nullptr) {
+            return data.capacity();
+        } else {
+            TRACCC_CUDA_ERROR_CHECK(cudaMemcpyAsync(
+                staging, data.size().ptr(), sizeof(typename T::size_type),
+                cudaMemcpyDeviceToHost, stream));
+            TRACCC_CUDA_ERROR_CHECK(cudaStreamSynchronize(stream));
+            return *staging;
+        }
+    }
+}
+
+}  // namespace traccc::cuda

--- a/tests/cuda/test_spacepoint_formation.cpp
+++ b/tests/cuda/test_spacepoint_formation.cpp
@@ -14,6 +14,7 @@
 
 // VecMem include(s).
 #include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/memory/cuda/host_memory_resource.hpp>
 #include <vecmem/memory/cuda/managed_memory_resource.hpp>
 #include <vecmem/memory/host_memory_resource.hpp>
 #include <vecmem/utils/cuda/async_copy.hpp>
@@ -27,7 +28,8 @@ TEST(CUDASpacepointFormation, cuda) {
 
     // Memory resource used by the EDM.
     vecmem::cuda::managed_memory_resource mng_mr;
-    traccc::memory_resource mr{mng_mr};
+    vecmem::cuda::host_memory_resource host_mr;
+    traccc::memory_resource mr{mng_mr, &host_mr};
 
     // Cuda stream
     traccc::cuda::stream stream;


### PR DESCRIPTION
Launching asynchronous copies into pageable memory is highly inefficient in CUDA, as it requires the entire CUDA context to lock, across multiple threads. Now that our kernels are running as fast as they are, this is starting to have a noticable impact on our performance. This commit avoids the copies into pageable memory by using some pinned memory for memory copies of sizes.