### PR TITLE
Free the memory properly in `array-wrapper-test`

### DIFF
--- a/tests/cuda/test_array_wrapper.cu
+++ b/tests/cuda/test_array_wrapper.cu
@@ -91,6 +91,8 @@ TEST(CUDAArrayWrapper, SoALayout) {
               cudaSuccess);
 
     ASSERT_EQ(host_result, n);
+
+    ASSERT_EQ(cudaFree(dev_result), cudaSuccess);
 }
 
 TEST(CUDAArrayWrapper, AoSLayout) {
@@ -124,4 +126,6 @@ TEST(CUDAArrayWrapper, AoSLayout) {
               cudaSuccess);
 
     ASSERT_EQ(host_result, n);
+
+    ASSERT_EQ(cudaFree(dev_result), cudaSuccess);
 }


### PR DESCRIPTION
Reported by @gagnonlg 
This unfreed memory makes the greedy ambiguity resolution tests fail when we run whole tests with `./bin/traccc_test_cuda`