### PR TITLE
Fix measurement selection bug in track finding

### DIFF
--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -110,7 +110,7 @@ TRACCC_HOST_DEVICE inline void find_tracks(
          * If we cannot find any corresponding measurements, set the number of
          * measurements to zero.
          */
-        if (lo == barcodes.end()) {
+        if (lo == barcodes.end() || *lo != bcd) {
             init_meas = 0;
         }
         /*


### PR DESCRIPTION
Our track finding uses `thrust::lower_bound` to select measurements on the current surface. This works perfectly if there are measurements on the current surface, as the lower bound algorithm will return the first measurement on that surface. If there aren't _any_ measurements on the surface, however, the algorithm will return a measurement on a _different_ surface, causing us to produce a few bogus tracks. This commit fixes this bug by additionally checking whether the result found is actually on the right surface.