### PR TITLE
fix: KF max pathlength

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -359,9 +359,10 @@ class kalman_fitter {
         // Set path limit
         const detray::tracking_surface last_sf{
             m_detector, last.filtered_params().surface_link()};
+        const auto& last_state_pos =
+            last_sf.transform(backward_cfg.context).translation();
         fitter_state.m_aborter_state.set_path_limit(
-            1.2f * vector::norm(
-                       last_sf.transform(backward_cfg.context).translation()));
+            1.5f * vector::norm(last_state_pos));
 
         typename backward_propagator_type::state propagation(
             last.smoothed_params(), m_field, m_detector,


### PR DESCRIPTION
Stop the smoother after 1.5x the forward pathlength (estimated from the centroid distance of the last track states surface)