### PR TITLE
feat: Skip the Kalman fitter on the first CKF step

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -96,6 +96,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/fitting/kalman_filter/kalman_actor.hpp"
   "include/traccc/fitting/kalman_filter/kalman_fitter.hpp"
   "include/traccc/fitting/kalman_filter/kalman_step_aborter.hpp"
+  "include/traccc/fitting/kalman_filter/measurement_selector.hpp"
   "include/traccc/fitting/kalman_filter/statistics_updater.hpp"
   "include/traccc/fitting/kalman_filter/two_filters_smoother.hpp"
   "include/traccc/fitting/details/kalman_fitting_types.hpp"

--- a/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -16,6 +16,7 @@
 #include "traccc/finding/finding_config.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
 #include "traccc/fitting/kalman_filter/is_line_visitor.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/sanity/contiguous_on.hpp"
 #include "traccc/utils/logging.hpp"
@@ -231,6 +232,9 @@ combinatorial_kalman_filter(
                                    bound_track_parameters<algebra_type>>>
                 best_links;
 
+            const bool is_line = detail::is_line(sf);
+            measurement_selector::config calib_cfg{};
+
             // Iterate over the measurements
             TRACCC_VERBOSE_HOST("No. measurements: " << (up - lo));
             for (unsigned int meas_id = lo; meas_id < up; meas_id++) {
@@ -239,42 +243,34 @@ combinatorial_kalman_filter(
                 // The measurement on surface to handle.
                 const edm::measurement meas = measurements.at(meas_id);
 
+                const scalar_type chi2 = measurement_selector::predicted_chi2(
+                    meas, in_param, calib_cfg, is_line);
+
+                // If the measurement is outside the chi2 cut, skip it
+                if (chi2 > config.chi2_max) {
+                    continue;
+                }
+
                 // Create a standalone track state object.
                 edm::track_state trk_state =
                     edm::make_track_state<algebra_type>(measurements, meas_id);
 
+                // Kalman filter status code
                 kalman_fitter_status res{kalman_fitter_status::ERROR_OTHER};
-                // Check if the measurement is even remotely close to the track
+
+                // Don't run the filter on the first measurement
                 if (step == 0 && !sf.has_material()) {
-                    detray::dmatrix<algebra_type, 2, 1> meas_local;
-                    edm::get_measurement_local<algebra_type>(meas, meas_local);
-
-                    const subspace<algebra_type, e_bound_size> subs(
-                        meas.subspace());
-                    detray::dmatrix<algebra_type, 2, e_bound_size> H =
-                        subs.template projector<2>();
-                    const auto residual = meas_local - H * in_param.vector();
-
-                    const scalar_type res_0{getter::element(residual, 0, 0)};
-                    const scalar_type res_1{
-                        meas.dimensions() == 1
-                            ? 0.f
-                            : getter::element(residual, 1, 0)};
-                    const scalar_type search_rad =
-                        math::sqrt(res_0 * res_0 + res_1 * res_1);
-                    if (search_rad > 0.f) {
-                        TRACCC_VERBOSE_HOST(
-                            "Measurement outside search radius: "
-                            << search_rad << " mm for meas. " << meas_id);
-                        continue;
-                    }
                     res = kalman_fitter_status::SUCCESS;
-                    trk_state.filtered_params() = in_param;
-                    trk_state.filtered_chi2() = 0.f;
 
-                    // Set the covariance to the measurement variance
-                    detray::dmatrix<algebra_type, 2, 2> V;
-                    edm::get_measurement_covariance<algebra_type>(meas, V);
+                    // Copy the full track parameters
+                    // TODO: Apply calibration ?
+                    trk_state.filtered_params() = in_param;
+
+                    // Update measurement covariance
+                    const auto V =
+                        measurement_selector::calibrated_measurement_covariance<
+                            algebra_type, 2>(meas, calib_cfg);
+
                     auto& filtered_cov =
                         trk_state.filtered_params().covariance();
                     getter::element(filtered_cov, e_bound_loc0, e_bound_loc0) =
@@ -282,20 +278,18 @@ combinatorial_kalman_filter(
                     getter::element(filtered_cov, e_bound_loc1, e_bound_loc1) =
                         getter::element(V, 1, 1);
                 } else {
-                    const bool is_line = detail::is_line(sf);
-
-                    // Run the Kalman update on a copy of the track parameters
-                    res = gain_matrix_updater<algebra_type>{}(
-                        trk_state, measurements, in_param, is_line);
+                    // Run the Kalman update on the track state
+                    constexpr gain_matrix_updater<algebra_type>
+                        kalman_updater{};
+                    res = kalman_updater(trk_state, meas, in_param, is_line);
                 }
 
-                const traccc::scalar chi2 = trk_state.filtered_chi2();
+                trk_state.filtered_chi2() = chi2;
 
                 TRACCC_DEBUG_HOST("KF status: " << fitter_debug_msg{res}());
 
                 // The chi2 from Kalman update should be less than chi2_max
-                if (res == kalman_fitter_status::SUCCESS &&
-                    (chi2 < config.chi2_max)) {
+                if (res == kalman_fitter_status::SUCCESS) {
 
                     TRACCC_VERBOSE_HOST("Found measurement: " << meas_id);
 

--- a/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -243,12 +243,51 @@ combinatorial_kalman_filter(
                 edm::track_state trk_state =
                     edm::make_track_state<algebra_type>(measurements, meas_id);
 
-                const bool is_line = detail::is_line(sf);
+                kalman_fitter_status res{kalman_fitter_status::ERROR_OTHER};
+                // Check if the measurement is even remotely close to the track
+                if (step == 0 && !sf.has_material()) {
+                    detray::dmatrix<algebra_type, 2, 1> meas_local;
+                    edm::get_measurement_local<algebra_type>(meas, meas_local);
 
-                // Run the Kalman update on a copy of the track parameters
-                const kalman_fitter_status res =
-                    gain_matrix_updater<algebra_type>{}(trk_state, measurements,
-                                                        in_param, is_line);
+                    const subspace<algebra_type, e_bound_size> subs(
+                        meas.subspace());
+                    detray::dmatrix<algebra_type, 2, e_bound_size> H =
+                        subs.template projector<2>();
+                    const auto residual = meas_local - H * in_param.vector();
+
+                    const scalar_type res_0{getter::element(residual, 0, 0)};
+                    const scalar_type res_1{
+                        meas.dimensions() == 1
+                            ? 0.f
+                            : getter::element(residual, 1, 0)};
+                    const scalar_type search_rad =
+                        math::sqrt(res_0 * res_0 + res_1 * res_1);
+                    if (search_rad > 0.f) {
+                        TRACCC_VERBOSE_HOST(
+                            "Measurement outside search radius: "
+                            << search_rad << " mm for meas. " << meas_id);
+                        continue;
+                    }
+                    res = kalman_fitter_status::SUCCESS;
+                    trk_state.filtered_params() = in_param;
+                    trk_state.filtered_chi2() = 0.f;
+
+                    // Set the covariance to the measurement variance
+                    detray::dmatrix<algebra_type, 2, 2> V;
+                    edm::get_measurement_covariance<algebra_type>(meas, V);
+                    auto& filtered_cov =
+                        trk_state.filtered_params().covariance();
+                    getter::element(filtered_cov, e_bound_loc0, e_bound_loc0) =
+                        getter::element(V, 0, 0);
+                    getter::element(filtered_cov, e_bound_loc1, e_bound_loc1) =
+                        getter::element(V, 1, 1);
+                } else {
+                    const bool is_line = detail::is_line(sf);
+
+                    // Run the Kalman update on a copy of the track parameters
+                    res = gain_matrix_updater<algebra_type>{}(
+                        trk_state, measurements, in_param, is_line);
+                }
 
                 const traccc::scalar chi2 = trk_state.filtered_chi2();
 

--- a/core/include/traccc/fitting/fitting_config.hpp
+++ b/core/include/traccc/fitting/fitting_config.hpp
@@ -29,6 +29,10 @@ struct fitting_config {
     float min_p = 100.f * traccc::unit<float>::MeV;
     float min_pT = 600.f * traccc::unit<float>::MeV;
 
+    // Maximal local radius a measurement is allowed to be away from the
+    // predicted track position in order to be considered as a condidate
+    float max_measurement_radius{5.f * traccc::unit<float>::mm};
+
     /// Particle hypothesis
     traccc::pdg_particle<traccc::scalar> ptc_hypothesis =
         traccc::pion_plus<traccc::scalar>();

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -12,12 +12,10 @@
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/definitions/track_parametrization.hpp"
 #include "traccc/edm/measurement_collection.hpp"
-#include "traccc/edm/measurement_helpers.hpp"
-#include "traccc/edm/track_state_collection.hpp"
 #include "traccc/fitting/details/regularize_covariance.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/utils/logging.hpp"
-#include "traccc/utils/subspace.hpp"
 
 namespace traccc {
 
@@ -43,17 +41,16 @@ struct gain_matrix_updater {
     /// @param bound_params bound parameter
     ///
     /// @return true if the update succeeds
-    template <typename track_state_backend_t>
+    template <typename track_state_backend_t, typename measurement_backend_t>
     [[nodiscard]] TRACCC_HOST_DEVICE inline kalman_fitter_status operator()(
         typename edm::track_state<track_state_backend_t>& trk_state,
-        const edm::measurement_collection::const_device& measurements,
+        const edm::measurement<measurement_backend_t>& measurement,
         const bound_track_parameters<algebra_t>& bound_params,
         const bool is_line) const {
 
         static constexpr unsigned int D = 2;
 
-        [[maybe_unused]] const unsigned int dim{
-            measurements.at(trk_state.measurement_index()).dimensions()};
+        [[maybe_unused]] const unsigned int dim{measurement.dimensions()};
 
         TRACCC_VERBOSE_HOST_DEVICE("Perform Kalman filtering...");
         TRACCC_VERBOSE_HOST_DEVICE("-> Measurement dim: %d", dim);
@@ -70,8 +67,7 @@ struct gain_matrix_updater {
 
         // Measurement data on surface
         matrix_type<D, 1> meas_local;
-        edm::get_measurement_local<algebra_t>(
-            measurements.at(trk_state.measurement_index()), meas_local);
+        edm::get_measurement_local<algebra_t>(measurement, meas_local);
 
         assert((dim > 1) || (getter::element(meas_local, 1u, 0u) == 0.f));
 
@@ -83,8 +79,7 @@ struct gain_matrix_updater {
         // Predicted covaraince of bound track parameters
         const bound_matrix_type& predicted_cov = bound_params.covariance();
 
-        const subspace<algebra_t, e_bound_size> subs(
-            measurements.at(trk_state.measurement_index()).subspace());
+        const subspace<algebra_t, e_bound_size> subs(measurement.subspace());
         matrix_type<D, e_bound_size> H = subs.template projector<D>();
 
         // Flip the sign of projector matrix element in case the first element
@@ -101,8 +96,7 @@ struct gain_matrix_updater {
 
         // Spatial resolution (Measurement covariance)
         matrix_type<D, D> V;
-        edm::get_measurement_covariance<algebra_t>(
-            measurements.at(trk_state.measurement_index()), V);
+        edm::get_measurement_covariance<algebra_t>(measurement, V);
         // @TODO: Fix properly
         if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
             getter::element(V, 1u, 1u) = 1000.f;

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -408,6 +408,8 @@ struct kalman_actor : detray::base_actor {
             const auto sf = navigation.current_surface();
             const bool is_line = detail::is_line(sf);
 
+            const auto measurement =
+                actor_state.m_measurements.at(trk_state.measurement_index());
             if (!actor_state.backward_mode) {
                 if constexpr (direction_e ==
                                   kalman_actor_direction::FORWARD_ONLY ||
@@ -419,8 +421,7 @@ struct kalman_actor : detray::base_actor {
                     // Forward filter
                     TRACCC_DEBUG_HOST_DEVICE("Run filtering...");
                     actor_state.fit_result = gain_matrix_updater<algebra_t>{}(
-                        trk_state, actor_state.m_measurements, bound_param,
-                        is_line);
+                        trk_state, measurement, bound_param, is_line);
 
                     // Update the propagation flow
                     bound_param = trk_state.filtered_params();
@@ -449,8 +450,7 @@ struct kalman_actor : detray::base_actor {
                     } else {
                         actor_state.fit_result =
                             two_filters_smoother<algebra_t>{}(
-                                trk_state, actor_state.m_measurements,
-                                bound_param, is_line);
+                                trk_state, measurement, bound_param, is_line);
                     }
                 } else {
                     assert(false);

--- a/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
+++ b/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
@@ -1,0 +1,285 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/definitions/track_parametrization.hpp"
+#include "traccc/edm/measurement_collection.hpp"
+#include "traccc/edm/measurement_helpers.hpp"
+#include "traccc/utils/logging.hpp"
+#include "traccc/utils/subspace.hpp"
+
+// System include(s)
+#include <limits>
+
+namespace traccc {
+
+/// Potential next measurement to be added to track
+struct candidate_measurement {
+    unsigned int meas_idx{std::numeric_limits<unsigned int>::max()};
+    float chi2{std::numeric_limits<float>::max()};
+
+    /// Define comparisons
+    TRACCC_HOST_DEVICE
+    constexpr bool operator<=>(const candidate_measurement& other) const =
+        default;
+};
+/// @}
+
+/// Associate a measurement to a candidate track
+struct measurement_selector {
+
+    template <detray::concepts::algebra A, unsigned int ROWS, unsigned int COLS>
+    using matrix_t = detray::dmatrix<A, ROWS, COLS>;
+
+    // Where to get the calibration from
+    struct config { /*TODO: implement calibration handling*/
+    };
+
+    /// Get the observation model for a given measurement
+    ///
+    /// @param measurement the measurement
+    /// @param bound_params predicted bound track parameters
+    /// @param is_line whether the measurement belong to a line surface
+    ///
+    /// @returns the projection matrix H
+    template <detray::concepts::algebra algebra_t, unsigned int D,
+              typename measurement_backend_t>
+    TRACCC_HOST_DEVICE static detray::dmatrix<algebra_t, D, e_bound_size>
+    observation_model(
+        const edm::measurement<measurement_backend_t>& measurement,
+        const bound_track_parameters<algebra_t>& bound_params,
+        const bool is_line) {
+
+        // Oservation model: Subspace of measurement space for this measurement
+        const subspace<algebra_t, e_bound_size> subs(measurement.subspace());
+        detray::dmatrix<algebra_t, D, e_bound_size> H =
+            subs.template projector<D>();
+
+        // Flip the sign of projector matrix element in case the first element
+        // of a line measurement is negative
+        if (is_line && bound_params.bound_local()[e_bound_loc0] < 0) {
+            getter::element(H, 0u, e_bound_loc0) = -1;
+        }
+
+        detray::dmatrix<algebra_t, D, 1> meas_local;
+        edm::get_measurement_local<algebra_t>(measurement, meas_local);
+        if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
+            // if (measurement.dimensions() == 1) {
+            getter::element(H, 1u, 0u) = 0.f;
+            getter::element(H, 1u, 1u) = 0.f;
+        }
+
+        TRACCC_DEBUG_HOST("--> Observation model (H):\n" << H);
+
+        return H;
+    }
+
+    /// Get the calibrated measurement position
+    ///
+    /// @param measurement the measurement
+    /// @param cfg how to apply calibrations
+    ///
+    /// @returns the projection matrix H
+    template <detray::concepts::algebra algebra_t, unsigned int D,
+              typename measurement_backend_t>
+    TRACCC_HOST_DEVICE static detray::dmatrix<algebra_t, D, 1>
+    calibrated_measurement_position(
+        const edm::measurement<measurement_backend_t>& measurement,
+        const config& /*cfg*/) {
+
+        // Measurement data on surface
+        detray::dmatrix<algebra_t, D, 1> meas_local;
+        edm::get_measurement_local<algebra_t>(measurement, meas_local);
+
+        TRACCC_DEBUG_HOST("--> Measurement position (uncalibrated):\n"
+                          << meas_local);
+
+        assert((measurement.dimensions() > 1) ||
+               (getter::element(meas_local, 1u, 0u) == 0.f));
+
+        return meas_local;
+    }
+
+    /// Get the calibrated measurement covariance
+    ///
+    /// @param measurement the measurement
+    /// @param cfg how to apply calibrations
+    ///
+    /// @returns the projection matrix H
+    template <detray::concepts::algebra algebra_t, unsigned int D,
+              typename measurement_backend_t>
+    TRACCC_HOST_DEVICE static detray::dmatrix<algebra_t, D, D>
+    calibrated_measurement_covariance(
+        const edm::measurement<measurement_backend_t>& measurement,
+        const config& /*cfg*/) {
+
+        // Measurement covariance
+        detray::dmatrix<algebra_t, D, D> V;
+        edm::get_measurement_covariance<algebra_t>(measurement, V);
+
+        detray::dmatrix<algebra_t, D, 1> meas_local;
+        edm::get_measurement_local<algebra_t>(measurement, meas_local);
+        // @TODO: Fix properly
+        if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
+            // if (measurement.dimensions() == 1) {
+            getter::element(V, 1u, 1u) = 10000.f;
+        }
+
+        TRACCC_DEBUG_HOST("--> Measurement covariance (uncalibrated):\n" << V);
+
+        return V;
+    }
+
+    /// Calculate the predicted chi2
+    ///
+    /// @brief Based on "Application of Kalman filtering to track and vertex
+    /// fitting", R.Frühwirth, NIM A
+    ///
+    /// @param measurement the measurement
+    /// @param bound_params predicted bound track parameters
+    /// @param cfg the calibration configuration
+    /// @param is_line whether the measurement belong to a line surface
+    ///
+    /// @returns the predicted chi2 of the calibrated measurement
+    template <typename measurement_backend_t,
+              detray::concepts::algebra algebra_t>
+    TRACCC_HOST_DEVICE static detray::dscalar<algebra_t> predicted_chi2(
+        const edm::measurement<measurement_backend_t>& measurement,
+        const bound_track_parameters<algebra_t>& bound_params,
+        const config& cfg, const bool is_line) {
+
+        using scalar_t = detray::dscalar<algebra_t>;
+
+        // Measurement maximal dimension
+        constexpr unsigned int D = 2;
+
+        TRACCC_VERBOSE_HOST_DEVICE("--> dim: %d", measurement.dimensions());
+
+        assert(measurement.dimensions() == 1u ||
+               measurement.dimensions() == 2u);
+
+        assert(!bound_params.is_invalid());
+        assert(!bound_params.surface_link().is_invalid());
+
+        // Get calibrated measurement and covariance
+        const matrix_t<algebra_t, D, 1> meas_local =
+            calibrated_measurement_position<algebra_t, D>(measurement, cfg);
+
+        const matrix_t<algebra_t, D, D> V =
+            calibrated_measurement_covariance<algebra_t, D>(measurement, cfg);
+
+        // Project the predicted covariance to the observation
+        const matrix_t<algebra_t, D, e_bound_size> H =
+            observation_model<algebra_t, D>(measurement, bound_params, is_line);
+
+        const matrix_t<algebra_t, D, D> R =
+            H * matrix::transposed_product<false, true>(
+                    bound_params.covariance(), H) +
+            V;
+
+        TRACCC_DEBUG_HOST("--> R:\n" << R);
+        TRACCC_DEBUG_HOST_DEVICE("--> det(R): %.10e", matrix::determinant(R));
+        TRACCC_DEBUG_HOST("--> R_inv:\n" << matrix::inverse(R));
+
+        // Residual between measurement and (projected) vector (innovation)
+        const matrix_t<algebra_t, D, 1> residual =
+            meas_local - H * bound_params.vector();
+
+        TRACCC_DEBUG_HOST("--> Predicted residual:\n" << residual);
+
+        const matrix_t<algebra_t, 1, 1> pred_chi2 =
+            matrix::transposed_product<true, false>(
+                residual, traccc::matrix::inverse(R)) *
+            residual;
+
+        const scalar_t pred_chi2_val{getter::element(pred_chi2, 0, 0)};
+
+        TRACCC_VERBOSE_HOST_DEVICE("--> chi2: %.10e", pred_chi2_val);
+
+        return pred_chi2_val;
+    }
+
+    /// Measurement selection (optimal)
+    ///
+    /// @param bound_params predicted bound track parameters
+    /// @param measurements the measurement container
+    /// @param meas_range contains the index ranges into the measurements
+    /// @param cfg the calibration configuration
+    /// @param is_line whether the measurement belong to a line surface
+    ///
+    /// @returns the optimal candidate measurement for the input params
+    template <detray::concepts::algebra algebra_t>
+    TRACCC_HOST_DEVICE static candidate_measurement find_optimal_measurement(
+        const bound_track_parameters<algebra_t>& bound_params,
+        const typename edm::measurement_collection::const_device& measurements,
+        vecmem::device_vector<unsigned int> meas_ranges, const config& cfg,
+        const bool is_line) {
+
+        using scalar_t = detray::dscalar<algebra_t>;
+
+        // The optimal candidate
+        candidate_measurement cand{};
+
+        // Iterate over the measurements for this surface
+        const unsigned int sf_idx{bound_params.surface_link().index()};
+        const unsigned int lo{sf_idx == 0u ? 0u : meas_ranges[sf_idx - 1]};
+        const unsigned int up{meas_ranges[sf_idx]};
+
+        TRACCC_VERBOSE_HOST_DEVICE("Have %d measurement(s) on surface %d...",
+                                   up - lo, sf_idx);
+
+        // Find the best fitting measurement by prediced chi2
+        // TODO: Load balancing
+        for (unsigned int meas_idx = lo; meas_idx < up; meas_idx++) {
+
+            TRACCC_VERBOSE_HOST_DEVICE("-> measurement %d:", meas_idx);
+
+            // Predicted chi2
+            const scalar_t chi2 = measurement_selector::predicted_chi2(
+                measurements.at(meas_idx), bound_params, cfg, is_line);
+
+            // Check predicted chi2 cut
+            if (chi2 < cand.chi2) {
+                cand = {meas_idx, static_cast<float>(chi2)};
+                // Found optimal
+                if (cand.chi2 <= std::numeric_limits<scalar_t>::epsilon()) {
+                    return cand;
+                }
+            }
+        }
+
+        return cand;
+    }
+
+    /// Measurement selection (collection of compatible measurements)
+    ///
+    /// @param bound_params predicted bound track parameters
+    /// @param measurements the measurement container
+    /// @param meas_range contains the index ranges into the measurements
+    /// @param cfg the calibration configuration
+    /// @param is_line whether the measurement belong to a line surface
+    ///
+    /// @returns a collection of compatible measurements, sorted by pred. chi2
+    template <detray::concepts::algebra algebra_t>
+    TRACCC_HOST_DEVICE static vecmem::vector<candidate_measurement>
+    find_compatible_measurements(
+        const bound_track_parameters<algebra_t>& /*bound_params*/,
+        const typename edm::measurement_collection::const_device&
+        /*measurements*/,
+        vecmem::device_vector<unsigned int> /*meas_ranges*/,
+        const config& /*cfg*/, const bool /*is_line*/) {
+        /* TODO: Implement*/
+        assert(false);
+        return {};
+    }
+};
+
+}  // namespace traccc

--- a/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
@@ -36,17 +36,16 @@ struct two_filters_smoother {
     /// @param bound_params bound parameter
     ///
     /// @return true if the update succeeds
+    template <typename track_state_backend_t, typename measurement_backend_t>
     [[nodiscard]] TRACCC_HOST_DEVICE inline kalman_fitter_status operator()(
-        typename edm::track_state_collection<algebra_t>::device::proxy_type&
-            trk_state,
-        const edm::measurement_collection::const_device& measurements,
+        typename edm::track_state<track_state_backend_t>& trk_state,
+        const edm::measurement<measurement_backend_t>& measurement,
         bound_track_parameters<algebra_t>& bound_params,
         const bool is_line) const {
 
         static constexpr unsigned int D = 2;
 
-        [[maybe_unused]] const unsigned int dim{
-            measurements.at(trk_state.measurement_index()).dimensions()};
+        [[maybe_unused]] const unsigned int dim{measurement.dimensions()};
 
         assert(dim == 1u || dim == 2u);
 
@@ -64,8 +63,7 @@ struct two_filters_smoother {
 
         // Measurement data on surface
         matrix_type<D, 1> meas_local;
-        edm::get_measurement_local<algebra_t>(
-            measurements.at(trk_state.measurement_index()), meas_local);
+        edm::get_measurement_local<algebra_t>(measurement, meas_local);
 
         assert((dim > 1) || (getter::element(meas_local, 1u, 0u) == 0.f));
 
@@ -131,8 +129,7 @@ struct two_filters_smoother {
         // Wrap the phi and theta angles in their valid ranges
         normalize_angles(trk_state.smoothed_params());
 
-        const subspace<algebra_t, e_bound_size> subs(
-            measurements.at(trk_state.measurement_index()).subspace());
+        const subspace<algebra_t, e_bound_size> subs(measurement.subspace());
         matrix_type<D, e_bound_size> H = subs.template projector<D>();
         // @TODO: Fix properly
         if (getter::element(meas_local, 1u, 0u) == 0.f /*dim == 1*/) {
@@ -144,8 +141,7 @@ struct two_filters_smoother {
 
         // Spatial resolution (Measurement covariance)
         matrix_type<D, D> V;
-        edm::get_measurement_covariance<algebra_t>(
-            measurements.at(trk_state.measurement_index()), V);
+        edm::get_measurement_covariance<algebra_t>(measurement, V);
         // @TODO: Fix properly
         if (getter::element(meas_local, 1u, 0u) == 0.f /*dim == 1*/) {
             getter::element(V, 1u, 1u) = 1000.f;

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -44,6 +44,8 @@ TRACCC_HOST_DEVICE inline void find_tracks(
     const finding_config& cfg, const find_tracks_payload<detector_t>& payload,
     const find_tracks_shared_payload& shared_payload) {
 
+    using algebra_t = typename detector_t::algebra_type;
+
     const unsigned int in_param_id = thread_id.getGlobalThreadIdX();
     const bool last_step =
         payload.step == cfg.max_track_candidates_per_track - 1;
@@ -169,10 +171,9 @@ TRACCC_HOST_DEVICE inline void find_tracks(
 
         barrier.blockBarrier();
 
-        std::optional<std::tuple<
-            typename edm::track_state_collection<
-                typename detector_t::algebra_type>::device::object_type,
-            unsigned int, unsigned int>>
+        std::optional<std::tuple<typename edm::track_state_collection<
+                                     algebra_t>::device::object_type,
+                                 unsigned int, unsigned int>>
             result = std::nullopt;
 
         /*
@@ -211,17 +212,58 @@ TRACCC_HOST_DEVICE inline void find_tracks(
             if (use_measurement) {
 
                 edm::track_state trk_state =
-                    edm::make_track_state<typename detector_t::algebra_type>(
-                        measurements, meas_idx);
+                    edm::make_track_state<algebra_t>(measurements, meas_idx);
 
                 const detray::tracking_surface sf{det, in_par.surface_link()};
 
-                const bool is_line = detail::is_line(sf);
+                kalman_fitter_status res{kalman_fitter_status::ERROR_OTHER};
+                // Check if the measurement is even remotely close to the track
+                if (payload.step == 0 && !sf.has_material()) {
+                    const auto& meas = measurements.at(meas_idx);
 
-                // Run the Kalman update
-                const kalman_fitter_status res =
-                    gain_matrix_updater<typename detector_t::algebra_type>{}(
+                    detray::dmatrix<algebra_t, 2, 1> meas_local;
+                    edm::get_measurement_local<algebra_t>(meas, meas_local);
+
+                    const subspace<algebra_t, e_bound_size> subs(
+                        meas.subspace());
+                    detray::dmatrix<algebra_t, 2, e_bound_size> H =
+                        subs.template projector<2>();
+
+                    const auto residual =
+                        meas_local -
+                        H * in_params.at(owner_global_thread_id).vector();
+
+                    const traccc::scalar res_0{getter::element(residual, 0, 0)};
+                    const traccc::scalar res_1{
+                        meas.dimensions() == 1
+                            ? 0.f
+                            : getter::element(residual, 1, 0)};
+                    const traccc::scalar search_rad =
+                        math::sqrt(res_0 * res_0 + res_1 * res_1);
+                    if (search_rad > 0.f) {
+                        use_measurement = false;
+                    }
+                    res = kalman_fitter_status::SUCCESS;
+                    trk_state.filtered_params() =
+                        in_params.at(owner_global_thread_id);
+                    trk_state.filtered_chi2() = 0.f;
+
+                    // Set the covariance to the measurement variance
+                    detray::dmatrix<algebra_t, 2, 2> V;
+                    edm::get_measurement_covariance<algebra_t>(meas, V);
+                    auto& filtered_cov =
+                        trk_state.filtered_params().covariance();
+                    getter::element(filtered_cov, e_bound_loc0, e_bound_loc0) =
+                        getter::element(V, 0, 0);
+                    getter::element(filtered_cov, e_bound_loc1, e_bound_loc1) =
+                        getter::element(V, 1, 1);
+                } else {
+                    const bool is_line = detail::is_line(sf);
+
+                    // Run the Kalman update on a copy of the track parameters
+                    res = gain_matrix_updater<algebra_t>{}(
                         trk_state, measurements, in_par, is_line);
+                }
 
                 TRACCC_DEBUG_DEVICE("KF status: %d", res);
 

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -211,58 +211,57 @@ TRACCC_HOST_DEVICE inline void find_tracks(
 
             if (use_measurement) {
 
+                const detray::tracking_surface sf{det, in_par.surface_link()};
+                const bool is_line = detail::is_line(sf);
+
+                measurement_selector::config calib_cfg{};
+
+                const edm::measurement meas = measurements.at(meas_idx);
+
+                // The filtered track state
                 edm::track_state trk_state =
                     edm::make_track_state<algebra_t>(measurements, meas_idx);
 
-                const detray::tracking_surface sf{det, in_par.surface_link()};
+                const traccc::scalar chi2 =
+                    measurement_selector::predicted_chi2(meas, in_par,
+                                                         calib_cfg, is_line);
 
+                trk_state.filtered_chi2() = chi2;
+
+                // If the measurement is outside the chi2 cut, skip it
+                if (chi2 > cfg.chi2_max) {
+                    use_measurement = false;
+                }
+
+                // Kalman filter status code
                 kalman_fitter_status res{kalman_fitter_status::ERROR_OTHER};
-                // Check if the measurement is even remotely close to the track
-                if (payload.step == 0 && !sf.has_material()) {
-                    const auto& meas = measurements.at(meas_idx);
 
-                    detray::dmatrix<algebra_t, 2, 1> meas_local;
-                    edm::get_measurement_local<algebra_t>(meas, meas_local);
+                if (use_measurement) {
+                    if (payload.step == 0 && chi2 == 0.f &&
+                        !sf.has_material()) {
+                        res = kalman_fitter_status::SUCCESS;
 
-                    const subspace<algebra_t, e_bound_size> subs(
-                        meas.subspace());
-                    detray::dmatrix<algebra_t, 2, e_bound_size> H =
-                        subs.template projector<2>();
+                        trk_state.filtered_params() = in_par;
 
-                    const auto residual =
-                        meas_local -
-                        H * in_params.at(owner_global_thread_id).vector();
+                        // Update measurement covariance
+                        const auto V = measurement_selector::
+                            calibrated_measurement_covariance<algebra_t, 2>(
+                                meas, calib_cfg);
 
-                    const traccc::scalar res_0{getter::element(residual, 0, 0)};
-                    const traccc::scalar res_1{
-                        meas.dimensions() == 1
-                            ? 0.f
-                            : getter::element(residual, 1, 0)};
-                    const traccc::scalar search_rad =
-                        math::sqrt(res_0 * res_0 + res_1 * res_1);
-                    if (search_rad > 0.f) {
-                        use_measurement = false;
+                        auto& filtered_cov =
+                            trk_state.filtered_params().covariance();
+                        getter::element(filtered_cov, e_bound_loc0,
+                                        e_bound_loc0) =
+                            getter::element(V, 0, 0);
+                        getter::element(filtered_cov, e_bound_loc1,
+                                        e_bound_loc1) =
+                            getter::element(V, 1, 1);
+                    } else {
+                        // Run the Kalman update on a copy of the track
+                        // parameters
+                        res = gain_matrix_updater<algebra_t>{}(trk_state, meas,
+                                                               in_par, is_line);
                     }
-                    res = kalman_fitter_status::SUCCESS;
-                    trk_state.filtered_params() =
-                        in_params.at(owner_global_thread_id);
-                    trk_state.filtered_chi2() = 0.f;
-
-                    // Set the covariance to the measurement variance
-                    detray::dmatrix<algebra_t, 2, 2> V;
-                    edm::get_measurement_covariance<algebra_t>(meas, V);
-                    auto& filtered_cov =
-                        trk_state.filtered_params().covariance();
-                    getter::element(filtered_cov, e_bound_loc0, e_bound_loc0) =
-                        getter::element(V, 0, 0);
-                    getter::element(filtered_cov, e_bound_loc1, e_bound_loc1) =
-                        getter::element(V, 1, 1);
-                } else {
-                    const bool is_line = detail::is_line(sf);
-
-                    // Run the Kalman update on a copy of the track parameters
-                    res = gain_matrix_updater<algebra_t>{}(
-                        trk_state, measurements, in_par, is_line);
                 }
 
                 TRACCC_DEBUG_DEVICE("KF status: %d", res);
@@ -278,13 +277,7 @@ TRACCC_HOST_DEVICE inline void find_tracks(
                  * but, more importantly, allows us to more easily use
                  * block-wide synchronization primitives.
                  */
-                if (const traccc::scalar chi2 = trk_state.filtered_chi2();
-                    res != kalman_fitter_status::SUCCESS ||
-                    chi2 >= cfg.chi2_max) {
-                    use_measurement = false;
-                }
-
-                if (use_measurement) {
+                if (use_measurement && res == kalman_fitter_status::SUCCESS) {
                     TRACCC_VERBOSE_DEVICE("Found measurement: %d", meas_idx);
                     result.emplace(trk_state, meas_idx, owner_local_thread_id);
                 }


### PR DESCRIPTION
Since it just retrieves the first measurement of the seed, the first Kalman gain matrix call can be skipped