### PR TITLE
feat: Update to detray v0.104.1

### DIFF
--- a/core/include/traccc/fitting/details/kalman_fitting.hpp
+++ b/core/include/traccc/fitting/details/kalman_fitting.hpp
@@ -88,7 +88,7 @@ typename edm::track_container<algebra_t>::host kalman_fitting(
             result_tracks_device.at(result_tracks_device.size() - 1),
             typename edm::track_state_collection<algebra_t>::device{
                 vecmem::get_data(result.states)},
-            measurements, seqs_buffer);
+            measurements, seqs_buffer, fitter.config().propagation);
 
         // Run the fitter. The status that it returns is not used here. The main
         // failure modes are saved onto the fitted track itself. Not sure what

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -164,7 +164,7 @@ struct kalman_actor : detray::actor {
             // Run Kalman Gain Updater
             const auto sf = navigation.get_surface();
 
-            const bool is_line = sf.template visit_mask<is_line_visitor>();
+            const bool is_line = detail::is_line(sf);
 
             kalman_fitter_status res = kalman_fitter_status::SUCCESS;
 
@@ -215,7 +215,9 @@ struct kalman_actor : detray::actor {
             actor_state.next();
 
             // Flag renavigation of the current candidate
-            navigation.set_high_trust();
+            if (math::fabs(navigation()) > 1.f * unit<float>::um) {
+                navigation.set_high_trust();
+            }
         }
     }
 };

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -110,11 +110,13 @@ class kalman_fitter {
                 track_states,
             const measurement_collection_types::const_device& measurements,
             vecmem::data::vector_view<detray::geometry::barcode>
-                sequence_buffer)
+                sequence_buffer,
+            const detray::propagation::config& prop_cfg)
             : m_fit_actor_state{track, track_states, measurements},
               m_sequencer_state(
                   vecmem::device_vector<detray::geometry::barcode>(
                       sequence_buffer)),
+              m_parameter_resetter{prop_cfg},
               m_fit_res{track},
               m_sequence_buffer(sequence_buffer) {}
 
@@ -122,8 +124,8 @@ class kalman_fitter {
         TRACCC_HOST_DEVICE
         typename forward_actor_chain_type::state_ref_tuple operator()() {
             return detray::tie(m_aborter_state, m_interactor_state,
-                               m_fit_actor_state, m_sequencer_state,
-                               m_step_aborter_state);
+                               m_fit_actor_state, m_parameter_resetter,
+                               m_sequencer_state, m_step_aborter_state);
         }
 
         /// @return the actor chain state
@@ -131,7 +133,8 @@ class kalman_fitter {
         typename backward_actor_chain_type::state_ref_tuple
         backward_actor_state() {
             return detray::tie(m_aborter_state, m_fit_actor_state,
-                               m_interactor_state, m_step_aborter_state);
+                               m_interactor_state, m_parameter_resetter,
+                               m_step_aborter_state);
         }
 
         /// Individual actor states
