### PR TITLE
Read measurement dimensionality from detector

### DIFF
--- a/examples/io/create_binaries.cpp
+++ b/examples/io/create_binaries.cpp
@@ -54,7 +54,7 @@ int create_binaries(const traccc::opts::detector& detector_opts,
             measurements{host_mr};
         traccc::edm::spacepoint_collection::host spacepoints{host_mr};
         traccc::io::read_spacepoints(spacepoints, measurements, event,
-                                     input_opts.directory, nullptr,
+                                     input_opts.directory, nullptr, nullptr,
                                      input_opts.format);
 
         // Write binary file(s)

--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -222,7 +222,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                     spacepoints_per_event, measurements_per_event, event,
                     input_opts.directory,
                     (input_opts.use_acts_geom_source ? &host_det : nullptr),
-                    input_opts.format);
+                    nullptr, input_opts.format);
 
             }  // stop measuring hit reading timer
 

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -166,7 +166,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
         traccc::io::read_spacepoints(
             spacepoints_per_event, measurements_per_event, event,
             input_opts.directory,
-            (input_opts.use_acts_geom_source ? &detector : nullptr),
+            (input_opts.use_acts_geom_source ? &detector : nullptr), nullptr,
             input_opts.format);
         n_measurements += measurements_per_event.size();
         n_spacepoints += spacepoints_per_event.size();

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -161,7 +161,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
         traccc::io::read_measurements(
             measurements_per_event, event, input_opts.directory,
             (input_opts.use_acts_geom_source ? &polymorphic_detector : nullptr),
-            input_opts.format);
+            nullptr, input_opts.format);
 
         // Run finding
         auto track_candidates = host_finding(

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -131,6 +131,11 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
      * Build a geometry
      *****************************/
 
+    traccc::silicon_detector_description::host host_det_descr{host_mr};
+    traccc::io::read_detector_description(
+        host_det_descr, detector_opts.detector_file,
+        detector_opts.digitization_file, traccc::data_format::json);
+
     // B field value
     const traccc::vector3 field_vec(seeding_opts);
     const auto host_field = traccc::details::make_magnetic_field(bfield_opts);
@@ -240,7 +245,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                     spacepoints_per_event, measurements_per_event, event,
                     input_opts.directory,
                     (input_opts.use_acts_geom_source ? &host_det : nullptr),
-                    input_opts.format);
+                    &host_det_descr, input_opts.format);
 
             }  // stop measuring hit reading timer
 

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -206,7 +206,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
         traccc::io::read_measurements(
             measurements_per_event, event, input_opts.directory,
             (input_opts.use_acts_geom_source ? &polymorphic_detector : nullptr),
-            input_opts.format);
+            nullptr, input_opts.format);
 
         traccc::edm::measurement_collection<traccc::default_algebra>::buffer
             measurements_cuda_buffer(

--- a/examples/run/kokkos/seeding_example_kokkos.cpp
+++ b/examples/run/kokkos/seeding_example_kokkos.cpp
@@ -110,7 +110,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                     spacepoints_per_event, measurements_per_event, event,
                     input_opts.directory,
                     (input_opts.use_acts_geom_source ? &host_det : nullptr),
-                    input_opts.format);
+                    nullptr, input_opts.format);
             }  // stop measuring hit reading timer
 
             {  // Spacepoin binning for kokkos

--- a/examples/run/sycl/seeding_example_sycl.sycl
+++ b/examples/run/sycl/seeding_example_sycl.sycl
@@ -153,7 +153,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
                     spacepoints_per_event, measurements_per_event, event,
                     input_opts.directory,
                     (input_opts.use_acts_geom_source ? &host_det : nullptr),
-                    input_opts.format);
+                    nullptr, input_opts.format);
 
             }  // stop measuring hit reading timer
 

--- a/io/include/traccc/io/csv/make_measurement_edm.hpp
+++ b/io/include/traccc/io/csv/make_measurement_edm.hpp
@@ -8,6 +8,7 @@
 // Project include(s).
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/edm/measurement_collection.hpp"
+#include "traccc/geometry/silicon_detector_description.hpp"
 
 // Local include(s).
 #include "traccc/io/csv/measurement.hpp"
@@ -25,6 +26,10 @@ namespace traccc::io::csv {
 void make_measurement_edm(
     const traccc::io::csv::measurement& csv_meas,
     edm::measurement_collection<default_algebra>::host::proxy_type& meas,
-    const std::map<geometry_id, geometry_id>* acts_to_detray_id);
+    const std::map<geometry_id, geometry_id>* acts_to_detray_id,
+    const traccc::silicon_detector_description::host* detector_description =
+        nullptr,
+    const std::map<geometry_id, std::size_t>*
+        geometry_id_to_detector_description_index = nullptr);
 
 }  // namespace traccc::io::csv

--- a/io/include/traccc/io/read_measurements.hpp
+++ b/io/include/traccc/io/read_measurements.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Local include(s).
+#include "traccc/geometry/silicon_detector_description.hpp"
 #include "traccc/io/data_format.hpp"
 
 // Project include(s).
