### PR TITLE
Add `grid_constant` qualifier to CUDA kernels

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -407,10 +407,10 @@ class kalman_fitter {
     // Detector object
     const detector_type& m_detector;
     // Field object
-    const bfield_type m_field;
+    const bfield_type& m_field;
 
     // Configuration object
-    config_type m_cfg;
+    const config_type& m_cfg;
 };
 
 }  // namespace traccc

--- a/device/common/include/traccc/fitting/device/fit_backward.hpp
+++ b/device/common/include/traccc/fitting/device/fit_backward.hpp
@@ -14,7 +14,7 @@ namespace traccc::device {
 
 template <typename fitter_t>
 TRACCC_HOST_DEVICE inline void fit_backward(
-    const global_index_t globalIndex, const typename fitter_t::config_type cfg,
+    const global_index_t globalIndex, const typename fitter_t::config_type& cfg,
     const fit_payload<fitter_t>& payload) {
 
     typename fitter_t::detector_type det(payload.det_data);

--- a/device/common/include/traccc/fitting/device/fit_forward.hpp
+++ b/device/common/include/traccc/fitting/device/fit_forward.hpp
@@ -14,7 +14,7 @@ namespace traccc::device {
 
 template <typename fitter_t>
 TRACCC_HOST_DEVICE inline void fit_forward(
-    const global_index_t globalIndex, const typename fitter_t::config_type cfg,
+    const global_index_t globalIndex, const typename fitter_t::config_type& cfg,
     const fit_payload<fitter_t>& payload) {
 
     typename fitter_t::detector_type det(payload.det_data);

--- a/device/cuda/src/finding/kernels/specializations/apply_interaction_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/apply_interaction_src.cuh
@@ -19,7 +19,7 @@ namespace kernels {
 
 template <typename detector_t>
 __global__ void apply_interaction(
-    const finding_config cfg,
+    const __grid_constant__ finding_config cfg,
     device::apply_interaction_payload<detector_t> payload) {
 
     device::apply_interaction<detector_t>(details::global_index1(), cfg,

--- a/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
@@ -21,7 +21,7 @@ namespace traccc::cuda {
 namespace kernels {
 
 template <typename detector_t>
-__global__ void find_tracks(const finding_config cfg,
+__global__ void find_tracks(const __grid_constant__ finding_config cfg,
                             device::find_tracks_payload<detector_t> payload) {
     __shared__ unsigned int shared_num_out_params;
     __shared__ unsigned int shared_out_offset;

--- a/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
@@ -19,8 +19,10 @@ namespace kernels {
 
 template <typename propagator_t, typename bfield_t>
 __global__ __launch_bounds__(128) void propagate_to_next_surface(
-    const finding_config cfg,
-    device::propagate_to_next_surface_payload<propagator_t, bfield_t> payload) {
+    const __grid_constant__ finding_config cfg,
+    const __grid_constant__
+        device::propagate_to_next_surface_payload<propagator_t, bfield_t>
+            payload) {
 
     device::propagate_to_next_surface<propagator_t, bfield_t>(
         details::global_index1(), cfg, payload);
@@ -32,7 +34,8 @@ template <typename propagator_t, typename bfield_t>
 void propagate_to_next_surface(
     const dim3& grid_size, const dim3& block_size, std::size_t shared_mem_size,
     const cudaStream_t& stream, const finding_config cfg,
-    device::propagate_to_next_surface_payload<propagator_t, bfield_t> payload) {
+    const device::propagate_to_next_surface_payload<propagator_t, bfield_t>
+        payload) {
 
     kernels::propagate_to_next_surface<<<grid_size, block_size, shared_mem_size,
                                          stream>>>(cfg, payload);

--- a/device/cuda/src/fitting/kernels/specializations/fit_backward_src.cuh
+++ b/device/cuda/src/fitting/kernels/specializations/fit_backward_src.cuh
@@ -15,7 +15,8 @@ namespace traccc::cuda {
 namespace kernels {
 template <typename fitter_t>
 __global__ __launch_bounds__(128) void fit_backward(
-    const fitting_config cfg, const device::fit_payload<fitter_t> payload) {
+    const __grid_constant__ fitting_config cfg,
+    const __grid_constant__ device::fit_payload<fitter_t> payload) {
     device::fit_backward<fitter_t>(details::global_index1(), cfg, payload);
 }
 }  // namespace kernels

--- a/device/cuda/src/fitting/kernels/specializations/fit_forward_src.cuh
+++ b/device/cuda/src/fitting/kernels/specializations/fit_forward_src.cuh
@@ -15,7 +15,8 @@ namespace traccc::cuda {
 namespace kernels {
 template <typename fitter_t>
 __global__ __launch_bounds__(128) void fit_forward(
-    const fitting_config cfg, const device::fit_payload<fitter_t> payload) {
+    const __grid_constant__ fitting_config cfg,
+    const __grid_constant__ device::fit_payload<fitter_t> payload) {
     device::fit_forward<fitter_t>(details::global_index1(), cfg, payload);
 }
 }  // namespace kernels


### PR DESCRIPTION
A recent CUDA update adds the `__grid_constant__` qualifier which can be added to kernel arguments which guarantees that they remain in constant memory rather than being moved into local memory.