@@ -140,6 +143,7 @@ class kalman_fitter {
         typename forward_fit_actor::state m_fit_actor_state;
         typename barcode_sequencer::state m_sequencer_state;
         kalman_step_aborter::state m_step_aborter_state{};
+        typename resetter::state m_parameter_resetter{};
 
         /// Fitting result per track
         typename edm::track_collection<algebra_type>::device::proxy_type

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -209,7 +209,7 @@ TRACCC_HOST_DEVICE inline void find_tracks(
 
                 const detray::tracking_surface sf{det, in_par.surface_link()};
 
-                const bool is_line = sf.template visit_mask<is_line_visitor>();
+                const bool is_line = detail::is_line(sf);
 
                 // Run the Kalman update
                 const kalman_fitter_status res =

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -62,7 +62,9 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     const bound_track_parameters<> in_par = params.at(param_id);
 
     // Create propagator
-    propagator_t propagator(cfg.propagation);
+    auto prop_cfg{cfg.propagation};
+    prop_cfg.navigation.estimate_scattering_noise = false;
+    propagator_t propagator(prop_cfg);
 
     // Create propagator state
     typename propagator_t::state propagation(in_par, payload.field_data, det);
@@ -87,9 +89,8 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     typename detray::detail::tuple_element<2, actor_tuple_type>::type::state s2{
         s3};
     // Parameter resetter
-    // typename detray::detail::tuple_element<4, actor_tuple_type>::type::state
-    // s4{
-    //    cfg.propagation};
+    typename detray::detail::tuple_element<4, actor_tuple_type>::type::state s4{
+        prop_cfg};
     // Momentum aborter
     typename detray::detail::tuple_element<5, actor_tuple_type>::type::state s5;
     // CKF aborter
@@ -101,7 +102,7 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     s5.min_p(static_cast<scalar_t>(cfg.min_p));
 
     // Propagate to the next surface
-    propagator.propagate(propagation, detray::tie(s0, s2, s3, s5, s6));
+    propagator.propagate(propagation, detray::tie(s0, s2, s3, s4, s5, s6));
 
     // If a surface found, add the parameter for the next step
     if (s6.success) {

--- a/device/common/include/traccc/fitting/device/fit_backward.hpp
+++ b/device/common/include/traccc/fitting/device/fit_backward.hpp
@@ -39,7 +39,8 @@ TRACCC_HOST_DEVICE inline void fit_backward(
     if (param_liveness.at(param_id) > 0u) {
         typename fitter_t::state fitter_state(
             track, tracks.states, tracks.measurements,
-            *(payload.barcodes_view.ptr() + param_id));
+            *(payload.barcodes_view.ptr() + param_id),
+            fitter.config().propagation);
 
         kalman_fitter_status fit_status = fitter.smooth(fitter_state);
 

--- a/device/common/include/traccc/fitting/device/fit_forward.hpp
+++ b/device/common/include/traccc/fitting/device/fit_forward.hpp
@@ -42,7 +42,7 @@ TRACCC_HOST_DEVICE inline void fit_forward(
 
     typename fitter_t::state fitter_state(
         track, tracks.states, tracks.measurements,
-        *(payload.barcodes_view.ptr() + param_id));
+        *(payload.barcodes_view.ptr() + param_id), fitter.config().propagation);
 
     kalman_fitter_status fit_status = fitter.filter(params, fitter_state);
 

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Algebra Plugins as part of the TRACCC project" )
 
 # Declare where to get Algebra Plugins from.
 set( TRACCC_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.28.0.tar.gz;URL_MD5;24fa671f564a332858599df60fb2228f"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.30.0.tar.gz;URL_MD5;d1ec191c6fea5bd0e73f62d4b0319b8c"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced( TRACCC_ALGEBRA_PLUGINS_SOURCE )
 FetchContent_Declare( AlgebraPlugins SYSTEM ${TRACCC_ALGEBRA_PLUGINS_SOURCE} )

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.103.0.tar.gz;URL_MD5;7df38072d676b63ee3f0f88bd84c0106"
+   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.104.1.tar.gz;URL_MD5;2233a3b9945122e1b3f16ac973c7d1be"
    CACHE STRING "Source for Detray, when built as part of this project" )
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
 FetchContent_Declare( Detray SYSTEM ${TRACCC_DETRAY_SOURCE} )

--- a/simulation/include/traccc/simulation/simulator.hpp
+++ b/simulation/include/traccc/simulation/simulator.hpp
@@ -82,6 +82,15 @@ struct simulator {
 
         m_cfg.ptc_type = ptc_type;
         m_track_generator->config().charge(ptc_type.charge());
+
+        // Turn off tracking features
+        m_cfg.propagation.stepping.do_covariance_transport = false;
+        m_cfg.propagation.stepping.use_eloss_gradient = false;
+        m_cfg.propagation.stepping.use_field_gradient = false;
+        m_cfg.propagation.navigation.estimate_scattering_noise = false;
+
+        m_resetter = typename detray::parameter_resetter<algebra_type>::state{
+            m_cfg.propagation};
     }
 
     config& get_config() { return m_cfg; }
@@ -108,8 +117,8 @@ struct simulator {
             m_scatterer.set_seed(event_id);
             writer_state.set_seed(event_id);
 
-            auto actor_states =
-                detray::tie(m_aborter_state, m_scatterer, writer_state);
+            auto actor_states = detray::tie(m_aborter_state, m_scatterer,
+                                            m_resetter, writer_state);
 
             for (auto track : *m_track_generator.get()) {
 
@@ -149,6 +158,7 @@ struct simulator {
     /// Actor states
     typename detray::momentum_aborter<scalar_type>::state m_aborter_state{};
     typename detray::random_scatterer<algebra_type>::state m_scatterer{};
+    typename detray::parameter_resetter<algebra_type>::state m_resetter{};
 };
 
 }  // namespace traccc

--- a/tests/cpu/test_kalman_fitter_wire_chamber.cpp
+++ b/tests/cpu/test_kalman_fitter_wire_chamber.cpp
@@ -132,6 +132,8 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
     fit_cfg.propagation.navigation.min_mask_tolerance =
         static_cast<float>(mask_tolerance);
     fit_cfg.propagation.navigation.search_window = search_window;
+    // TODO: Disable until overlaps are handled correctly
+    fit_cfg.propagation.navigation.estimate_scattering_noise = false;
     fit_cfg.ptc_hypothesis = ptc;
     traccc::host::kalman_fitting_algorithm fitting(fit_cfg, host_mr, copy);
 


### PR DESCRIPTION
In the new detray version, the mask tolerances are scaled according to the positional and directional covariances found on the previous surfaces (scaled with the distance to the next surface, but not transported with a full Jacobian). This will allow to open (and close) the surface finding tolerances dynamically, according to how well known the track model is. Since this can lead to including more surfaces in the CKF on which ultimately no fitting measurement could be found (and hence would lead to the loss of the track due to an increased hole count), the navigator now knows if a surface was only included due to an "edge hit" in the tolerance band. In this case, no hole is flagged and the track can be kept alive. Any data like this, which needs to be retained after the propagation is halted, has been added to the new ```propagation_data``` struct that is passed between the different kernels. The last and second last sensitive visited is added to the CKF-aborter, so that no propagation loops on now overlapping surfaces occur.

Edit: The mask tolerance scaling is turned off for the CKF but enabled for the KF (by the defaults in the propagation config).