### PR TITLE
ref: Use the pion hypothesis by default

### DIFF
--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -62,7 +62,7 @@ struct finding_config {
 
     /// Particle hypothesis
     traccc::pdg_particle<traccc::scalar> ptc_hypothesis =
-        traccc::muon<traccc::scalar>();
+        traccc::pion_plus<traccc::scalar>();
 
     /// Minimum track length in order for a track to be a candidate for
     /// duplicate removal.

--- a/core/include/traccc/fitting/fitting_config.hpp
+++ b/core/include/traccc/fitting/fitting_config.hpp
@@ -31,7 +31,7 @@ struct fitting_config {
 
     /// Particle hypothesis
     traccc::pdg_particle<traccc::scalar> ptc_hypothesis =
-        traccc::muon<traccc::scalar>();
+        traccc::pion_plus<traccc::scalar>();
 
     /// Smoothing with backward filter
     traccc::scalar covariance_inflation_factor = 1e3f;


### PR DESCRIPTION
This harmonizes the default particle hypothesis with ACTS