### PR TITLE
fix: Number of truth particles in finding performance writer

### DIFF
--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -149,6 +149,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
             seeds.push_back(truth_track_candidates.tracks.at(i_trk).params());
         }
 
+        std::cout << "Number of seeds: " << seeds.size() << std::endl;
+
         // Read measurements
         traccc::measurement_collection_types::host measurements_per_event{
             &host_mr};

--- a/performance/src/efficiency/finding_performance_writer.cpp
+++ b/performance/src/efficiency/finding_performance_writer.cpp
@@ -241,9 +241,16 @@ void finding_performance_writer::write_common(
 
     // For each truth particle...
     for (auto const& [pid, ptc] : evt_data.m_particle_map) {
-        std::size_t num_measurements = 0;
+
+        auto ptc_particle =
+            detail::particle_from_pdg_number<scalar>(ptc.particle_type);
+        if (ptc_particle.pdg_num() == 0) {
+            // TODO: Add some debug logging here.
+            continue;
+        }
 
         // Find the number of measurements belonging to this track
+        std::size_t num_measurements = 0;
         if (auto it = evt_data.m_ptc_to_meas_map.find(ptc);
             it != evt_data.m_ptc_to_meas_map.end()) {
             num_measurements = it->second.size();
@@ -273,6 +280,8 @@ void finding_performance_writer::write_common(
             total_matched_truth_particles++;
             n_matched_seeds_for_particle = it->second;
             total_duplicate_tracks += n_matched_seeds_for_particle - 1;
+        } else {
+            TRACCC_DEBUG("Not matched: " << pid);
         }
 
         // Finds how many (fake) tracks were made with at least one hit from the


### PR DESCRIPTION
Fixes the efficiencies of the CKF truth finding example by removing truth particles with PDG number 0. This is synchronized with the truth candidate generation, which applies the same filter