@@ -37,6 +38,8 @@ std::vector<measurement_id_type> read_measurements(
     edm::measurement_collection<default_algebra>::host& measurements,
     std::size_t event, std::string_view directory,
     const traccc::host_detector* detector = nullptr,
+    const traccc::silicon_detector_description::host* detector_description =
+        nullptr,
     const bool sort_measurements = true, data_format format = data_format::csv);
 
 /// Read measurement data into memory
@@ -51,6 +54,8 @@ std::vector<measurement_id_type> read_measurements(
 std::vector<measurement_id_type> read_measurements(
     edm::measurement_collection<default_algebra>::host& measurements,
     std::string_view filename, const traccc::host_detector* detector = nullptr,
+    const traccc::silicon_detector_description::host* detector_description =
+        nullptr,
     const bool sort_measurements = true, data_format format = data_format::csv);
 
 }  // namespace traccc::io

--- a/io/include/traccc/io/read_spacepoints.hpp
+++ b/io/include/traccc/io/read_spacepoints.hpp
@@ -15,6 +15,7 @@
 #include "traccc/edm/spacepoint_collection.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/host_detector.hpp"
+#include "traccc/geometry/silicon_detector_description.hpp"
 
 // System include(s).
 #include <cstddef>
@@ -39,6 +40,8 @@ void read_spacepoints(
     edm::measurement_collection<default_algebra>::host& measurements,
     std::size_t event, std::string_view directory,
     const traccc::host_detector* detector = nullptr,
+    const traccc::silicon_detector_description::host* detector_description =
+        nullptr,
     data_format format = data_format::csv);
 
 /// Read spacepoint data into memory
@@ -60,6 +63,8 @@ void read_spacepoints(
     std::string_view hit_filename, std::string_view meas_filename,
     std::string_view meas_hit_map_filename,
     const traccc::host_detector* detector = nullptr,
+    const traccc::silicon_detector_description::host* detector_description =
+        nullptr,
     data_format format = data_format::csv);
 
 }  // namespace traccc::io

--- a/io/src/csv/read_measurements.hpp
+++ b/io/src/csv/read_measurements.hpp
@@ -12,6 +12,7 @@
 #include "traccc/edm/measurement_collection.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/host_detector.hpp"
+#include "traccc/geometry/silicon_detector_description.hpp"
 
 // System include(s).
 #include <string_view>
