### PR TITLE
Cell Sorting, main branch (2026.02.20.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2025 CERN for the benefit of the ACTS project
+# (c) 2021-2026 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -78,6 +78,8 @@ traccc_add_library( traccc_core core TYPE SHARED
   "src/clusterization/measurement_sorting_algorithm.cpp"
   "include/traccc/clusterization/clusterization_algorithm.hpp"
   "src/clusterization/clusterization_algorithm.cpp"
+  "include/traccc/clusterization/silicon_cell_sorting_algorithm.hpp"
+  "src/clusterization/silicon_cell_sorting_algorithm.cpp"
   # Finding algorithmic code
   "include/traccc/finding/candidate_link.hpp"
   "include/traccc/finding/finding_config.hpp"

--- a/core/include/traccc/clusterization/silicon_cell_sorting_algorithm.hpp
+++ b/core/include/traccc/clusterization/silicon_cell_sorting_algorithm.hpp
@@ -1,0 +1,59 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Library include(s).
+#include "traccc/edm/silicon_cell_collection.hpp"
+#include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/messaging.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/memory_resource.hpp>
+
+// System include(s).
+#include <functional>
+#include <memory>
+
+namespace traccc::host {
+
+/// Algorithm sorting the detector cell information
+///
+/// Clusterization algorithms may (and do) rely on cells being "strictly
+/// sorted". This algorithm can be used to make sure that this would be the
+/// case.
+///
+class silicon_cell_sorting_algorithm
+    : public algorithm<edm::silicon_cell_collection::host(
+          const edm::silicon_cell_collection::const_view&)>,
+      public messaging {
+
+    public:
+    /// Constructor
+    ///
+    /// @param mr The memory resource to use for the algorithm
+    /// @param logger The logger to use for the algorithm
+    ///
+    silicon_cell_sorting_algorithm(
+        vecmem::memory_resource& mr,
+        std::unique_ptr<const Logger> logger = getDummyLogger().clone());
+
+    /// Callable operator performing the sorting on a container
+    ///
+    /// @param cells The cells to sort
+    /// @return The sorted cells
+    ///
+    output_type operator()(
+        const edm::silicon_cell_collection::const_view& cells) const override;
+
+    private:
+    /// The memory resource to use
+    std::reference_wrapper<vecmem::memory_resource> m_mr;
+
+};  // class silicon_cell_sorting_algorithm
+
+}  // namespace traccc::host

--- a/core/src/clusterization/silicon_cell_sorting_algorithm.cpp
+++ b/core/src/clusterization/silicon_cell_sorting_algorithm.cpp
@@ -1,0 +1,48 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Library include(s).
+#include "traccc/clusterization/silicon_cell_sorting_algorithm.hpp"
+
+// System include(s).
+#include <algorithm>
+#include <numeric>
+
+namespace traccc::host {
+
+silicon_cell_sorting_algorithm::silicon_cell_sorting_algorithm(
+    vecmem::memory_resource& mr, std::unique_ptr<const Logger> logger)
+    : messaging(std::move(logger)), m_mr(mr) {}
+
+silicon_cell_sorting_algorithm::output_type
+silicon_cell_sorting_algorithm::operator()(
+    const edm::silicon_cell_collection::const_view& cells_view) const {
+
+    // Create a device container on top of the view.
+    const edm::silicon_cell_collection::const_device cells{cells_view};
+
+    // Create a vector of cell indices, which would be sorted.
+    vecmem::vector<unsigned int> indices(cells.size(), &(m_mr.get()));
+    std::iota(indices.begin(), indices.end(), 0u);
+
+    // Sort the indices according to the cells.
+    std::sort(indices.begin(), indices.end(),
+              [&](unsigned int lhs, unsigned int rhs) {
+                  return cells.at(lhs) < cells.at(rhs);
+              });
+
+    // Fill an output container with the sorted cells.
+    edm::silicon_cell_collection::host result{m_mr.get()};
+    for (unsigned int i : indices) {
+        result.push_back(cells.at(i));
+    }
+
+    // Return the sorted cells.
+    return result;
+}
+
+}  // namespace traccc::host

--- a/device/alpaka/CMakeLists.txt
+++ b/device/alpaka/CMakeLists.txt
@@ -44,6 +44,8 @@ traccc_add_alpaka_library( traccc_alpaka alpaka TYPE SHARED
   "src/clusterization/clusterization_algorithm.cpp"
   "include/traccc/alpaka/clusterization/measurement_sorting_algorithm.hpp"
   "src/clusterization/measurement_sorting_algorithm.cpp"
+  "include/traccc/alpaka/clusterization/silicon_cell_sorting_algorithm.hpp"
+  "src/clusterization/silicon_cell_sorting_algorithm.cpp"
   # Seeding code
   "include/traccc/alpaka/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp"
   "src/seeding/silicon_pixel_spacepoint_formation_algorithm.cpp"

--- a/device/alpaka/include/traccc/alpaka/clusterization/silicon_cell_sorting_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/clusterization/silicon_cell_sorting_algorithm.hpp
@@ -1,0 +1,58 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "traccc/alpaka/utils/algorithm_base.hpp"
+
+// Project include(s).
+#include "traccc/device/algorithm_base.hpp"
+#include "traccc/edm/silicon_cell_collection.hpp"
+#include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/messaging.hpp"
+
+namespace traccc::alpaka {
+
+/// Algorithm sorting the detector cell information
+///
+/// Clusterization algorithms may (and do) rely on cells being "strictly
+/// sorted". This algorithm can be used to make sure that this would be the
+/// case.
+///
+class silicon_cell_sorting_algorithm
+    : public algorithm<edm::silicon_cell_collection::buffer(
+          const edm::silicon_cell_collection::const_view&)>,
+      device::algorithm_base,
+      alpaka::algorithm_base,
+      public messaging {
+
+    public:
+    /// Constructor for the algorithm
+    ///
+    /// @param mr The memory resource(s) to use in the algorithm
+    /// @param copy The copy object to use for copying data between device
+    ///             and host memory blocks
+    /// @param q The Alpaka queue to perform the operations in
+    /// @param config The clustering configuration
+    ///
+    silicon_cell_sorting_algorithm(
+        const traccc::memory_resource& mr, ::vecmem::copy& copy,
+        alpaka::queue& q,
+        std::unique_ptr<const Logger> logger = getDummyLogger().clone());
+
+    /// Callable operator performing the sorting on a container
+    ///
+    /// @param cells The cells to sort
+    /// @return The sorted cells
+    ///
+    output_type operator()(
+        const edm::silicon_cell_collection::const_view& cells) const override;
+
+};  // class silicon_cell_sorting_algorithm
+
+}  // namespace traccc::alpaka

--- a/device/alpaka/src/clusterization/silicon_cell_sorting_algorithm.cpp
+++ b/device/alpaka/src/clusterization/silicon_cell_sorting_algorithm.cpp
@@ -1,0 +1,109 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "traccc/alpaka/clusterization/silicon_cell_sorting_algorithm.hpp"
+
+#include "../utils/get_queue.hpp"
+#include "../utils/parallel_algorithms.hpp"
+#include "../utils/thread_id.hpp"
+
+// Project include(s).
+#include "traccc/clusterization/device/silicon_cell_sorter.hpp"
+#include "traccc/clusterization/device/sorting_index_filler.hpp"
+
+namespace traccc::alpaka {
+namespace kernels {
+
+/// Kernel filling the output buffer with sorted cells.
+struct fill_sorted_silicon_cells {
+    /// @param[in] acc Alpaka accelerator object
+    /// @param[in] input_view View of the input cells
+    /// @param[out] output_view View of the output cells
+    /// @param[in] sorted_indices_view View of the sorted cell indices
+    ///
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        const edm::silicon_cell_collection::const_view input_view,
+        edm::silicon_cell_collection::view output_view,
+        const vecmem::data::vector_view<const unsigned int> sorted_indices_view)
+        const {
+
+        // Create the device objects.
+        const edm::silicon_cell_collection::const_device input{input_view};
+        edm::silicon_cell_collection::device output{output_view};
+        const vecmem::device_vector<const unsigned int> sorted_indices{
+            sorted_indices_view};
+
+        // Stop early if we can.
+        const unsigned int index = details::thread_id1{acc}.getGlobalThreadId();
+        if (index >= input.size()) {
+            return;
+        }
+
+        // Copy one measurement into the correct position.
+        output.at(index) = input.at(sorted_indices.at(index));
+    }
+};  // struct fill_sorted_silicon_cells
+
+}  // namespace kernels
+
+silicon_cell_sorting_algorithm::silicon_cell_sorting_algorithm(
+    const traccc::memory_resource& mr, vecmem::copy& copy, alpaka::queue& q,
+    std::unique_ptr<const Logger> logger)
+    : device::algorithm_base(mr, copy),
+      alpaka::algorithm_base(q),
+      messaging(std::move(logger)) {}
+
+auto silicon_cell_sorting_algorithm::operator()(
+    const edm::silicon_cell_collection::const_view& cells_view) const
+    -> output_type {
+
+    // Exit early if there are no cells.
+    if (cells_view.capacity() == 0) {
+        return {};
+    }
+
+    // Get a convenience variable for the queue that we'll be using.
+    auto& aqueue = details::get_queue(queue());
+
+    // Create a vector of cell indices, which would be sorted.
+    vecmem::data::vector_buffer<unsigned int> indices(cells_view.capacity(),
+                                                      mr().main);
+    copy().setup(indices)->wait();
+    details::for_each(aqueue, mr(), indices.ptr(),
+                      indices.ptr() + indices.capacity(),
+                      device::sorting_index_filler{indices});
+
+    // Sort the indices according to the (correct) order of the cells.
+    details::sort(aqueue, mr(), indices.ptr(),
+                  indices.ptr() + indices.capacity(),
+                  device::silicon_cell_sorter{cells_view});
+
+    // Create the output buffer.
+    output_type result{cells_view.capacity(), mr().main,
+                       cells_view.size().capacity()
+                           ? vecmem::data::buffer_type::resizable
+                           : vecmem::data::buffer_type::fixed_size};
+    copy().setup(result)->ignore();
+    copy()(cells_view.size(), result.size())->ignore();
+
+    // Fill it with the sorted cells.
+    const unsigned int BLOCK_SIZE = warp_size() * 8;
+    const unsigned int n_blocks =
+        (cells_view.capacity() + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    auto workDiv = makeWorkDiv<Acc>(BLOCK_SIZE, n_blocks);
+    ::alpaka::exec<Acc>(aqueue, workDiv, kernels::fill_sorted_silicon_cells{},
+                        cells_view, vecmem::get_data(result),
+                        vecmem::get_data(indices));
+
+    // Return the sorted buffer.
+    return result;
+}
+
+}  // namespace traccc::alpaka

--- a/device/common/CMakeLists.txt
+++ b/device/common/CMakeLists.txt
@@ -34,6 +34,7 @@ traccc_add_library( traccc_device_common device_common
    "include/traccc/clusterization/device/barcode_based_sorter.hpp"
    "include/traccc/clusterization/device/ccl_kernel_definitions.hpp"
    "include/traccc/clusterization/device/ccl_kernel.hpp"
+   "include/traccc/clusterization/device/silicon_cell_sorter.hpp"
    "include/traccc/clusterization/device/sorting_index_filler.hpp"
    "include/traccc/clusterization/device/clusterization_algorithm.hpp"
    "src/clusterization/clusterization_algorithm.cpp"

--- a/device/common/include/traccc/clusterization/device/silicon_cell_sorter.hpp
+++ b/device/common/include/traccc/clusterization/device/silicon_cell_sorter.hpp
@@ -1,0 +1,51 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/silicon_cell_collection.hpp"
+
+namespace traccc::device {
+
+/// Functor to help with sorting cells on a device
+class silicon_cell_sorter {
+
+    public:
+    /// Constructor, capturing the silicon cells to sort indices by
+    silicon_cell_sorter(const edm::silicon_cell_collection::const_view& cells)
+        : m_cells(cells) {}
+
+    /// Index comparison operator
+    ///
+    /// The logic is a bit convoluted here. :-( The index sequence/vector that
+    /// we sort may be larger than the cell collection. (Whenever we are dealing
+    /// with resizable cell collections. Which may happen sometimes.) In this
+    /// case the behaviour should be that for the non-existent cells the indices
+    /// should be left unchanged. Which the following logic should do...
+    ///
+    TRACCC_HOST_DEVICE bool operator()(unsigned int lhs,
+                                       unsigned int rhs) const {
+
+        const edm::silicon_cell_collection::const_device cells{m_cells};
+        if (lhs >= cells.size()) {
+            return false;
+        }
+        if (rhs >= cells.size()) {
+            return true;
+        }
+        return cells.at(lhs) < cells.at(rhs);
+    }
+
+    private:
+    /// The cells to sort indices by
+    edm::silicon_cell_collection::const_view m_cells;
+
+};  // class silicon_cell_sorter
+
+}  // namespace traccc::device

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -51,6 +51,8 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/clusterization/clusterization_algorithm.cu"
   "include/traccc/cuda/clusterization/measurement_sorting_algorithm.hpp"
   "src/clusterization/measurement_sorting_algorithm.cu"
+  "include/traccc/cuda/clusterization/silicon_cell_sorting_algorithm.hpp"
+  "src/clusterization/silicon_cell_sorting_algorithm.cu"
   "src/clusterization/kernels/ccl_kernel.cu"
   "src/clusterization/kernels/ccl_kernel.cuh"
   "src/clusterization/kernels/reify_cluster_data.cu"

--- a/device/cuda/include/traccc/cuda/clusterization/silicon_cell_sorting_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/clusterization/silicon_cell_sorting_algorithm.hpp
@@ -1,0 +1,58 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "traccc/cuda/utils/algorithm_base.hpp"
+
+// Project include(s).
+#include "traccc/device/algorithm_base.hpp"
+#include "traccc/edm/silicon_cell_collection.hpp"
+#include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/messaging.hpp"
+
+namespace traccc::cuda {
+
+/// Algorithm sorting the detector cell information
+///
+/// Clusterization algorithms may (and do) rely on cells being "strictly
+/// sorted". This algorithm can be used to make sure that this would be the
+/// case.
+///
+class silicon_cell_sorting_algorithm
+    : public algorithm<edm::silicon_cell_collection::buffer(
+          const edm::silicon_cell_collection::const_view&)>,
+      device::algorithm_base,
+      cuda::algorithm_base,
+      public messaging {
+
+    public:
+    /// Constructor for the algorithm
+    ///
+    /// @param mr The memory resource(s) to use in the algorithm
+    /// @param copy The copy object to use for copying data between device
+    ///             and host memory blocks
+    /// @param str The CUDA stream to perform the operations in
+    /// @param config The clustering configuration
+    ///
+    silicon_cell_sorting_algorithm(
+        const traccc::memory_resource& mr, ::vecmem::copy& copy,
+        cuda::stream& str,
+        std::unique_ptr<const Logger> logger = getDummyLogger().clone());
+
+    /// Callable operator performing the sorting on a container
+    ///
+    /// @param cells The cells to sort
+    /// @return The sorted cells
+    ///
+    output_type operator()(
+        const edm::silicon_cell_collection::const_view& cells) const override;
+
+};  // class silicon_cell_sorting_algorithm
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/clusterization/silicon_cell_sorting_algorithm.cu
+++ b/device/cuda/src/clusterization/silicon_cell_sorting_algorithm.cu
@@ -1,0 +1,108 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../utils/cuda_error_handling.hpp"
+#include "../utils/thread_id.hpp"
+#include "../utils/utils.hpp"
+#include "traccc/cuda/clusterization/silicon_cell_sorting_algorithm.hpp"
+
+// Project include(s).
+#include "traccc/clusterization/device/silicon_cell_sorter.hpp"
+#include "traccc/clusterization/device/sorting_index_filler.hpp"
+
+// Thrust include(s).
+#include <thrust/for_each.h>
+#include <thrust/sort.h>
+
+namespace traccc::cuda {
+namespace kernels {
+
+/// Kernel filling the output buffer with sorted cells.
+///
+/// @param[in] input_view View of the input cells
+/// @param[out] output_view View of the output cells
+/// @param[in] sorted_indices_view View of the sorted cell indices
+///
+__global__ void fill_sorted_silicon_cells(
+    const edm::silicon_cell_collection::const_view input_view,
+    edm::silicon_cell_collection::view output_view,
+    const vecmem::data::vector_view<const unsigned int> sorted_indices_view) {
+
+    // Create the device objects.
+    const edm::silicon_cell_collection::const_device input{input_view};
+    edm::silicon_cell_collection::device output{output_view};
+    const vecmem::device_vector<const unsigned int> sorted_indices{
+        sorted_indices_view};
+
+    // Stop early if we can.
+    const unsigned int index = details::thread_id1{}.getGlobalThreadId();
+    if (index >= input.size()) {
+        return;
+    }
+
+    // Copy one measurement into the correct position.
+    output.at(index) = input.at(sorted_indices.at(index));
+}
+
+}  // namespace kernels
+
+silicon_cell_sorting_algorithm::silicon_cell_sorting_algorithm(
+    const traccc::memory_resource& mr, vecmem::copy& copy, cuda::stream& str,
+    std::unique_ptr<const Logger> logger)
+    : device::algorithm_base(mr, copy),
+      cuda::algorithm_base(str),
+      messaging(std::move(logger)) {}
+
+auto silicon_cell_sorting_algorithm::operator()(
+    const edm::silicon_cell_collection::const_view& cells_view) const
+    -> output_type {
+
+    // Exit early if there are no cells.
+    if (cells_view.capacity() == 0) {
+        return {};
+    }
+
+    // Get a convenience variable for the stream that we'll be using.
+    cudaStream_t cstream = details::get_stream(stream());
+    // Set up the Thrust execution policy.
+    auto policy =
+        thrust::cuda::par_nosync(std::pmr::polymorphic_allocator(&(mr().main)))
+            .on(cstream);
+
+    // Create a vector of cell indices, which would be sorted.
+    vecmem::data::vector_buffer<unsigned int> indices(cells_view.capacity(),
+                                                      mr().main);
+    copy().setup(indices)->wait();
+    thrust::for_each(policy, indices.ptr(), indices.ptr() + indices.capacity(),
+                     device::sorting_index_filler{indices});
+
+    // Sort the indices according to the (correct) order of the cells.
+    thrust::sort(policy, indices.ptr(), indices.ptr() + indices.capacity(),
+                 device::silicon_cell_sorter{cells_view});
+
+    // Create the output buffer.
+    output_type result{cells_view.capacity(), mr().main,
+                       cells_view.size().capacity()
+                           ? vecmem::data::buffer_type::resizable
+                           : vecmem::data::buffer_type::fixed_size};
+    copy().setup(result)->ignore();
+    copy()(cells_view.size(), result.size())->ignore();
+
+    // Fill it with the sorted cells.
+    const unsigned int BLOCK_SIZE = warp_size() * 8;
+    const unsigned int n_blocks =
+        (cells_view.capacity() + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    kernels::fill_sorted_silicon_cells<<<n_blocks, BLOCK_SIZE, 0, cstream>>>(
+        cells_view, result, indices);
+    TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+
+    // Return the sorted buffer.
+    return result;
+}
+
+}  // namespace traccc::cuda

--- a/device/sycl/CMakeLists.txt
+++ b/device/sycl/CMakeLists.txt
@@ -18,6 +18,8 @@ traccc_add_library( traccc_sycl sycl TYPE SHARED
   "src/clusterization/clusterization_algorithm.sycl"
   "include/traccc/sycl/clusterization/measurement_sorting_algorithm.hpp"
   "src/clusterization/measurement_sorting_algorithm.sycl"
+  "include/traccc/sycl/clusterization/silicon_cell_sorting_algorithm.hpp"
+  "src/clusterization/silicon_cell_sorting_algorithm.sycl"
   # Seeding algorithm(s).
   "include/traccc/sycl/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp"
   "src/seeding/silicon_pixel_spacepoint_formation_algorithm.sycl"

--- a/device/sycl/include/traccc/sycl/clusterization/silicon_cell_sorting_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/silicon_cell_sorting_algorithm.hpp
@@ -1,0 +1,58 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "traccc/sycl/utils/algorithm_base.hpp"
+
+// Project include(s).
+#include "traccc/device/algorithm_base.hpp"
+#include "traccc/edm/silicon_cell_collection.hpp"
+#include "traccc/utils/algorithm.hpp"
+#include "traccc/utils/messaging.hpp"
+
+namespace traccc::sycl {
+
+/// Algorithm sorting the detector cell information
+///
+/// Clusterization algorithms may (and do) rely on cells being "strictly
+/// sorted". This algorithm can be used to make sure that this would be the
+/// case.
+///
+class silicon_cell_sorting_algorithm
+    : public algorithm<edm::silicon_cell_collection::buffer(
+          const edm::silicon_cell_collection::const_view&)>,
+      device::algorithm_base,
+      sycl::algorithm_base,
+      public messaging {
+
+    public:
+    /// Constructor for the algorithm
+    ///
+    /// @param mr The memory resource(s) to use in the algorithm
+    /// @param copy The copy object to use for copying data between device
+    ///             and host memory blocks
+    /// @param q The SYCL queue to perform the operations in
+    /// @param config The clustering configuration
+    ///
+    silicon_cell_sorting_algorithm(
+        const traccc::memory_resource& mr, ::vecmem::copy& copy,
+        sycl::queue_wrapper& q,
+        std::unique_ptr<const Logger> logger = getDummyLogger().clone());
+
+    /// Callable operator performing the sorting on a container
+    ///
+    /// @param cells The cells to sort
+    /// @return The sorted cells
+    ///
+    output_type operator()(
+        const edm::silicon_cell_collection::const_view& cells) const override;
+
+};  // class silicon_cell_sorting_algorithm
+
+}  // namespace traccc::sycl

--- a/device/sycl/src/clusterization/silicon_cell_sorting_algorithm.sycl
+++ b/device/sycl/src/clusterization/silicon_cell_sorting_algorithm.sycl
@@ -1,0 +1,100 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../utils/calculate1DimNdRange.hpp"
+#include "../utils/get_queue.hpp"
+#include "../utils/oneDPL.hpp"
+#include "traccc/sycl/clusterization/silicon_cell_sorting_algorithm.hpp"
+
+// Project include(s).
+#include "traccc/clusterization/device/silicon_cell_sorter.hpp"
+#include "traccc/clusterization/device/sorting_index_filler.hpp"
+
+namespace traccc::sycl {
+namespace kernels {
+
+/// Kernel filling the output buffer with sorted cells.
+struct fill_sorted_silicon_cells {};
+
+}  // namespace kernels
+
+silicon_cell_sorting_algorithm::silicon_cell_sorting_algorithm(
+    const traccc::memory_resource& mr, vecmem::copy& copy,
+    sycl::queue_wrapper& q, std::unique_ptr<const Logger> logger)
+    : device::algorithm_base(mr, copy),
+      sycl::algorithm_base(q),
+      messaging(std::move(logger)) {}
+
+auto silicon_cell_sorting_algorithm::operator()(
+    const edm::silicon_cell_collection::const_view& cells_view) const
+    -> output_type {
+
+    // Exit early if there are no cells.
+    if (cells_view.capacity() == 0) {
+        return {};
+    }
+
+    // Get the SYCL queue to use for the algorithm.
+    ::sycl::queue& squeue = details::get_queue(queue());
+
+    // oneDPL policy to use, forcing execution onto the same device that the
+    // hand-written kernels would run on.
+    auto policy = oneapi::dpl::execution::device_policy{squeue};
+
+    // Create a vector of cell indices, which would be sorted.
+    vecmem::data::vector_buffer<unsigned int> indices(cells_view.capacity(),
+                                                      mr().main);
+    copy().setup(indices)->wait();
+    oneapi::dpl::for_each(policy, indices.ptr(),
+                          indices.ptr() + indices.capacity(),
+                          device::sorting_index_filler{indices});
+
+    // Sort the indices according to the (correct) order of the cells.
+    oneapi::dpl::sort(policy, indices.ptr(), indices.ptr() + indices.capacity(),
+                      device::silicon_cell_sorter{cells_view});
+
+    // Create the output buffer.
+    output_type result{cells_view.capacity(), mr().main,
+                       cells_view.size().capacity()
+                           ? vecmem::data::buffer_type::resizable
+                           : vecmem::data::buffer_type::fixed_size};
+    copy().setup(result)->ignore();
+    copy()(cells_view.size(), result.size())->ignore();
+
+    // Fill it with the sorted cells.
+    const unsigned int BLOCK_SIZE = warp_size() * 8;
+    squeue.submit([&](::sycl::handler& h) {
+        h.parallel_for<kernels::fill_sorted_silicon_cells>(
+            details::calculate1DimNdRange(cells_view.capacity(), BLOCK_SIZE),
+            [input_view = cells_view, output_view = vecmem::get_data(result),
+             sorted_indices_view =
+                 vecmem::get_data(indices)](::sycl::nd_item<1> item) {
+                // Create the device objects.
+                const edm::silicon_cell_collection::const_device input{
+                    input_view};
+                edm::silicon_cell_collection::device output{output_view};
+                const vecmem::device_vector<const unsigned int> sorted_indices{
+                    sorted_indices_view};
+
+                // Stop early if we can.
+                const unsigned int index =
+                    static_cast<unsigned int>(item.get_global_id(0));
+                if (index >= input.size()) {
+                    return;
+                }
+
+                // Copy one measurement into the correct position.
+                output.at(index) = input.at(sorted_indices.at(index));
+            });
+    });
+
+    // Return the sorted buffer.
+    return result;
+}
+
+}  // namespace traccc::sycl

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -43,9 +43,13 @@ full_chain_algorithm::full_chain_algorithm(
               m_det_descr.get().size()),
           m_vecmem_objects.device_mr()),
       m_detector(detector),
+      m_cell_sorting({m_cached_device_mr, &m_cached_pinned_host_mr},
+                     m_vecmem_objects.async_copy(), m_queue,
+                     logger->cloneWithSuffix("CellSortingAlg")),
       m_clusterization({m_cached_device_mr, &m_cached_pinned_host_mr},
                        m_vecmem_objects.async_copy(), m_queue,
-                       clustering_config),
+                       clustering_config,
+                       logger->cloneWithSuffix("ClusteringAlg")),
       m_measurement_sorting({m_cached_device_mr, &m_cached_pinned_host_mr},
                             m_vecmem_objects.async_copy(), m_queue,
                             logger->cloneWithSuffix("MeasSortingAlg")),
@@ -103,9 +107,13 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
               m_det_descr.get().size()),
           m_vecmem_objects.device_mr()),
       m_detector(parent.m_detector),
+      m_cell_sorting({m_cached_device_mr, &m_cached_pinned_host_mr},
+                     m_vecmem_objects.async_copy(), m_queue,
+                     parent.logger().cloneWithSuffix("CellSortingAlg")),
       m_clusterization({m_cached_device_mr, &m_cached_pinned_host_mr},
                        m_vecmem_objects.async_copy(), m_queue,
-                       parent.m_clustering_config),
+                       parent.m_clustering_config,
+                       parent.logger().cloneWithSuffix("ClusteringAlg")),
       m_measurement_sorting({m_cached_device_mr, &m_cached_pinned_host_mr},
                             m_vecmem_objects.async_copy(), m_queue,
                             parent.logger().cloneWithSuffix("MeasSortingAlg")),
@@ -161,8 +169,9 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
         ->ignore();
 
     // Run the clusterization (asynchronously).
+    const auto sorted_cells = m_cell_sorting(cells_buffer);
     const auto unsorted_measurements =
-        m_clusterization(cells_buffer, m_device_det_descr);
+        m_clusterization(sorted_cells, m_device_det_descr);
     const measurement_sorting_algorithm::output_type measurements =
         m_measurement_sorting(unsorted_measurements);
 
@@ -218,8 +227,9 @@ bound_track_parameters_collection_types::host full_chain_algorithm::seeding(
         ->ignore();
 
     // Run the clusterization (asynchronously).
+    const auto sorted_cells = m_cell_sorting(cells_buffer);
     const auto unsorted_measurements =
-        m_clusterization(cells_buffer, m_device_det_descr);
+        m_clusterization(sorted_cells, m_device_det_descr);
     const measurement_sorting_algorithm::output_type measurements =
         m_measurement_sorting(unsorted_measurements);
 

--- a/examples/run/alpaka/full_chain_algorithm.hpp
+++ b/examples/run/alpaka/full_chain_algorithm.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "traccc/alpaka/clusterization/clusterization_algorithm.hpp"
 #include "traccc/alpaka/clusterization/measurement_sorting_algorithm.hpp"
+#include "traccc/alpaka/clusterization/silicon_cell_sorting_algorithm.hpp"
 #include "traccc/alpaka/finding/combinatorial_kalman_filter_algorithm.hpp"
 #include "traccc/alpaka/fitting/kalman_fitting_algorithm.hpp"
 #include "traccc/alpaka/seeding/seed_parameter_estimation_algorithm.hpp"
@@ -146,6 +147,8 @@ class full_chain_algorithm
     /// @name Sub-algorithms used by this full-chain algorithm
     /// @{
 
+    /// Cell sorting algorithm
+    silicon_cell_sorting_algorithm m_cell_sorting;
     /// Clusterization algorithm
     clusterization_algorithm m_clusterization;
     /// Measurement sorting algorithm

--- a/examples/run/common/throughput_mt.ipp
+++ b/examples/run/common/throughput_mt.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -134,10 +134,11 @@ int throughput_mt(std::string_view description, int argc, char* argv[]) {
                 for (std::size_t event = event_range.begin();
                      event != event_range.end(); ++event) {
                     static constexpr bool DEDUPLICATE = true;
+                    static constexpr bool RANDOMIZE = true;
                     io::read_cells(input.at(event - input_opts.skip), event,
                                    input_opts.directory, logger().clone(),
                                    &det_descr, input_opts.format, DEDUPLICATE,
-                                   input_opts.use_acts_geom_source);
+                                   input_opts.use_acts_geom_source, RANDOMIZE);
                 }
             });
     }

