### PR TITLE
Measurement Sorting Fix, main branch (2025.11.19.)

### DIFF
--- a/device/alpaka/src/clusterization/measurement_sorting_algorithm.cpp
+++ b/device/alpaka/src/clusterization/measurement_sorting_algorithm.cpp
@@ -69,6 +69,11 @@ measurement_sorting_algorithm::operator()(
     const edm::measurement_collection<default_algebra>::const_view&
         measurements_view) const {
 
+    // Exit early if there are no measurements.
+    if (measurements_view.capacity() == 0) {
+        return {};
+    }
+
     // Get a convenience variable for the queue that we'll be using.
     auto queue = details::get_queue(m_queue);
 

--- a/device/cuda/src/clusterization/measurement_sorting_algorithm.cu
+++ b/device/cuda/src/clusterization/measurement_sorting_algorithm.cu
@@ -68,6 +68,11 @@ measurement_sorting_algorithm::operator()(
     const edm::measurement_collection<default_algebra>::const_view&
         measurements_view) const {
 
+    // Exit early if there are no measurements.
+    if (measurements_view.capacity() == 0) {
+        return {};
+    }
+
     // Get a convenience variable for the stream that we'll be using.
     cudaStream_t stream = details::get_stream(m_stream);
     // Set up the Thrust execution policy.

--- a/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
+++ b/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
@@ -36,6 +36,11 @@ measurement_sorting_algorithm::operator()(
     const edm::measurement_collection<default_algebra>::const_view&
         measurements_view) const {
 
+    // Exit early if there are no measurements.
+    if (measurements_view.capacity() == 0) {
+        return {};
+    }
+
     // Get the SYCL queue to use for the algorithm.
     ::sycl::queue& queue = details::get_queue(m_queue.get());
 


### PR DESCRIPTION
Made measurement sorting handle empty collections correctly. Since as @bwynneHEP found, the algorithms after the latest rewrite don't work correctly with empty inputs. 😦

Did not bother with the host algorithm, because:
  - It's not actively used in any current workflow;
  - It works correctly without this optimization as well.