### PR TITLE
Expand fitter error handling code

### DIFF
--- a/core/include/traccc/edm/track_fit_outcome.hpp
+++ b/core/include/traccc/edm/track_fit_outcome.hpp
@@ -18,6 +18,10 @@ enum class track_fit_outcome : std::uint16_t {
     SUCCESS,
     FAILURE_NON_POSITIVE_NDF,
     FAILURE_NOT_ALL_SMOOTHED,
+    // Failure in the forward fit, not otherwise specified.
+    FAILURE_FORWARD,
+    // Failure in the backward fit, not otherwise specified.
+    FAILURE_BACKWARD,
     MAX_OUTCOME
 };
 

--- a/core/include/traccc/fitting/status_codes.hpp
+++ b/core/include/traccc/fitting/status_codes.hpp
@@ -22,6 +22,8 @@ enum class kalman_fitter_status : uint32_t {
     ERROR_UPDATER_CHI2_NOT_FINITE,
     ERROR_BARCODE_SEQUENCE_OVERFLOW,
     ERROR_INVALID_TRACK_STATE,
+    ERROR_TRACK_STATES_EMPTY,
+    ERROR_NOT_ALL_TRACK_STATES_FOUND,
     ERROR_OTHER,
     MAX_STATUS
 };
@@ -60,6 +62,12 @@ struct fitter_debug_msg {
             case ERROR_INVALID_TRACK_STATE: {
                 return msg +
                        "Invalid track state in forward pass (skipped or error)";
+            }
+            case ERROR_TRACK_STATES_EMPTY: {
+                return msg + "List of track states was empty";
+            }
+            case ERROR_NOT_ALL_TRACK_STATES_FOUND: {
+                return msg + "Not all track states were recovered in fit";
             }
             case ERROR_OTHER: {
                 return msg + "Unspecified error";

--- a/device/common/include/traccc/fitting/device/fit_backward.hpp
+++ b/device/common/include/traccc/fitting/device/fit_backward.hpp
@@ -54,6 +54,8 @@ TRACCC_HOST_DEVICE inline void fit_backward(
 
             track = fitter_state.m_fit_res;
         } else {
+            fitter_state.m_fit_res.fit_outcome() =
+                track_fit_outcome::FAILURE_BACKWARD;
             param_liveness.at(param_id) = 0u;
         }
 

--- a/device/common/include/traccc/fitting/device/fit_forward.hpp
+++ b/device/common/include/traccc/fitting/device/fit_forward.hpp
@@ -47,6 +47,8 @@ TRACCC_HOST_DEVICE inline void fit_forward(
     kalman_fitter_status fit_status = fitter.filter(params, fitter_state);
 
     if (fit_status != kalman_fitter_status::SUCCESS) {
+        fitter_state.m_fit_res.fit_outcome() =
+            track_fit_outcome::FAILURE_FORWARD;
         param_liveness.at(param_id) = 0u;
     }
 }

--- a/examples/run/common/print_fitted_tracks_statistics.cpp
+++ b/examples/run/common/print_fitted_tracks_statistics.cpp
@@ -14,9 +14,12 @@ void print_fitted_tracks_statistics(
     const edm::track_container<default_algebra>::host& tracks,
     const Logger& log) {
 
+    std::size_t unknown = 0;
     std::size_t success = 0;
     std::size_t non_positive_ndf = 0;
     std::size_t not_all_smoothed = 0;
+    std::size_t forward = 0;
+    std::size_t backward = 0;
 
     for (track_fit_outcome outcome : tracks.tracks.fit_outcome()) {
         if (outcome == track_fit_outcome::SUCCESS) {
@@ -25,6 +28,12 @@ void print_fitted_tracks_statistics(
             ++non_positive_ndf;
         } else if (outcome == track_fit_outcome::FAILURE_NOT_ALL_SMOOTHED) {
             ++not_all_smoothed;
+        } else if (outcome == track_fit_outcome::FAILURE_FORWARD) {
+            ++forward;
+        } else if (outcome == track_fit_outcome::FAILURE_BACKWARD) {
+            ++backward;
+        } else {
+            ++unknown;
         }
     }
 
@@ -32,6 +41,9 @@ void print_fitted_tracks_statistics(
     TRACCC_INFO("Success: " << success
                             << "  Non positive NDF: " << non_positive_ndf
                             << "  Not all smoothed: " << not_all_smoothed
+                            << "  Forward failure: " << forward
+                            << "  Backward failure: " << backward
+                            << "  Unknown: " << unknown
                             << "  Total: " << tracks.tracks.size());
 }
 


### PR DESCRIPTION
This commit updates the Kálmán fitter error handling code by explicitly marking failures in the forward and backwards fitting step. It also resolves an issue where the smoother would start from invalid track states.