### PR TITLE
feat: Build detectors with custom metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,11 @@ endif()
 # In order to generate specializations for our kernels, we need to have both
 # a working Python interpreter, and a list of supported detectors.
 find_package (Python COMPONENTS Interpreter REQUIRED)
-set(TRACCC_SUPPORTED_DETECTORS "default_detector;telescope_detector;toy_detector")
+# The detector types supported by this build of traccc.
+set( TRACCC_SUPPORTED_DETECTORS
+   "default_detector;odd_detector;telescope_detector"
+   CACHE STRING
+   "Semicolon-separated list of detector types to support in this build" )
 
 # Set up build profiling for the project.
 if( CTEST_USE_LAUNCHERS )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -148,3 +148,17 @@ target_compile_definitions( traccc_core
 # Set the algebra-plugins plugin to use.
 message(STATUS "Building with plugin type: " ${TRACCC_ALGEBRA_PLUGINS})
 target_compile_definitions(traccc_core PUBLIC ALGEBRA_PLUGINS_INCLUDE_${TRACCC_ALGEBRA_PLUGINS})
+
+string(REPLACE ";" ", " TRACCC_DETECTOR_TYPES "${TRACCC_SUPPORTED_DETECTORS}")
+message(STATUS "Building with detector types: ${TRACCC_DETECTOR_TYPES}")
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/traccc/geometry/detector_type_list.hpp.in"
+  "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/include/traccc/geometry/detector_type_list.hpp"
+  @ONLY)
+
+target_include_directories(traccc_core
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/include> )
+
+install(
+  DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/include/"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" )

--- a/core/include/traccc/geometry/detector.hpp
+++ b/core/include/traccc/geometry/detector.hpp
@@ -13,6 +13,8 @@
 // Detray include(s).
 #include <detray/core/detector.hpp>
 #include <detray/detectors/default_metadata.hpp>
+#include <detray/detectors/itk_metadata.hpp>
+#include <detray/detectors/odd_metadata.hpp>
 #include <detray/detectors/telescope_metadata.hpp>
 #include <detray/detectors/toy_metadata.hpp>
 
@@ -75,17 +77,24 @@ concept is_detector_traits = requires {
     typename T::buffer;
 };
 
-/// Default detector (also used for ODD)
+/// Default detector (can contain any detector data)
 using default_detector =
     detector_traits<detray::default_metadata<traccc::default_algebra>>;
 
-/// Telescope detector
+/// ATLAS Inner Tracker (ITk) detector
+using itk_detector =
+    detector_traits<detray::itk_metadata<traccc::default_algebra>>;
+
+/// Open Data Detector (ODD) detector
+using odd_detector =
+    detector_traits<detray::odd_metadata<traccc::default_algebra>>;
+
+/// Detray telescope detector (test detector)
 using telescope_detector = detector_traits<
     detray::telescope_metadata<traccc::default_algebra, detray::rectangle2D>>;
 
-/// Toy detector
+/// Detray toy detector (test detector)
 using toy_detector =
     detector_traits<detray::toy_metadata<traccc::default_algebra>>;
 
-using detector_type_list = std::tuple<default_detector, telescope_detector>;
 }  // namespace traccc

--- a/core/include/traccc/geometry/detector_buffer.hpp
+++ b/core/include/traccc/geometry/detector_buffer.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/geometry/detector.hpp"
+#include "traccc/geometry/detector_type_list.hpp"
 #include "traccc/geometry/host_detector.hpp"
 #include "traccc/geometry/move_only_any.hpp"
 

--- a/core/include/traccc/geometry/detector_type_list.hpp.in
+++ b/core/include/traccc/geometry/detector_type_list.hpp.in
@@ -1,0 +1,21 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "traccc/geometry/detector.hpp"
+
+// System include(s).
+#include <tuple>
+
+namespace traccc {
+
+/// Detector types supported by the built libraries.
+using detector_type_list = std::tuple<@TRACCC_DETECTOR_TYPES@>;
+
+}  // namespace traccc

--- a/core/include/traccc/geometry/host_detector.hpp
+++ b/core/include/traccc/geometry/host_detector.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/geometry/detector.hpp"
+#include "traccc/geometry/detector_type_list.hpp"
 #include "traccc/geometry/move_only_any.hpp"
 
 // Detray include(s).

--- a/device/sycl/src/finding/combinatorial_kalman_filter_algorithm.sycl
+++ b/device/sycl/src/finding/combinatorial_kalman_filter_algorithm.sycl
@@ -14,6 +14,7 @@
 
 // Project include(s).
 #include "traccc/bfield/magnetic_field_types.hpp"
+#include "traccc/geometry/detector_type_list.hpp"
 #include "traccc/utils/detector_buffer_bfield_visitor.hpp"
 #include "traccc/utils/propagation.hpp"
 