--- a/examples/run/common/throughput_st.ipp
+++ b/examples/run/common/throughput_st.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -114,9 +114,11 @@ int throughput_st(std::string_view description, int argc, char* argv[]) {
              i < input_opts.skip + input_opts.events; ++i) {
             input.emplace_back(host_mr);
             static constexpr bool DEDUPLICATE = true;
+            static constexpr bool RANDOMIZE = true;
             io::read_cells(input.back(), i, input_opts.directory,
                            logger().clone(), &det_descr, input_opts.format,
-                           DEDUPLICATE, input_opts.use_acts_geom_source);
+                           DEDUPLICATE, input_opts.use_acts_geom_source,
+                           RANDOMIZE);
         }
     }
 

--- a/examples/run/cuda/full_chain_algorithm.hpp
+++ b/examples/run/cuda/full_chain_algorithm.hpp
@@ -11,6 +11,7 @@
 #include "traccc/clusterization/clustering_config.hpp"
 #include "traccc/cuda/clusterization/clusterization_algorithm.hpp"
 #include "traccc/cuda/clusterization/measurement_sorting_algorithm.hpp"
+#include "traccc/cuda/clusterization/silicon_cell_sorting_algorithm.hpp"
 #include "traccc/cuda/finding/combinatorial_kalman_filter_algorithm.hpp"
 #include "traccc/cuda/fitting/kalman_fitting_algorithm.hpp"
 #include "traccc/cuda/seeding/seed_parameter_estimation_algorithm.hpp"
