### PR TITLE
Additional CUDA Warnings, main branch (2025.11.17.)

### DIFF
--- a/cmake/traccc-compiler-options-cuda.cmake
+++ b/cmake/traccc-compiler-options-cuda.cmake
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -20,6 +20,8 @@ if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
 endif()
 
 if( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA" )
+   traccc_add_flag( CMAKE_CUDA_FLAGS "-Wall" )
+   traccc_add_flag( CMAKE_CUDA_FLAGS "-Wextra" )
    traccc_add_flag( CMAKE_CUDA_FLAGS "-Wconversion" )
 endif()
 


### PR DESCRIPTION
While working on #1193 I was reminded that we don't have all too many warnings turned on for our CUDA builds at the moment.

I was expecting that at least some failures would show up when I added `-Wall` and `-Wextra`, but surprisingly nothing did. The common device code is of course checked already by the Alpaka and SYCL builds, but I could've still imagined something hiding in the CUDA specific code. 🤔

In any case, having these active should be a good thing.