@@ -29,6 +30,8 @@ namespace traccc::io::csv {
 std::vector<measurement_id_type> read_measurements(
     edm::measurement_collection<default_algebra>::host& measurements,
     std::string_view filename, const traccc::host_detector* detector = nullptr,
+    const traccc::silicon_detector_description::host* detector_description =
+        nullptr,
     const bool do_sort = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_particles.cpp
+++ b/io/src/csv/read_particles.cpp
@@ -45,7 +45,9 @@ void read_particles(
     edm::measurement_collection<default_algebra>::host& measurements,
     std::string_view particles_file, std::string_view hits_file,
     std::string_view measurements_file, std::string_view hit_map_file,
-    const traccc::host_detector* detector, const bool sort_measurements) {
+    const traccc::host_detector* detector,
+    const traccc::silicon_detector_description::host* detector_description,
+    const bool sort_measurements) {
 
     // Memory resource used by the temporary collections.
     vecmem::host_memory_resource mr;
@@ -60,8 +62,9 @@ void read_particles(
     read_particles(temp_particles, particles_file);
 
     // Read in all measurements.
-    const std::vector<measurement_id_type> new_idx_map = read_measurements(
-        measurements, measurements_file, detector, sort_measurements);
+    const std::vector<measurement_id_type> new_idx_map =
+        read_measurements(measurements, measurements_file, detector,
+                          detector_description, sort_measurements);
 
     // Make a hit to measurement map.
     std::unordered_map<std::size_t, measurement_id_type> hit_to_measurement;

--- a/io/src/csv/read_particles.hpp
+++ b/io/src/csv/read_particles.hpp
@@ -12,6 +12,7 @@
 #include "traccc/edm/particle.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/host_detector.hpp"
+#include "traccc/geometry/silicon_detector_description.hpp"
 
 // System include(s).
 #include <string_view>
@@ -41,6 +42,9 @@ void read_particles(
     edm::measurement_collection<default_algebra>::host& measurements,
     std::string_view particles_file, std::string_view hits_file,
     std::string_view measurements_file, std::string_view hit_map_file,
-    const traccc::host_detector* detector, const bool sort_measurements = true);
+    const traccc::host_detector* detector,
+    const traccc::silicon_detector_description::host* detector_description =
+        nullptr,
+    const bool sort_measurements = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_spacepoints.cpp
+++ b/io/src/csv/read_spacepoints.cpp
@@ -27,11 +27,14 @@ void read_spacepoints(
     edm::measurement_collection<default_algebra>::host& measurements,
     std::string_view hit_filename, std::string_view meas_filename,
     std::string_view meas_hit_map_filename,
-    const traccc::host_detector* detector, const bool sort_measurements) {
+    const traccc::host_detector* detector,
+    const traccc::silicon_detector_description::host* detector_description,
+    const bool sort_measurements) {
 
     // Read all measurements.
-    const std::vector<measurement_id_type> new_idx_map = read_measurements(
-        measurements, meas_filename, detector, sort_measurements);
+    const std::vector<measurement_id_type> new_idx_map =
+        read_measurements(measurements, meas_filename, detector,
+                          detector_description, sort_measurements);
 
     // Measurement hit id reader
     auto mhid_reader =

--- a/io/src/csv/read_spacepoints.hpp
+++ b/io/src/csv/read_spacepoints.hpp
@@ -12,6 +12,7 @@
 #include "traccc/edm/spacepoint_collection.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/host_detector.hpp"
+#include "traccc/geometry/silicon_detector_description.hpp"
 
 // System include(s).
 #include <string_view>
@@ -34,6 +35,8 @@ void read_spacepoints(
     std::string_view hit_filename, std::string_view meas_filename,
     std::string_view meas_hit_map_filename,
     const traccc::host_detector* detector = nullptr,
+    const traccc::silicon_detector_description::host* detector_description =
+        nullptr,
     const bool sort_measurements = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/read_measurements.cpp
+++ b/io/src/read_measurements.cpp
@@ -20,8 +20,9 @@ namespace traccc::io {
 std::vector<measurement_id_type> read_measurements(
     edm::measurement_collection<default_algebra>::host& measurements,
     std::size_t event, std::string_view directory,
-    const traccc::host_detector* detector, const bool sort_measurements,
-    data_format format) {
+    const traccc::host_detector* detector,
+    const traccc::silicon_detector_description::host* detector_description,
+    const bool sort_measurements, data_format format) {
 
     switch (format) {
         case data_format::csv: {
@@ -31,7 +32,7 @@ std::vector<measurement_id_type> read_measurements(
                                    std::filesystem::path(get_event_filename(
                                        event, "-measurements.csv")))
                                       .native()),
-                detector, sort_measurements, format);
+                detector, detector_description, sort_measurements, format);
         }
         case data_format::binary: {
             return read_measurements(
@@ -40,7 +41,7 @@ std::vector<measurement_id_type> read_measurements(
                                    std::filesystem::path(get_event_filename(
                                        event, "-measurements.dat")))
                                       .native()),
-                detector, sort_measurements, format);
+                detector, detector_description, sort_measurements, format);
         }
         default:
             throw std::invalid_argument("Unsupported data format");
@@ -50,11 +51,13 @@ std::vector<measurement_id_type> read_measurements(
 std::vector<measurement_id_type> read_measurements(
     edm::measurement_collection<default_algebra>::host& measurements,
     std::string_view filename, const traccc::host_detector* detector,
+    const traccc::silicon_detector_description::host* detector_description,
     const bool sort_measurements, data_format format) {
 
     switch (format) {
         case data_format::csv:
             return csv::read_measurements(measurements, filename, detector,
+                                          detector_description,
                                           sort_measurements);
         case data_format::binary:
             details::read_binary_soa(measurements, filename);

--- a/io/src/read_spacepoints.cpp
+++ b/io/src/read_spacepoints.cpp
@@ -21,7 +21,9 @@ void read_spacepoints(
     edm::spacepoint_collection::host& spacepoints,
     edm::measurement_collection<default_algebra>::host& measurements,
     std::size_t event, std::string_view directory,
-    const traccc::host_detector* detector, data_format format) {
+    const traccc::host_detector* detector,
+    const traccc::silicon_detector_description::host* detector_description,
+    data_format format) {
 
     switch (format) {
         case data_format::csv: {
@@ -39,7 +41,7 @@ void read_spacepoints(
                                    std::filesystem::path(get_event_filename(
                                        event, "-measurement-simhit-map.csv")))
                                       .native()),
-                detector, format);
+                detector, detector_description, format);
             break;
         }
         case data_format::binary: {
@@ -53,7 +55,7 @@ void read_spacepoints(
                                    std::filesystem::path(get_event_filename(
                                        event, "-measurements.dat")))
                                       .native()),
-                "", detector, format);
+                "", detector, detector_description, format);
             break;
         }
         default:
@@ -66,13 +68,15 @@ void read_spacepoints(
     edm::measurement_collection<default_algebra>::host& measurements,
     std::string_view hit_filename, std::string_view meas_filename,
     std::string_view meas_hit_map_filename,
-    const traccc::host_detector* detector, data_format format) {
+    const traccc::host_detector* detector,
+    const traccc::silicon_detector_description::host* detector_description,
+    data_format format) {
 
     switch (format) {
         case data_format::csv:
             csv::read_spacepoints(spacepoints, measurements, hit_filename,
                                   meas_filename, meas_hit_map_filename,
-                                  detector);
+                                  detector, detector_description);
             break;
         case data_format::binary:
             details::read_binary_soa(spacepoints, hit_filename);


### PR DESCRIPTION
This commit switched the measurement IO code to optionally get the dimensionality from the detector description rather than from the measurement input data.