### PR TITLE
ref: Additional error handling in the KF for negative variances and smoothed chi2

### DIFF
--- a/core/include/traccc/fitting/details/regularize_covariance.hpp
+++ b/core/include/traccc/fitting/details/regularize_covariance.hpp
@@ -1,0 +1,52 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/edm/track_parameters.hpp"
+#include "traccc/utils/logging.hpp"
+
+namespace traccc::details {
+
+/// Check the covariance matirx and try to make it positive semi-definite
+///
+/// @param[out] cov  covariance matrix
+/// @param[in] min_var variance threshold below which to flag an error
+template <detray::concepts::algebra algebra_t>
+TRACCC_HOST_DEVICE constexpr bool regularize_covariance(
+    traccc::bound_matrix<algebra_t>& cov,
+    const detray::dscalar<algebra_t> min_var) {
+
+    if (getter::element(cov, 0, 0) < min_var ||
+        getter::element(cov, 1, 1) < min_var ||
+        getter::element(cov, 2, 2) < min_var ||
+        getter::element(cov, 3, 3) < min_var ||
+        getter::element(cov, 4, 4) < min_var ||
+        getter::element(cov, 5, 5) < min_var) {
+        TRACCC_ERROR_HOST_DEVICE("Negative variance");
+        return false;
+    } else if (getter::element(cov, 0, 0) < 0.f ||
+               getter::element(cov, 1, 1) < 0.f ||
+               getter::element(cov, 2, 2) < 0.f ||
+               getter::element(cov, 3, 3) < 0.f ||
+               getter::element(cov, 4, 4) < 0.f ||
+               getter::element(cov, 5, 5) < 0.f) {
+        TRACCC_WARNING_HOST_DEVICE("Negative variance: Regularize...");
+    }
+
+    getter::element(cov, 0, 0) = math::fabs(getter::element(cov, 0, 0));
+    getter::element(cov, 1, 1) = math::fabs(getter::element(cov, 1, 1));
+    getter::element(cov, 2, 2) = math::fabs(getter::element(cov, 2, 2));
+    getter::element(cov, 3, 3) = math::fabs(getter::element(cov, 3, 3));
+    getter::element(cov, 4, 4) = math::fabs(getter::element(cov, 4, 4));
+    getter::element(cov, 5, 5) = math::fabs(getter::element(cov, 5, 5));
+
+    return true;
+}
+
+}  // namespace traccc::details

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -13,6 +13,7 @@
 #include "traccc/edm/measurement_collection.hpp"
 #include "traccc/edm/measurement_helpers.hpp"
 #include "traccc/edm/track_state_collection.hpp"
+#include "traccc/fitting/details/regularize_covariance.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/utils/logging.hpp"
 #include "traccc/utils/subspace.hpp"
