### PR TITLE
Bug Fix: Correct copy typo.

### DIFF
--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -100,7 +100,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
                               detector_opts.grid_file);
 
     const traccc::detector_buffer detector_buffer =
-        traccc::buffer_from_host_detector(host_det, device_mr, host_copy);
+        traccc::buffer_from_host_detector(host_det, device_mr, copy);
 
     // Output stats
     uint64_t n_cells = 0;


### PR DESCRIPTION
Tiny change, the new polymorphic detector code was using the host copy function, rather than the device one, causing a seg fault when I tried to test this example. It is correct in the other Alpaka examples.