### PR TITLE
fix: the indices in the host track parameter estimation

### DIFF
--- a/core/src/seeding/track_params_estimation.cpp
+++ b/core/src/seeding/track_params_estimation.cpp
@@ -57,33 +57,33 @@ track_params_estimation::output_type track_params_estimation::operator()(
                        << spacepoints.at(seeds.at(i).top_index()).radius());
 
         // Calculate the track parameter vector.
-        bound_track_parameters<>& track_params = result[i];
+        bound_track_parameters<>& track_params = result.at(i);
         seed_to_bound_param_vector(track_params, measurements, spacepoints,
-                                   seeds[i], bfield);
+                                   seeds.at(i), bfield);
 
         // Set Covariance
-        for (std::size_t j = 0; j < e_bound_size; ++j) {
-            scalar var = m_config.initial_sigma[i] * m_config.initial_sigma[i];
+        for (std::size_t j = 0u; j < e_bound_size; ++j) {
+            scalar var =
+                m_config.initial_sigma.at(j) * m_config.initial_sigma.at(j);
 
-            if (i == e_bound_qoverp) {
+            if (j == e_bound_qoverp) {
                 scalar var_theta = getter::element(
                     track_params.covariance(), e_bound_theta, e_bound_theta);
 
                 var += math::pow(m_config.initial_sigma_qopt *
-                                     math::sin(track_params[e_bound_theta]),
+                                     math::sin(track_params.theta()),
                                  2.f);
-                var += math::pow(m_config.initial_sigma_pt_rel *
-                                     track_params[e_bound_qoverp],
-                                 2.f);
+                var += math::pow(
+                    m_config.initial_sigma_pt_rel * track_params.qop(), 2.f);
                 var += var_theta *
-                       math::pow(track_params[e_bound_qoverp] /
-                                     math::tan(track_params[e_bound_theta]),
-                                 2.f);
+                       math::pow(
+                           track_params.qop() / math::tan(track_params.theta()),
+                           2.f);
             }
 
-            var *= m_config.initial_inflation[i];
+            var *= m_config.initial_inflation.at(j);
 
-            getter::element(track_params.covariance(), i, i) = var;
+            getter::element(track_params.covariance(), j, j) = var;
         }
     }
 

--- a/device/common/include/traccc/seeding/device/impl/estimate_track_params.ipp
+++ b/device/common/include/traccc/seeding/device/impl/estimate_track_params.ipp
@@ -61,18 +61,18 @@ inline void estimate_track_params(
                 track_params.covariance(), e_bound_theta, e_bound_theta);
 
             // Contribution from sigma(q/pt)
-            const scalar sigma_qopt = config.initial_sigma_qopt *
-                                      math::sin(track_params[e_bound_theta]);
+            const scalar sigma_qopt =
+                config.initial_sigma_qopt * math::sin(track_params.theta());
             var += sigma_qopt * sigma_qopt;
 
             // Contribution from sigma(pt)/pt
             const scalar sigma_pt_rel =
-                config.initial_sigma_pt_rel * track_params[e_bound_qoverp];
+                config.initial_sigma_pt_rel * track_params.qop();
             var += sigma_pt_rel * sigma_pt_rel;
 
             // Contribution from sigma(theta)
-            scalar sigma_theta = track_params[e_bound_qoverp] /
-                                 math::tan(track_params[e_bound_theta]);
+            scalar sigma_theta =
+                track_params.qop() / math::tan(track_params.theta());
             var += var_theta * sigma_theta * sigma_theta;
         }
 


### PR DESCRIPTION
Fixes the indices into the track parameters for the host track parameter estimation. This avoids a segmentation fault.
Also changes the access to the track parameters to the getters of the track parameter class to include their assertions.