@@ -49,23 +50,10 @@ struct gain_matrix_updater {
         const bound_track_parameters<algebra_t>& bound_params,
         const bool is_line) const {
 
-        const auto D =
-            measurements.at(trk_state.measurement_index()).dimensions();
-
-        assert(D == 1u || D == 2u);
-
-        return update(trk_state, measurements, bound_params, D, is_line);
-    }
-
-    template <typename track_state_backend_t>
-    [[nodiscard]] TRACCC_HOST_DEVICE inline kalman_fitter_status update(
-        typename edm::track_state<track_state_backend_t>& trk_state,
-        const edm::measurement_collection<default_algebra>::const_device&
-            measurements,
-        const bound_track_parameters<algebra_t>& bound_params,
-        const unsigned int dim, const bool is_line) const {
-
         static constexpr unsigned int D = 2;
+
+        [[maybe_unused]] const unsigned int dim{
+            measurements.at(trk_state.measurement_index()).dimensions()};
 
         TRACCC_VERBOSE_HOST_DEVICE("In gain-matrix-updater...");
         TRACCC_VERBOSE_HOST_DEVICE("Measurement dim: %d", dim);
@@ -105,7 +93,8 @@ struct gain_matrix_updater {
             getter::element(H, 0u, e_bound_loc0) = -1;
         }
 
-        if (dim == 1) {
+        // @TODO: Fix properly
+        if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
             getter::element(H, 1u, 0u) = 0.f;
             getter::element(H, 1u, 1u) = 0.f;
         }
@@ -114,9 +103,9 @@ struct gain_matrix_updater {
         matrix_type<D, D> V;
         edm::get_measurement_covariance<algebra_t>(
             measurements.at(trk_state.measurement_index()), V);
-
-        if (dim == 1) {
-            getter::element(V, 1u, 1u) = 1.f;
+        // @TODO: Fix properly
+        if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
+            getter::element(V, 1u, 1u) = 1000.f;
         }
 
         TRACCC_DEBUG_HOST("Measurement position: " << meas_local);
@@ -140,12 +129,20 @@ struct gain_matrix_updater {
         const matrix_type<6, 1> filtered_vec =
             predicted_vec + K * (meas_local - H * predicted_vec);
         const matrix_type<6, 6> i_minus_kh = I66 - K * H;
-        const matrix_type<6, 6> filtered_cov =
+        matrix_type<6, 6> filtered_cov =
             i_minus_kh * predicted_cov * matrix::transpose(i_minus_kh) +
             K * V * matrix::transpose(K);
 
         TRACCC_DEBUG_HOST("Filtered param:\n" << filtered_vec);
         TRACCC_DEBUG_HOST("Filtered cov:\n" << filtered_cov);
+
+        // Check the covariance for consistency
+        // @TODO: Need to understand why negative variance happens
+        if (constexpr traccc::scalar min_var{-0.01f};
+            !details::regularize_covariance<algebra_t>(filtered_cov, min_var)) {
+            TRACCC_ERROR_HOST_DEVICE("Negative variance after filtering");
+            return kalman_fitter_status::ERROR_UPDATER_INVALID_COVARIANCE;
+        }
 
         // Return false if track is parallel to z-axis or phi is not finite
         if (!std::isfinite(getter::element(filtered_vec, e_bound_theta, 0))) {
@@ -204,7 +201,7 @@ struct gain_matrix_updater {
             TRACCC_ERROR_HOST_DEVICE(
                 "Hit theta pole after filtering : %f (unrecoverable error "
                 "pre-normalization)",
-                theta);
+                trk_state.filtered_params().theta());
             return kalman_fitter_status::ERROR_THETA_POLE;
         }
 

--- a/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
@@ -13,6 +13,7 @@
 #include "traccc/edm/measurement_collection.hpp"
 #include "traccc/edm/measurement_helpers.hpp"
 #include "traccc/edm/track_state_collection.hpp"
+#include "traccc/fitting/details/regularize_covariance.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/utils/logging.hpp"
 
@@ -43,24 +44,10 @@ struct two_filters_smoother {
         bound_track_parameters<algebra_t>& bound_params,
         const bool is_line) const {
 
-        const auto D =
-            measurements.at(trk_state.measurement_index()).dimensions();
-        assert(D == 1u || D == 2u);
-
-        return smoothe(trk_state, measurements, bound_params, D, is_line);
-    }
-
-    // Reference: The Optimun Linear Smoother as a Combination of Two Optimum
-    // Linear Filters
-    [[nodiscard]] TRACCC_HOST_DEVICE inline kalman_fitter_status smoothe(
-        typename edm::track_state_collection<algebra_t>::device::proxy_type&
-            trk_state,
-        const typename edm::measurement_collection<algebra_t>::const_device&
-            measurements,
-        bound_track_parameters<algebra_t>& bound_params, const unsigned int dim,
-        const bool is_line) const {
-
         static constexpr unsigned int D = 2;
+
+        [[maybe_unused]] const unsigned int dim{
+            measurements.at(trk_state.measurement_index()).dimensions()};
 
         assert(dim == 1u || dim == 2u);
 
@@ -102,8 +89,16 @@ struct two_filters_smoother {
             predicted_cov_inv + filtered_cov_inv;
 
         assert(matrix::determinant(smoothed_cov_inv) != 0.f);
-        const matrix_type<e_bound_size, e_bound_size> smoothed_cov =
+        matrix_type<e_bound_size, e_bound_size> smoothed_cov =
             matrix::inverse(smoothed_cov_inv);
+
+        // Check the covariance for consistency
+        // @TODO: Need to understand why negative variance happens
+        if (constexpr traccc::scalar min_var{-0.01f};
+            !details::regularize_covariance<algebra_t>(smoothed_cov, min_var)) {
+            TRACCC_ERROR_HOST_DEVICE("Negative variance after smoothing");
+            return kalman_fitter_status::ERROR_SMOOTHER_INVALID_COVARIANCE;
+        }
 
         // Eq (3.38) of "Pattern Recognition, Tracking and Vertex
         // Reconstruction in Particle Detectors"
@@ -140,7 +135,8 @@ struct two_filters_smoother {
         const subspace<algebra_t, e_bound_size> subs(
             measurements.at(trk_state.measurement_index()).subspace());
         matrix_type<D, e_bound_size> H = subs.template projector<D>();
-        if (dim == 1) {
+        // @TODO: Fix properly
+        if (getter::element(meas_local, 1u, 0u) == 0.f /*dim == 1*/) {
             getter::element(H, 1u, 0u) = 0.f;
             getter::element(H, 1u, 1u) = 0.f;
         }
@@ -151,8 +147,9 @@ struct two_filters_smoother {
         matrix_type<D, D> V;
         edm::get_measurement_covariance<algebra_t>(
             measurements.at(trk_state.measurement_index()), V);
-        if (dim == 1) {
-            getter::element(V, 1u, 1u) = 1.f;
+        // @TODO: Fix properly
+        if (getter::element(meas_local, 1u, 0u) == 0.f /*dim == 1*/) {
+            getter::element(V, 1u, 1u) = 1000.f;
         }
 
         TRACCC_DEBUG_HOST("Measurement position: " << meas_local);
@@ -180,12 +177,16 @@ struct two_filters_smoother {
         TRACCC_DEBUG_HOST("R_smt:\n" << R_smt);
         TRACCC_DEBUG_HOST_DEVICE("det(R_smt): %f", matrix::determinant(R_smt));
         TRACCC_DEBUG_HOST("R_smt_inv:\n" << matrix::inverse(R_smt));
-        TRACCC_VERBOSE_HOST_DEVICE("Chi2: %f", chi2_smt_value);
+        TRACCC_VERBOSE_HOST_DEVICE("Smoothed chi2: %f", chi2_smt_value);
 
         if (chi2_smt_value < 0.f) {
             TRACCC_ERROR_HOST_DEVICE("Smoothed chi2 negative: %f",
                                      chi2_smt_value);
-            return kalman_fitter_status::ERROR_SMOOTHER_CHI2_NEGATIVE;
+
+            // @TODO: Need to understand why negative chi2 happens
+            if (chi2_smt_value < -10.f) {
+                return kalman_fitter_status::ERROR_SMOOTHER_CHI2_NEGATIVE;
+            }
         }
 
         if (!std::isfinite(chi2_smt_value)) {
@@ -226,9 +227,17 @@ struct two_filters_smoother {
         const matrix_type<6, 1> filtered_vec =
             predicted_vec + K * (meas_local - H * predicted_vec);
         const matrix_type<6, 6> i_minus_kh = I66 - K * H;
-        const matrix_type<6, 6> filtered_cov =
+        matrix_type<6, 6> filtered_cov =
             i_minus_kh * predicted_cov * matrix::transpose(i_minus_kh) +
             K * V * matrix::transpose(K);
+
+        // Check the covariance for consistency
+        // @TODO: Need to understand why negative variance happens
+        if (constexpr traccc::scalar min_var{-0.01f};
+            !details::regularize_covariance<algebra_t>(filtered_cov, min_var)) {
+            TRACCC_ERROR_HOST_DEVICE("Negative variance after filtering");
+            return kalman_fitter_status::ERROR_SMOOTHER_INVALID_COVARIANCE;
+        }
 
         // Update the bound track parameters
         bound_params.set_vector(filtered_vec);
@@ -273,15 +282,15 @@ struct two_filters_smoother {
         TRACCC_DEBUG_HOST("R:\n" << R);
         TRACCC_DEBUG_HOST_DEVICE("det(R): %f", matrix::determinant(R));
         TRACCC_DEBUG_HOST("R_inv:\n" << matrix::inverse(R));
-        TRACCC_VERBOSE_HOST_DEVICE("Chi2: %f", chi2_val);
+        TRACCC_VERBOSE_HOST_DEVICE("Filtered chi2: %f", chi2_val);
 
         if (chi2_val < 0.f) {
-            TRACCC_ERROR_HOST_DEVICE("Chi2 negative: %f", chi2_val);
+            TRACCC_ERROR_HOST_DEVICE("Filtered chi2 negative: %f", chi2_val);
             return kalman_fitter_status::ERROR_SMOOTHER_CHI2_NEGATIVE;
         }
 
         if (!std::isfinite(chi2_val)) {
-            TRACCC_ERROR_HOST_DEVICE("Chi2 infinite");
+            TRACCC_ERROR_HOST_DEVICE("Filtered chi2 infinite");
             return kalman_fitter_status::ERROR_SMOOTHER_CHI2_NOT_FINITE;
         }
 

--- a/core/include/traccc/fitting/status_codes.hpp
+++ b/core/include/traccc/fitting/status_codes.hpp
@@ -18,8 +18,10 @@ enum class kalman_fitter_status : uint32_t {
     ERROR_INVERSION,
     ERROR_SMOOTHER_CHI2_NEGATIVE,
     ERROR_SMOOTHER_CHI2_NOT_FINITE,
+    ERROR_SMOOTHER_INVALID_COVARIANCE,
     ERROR_UPDATER_CHI2_NEGATIVE,
     ERROR_UPDATER_CHI2_NOT_FINITE,
+    ERROR_UPDATER_INVALID_COVARIANCE,
     ERROR_BARCODE_SEQUENCE_OVERFLOW,
     ERROR_INVALID_TRACK_STATE,
     ERROR_OTHER,
@@ -48,11 +50,17 @@ struct fitter_debug_msg {
             case ERROR_SMOOTHER_CHI2_NOT_FINITE: {
                 return msg + "Invalid chi2 in smoother";
             }
+            case ERROR_SMOOTHER_INVALID_COVARIANCE: {
+                return msg + "Invalid track covariance during smoothing";
+            }
             case ERROR_UPDATER_CHI2_NEGATIVE: {
                 return msg + "Negative chi2 in gain matrix updater";
             }
             case ERROR_UPDATER_CHI2_NOT_FINITE: {
                 return msg + "Invalid chi2 in gain matrix updater";
+            }
+            case ERROR_UPDATER_INVALID_COVARIANCE: {
+                return msg + "Invalid track covariance in forward fit";
             }
             case ERROR_BARCODE_SEQUENCE_OVERFLOW: {
                 return msg + "Barcode sequence overflow in direct navigator";
@@ -65,7 +73,8 @@ struct fitter_debug_msg {
                 return msg + "Unspecified error";
             }
             default: {
-                return "";
+                return "Not a defined error code: " +
+                       std::to_string(static_cast<int>(m_error_code));
             }
         }
     }


### PR DESCRIPTION
Add the check for negative diagonal elements to the KF. If the variance is just *slightly* negative, take the absolute value, otherwise throw an error. The error is a new Kalman fitter status "ERROR_UPDATER_INVALID_COVARIANCE" or "ERROR_SMOOTHER_INVALID_COVARIANCE". 

The requirements for the smoothed chi2 have been relaxed, so that the fit will only be aborted if it is below -10. 

Edit: Also contains a hotfix for the strip measurement projector matrix, which will get properly fixed in a later PR