### PR TITLE
Avoid several copies into pageable CUDA memory

### DIFF
--- a/device/cuda/src/finding/combinatorial_kalman_filter.cuh
+++ b/device/cuda/src/finding/combinatorial_kalman_filter.cuh
@@ -118,7 +118,8 @@ combinatorial_kalman_filter(
      * Measurement Operations
      *****************************************************************/
 
-    const auto n_measurements = copy.get_size(measurements_view);
+    const auto n_measurements =
+        get_size(measurements_view, size_staging_ptr.get(), stream);
 
     // Access the detector view as a detector object
     detector_t device_det(det);

--- a/device/cuda/src/seeding/seed_finding.cu
+++ b/device/cuda/src/seeding/seed_finding.cu
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "../utils/cuda_error_handling.hpp"
+#include "../utils/get_size.hpp"
 #include "../utils/global_index.hpp"
 #include "../utils/utils.hpp"
 #include "traccc/cuda/seeding/details/seed_finding.hpp"
@@ -183,7 +184,9 @@ edm::seed_collection::buffer seed_finding::operator()(
     vecmem::data::vector_buffer sp_grid_prefix_sum_buff =
         make_prefix_sum_buff(grid_sizes, m_copy, m_mr, m_stream);
 
-    const auto num_spacepoints = m_copy.get_size(sp_grid_prefix_sum_buff);
+    const auto num_spacepoints =
+        get_size(sp_grid_prefix_sum_buff, size_staging_ptr.get(), stream);
+
     if (num_spacepoints == 0) {
         return {0, m_mr.main};
     }

--- a/device/cuda/src/seeding/spacepoint_formation_algorithm.cu
+++ b/device/cuda/src/seeding/spacepoint_formation_algorithm.cu
@@ -51,7 +51,8 @@ edm::spacepoint_collection::buffer spacepoint_formation_algorithm::operator()(
         vecmem::make_unique_alloc<unsigned int>(*(m_mr.host));
 
     // Get the number of measurements.
-    const auto num_measurements = m_copy.get().get_size(measurements_view);
+    const auto num_measurements =
+        get_size(measurements_view, size_staging_ptr.get(), stream);
 
     // Create the result buffer.
     edm::spacepoint_collection::buffer spacepoints(


### PR DESCRIPTION
This commit replaces some of our copies (particularly through vecmem's `get_size` function) into pageable memory by copies into pinned memory. This provides a roughly 10% throughput increase.