### PR TITLE
Save disk space in CUDA CI job

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -98,22 +98,38 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          apt install -y zstd
+          apt install -y zstd wget
           curl --retry 5 --retry-delay 10 --output deps.tar.zst https://acts.web.cern.ch/ACTS/ci/ubuntu-24.04/deps.v6.tar.zst
           tar -xf deps.tar.zst -C /usr/local --strip-components=1
           rm deps.tar.zst
+      - name: Build ACTS
+        run: |
+          wget https://github.com/acts-project/acts/archive/refs/tags/v44.0.1.tar.gz
+          tar -xvf v44.0.1.tar.gz
+          export CXX=g++
+          cmake \
+            -S acts-44.0.1 \
+            -B /acts_build/ \
+            -DACTS_BUILD_PLUGIN_JSON=ON \
+            -DCMAKE_INSTALL_PREFIX=/acts_install/ \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build /acts_build/ -- -j $(nproc)
+          cmake --install /acts_build/
       - name: Configure
         run: |
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
+          export CMAKE_PREFIX_PATH=/acts_install/:${CMAKE_PREFIX_PATH}
           cmake \
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
             ${{ matrix.platform.options }} \
+            -DTRACCC_USE_SYSTEM_ACTS=ON \
+            -DDETRAY_USE_SYSTEM_NLOHMANN=ON \
             -S ${GITHUB_WORKSPACE} \
             -B build
       - name: Build
         run: |
           source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.platform.name }}
-          cmake --build build
+          cmake --build build -- -j $(nproc)
       - name: Download data files
         if: "matrix.platform.run_tests"
         run: data/traccc_data_get_files.sh


### PR DESCRIPTION
The CUDA CI jobs are currently running out of disk space. This commit builds ACTS separately, as a release build, in order to save space.