### PR TITLE
Update detray to v0.103.0

### DIFF
--- a/core/include/traccc/finding/details/combinatorial_kalman_filter_types.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter_types.hpp
@@ -33,9 +33,11 @@ namespace traccc::details {
 /// @tparam bfield_t The type of magnetic field to use
 ///
 template <typename bfield_t>
-using ckf_stepper_t =
-    detray::rk_stepper<bfield_t, traccc::default_algebra,
-                       detray::constrained_step<traccc::scalar>>;
+using ckf_stepper_t = detray::rk_stepper<
+    bfield_t, traccc::default_algebra, detray::constrained_step<traccc::scalar>,
+    detray::stepper_rk_policy<traccc::scalar>, detray::stepping::void_inspector,
+    static_cast<std::uint32_t>(
+        detray::rk_stepper_flags::e_allow_covariance_transport)>;
 
 /// Interactor used in the Combinatorial Kalman Filter (CKF)
 using ckf_interactor_t =

--- a/core/include/traccc/fitting/details/kalman_fitting_types.hpp
+++ b/core/include/traccc/fitting/details/kalman_fitting_types.hpp
@@ -27,8 +27,13 @@ namespace traccc::details {
 ///
 template <typename detector_t, typename bfield_t>
 using kalman_fitter_t = kalman_fitter<
-    detray::rk_stepper<bfield_t, typename detector_t::algebra_type,
-                       detray::constrained_step<traccc::scalar>>,
+    detray::rk_stepper<
+        bfield_t, typename detector_t::algebra_type,
+        detray::constrained_step<traccc::scalar>,
+        detray::stepper_rk_policy<traccc::scalar>,
+        detray::stepping::void_inspector,
+        static_cast<std::uint32_t>(
+            detray::rk_stepper_flags::e_allow_covariance_transport)>,
     detray::navigator<std::add_const_t<detector_t>>>;
 
 }  // namespace traccc::details

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.102.0.tar.gz;URL_MD5;69421d1a0d606be1d627bd1cce7ff0fb"
+   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.103.0.tar.gz;URL_MD5;7df38072d676b63ee3f0f88bd84c0106"
    CACHE STRING "Source for Detray, when built as part of this project" )
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
 FetchContent_Declare( Detray SYSTEM ${TRACCC_DETRAY_SOURCE} )


### PR DESCRIPTION
This commit upgrades detray to version 0.103.0 and disables the magnetic field gradient in the Runge-Kutta steppers.