@@ -35,7 +36,7 @@ combinatorial_kalman_filter_algorithm::operator()(
 
     // Perform the track finding using the templated implementation.
     return detector_buffer_magnetic_field_visitor<
-        detector_type_list, sycl::bfield_type_list<scalar>>(
+        traccc::detector_type_list, sycl::bfield_type_list<scalar>>(
         detector, field,
         [&]<typename detector_t, typename bfield_view_t>(
             const typename detector_t::view& det, const bfield_view_t& bfield) {

--- a/device/sycl/src/utils/detector_types.hpp
+++ b/device/sycl/src/utils/detector_types.hpp
@@ -9,6 +9,7 @@
 
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/geometry/detector.hpp"
+#include "traccc/geometry/detector_type_list.hpp"
 
 namespace traccc::sycl {
 
@@ -18,18 +19,30 @@ namespace traccc::sycl {
  */
 struct default_detector_kernel_tag {};
 struct telescope_detector_kernel_tag {};
+struct odd_detector_kernel_tag {};
+struct itk_detector_kernel_tag {};
 
 template <typename T>
 struct detector_tag_selector {};
 
 template <>
-struct detector_tag_selector<default_detector> {
+struct detector_tag_selector<traccc::default_detector> {
     using type = default_detector_kernel_tag;
 };
 
 template <>
-struct detector_tag_selector<telescope_detector> {
+struct detector_tag_selector<traccc::telescope_detector> {
     using type = telescope_detector_kernel_tag;
+};
+
+template <>
+struct detector_tag_selector<traccc::odd_detector> {
+    using type = odd_detector_kernel_tag;
+};
+
+template <>
+struct detector_tag_selector<traccc::itk_detector> {
+    using type = itk_detector_kernel_tag;
 };
 
 template <typename T>
@@ -48,7 +61,7 @@ struct detector_tag_existance_validator<std::tuple<Ts...>> {
 };
 
 static_assert(
-    detector_tag_existance_validator<detector_type_list>::value,
+    detector_tag_existance_validator<traccc::detector_type_list>::value,
     "Not all detector types registered for SYCL have an accompanying tag");
 
 }  // namespace traccc::sycl

--- a/io/src/read_detector.cpp
+++ b/io/src/read_detector.cpp
@@ -59,8 +59,11 @@ void read_detector(host_detector& detector, vecmem::memory_resource& mr,
 
     // TODO: Update this
     if (header.detector == "Cylindrical detector from DD4hep blueprint") {
-        ::read_detector<default_detector>(detector, mr, geometry_file,
-                                          material_file, grid_file);
+        ::read_detector<odd_detector>(detector, mr, geometry_file,
+                                      material_file, grid_file);
+    } else if (header.detector == "detray_detector") {
+        ::read_detector<itk_detector>(detector, mr, geometry_file,
+                                      material_file, grid_file);
     } else {
         // TODO: Warning here
         ::read_detector<default_detector>(detector, mr, geometry_file,

--- a/io/src/read_detector_description.cpp
+++ b/io/src/read_detector_description.cpp
@@ -15,6 +15,7 @@
 
 // Detray include(s)
 #include <detray/geometry/tracking_surface.hpp>
+#include <detray/io/frontend/impl/json_readers.hpp>
 #include <detray/utils/type_registry.hpp>
 
 // VecMem include(s).
@@ -49,8 +50,8 @@ void read_json_dd_impl(traccc::silicon_detector_description::host& dd,
                        const traccc::digitization_config& digi)
     requires(traccc::is_detector_traits<detector_traits_t>)
 {
-    const traccc::default_detector::host& detector_host =
-        detector.as<traccc::default_detector>();
+    const typename detector_traits_t::host& detector_host =
+        detector.as<detector_traits_t>();
 
     // Iterate over the surfaces of the detector.
     const typename detector_traits_t::host::surface_lookup_container& surfaces =
@@ -118,8 +119,19 @@ void read_json_dd(traccc::silicon_detector_description::host& dd,
     traccc::host_detector detector;
     traccc::io::read_detector(detector, mr, geometry_file);
 
-    read_json_dd_impl<traccc::default_detector>(dd, detector, digi);
-    // detector_buffer_visitor
+    // TODO: Implement detector visitor!
+    // Peek at the header to determine the kind of detector that is needed
+    const auto header = detray::io::detail::deserialize_json_header(
+        traccc::io::get_absolute_path(geometry_file));
+
+    if (header.detector == "Cylindrical detector from DD4hep blueprint") {
+        read_json_dd_impl<traccc::odd_detector>(dd, detector, digi);
+    } else if (header.detector == "detray_detector") {
+        read_json_dd_impl<traccc::itk_detector>(dd, detector, digi);
+    } else {
+        // TODO: Warning here
+        read_json_dd_impl<traccc::default_detector>(dd, detector, digi);
+    }
 }
 
 }  // namespace


### PR DESCRIPTION
Build the ODD and ITk detectors with their custom metadata. Also remove the io roundtrip in the tests for the telescope and toy detector, since the custom metadata of the test detectors is already getting compiled and they do not need to be read into the default detector anymore