@@ -146,6 +147,8 @@ class full_chain_algorithm
     /// @name Sub-algorithms used by this full-chain algorithm
     /// @{
 
+    /// Cell sorting algorithm
+    silicon_cell_sorting_algorithm m_cell_sorting;
     /// Clusterization algorithm
     clusterization_algorithm m_clusterization;
     /// Measurement sorting algorithm

--- a/examples/run/sycl/full_chain_algorithm.hpp
+++ b/examples/run/sycl/full_chain_algorithm.hpp
@@ -16,6 +16,7 @@
 #include "traccc/geometry/silicon_detector_description.hpp"
 #include "traccc/sycl/clusterization/clusterization_algorithm.hpp"
 #include "traccc/sycl/clusterization/measurement_sorting_algorithm.hpp"
+#include "traccc/sycl/clusterization/silicon_cell_sorting_algorithm.hpp"
 #include "traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp"
 #include "traccc/sycl/fitting/kalman_fitting_algorithm.hpp"
 #include "traccc/sycl/seeding/seed_parameter_estimation_algorithm.hpp"
@@ -148,6 +149,8 @@ class full_chain_algorithm
     /// @name Sub-algorithms used by this full-chain algorithm
     /// @{
 
+    /// Cell sorting algorithm
+    silicon_cell_sorting_algorithm m_cell_sorting;
     /// Clusterization algorithm
     clusterization_algorithm m_clusterization;
     /// Measurement sorting algorithm

