### PR TITLE
Compute Kálmán filter chi2 from predicted state

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -66,7 +66,6 @@ struct gain_matrix_updater {
         // Some identity matrices
         // @TODO: Make constexpr work
         const auto I66 = matrix::identity<bound_matrix_type>();
-        const auto I_m = matrix::identity<matrix_type<D, D>>();
 
         // Measurement data on surface
         matrix_type<D, 1> meas_local;
@@ -112,6 +111,31 @@ struct gain_matrix_updater {
         TRACCC_DEBUG_HOST("-> Measurement variance:\n" << V);
         TRACCC_DEBUG_HOST("-> Predicted residual:\n"
                           << meas_local - H * predicted_vec);
+
+        scalar chi2_val;
+
+        {
+            // Calculate the chi square
+            const matrix_type<D, D> R =
+                V + (H * predicted_cov * matrix::transpose(H));
+            // Residual between measurement and predicted vector
+            const matrix_type<D, 1> residual = meas_local - H * predicted_vec;
+            const matrix_type<1, 1> chi2_mat =
+                matrix::transposed_product<true, false>(residual,
+                                                        matrix::inverse(R)) *
+                residual;
+            chi2_val = getter::element(chi2_mat, 0, 0);
+
+            if (chi2_val < 0.f) {
+                TRACCC_ERROR_HOST_DEVICE("Chi2 negative");
+                return kalman_fitter_status::ERROR_UPDATER_CHI2_NEGATIVE;
+            }
+
+            if (!std::isfinite(chi2_val)) {
+                TRACCC_ERROR_HOST_DEVICE("Chi2 infinite");
+                return kalman_fitter_status::ERROR_UPDATER_CHI2_NOT_FINITE;
+            }
+        }
 
         const matrix_type<e_bound_size, D> projected_cov =
             matrix::transposed_product<false, true>(predicted_cov, H);
@@ -163,17 +187,6 @@ struct gain_matrix_updater {
             return kalman_fitter_status::ERROR_QOP_ZERO;
         }
 
-        // Residual between measurement and (projected) filtered vector
-        const matrix_type<D, 1> residual = meas_local - H * filtered_vec;
-
-        // Calculate the chi square
-        const matrix_type<D, D> R = (I_m - H * K) * V;
-        const matrix_type<1, 1> chi2 = matrix::transposed_product<true, false>(
-                                           residual, matrix::inverse(R)) *
-                                       residual;
-
-        const scalar chi2_val{getter::element(chi2, 0, 0)};
-
         TRACCC_DEBUG_HOST("-> Filtered residual:\n" << residual);
         TRACCC_DEBUG_HOST("-> R:\n" << R);
         TRACCC_DEBUG_HOST("-> det(R): " << std::scientific
@@ -181,16 +194,6 @@ struct gain_matrix_updater {
                                         << std::defaultfloat);
         TRACCC_DEBUG_HOST("-> R_inv:\n" << matrix::inverse(R));
         TRACCC_VERBOSE_HOST_DEVICE("-> Chi2: %f", chi2_val);
-
-        if (chi2_val < 0.f) {
-            TRACCC_ERROR_HOST_DEVICE("Chi2 negative");
-            return kalman_fitter_status::ERROR_UPDATER_CHI2_NEGATIVE;
-        }
-
-        if (!std::isfinite(chi2_val)) {
-            TRACCC_ERROR_HOST_DEVICE("Chi2 infinite");
-            return kalman_fitter_status::ERROR_UPDATER_CHI2_NOT_FINITE;
-        }
 
         // Set the chi2 for this track and measurement
         trk_state.filtered_params().set_vector(filtered_vec);

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -117,12 +117,12 @@ struct gain_matrix_updater {
         const matrix_type<2, 1> projected_vec = H * predicted_vec;
         const matrix_type<D, D> R_inv =
             matrix::inverse(V + (H * projected_cov));
+        // Residual between measurement and predicted vector
+        const matrix_type<D, 1> residual = meas_local - projected_vec;
 
         // Calculate the chi square
         scalar chi2_val;
         {
-            // Residual between measurement and predicted vector
-            const matrix_type<D, 1> residual = meas_local - projected_vec;
             const matrix_type<1, 1> chi2_mat =
                 matrix::transposed_product<true, false>(residual, R_inv) *
                 residual;
@@ -146,8 +146,7 @@ struct gain_matrix_updater {
         TRACCC_DEBUG_HOST("-> K:\n" << K);
 
         // Calculate the filtered track parameters
-        const matrix_type<6, 1> filtered_vec =
-            predicted_vec + K * (meas_local - projected_vec);
+        const matrix_type<6, 1> filtered_vec = predicted_vec + K * residual;
         const matrix_type<6, 6> i_minus_kh = I66 - K * H;
         matrix_type<6, 6> filtered_cov =
             i_minus_kh * predicted_cov * matrix::transpose(i_minus_kh) +

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -112,17 +112,19 @@ struct gain_matrix_updater {
         TRACCC_DEBUG_HOST("-> Predicted residual:\n"
                           << meas_local - H * predicted_vec);
 
-        scalar chi2_val;
+        const matrix_type<e_bound_size, D> projected_cov =
+            matrix::transposed_product<false, true>(predicted_cov, H);
+        const matrix_type<2, 1> projected_vec = H * predicted_vec;
+        const matrix_type<D, D> R_inv =
+            matrix::inverse(V + (H * projected_cov));
 
+        // Calculate the chi square
+        scalar chi2_val;
         {
-            // Calculate the chi square
-            const matrix_type<D, D> R =
-                V + (H * predicted_cov * matrix::transpose(H));
             // Residual between measurement and predicted vector
-            const matrix_type<D, 1> residual = meas_local - H * predicted_vec;
+            const matrix_type<D, 1> residual = meas_local - projected_vec;
             const matrix_type<1, 1> chi2_mat =
-                matrix::transposed_product<true, false>(residual,
-                                                        matrix::inverse(R)) *
+                matrix::transposed_product<true, false>(residual, R_inv) *
                 residual;
             chi2_val = getter::element(chi2_mat, 0, 0);
 
@@ -137,21 +139,15 @@ struct gain_matrix_updater {
             }
         }
 
-        const matrix_type<e_bound_size, D> projected_cov =
-            matrix::transposed_product<false, true>(predicted_cov, H);
-
-        const matrix_type<D, D> M = H * projected_cov + V;
-
         // Kalman gain matrix
-        assert(matrix::determinant(M) != 0.f);
-        const matrix_type<6, D> K = projected_cov * matrix::inverse(M);
+        const matrix_type<6, D> K = projected_cov * R_inv;
 
         TRACCC_DEBUG_HOST("-> H:\n" << H);
         TRACCC_DEBUG_HOST("-> K:\n" << K);
 
         // Calculate the filtered track parameters
         const matrix_type<6, 1> filtered_vec =
-            predicted_vec + K * (meas_local - H * predicted_vec);
+            predicted_vec + K * (meas_local - projected_vec);
         const matrix_type<6, 6> i_minus_kh = I66 - K * H;
         matrix_type<6, 6> filtered_cov =
             i_minus_kh * predicted_cov * matrix::transpose(i_minus_kh) +


### PR DESCRIPTION
This commit migrates the computation of the chi2 value in our gain matrix updater to use the predicted state rather than the filtered state. This is mathematically equivalent but potentially more stable.