### PR TITLE
Fix invalid state containers in CUDA examples

### DIFF
--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -371,6 +371,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
             ->wait();
         async_copy(track_states_cuda_buffer.states, track_states_cuda.states)
             ->wait();
+        track_states_cuda.measurements =
+            vecmem::get_data(measurements_per_event);
 
         if (accelerator_opts.compare_with_cpu) {
             // Show which event we are currently presenting the results for.

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -423,6 +423,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
         copy(track_states_buffer.states, track_states_cuda.states,
              vecmem::copy::type::device_to_host)
             ->wait();
+        track_states_cuda.measurements =
+            vecmem::get_data(measurements_per_event_cuda);
         stream.synchronize();
 
         if (accelerator_opts.compare_with_cpu) {


### PR DESCRIPTION
Unfortunately it seems that I was way too quick to merge in #1178 as I am now discovering that that PR contains some serious design flaws. In this particular case, the default constructor for the new "track container" allows for such a container to be created without any measurements, which makes it extremely easy to create a track container in an invalid state, i.e. with states containing valid measurement IDs but without any measurements at all. This commit fixes this issue in two of the CUDA examples. It is likely that the issue exists in many other examples, but these are the most pressing to fix.