--- a/io/include/traccc/io/read_cells.hpp
+++ b/io/include/traccc/io/read_cells.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -35,13 +35,14 @@ namespace traccc::io {
 /// @param[in]  use_acts_geometry_id Whether to treat the geometry ID as an
 ///                                  "Acts geometry ID", or a
 ///                                  "Detray geometry ID"
+/// @param[in]  randomize    Whether to randomize the order of the cells or not
 ///
 void read_cells(edm::silicon_cell_collection::host& cells, std::size_t event,
                 std::string_view directory,
                 std::unique_ptr<const Logger> logger = getDummyLogger().clone(),
                 const silicon_detector_description::host* dd = nullptr,
                 data_format format = data_format::csv, bool deduplicate = true,
-                bool use_acts_geometry_id = true);
+                bool use_acts_geometry_id = true, bool randomize = false);
 
 /// Read cell data into memory
 ///
@@ -55,12 +56,13 @@ void read_cells(edm::silicon_cell_collection::host& cells, std::size_t event,
 /// @param[in]  use_acts_geometry_id Whether to treat the geometry ID as an
 ///                                  "Acts geometry ID", or a
 ///                                  "Detray geometry ID"
+/// @param[in]  randomize    Whether to randomize the order of the cells or not
 ///
 void read_cells(edm::silicon_cell_collection::host& cells,
                 std::string_view filename,
                 std::unique_ptr<const Logger> logger = getDummyLogger().clone(),
                 const silicon_detector_description::host* dd = nullptr,
                 data_format format = data_format::csv, bool deduplicate = true,
-                bool use_acts_geometry_id = true);
+                bool use_acts_geometry_id = true, bool randomize = false);
 
 }  // namespace traccc::io

