### PR TITLE
fix: add parameter resetter to CKF

### DIFF
--- a/core/include/traccc/finding/actors/ckf_aborter.hpp
+++ b/core/include/traccc/finding/actors/ckf_aborter.hpp
@@ -38,7 +38,7 @@ struct ckf_aborter : detray::actor {
                                        propagator_state_t &prop_state) const {
 
         auto &navigation = prop_state._navigation;
-        auto &stepping = prop_state._stepping;
+        const auto &stepping = prop_state._stepping;
 
         abrt_state.count++;
         abrt_state.path_from_surface += stepping.step_size();
@@ -51,8 +51,7 @@ struct ckf_aborter : detray::actor {
         }
 
         // Reset path from surface
-        if (navigation.is_on_sensitive() ||
-            navigation.encountered_sf_material()) {
+        if (navigation.is_on_sensitive()) {
             abrt_state.path_from_surface = 0.f;
         }
 

--- a/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -477,20 +477,22 @@ combinatorial_kalman_filter(
             traccc::details::ckf_interactor_t::state s2;
             typename interaction_register<
                 traccc::details::ckf_interactor_t>::state s1{s2};
-            typename detray::momentum_aborter<scalar_type>::state s3{};
-            typename ckf_aborter::state s4;
+            // typename detray::parameter_resetter<
+            //     typename detector_t::algebra_type>::state s3{};
+            typename detray::momentum_aborter<scalar_type>::state s4{};
+            typename ckf_aborter::state s5;
             // Update the actor config
-            s4.min_step_length = config.min_step_length_for_next_surface;
-            s4.max_count = config.max_step_counts_for_next_surface;
-            s3.min_pT(static_cast<scalar_type>(config.min_pT));
-            s3.min_p(static_cast<scalar_type>(config.min_p));
+            s4.min_pT(static_cast<scalar_type>(config.min_pT));
+            s4.min_p(static_cast<scalar_type>(config.min_p));
+            s5.min_step_length = config.min_step_length_for_next_surface;
+            s5.max_count = config.max_step_counts_for_next_surface;
 
             // Propagate to the next surface
-            propagator.propagate(propagation, detray::tie(s0, s1, s2, s3, s4));
+            propagator.propagate(propagation, detray::tie(s0, s1, s2, s4, s5));
 
             // If a surface found, add the parameter for the next
             // step
-            if (s4.success) {
+            if (s5.success) {
                 assert(propagation._navigation.is_on_sensitive());
                 assert(!propagation._stepping.bound_params().is_invalid());
 
@@ -499,14 +501,14 @@ combinatorial_kalman_filter(
             }
             // Unless the track found a surface, it is considered a
             // tip
-            else if (!s4.success &&
+            else if (!s5.success &&
                      (step >= (config.min_track_candidates_per_track - 1u))) {
                 tips.push_back({step, link_id});
             }
 
             // If no more CKF step is expected, current candidate is
             // kept as a tip
-            if (s4.success &&
+            if (s5.success &&
                 (step == (config.max_track_candidates_per_track - 1u))) {
                 tips.push_back({step, link_id});
             }

--- a/core/include/traccc/finding/details/combinatorial_kalman_filter_types.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter_types.hpp
@@ -17,6 +17,7 @@
 #include <detray/navigation/navigator.hpp>
 #include <detray/propagator/actor_chain.hpp>
 #include <detray/propagator/actors/aborters.hpp>
+#include <detray/propagator/actors/parameter_resetter.hpp>
 #include <detray/propagator/actors/parameter_transporter.hpp>
 #include <detray/propagator/actors/pointwise_material_interactor.hpp>
 #include <detray/propagator/constrained_step.hpp>
@@ -49,6 +50,7 @@ using ckf_actor_chain_t =
                         detray::parameter_transporter<traccc::default_algebra>,
                         interaction_register<ckf_interactor_t>,
                         ckf_interactor_t,
+                        detray::parameter_resetter<traccc::default_algebra>,
                         detray::momentum_aborter<traccc::scalar>, ckf_aborter>;
 
 /// Propagator type used in the Combinatorial Kalman Filter (CKF)

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -77,25 +77,34 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     // @NOTE: Post material interaction might be required here
     using actor_tuple_type =
         typename propagator_t::actor_chain_type::actor_tuple;
+    // Pathlimit aborter
     typename detray::detail::tuple_element<0, actor_tuple_type>::type::state
         s0{};
+    // CKF-interactor
     typename detray::detail::tuple_element<3, actor_tuple_type>::type::state
         s3{};
+    // Interaction register
     typename detray::detail::tuple_element<2, actor_tuple_type>::type::state s2{
         s3};
-    typename detray::detail::tuple_element<4, actor_tuple_type>::type::state s4;
-
+    // Parameter resetter
+    // typename detray::detail::tuple_element<4, actor_tuple_type>::type::state
+    // s4{
+    //    cfg.propagation};
+    // Momentum aborter
     typename detray::detail::tuple_element<5, actor_tuple_type>::type::state s5;
-    s5.min_step_length = cfg.min_step_length_for_next_surface;
-    s5.max_count = cfg.max_step_counts_for_next_surface;
-    s4.min_pT(static_cast<scalar_t>(cfg.min_pT));
-    s4.min_p(static_cast<scalar_t>(cfg.min_p));
+    // CKF aborter
+    typename detray::detail::tuple_element<6, actor_tuple_type>::type::state s6;
+
+    s6.min_step_length = cfg.min_step_length_for_next_surface;
+    s6.max_count = cfg.max_step_counts_for_next_surface;
+    s5.min_pT(static_cast<scalar_t>(cfg.min_pT));
+    s5.min_p(static_cast<scalar_t>(cfg.min_p));
 
     // Propagate to the next surface
-    propagator.propagate(propagation, detray::tie(s0, s2, s3, s4, s5));
+    propagator.propagate(propagation, detray::tie(s0, s2, s3, s5, s6));
 
     // If a surface found, add the parameter for the next step
-    if (s5.success) {
+    if (s6.success) {
         assert(propagation._navigation.is_on_sensitive());
         assert(!propagation._stepping.bound_params().is_invalid());
 


### PR DESCRIPTION
Add the parameter restter to the CKF actor chain, so that momentum changes due to material on passive and portal surfaces it updated on the free track parameters that are used by the stepper for the B-field integration