### PR TITLE
VecMem Update, main branch (2025.10.01.)

### DIFF
--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.20.0.tar.gz;URL_MD5;3fd8f4608956bf6e51b47a9f0f7f83a1"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.21.0.tar.gz;URL_MD5;4a02195eef26491b9b196d1945c1c594"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem SYSTEM ${TRACCC_VECMEM_SOURCE} )


### PR DESCRIPTION
Updated the project to [VecMem 1.21.0](https://github.com/acts-project/vecmem/releases/tag/v1.21.0).

This is to fix an issue with zero sized track buffers, found by @flg some time ago already.