--- a/io/src/csv/read_cells.hpp
+++ b/io/src/csv/read_cells.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -26,11 +26,14 @@ namespace traccc::io::csv {
 /// @param[in]  use_acts_geometry_id Whether to treat the geometry ID as an
 ///                                  "Acts geometry ID", or a
 ///                                  "Detray geometry ID"
+/// @param[in]  randomize    Whether to randomize the order of the cells or not
+///
 ///
 void read_cells(edm::silicon_cell_collection::host& cells,
                 std::string_view filename,
                 std::unique_ptr<const Logger> logger = getDummyLogger().clone(),
                 const silicon_detector_description::host* dd = nullptr,
-                bool deduplicate = true, bool use_acts_geometry_id = true);
+                bool deduplicate = true, bool use_acts_geometry_id = true,
+                bool randomize = false);
 
 }  // namespace traccc::io::csv

--- a/io/src/read_cells.cpp
+++ b/io/src/read_cells.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,8 +21,8 @@ void read_cells(edm::silicon_cell_collection::host& cells, std::size_t event,
                 std::string_view directory,
                 std::unique_ptr<const Logger> ilogger,
                 const silicon_detector_description::host* dd,
-                data_format format, bool deduplicate,
-                bool use_acts_geometry_id) {
+                data_format format, bool deduplicate, bool use_acts_geometry_id,
+                bool randomize) {
 
     switch (format) {
         case data_format::csv:
@@ -32,8 +32,8 @@ void read_cells(edm::silicon_cell_collection::host& cells, std::size_t event,
                                    std::filesystem::path(
                                        get_event_filename(event, "-cells.csv")))
                                       .native()),
-                ilogger->clone(), dd, format, deduplicate,
-                use_acts_geometry_id);
+                ilogger->clone(), dd, format, deduplicate, use_acts_geometry_id,
+                randomize);
             break;
 
         case data_format::binary:
