### PR TITLE
feat: update to detray v0.106.0

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/is_line_visitor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/is_line_visitor.hpp
@@ -10,6 +10,7 @@
 #include <detray/geometry/mask.hpp>
 #include <detray/geometry/shapes/line.hpp>
 #include <detray/geometry/surface.hpp>
+#include <detray/utils/type_registry.hpp>
 
 #include "traccc/definitions/qualifiers.hpp"
 
@@ -23,12 +24,12 @@ template <typename detector_t>
     using straw_tube = detray::mask<detray::line<false>, algebra_t>;
     using wire_cell = detray::mask<detray::line<true>, algebra_t>;
 
-    if constexpr (detector_t::masks::template is_defined<straw_tube>() ||
-                  detector_t::masks::template is_defined<wire_cell>()) {
+    using mask_registry_t = typename detector_t::masks;
+    if constexpr (detray::types::contains<mask_registry_t, straw_tube> ||
+                  detray::types::contains<mask_registry_t, wire_cell>) {
         return (sf.shape_id() ==
-                detector_t::masks::template get_id<straw_tube>()) ||
-               (sf.shape_id() ==
-                detector_t::masks::template get_id<wire_cell>());
+                detray::types::id<mask_registry_t, straw_tube>) ||
+               (sf.shape_id() == detray::types::id<mask_registry_t, wire_cell>);
     } else {
         return false;
     }

--- a/extern/detray/CMakeLists.txt
+++ b/extern/detray/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Detray as part of the TRACCC project" )
 
 # Declare where to get Detray from.
 set( TRACCC_DETRAY_SOURCE
-   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.105.1.tar.gz;URL_MD5;a9c1f5b6243ceaa4315fd7b25f2b4311"
+   "URL;https://github.com/acts-project/detray/archive/refs/tags/v0.106.0.tar.gz;URL_MD5;cf79d6936866a4d6e8b6cf3ee56b05a6"
    CACHE STRING "Source for Detray, when built as part of this project" )
 mark_as_advanced( TRACCC_DETRAY_SOURCE )
 FetchContent_Declare( Detray SYSTEM ${TRACCC_DETRAY_SOURCE} )

--- a/io/src/read_detector_description.cpp
+++ b/io/src/read_detector_description.cpp
@@ -15,6 +15,7 @@
 
 // Detray include(s)
 #include <detray/geometry/tracking_surface.hpp>
+#include <detray/utils/type_registry.hpp>
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -80,11 +81,15 @@ void read_json_dd_impl(traccc::silicon_detector_description::host& dd,
         dd.measurement_translation().back() = {0.f, 0.f};
         dd.subspace().back() = {0, 1};
 
+        // ITk specific type
         using annulus_t =
             detray::mask<detray::annulus2D, traccc::default_algebra>;
-        if (surface_desc.mask().id() ==
-            detector_traits_t::host::masks::template get_id<annulus_t>()) {
-            dd.subspace().back() = {1, 0};
+        using mask_registry_t = typename detector_traits_t::host::masks;
+        if constexpr (detray::types::contains<mask_registry_t, annulus_t>) {
+            if (surface_desc.mask().id() ==
+                detray::types::id<mask_registry_t, annulus_t>) {
+                dd.subspace().back() = {1, 0};
+            }
         }
 
         // Find the module's digitization configuration.


### PR DESCRIPTION
Fixes a bug in detray, where tracks that don't advance the track position because they are bouncing between overlaps get aborted eventually. The API changes come from the cleanup in the detray type registry, which allows compile time information about the detector type