### PR TITLE
Fix hole and tip making bugs in track finding

### DIFF
--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -529,7 +529,7 @@ TRACCC_HOST_DEVICE inline void find_tracks(
             payload.step > 0 ? links.at(prev_link_idx).seed_idx : in_param_id;
         n_skipped = payload.step == 0 ? 0 : links.at(prev_link_idx).n_skipped;
         in_param_can_create_hole =
-            (n_skipped <= cfg.max_num_skipping_per_cand) && (!last_step);
+            (n_skipped < cfg.max_num_skipping_per_cand) && (!last_step);
         prev_ndf_sum = payload.step == 0 ? 0 : links.at(prev_link_idx).ndf_sum;
         prev_chi2_sum =
             payload.step == 0 ? 0.f : links.at(prev_link_idx).chi2_sum;
@@ -641,7 +641,7 @@ TRACCC_HOST_DEVICE inline void find_tracks(
 
                 if (last_step &&
                     n_cands >= cfg.min_track_candidates_per_track) {
-                    auto tip_pos = tips.push_back(param_pos);
+                    auto tip_pos = tips.push_back(out_offset);
                     tip_lengths.at(tip_pos) = n_cands;
                 }
             }


### PR DESCRIPTION
This commit fices two minor bugs in the track finding kernel, namely:

1. It fixes an issue where a `<=` operator was incorrectly used to compare the current hole counts of track candidates with the maximum, allowing tracks to have one more hole than intended.
2. It fixes a bug where, in the (very unlikely) case that tips have to be created when the track finding process has reached its last stage, a tip would be created with an incorrect link index.