### PR TITLE
fix: Several small bugs in the KF

### DIFF
--- a/core/include/traccc/edm/track_parameters.hpp
+++ b/core/include/traccc/edm/track_parameters.hpp
@@ -14,6 +14,7 @@
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/definitions/track_parametrization.hpp"
 #include "traccc/edm/container.hpp"
+#include "traccc/utils/trigonometric_helpers.hpp"
 
 // detray include(s).
 #include <detray/tracks/tracks.hpp>
@@ -48,19 +49,15 @@ using bound_track_parameters_collection_types =
 
 // Wrap the phi of track parameters to [-pi,pi]
 template <detray::concepts::algebra algebra_t>
-TRACCC_HOST_DEVICE inline void wrap_phi(
+TRACCC_HOST_DEVICE constexpr void normalize_angles(
     bound_track_parameters<algebra_t>& param) {
+    traccc::scalar phi;
+    traccc::scalar theta;
 
-    traccc::scalar phi = param.phi();
-    static constexpr traccc::scalar TWOPI =
-        2.f * traccc::constant<traccc::scalar>::pi;
-    phi = math::fmod(phi, TWOPI);
-    if (phi > traccc::constant<traccc::scalar>::pi) {
-        phi -= TWOPI;
-    } else if (phi < -traccc::constant<traccc::scalar>::pi) {
-        phi += TWOPI;
-    }
+    std::tie(phi, theta) = detail::wrap_phi_theta(param.phi(), param.theta());
+
     param.set_phi(phi);
+    param.set_theta(theta);
 }
 
 /// Covariance inflation used for track fitting

--- a/core/include/traccc/fitting/fitting_config.hpp
+++ b/core/include/traccc/fitting/fitting_config.hpp
@@ -34,7 +34,7 @@ struct fitting_config {
     std::size_t barcode_sequence_size_factor = 5;
     std::size_t min_barcode_sequence_capacity = 100;
     traccc::scalar backward_filter_mask_tolerance =
-        5.f * traccc::unit<scalar>::mm;
+        10.f * traccc::unit<scalar>::m;
 };
 
 }  // namespace traccc

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -173,6 +173,9 @@ struct kalman_actor : detray::actor {
                                   kalman_actor_direction::FORWARD_ONLY ||
                               direction_e ==
                                   kalman_actor_direction::BIDIRECTIONAL) {
+                    // Wrap the phi and theta angles in their valid ranges
+                    normalize_angles(propagation._stepping.bound_params());
+
                     // Forward filter
                     res = gain_matrix_updater<algebra_t>{}(
                         trk_state, actor_state.m_measurements,

--- a/core/include/traccc/fitting/status_codes.hpp
+++ b/core/include/traccc/fitting/status_codes.hpp
@@ -14,7 +14,7 @@ namespace traccc {
 enum class kalman_fitter_status : uint32_t {
     SUCCESS,
     ERROR_QOP_ZERO,
-    ERROR_THETA_ZERO,
+    ERROR_THETA_POLE,
     ERROR_INVERSION,
     ERROR_SMOOTHER_CHI2_NEGATIVE,
     ERROR_SMOOTHER_CHI2_NOT_FINITE,
@@ -36,8 +36,8 @@ struct fitter_debug_msg {
             case ERROR_QOP_ZERO: {
                 return msg + "Track qop is zero";
             }
-            case ERROR_THETA_ZERO: {
-                return msg + "Track theta is zero";
+            case ERROR_THETA_POLE: {
+                return msg + "Track theta hit pole";
             }
             case ERROR_INVERSION: {
                 return msg + "Failed matrix inversion";
@@ -49,10 +49,10 @@ struct fitter_debug_msg {
                 return msg + "Invalid chi2 in smoother";
             }
             case ERROR_UPDATER_CHI2_NEGATIVE: {
-                return msg + "Negative chi2 in gain matrix update";
+                return msg + "Negative chi2 in gain matrix updater";
             }
             case ERROR_UPDATER_CHI2_NOT_FINITE: {
-                return msg + "Invalid chi2 in gain matrix update";
+                return msg + "Invalid chi2 in gain matrix updater";
             }
             case ERROR_BARCODE_SEQUENCE_OVERFLOW: {
                 return msg + "Barcode sequence overflow in direct navigator";

--- a/core/include/traccc/seeding/doublet_finding_helper.hpp
+++ b/core/include/traccc/seeding/doublet_finding_helper.hpp
@@ -77,7 +77,7 @@ bool TRACCC_HOST_DEVICE doublet_finding_helper::isCompatible(
         (math::fabs(cotTheta) >= config.cotThetaMax * deltaR) ||
         (zOrigin <= config.collisionRegionMin * deltaR) ||
         (zOrigin >= config.collisionRegionMax * deltaR) ||
-        std::abs(cotTheta) >= config.deltaZMax) {
+        math::fabs(cotTheta) >= config.deltaZMax) {
         return false;
     }
 

--- a/core/include/traccc/utils/trigonometric_helpers.hpp
+++ b/core/include/traccc/utils/trigonometric_helpers.hpp
@@ -1,0 +1,83 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/common.hpp"
+#include "traccc/definitions/math.hpp"
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
+
+/// @see
+/// https://github.com/acts-project/acts/blob/8098e6953ac35771c34a4e3b13dbfee50869a0c1/Core/include/Acts/Utilities/detail/periodic.hpp
+namespace traccc::detail {
+
+/// Wrap a periodic value back into the nominal range.
+TRACCC_HOST_DEVICE
+constexpr traccc::scalar wrap_periodic(traccc::scalar value,
+                                       traccc::scalar start,
+                                       traccc::scalar range) {
+    // only wrap if really necessary
+    const traccc::scalar diff{value - start};
+    return ((0 <= diff) && (diff < range))
+               ? value
+               : (value - range * math::floor(diff / range));
+}
+
+/// Calculate the equivalent angle in the [-pi, pi) range.
+TRACCC_HOST_DEVICE
+constexpr traccc::scalar wrap_phi(traccc::scalar phi) {
+    constexpr traccc::scalar PI{traccc::constant<traccc::scalar>::pi};
+    constexpr traccc::scalar TWOPI{2.f * traccc::constant<traccc::scalar>::pi};
+    return wrap_periodic(phi, -PI, TWOPI);
+}
+
+/// Calculate the equivalent angle in the [0, 2*pi) range.
+TRACCC_HOST_DEVICE
+constexpr traccc::scalar wrap_theta(traccc::scalar theta) {
+    constexpr traccc::scalar TWOPI{2.f * traccc::constant<traccc::scalar>::pi};
+    return wrap_periodic(theta, 0.f, TWOPI);
+}
+
+/// Ensure both phi and theta direction angles are within the allowed range.
+///
+/// @param[in] phi Transverse direction angle
+/// @param[in] theta Longitudinal direction angle
+/// @return pair<phi,theta> containing the updated angles
+///
+/// The phi angle is truly cyclic, i.e. all values outside the nominal range
+/// [-pi,pi) have a corresponding value inside nominal range, independent from
+/// the theta angle. The theta angle is more complicated. Imagine that the two
+/// angles describe a position on the unit sphere. If theta moves outside its
+/// nominal range [0,pi], we are moving over one of the two poles of the unit
+/// sphere along the great circle defined by phi. The angles still describe a
+/// valid position on the unit sphere, but to describe it with angles within
+/// their nominal range, both phi and theta need to be updated; when moving over
+/// the poles, phi needs to be flipped by 180degree to allow theta to remain
+/// within its nominal range.
+constexpr std::pair<traccc::scalar, traccc::scalar> wrap_phi_theta(
+    traccc::scalar phi, traccc::scalar theta) {
+    constexpr traccc::scalar PI{traccc::constant<traccc::scalar>::pi};
+    constexpr traccc::scalar TWOPI{2.f * traccc::constant<traccc::scalar>::pi};
+
+    // wrap to [0,2pi). while the nominal range of theta is [0,pi], it is
+    // periodic, i.e. describes identical positions, in the full [0,2pi) range.
+    // moving it first to the periodic range simplifies further steps as the
+    // possible range of theta becomes fixed.
+    theta = wrap_theta(theta);
+    if (PI < theta) {
+        // theta is in the second half of the great circle and outside its
+        // nominal range. need to change both phi and theta to be within range.
+        phi += PI;
+        theta = TWOPI - theta;
+    }
+
+    return {wrap_phi(phi), theta};
+}
+
+}  // namespace traccc::detail

--- a/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
@@ -28,7 +28,6 @@
 #include "traccc/finding/device/propagate_to_next_surface.hpp"
 #include "traccc/finding/device/remove_duplicates.hpp"
 #include "traccc/finding/finding_config.hpp"
-#include "traccc/utils/logging.hpp"
 #include "traccc/utils/memory_resource.hpp"
 #include "traccc/utils/projections.hpp"
 #include "traccc/utils/propagation.hpp"

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -527,8 +527,8 @@ TRACCC_HOST_DEVICE inline void find_tracks(
     }
 
     /*
-     * Compute the offset at which this block will write, as well as the index
-     * at which this block will write.
+     * Compute the offset at which this block will write, as well as the
+     * index at which this block will write.
      */
     if (in_param_is_live) {
         local_num_params = std::get<1>(decode_insertion_mutex(

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -111,13 +111,27 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
 
         params[param_id] = propagation._stepping.bound_params();
         params_liveness[param_id] = 1u;
+
+        const scalar theta = params[param_id].theta();
+        if (theta <= 0.f || theta >= 2.f * constant<traccc::scalar>::pi) {
+            params_liveness[param_id] = 0u;
+        }
+
+        if (!std::isfinite(params[param_id].phi())) {
+            params_liveness[param_id] = 0u;
+        }
+
+        if (math::fabs(params[param_id].qop()) == 0.f) {
+            params_liveness[param_id] = 0u;
+        }
     } else {
         params_liveness[param_id] = 0u;
+    }
 
-        if (n_cands >= cfg.min_track_candidates_per_track) {
-            auto tip_pos = tips.push_back(link_idx);
-            tip_lengths.at(tip_pos) = n_cands;
-        }
+    if (params_liveness[param_id] == 0 &&
+        n_cands >= cfg.min_track_candidates_per_track) {
+        auto tip_pos = tips.push_back(link_idx);
+        tip_lengths.at(tip_pos) = n_cands;
     }
 }
 


### PR DESCRIPTION
Fix several small bugs:
- wrap the phi and theta angles the same way as ACTS does
- Move the error checks in the gain matrix updater and two filter smoother to where the data is produced that they are checking
- Reject faulty input track parameters in the CKF, instead of at the end of the KF
- Allow more mask tolerance in the direct navigator. This saves a few tracks, but does not solve the underlying bug that the direct navigator oscillates around the surface until the kalman aborter stops it.
- rename the `THETA_ZERO` error to `THETA_POLE` for clarity