@@ -43,7 +43,7 @@ void read_cells(edm::silicon_cell_collection::host& cells, std::size_t event,
                                    std::filesystem::path(
                                        get_event_filename(event, "-cells.dat")))
                                       .native()),
-                ilogger->clone(), dd, format, deduplicate);
+                ilogger->clone(), dd, format, deduplicate, randomize);
             break;
 
         default:
@@ -55,13 +55,13 @@ void read_cells(edm::silicon_cell_collection::host& cells,
                 std::string_view filename,
                 std::unique_ptr<const Logger> ilogger,
                 const silicon_detector_description::host* dd,
-                data_format format, bool deduplicate,
-                bool use_acts_geometry_id) {
+                data_format format, bool deduplicate, bool use_acts_geometry_id,
+                bool randomize) {
 
     switch (format) {
         case data_format::csv:
             csv::read_cells(cells, filename, ilogger->clone(), dd, deduplicate,
-                            use_acts_geometry_id);
+                            use_acts_geometry_id, randomize);
             break;
 
         case data_format::binary:


### PR DESCRIPTION
After earlier discussions about how fast we can be with sorting cells as part of the throughput measurements, I spent some time in putting up some code for this.

I introduced "cell sorting algorithms" for all backends. In pretty much the same way in which the measurement sorting algorithms are implemented.

Then I taught `traccc::io::read_cells(...)` how to randomize the order of the cells on request. I did it like this because the CSV reading code is fundamentally set up such that it would output a sorted vector of cells. Instead of completely re-thinking the logic of the I/O code, it was easier to add a shuffling step at the end. (When the user asks for it.)

Finally I updated the throughput measurement applications to:
  - shuffle the cells that they read into host memory;
  - make use of the appropriate cell sorting algorithm as part of their data processing.

Unfortunately the result is slightly worse than what I was hoping for. :frowning: With the current `main` branch I see the following (reference) throughput on our trusty ol' A5000:

```
[bash][pcadp04]:traccc > ./build_current/bin/traccc_throughput_mt_cuda --input-directory /data/Acts/odd-simulations-20240509/geant4_ttbar_mu200/ --input-events=20 --track-candidates-range=5:100 --seedfinder-vertex-range=-150:150 --finding-run-mbf-smoother=false --processed-events=500 --deterministic --cpu-threads=8
...
Warm-up processing [==================================================] 100% [00m:00s]                                            
Event processing   [==================================================] 100% [00m:00s]                                            
04:34:29 PM ThroughputExample             INFO      Reconstructed track parameters: 2622220
04:34:29 PM ThroughputExample             INFO      Time totals:                   File reading  1249 ms
04:34:29 PM ThroughputExample             INFO                  Warm-up processing  153 ms
04:34:29 PM ThroughputExample             INFO                    Event processing  5087 ms
04:34:29 PM ThroughputExample             INFO      Throughput:            Warm-up processing  15.3186 ms/event, 65.2802 events/s
04:34:29 PM ThroughputExample             INFO                    Event processing  10.1754 ms/event, 98.2765 events/s
[bash][pcadp04]:traccc >
```

While when I add an extra sorting step, I get:

```
[bash][pcadp04]:traccc > ./build_new/bin/traccc_throughput_mt_cuda --input-directory /data/Acts/odd-simulations-20240509/geant4_ttbar_mu200/ --input-events=20 --track-candidates-range=5:100 --seedfinder-vertex-range=-150:150 --finding-run-mbf-smoother=false --processed-events=500 --deterministic --cpu-threads=8
...
Warm-up processing [==================================================] 100% [00m:00s]                                            
Event processing   [==================================================] 100% [00m:00s]                                            
04:35:53 PM ThroughputExample             INFO      Reconstructed track parameters: 2622229
04:35:53 PM ThroughputExample             INFO      Time totals:                   File reading  975 ms
04:35:53 PM ThroughputExample             INFO                  Warm-up processing  161 ms
04:35:53 PM ThroughputExample             INFO                    Event processing  5510 ms
04:35:53 PM ThroughputExample             INFO      Throughput:            Warm-up processing  16.1115 ms/event, 62.0676 events/s
04:35:53 PM ThroughputExample             INFO                    Event processing  11.0217 ms/event, 90.7302 events/s
[bash][pcadp04]:traccc >
```

So the cell sorting adds almost an entire millisecond to the event processing. :frowning: Way more than I was expecting...

I didn't do any deeper profiling on the sorting code. It's not impossible that it could still be improved. And it's also worth remembering that the random shuffling of the cells that the code does is a much worse scenario than what we would ever get from real data. Even under the least ideal circumstances.

Still, I was hoping for a quicker sorting, even with all this taken into account. :thinking:

Pinging @flg, @paradajzblond.