### PR TITLE
Implement module-by-module cell sorting

### DIFF
--- a/core/include/traccc/clusterization/clustering_config.hpp
+++ b/core/include/traccc/clusterization/clustering_config.hpp
@@ -91,6 +91,11 @@ struct clustering_config {
         clustering_diameter_strategy::CHANNEL1;
 
     /**
+     * @brief Sort the cells before running
+     */
+    bool sort_cells = false;
+
+    /**
      * @brief The maximum number of cells per partition.
      */
     TRACCC_HOST_DEVICE constexpr unsigned int max_partition_size() const {

--- a/device/alpaka/include/traccc/alpaka/clusterization/clusterization_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/clusterization/clusterization_algorithm.hpp
@@ -49,8 +49,20 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     /// @param cells     All cells in an event
     /// @return @c true if the input data is valid, @c false otherwise
     ///
-    bool input_is_valid(
+    bool input_is_contiguous(
         const edm::silicon_cell_collection::const_view& cells) const override;
+
+    /// Function that asserts the inputs are sorted.
+    bool input_is_sorted(
+        const edm::silicon_cell_collection::const_view& cells) const override;
+
+    /// Cell sorting algorithm
+    void sort_cells_kernel(
+        const unsigned int num_cells,
+        const edm::silicon_cell_collection::const_view& cells,
+        edm::silicon_cell_collection::view& new_cells,
+        vecmem::data::vector_view<unsigned int>& permutation_map_view,
+        bool write_permutation) const override;
 
     /// Main CCL kernel launcher
     void ccl_kernel(const ccl_kernel_payload& payload) const override;
@@ -64,7 +76,9 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     void cluster_maker_kernel(
         unsigned int num_cells,
         const vecmem::data::vector_view<unsigned int>& disjoint_set,
-        edm::silicon_cluster_collection::view& cluster_data) const override;
+        edm::silicon_cluster_collection::view& cluster_data,
+        const vecmem::data::vector_view<const unsigned int>&
+            permutation_map_view) const override;
 
     /// @}
 

--- a/device/alpaka/src/clusterization/clusterization_algorithm.cpp
+++ b/device/alpaka/src/clusterization/clusterization_algorithm.cpp
@@ -20,6 +20,9 @@
 #include "traccc/utils/projections.hpp"
 #include "traccc/utils/relations.hpp"
 
+// System include(s).
+#include <stdexcept>
+
 namespace traccc::alpaka {
 namespace kernels {
 
@@ -80,10 +83,12 @@ struct reify_cluster_data {
     ALPAKA_FN_ACC void operator()(
         TAcc const& acc,
         vecmem::data::vector_view<const unsigned int> disjoint_set_view,
+        vecmem::data::vector_view<const unsigned int> permutation_map_view,
         traccc::edm::silicon_cluster_collection::view cluster_view) const {
 
         device::reify_cluster_data(details::thread_id1{acc}.getGlobalThreadId(),
-                                   disjoint_set_view, cluster_view);
+                                   disjoint_set_view, permutation_map_view,
+                                   cluster_view);
     }
 
 };  // struct reify_cluster_data
@@ -97,11 +102,27 @@ clusterization_algorithm::clusterization_algorithm(
     : device::clusterization_algorithm(mr, copy, config, std::move(logger)),
       alpaka::algorithm_base(q) {}
 
-bool clusterization_algorithm::input_is_valid(
+bool clusterization_algorithm::input_is_contiguous(
     const edm::silicon_cell_collection::const_view&) const {
 
     // TODO: implement sanity checks for the input data in Alpaka
     return true;
+}
+
+bool clusterization_algorithm::input_is_sorted(
+    const edm::silicon_cell_collection::const_view&) const {
+
+    // TODO: implement sanity checks for the input data in Alpaka
+    return true;
+}
+
+void clusterization_algorithm::sort_cells_kernel(
+    const unsigned int, const edm::silicon_cell_collection::const_view&,
+    edm::silicon_cell_collection::view&,
+    vecmem::data::vector_view<unsigned int>&, const bool) const {
+
+    throw std::runtime_error(
+        "Cell sorting is not yet implemented for the Alpaka backend.");
 }
 
 void clusterization_algorithm::ccl_kernel(
@@ -126,7 +147,9 @@ void clusterization_algorithm::ccl_kernel(
 void clusterization_algorithm::cluster_maker_kernel(
     unsigned int num_cells,
     const vecmem::data::vector_view<unsigned int>& disjoint_set,
-    edm::silicon_cluster_collection::view& cluster_data) const {
+    edm::silicon_cluster_collection::view& cluster_data,
+    const vecmem::data::vector_view<const unsigned int>& permutation_map_view)
+    const {
 
     const unsigned int num_threads = warp_size() * 16u;
     const unsigned int num_blocks = (num_cells + num_threads - 1) / num_threads;
@@ -136,7 +159,10 @@ void clusterization_algorithm::cluster_maker_kernel(
     auto workDiv = makeWorkDiv<Acc>(num_blocks, num_threads);
     ::alpaka::exec<Acc>(details::get_queue(queue()), workDiv,
                         kernels::reify_cluster_data{}, disjoint_set,
-                        cluster_data);
+                        permutation_map_view, cluster_data);
+    // The base class destroys the input buffers right after this call, so
+    // the kernel must finish before returning.
+    queue().synchronize();
 }
 
 }  // namespace traccc::alpaka

--- a/device/common/include/traccc/clusterization/device/clusterization_algorithm.hpp
+++ b/device/common/include/traccc/clusterization/device/clusterization_algorithm.hpp
@@ -109,13 +109,39 @@ class clusterization_algorithm
     /// @name Function(s) to be implemented by derived classes
     /// @{
 
-    /// Function meant to perform sanity checks on the input data
+    /// Function meant to perform sanity checks on the input data, namely to
+    /// assert that the input is contiguous.
     ///
     /// @param cells     All cells in an event
     /// @return @c true if the input data is valid, @c false otherwise
     ///
-    virtual bool input_is_valid(
+    virtual bool input_is_contiguous(
         const edm::silicon_cell_collection::const_view& cells) const = 0;
+
+    /// Function to assert that the input is sorted, which it might only be
+    /// after the sorting step has been completed.
+    virtual bool input_is_sorted(
+        const edm::silicon_cell_collection::const_view& cells) const = 0;
+
+    /// Sort cells before running the CCL kernel.
+    ///
+    /// @param num_cells            Number of cells in the event
+    /// @param cells                The unsorted input cells
+    /// @param new_cells            Output collection receiving the sorted
+    ///                             cells
+    /// @param permutation_map_view Buffer mapping sorted cell indices back to
+    ///                             indices in the input collection
+    /// @param write_permutation    If @c false, the implementation is not
+    ///                             required to fill the permutation map (it
+    ///                             may still use the buffer as scratch
+    ///                             space); if @c true, the map must be
+    ///                             complete on return
+    virtual void sort_cells_kernel(
+        const unsigned int num_cells,
+        const edm::silicon_cell_collection::const_view& cells,
+        edm::silicon_cell_collection::view& new_cells,
+        vecmem::data::vector_view<unsigned int>& permutation_map_view,
+        bool write_permutation) const = 0;
 
     /// Payload for the @c ccl_kernel function
     struct ccl_kernel_payload {
@@ -149,20 +175,33 @@ class clusterization_algorithm
 
     /// Main CCL kernel launcher
     ///
+    /// If the configuration enables cell sorting, implementations must not
+    /// return until the kernel has finished executing: the sorted cell
+    /// collection and the permutation map are destroyed soon after this call
+    /// returns.
+    ///
     /// @param payload The payload containing all necessary data for the kernel
     ///
     virtual void ccl_kernel(const ccl_kernel_payload& payload) const = 0;
 
     /// Cluster data reification kernel launcher
     ///
+    /// Implementations must not return until the kernel has finished
+    /// executing: the disjoint set and permutation map buffers are destroyed
+    /// soon after this call returns.
+    ///
     /// @param num_cells    Number of cells in the event
     /// @param disjoint_set Buffer for the disjoint set data structure
     /// @param cluster_data The cluster collection to fill
+    /// @param permutation_map_view Map from sorted cell indices back to
+    ///                             indices in the original input collection
     ///
     virtual void cluster_maker_kernel(
         unsigned int num_cells,
         const vecmem::data::vector_view<unsigned int>& disjoint_set,
-        edm::silicon_cluster_collection::view& cluster_data) const = 0;
+        edm::silicon_cluster_collection::view& cluster_data,
+        const vecmem::data::vector_view<const unsigned int>&
+            permutation_map_view) const = 0;
 
     /// @}
 

--- a/device/common/include/traccc/clusterization/device/impl/reify_cluster_data.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/reify_cluster_data.ipp
@@ -12,18 +12,27 @@ namespace traccc::device {
 TRACCC_HOST_DEVICE inline void reify_cluster_data(
     global_index_t thread_id,
     vecmem::data::vector_view<const unsigned int> disjoint_set_view,
+    vecmem::data::vector_view<const unsigned int> permutation_map_view,
     traccc::edm::silicon_cluster_collection::view cluster_view) {
 
     // Create the device objects.
     const vecmem::device_vector<const unsigned int> disjoint_set(
         disjoint_set_view);
     traccc::edm::silicon_cluster_collection::device clusters(cluster_view);
+    const vecmem::device_vector<const unsigned int> permutation_map(
+        permutation_map_view);
 
     // Fill the output container.
     if (thread_id < disjoint_set.size()) {
-        clusters.cell_indices()
-            .at(disjoint_set.at(thread_id))
-            .push_back(thread_id);
+        unsigned int value;
+
+        if (permutation_map.size() > 0) {
+            value = permutation_map.at(thread_id);
+        } else {
+            value = thread_id;
+        }
+
+        clusters.cell_indices().at(disjoint_set.at(thread_id)).push_back(value);
     }
 }
 

--- a/device/common/include/traccc/clusterization/device/reify_cluster_data.hpp
+++ b/device/common/include/traccc/clusterization/device/reify_cluster_data.hpp
@@ -28,6 +28,7 @@ namespace traccc::device {
 TRACCC_HOST_DEVICE inline void reify_cluster_data(
     global_index_t thread_id,
     vecmem::data::vector_view<const unsigned int> disjoint_set_view,
+    vecmem::data::vector_view<const unsigned int> permutation_map_view,
     traccc::edm::silicon_cluster_collection::view cluster_view);
 
 }  // namespace traccc::device

--- a/device/common/src/clusterization/clusterization_algorithm.cpp
+++ b/device/common/src/clusterization/clusterization_algorithm.cpp
@@ -9,6 +9,7 @@
 #include "traccc/clusterization/device/clusterization_algorithm.hpp"
 
 #include <limits>
+#include <stdexcept>
 
 namespace traccc::device {
 
@@ -87,7 +88,7 @@ clusterization_algorithm::execute_impl(
     bool keep_disjoint_set) const {
 
     // Check the input data in debug mode.
-    assert(input_is_valid(cells));
+    assert(input_is_contiguous(cells));
 
     // Get the number of cells, in an asynchronous way if possible.
     edm::silicon_cell_collection::const_view::size_type num_cells = 0u;
@@ -128,10 +129,40 @@ clusterization_algorithm::execute_impl(
         cluster_sizes = {num_cells, mr().main};
     }
 
+    std::optional<edm::silicon_cell_collection::buffer> sorted_cells;
+    vecmem::data::vector_buffer<unsigned int> permutation_map_buffer;
+    edm::silicon_cell_collection::const_view sorted_cells_view;
+
+    if (m_config.sort_cells) {
+        sorted_cells =
+            edm::silicon_cell_collection::buffer(num_cells, mr().main);
+        copy().setup(*sorted_cells)->ignore();
+        // The permutation map contents are only needed to reify the cluster
+        // data, but the buffer is allocated unconditionally because
+        // implementations may use it as scratch space while sorting.
+        permutation_map_buffer =
+            vecmem::data::vector_buffer<unsigned int>(num_cells, mr().main);
+        copy().setup(permutation_map_buffer)->ignore();
+
+        sort_cells_kernel(num_cells, cells, *sorted_cells,
+                          permutation_map_buffer, keep_disjoint_set);
+        sorted_cells_view =
+            edm::silicon_cell_collection::const_view(*sorted_cells);
+    } else {
+        sorted_cells_view = edm::silicon_cell_collection::const_view(cells);
+    }
+
+    // Sorting must preserve module contiguity; a violation here indicates a
+    // defect in the sorting kernel (e.g. key construction), which the
+    // ordering check alone cannot detect.
+    assert(input_is_contiguous(sorted_cells_view));
+    assert(input_is_sorted(sorted_cells_view));
+
     // Launch the CCL kernel.
-    ccl_kernel({num_cells, m_config, cells, det_descr, det_cond, measurements,
-                m_f_backup, m_gf_backup, m_adjc_backup, m_adjv_backup,
-                m_backup_mutex.get(), disjoint_set, cluster_sizes});
+    ccl_kernel({num_cells, m_config, sorted_cells_view, det_descr, det_cond,
+                measurements, m_f_backup, m_gf_backup, m_adjc_backup,
+                m_adjv_backup, m_backup_mutex.get(), disjoint_set,
+                cluster_sizes});
 
     std::optional<edm::silicon_cluster_collection::buffer> cluster_data =
         std::nullopt;
@@ -167,7 +198,8 @@ clusterization_algorithm::execute_impl(
         copy().setup(*cluster_data)->ignore();
 
         // Run the cluster data reification kernel.
-        cluster_maker_kernel(num_cells, disjoint_set, *cluster_data);
+        cluster_maker_kernel(num_cells, disjoint_set, *cluster_data,
+                             permutation_map_buffer);
     }
 
     // Return the reconstructed measurements.

--- a/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
@@ -50,11 +50,23 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     /// @param cells     All cells in an event
     /// @return @c true if the input data is valid, @c false otherwise
     ///
-    bool input_is_valid(
+    bool input_is_contiguous(
+        const edm::silicon_cell_collection::const_view& cells) const override;
+
+    /// Function that asserts the inputs are sorted.
+    bool input_is_sorted(
         const edm::silicon_cell_collection::const_view& cells) const override;
 
     /// Main CCL kernel launcher
     void ccl_kernel(const ccl_kernel_payload& payload) const override;
+
+    /// Cell sorting algorithm
+    void sort_cells_kernel(
+        const unsigned int num_cells,
+        const edm::silicon_cell_collection::const_view& cells,
+        edm::silicon_cell_collection::view& new_cells,
+        vecmem::data::vector_view<unsigned int>& permutation_map_view,
+        bool write_permutation) const override;
 
     /// Cluster data reification kernel launcher
     ///
@@ -65,7 +77,9 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     void cluster_maker_kernel(
         unsigned int num_cells,
         const vecmem::data::vector_view<unsigned int>& disjoint_set,
-        edm::silicon_cluster_collection::view& cluster_data) const override;
+        edm::silicon_cluster_collection::view& cluster_data,
+        const vecmem::data::vector_view<const unsigned int>&
+            permutation_map_view) const override;
 
     /// @}
 

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -8,9 +8,12 @@
 // CUDA Library include(s).
 #include "../sanity/contiguous_on.cuh"
 #include "../sanity/ordered_on.cuh"
+#include "../utils/barrier.hpp"
 #include "../utils/cuda_error_handling.hpp"
+#include "../utils/thread_id.hpp"
 #include "./kernels/ccl_kernel.cuh"
 #include "./kernels/reify_cluster_data.cuh"
+#include "./kernels/sort_cells.cuh"
 #include "traccc/clusterization/device/ccl_kernel_definitions.hpp"
 #include "traccc/cuda/clusterization/clusterization_algorithm.hpp"
 #include "traccc/utils/projections.hpp"
@@ -18,6 +21,8 @@
 
 // Vecmem include(s).
 #include <cstring>
+#include <limits>
+#include <vecmem/containers/device_vector.hpp>
 #include <vecmem/utils/copy.hpp>
 
 namespace traccc::cuda {
@@ -29,14 +34,41 @@ clusterization_algorithm::clusterization_algorithm(
     : device::clusterization_algorithm(mr, copy, config, std::move(logger)),
       cuda::algorithm_base(str) {}
 
-bool clusterization_algorithm::input_is_valid(
+bool clusterization_algorithm::input_is_contiguous(
     const edm::silicon_cell_collection::const_view& cells) const {
 
-    return (is_contiguous_on<edm::silicon_cell_collection::const_device>(
-                cell_module_projection(), mr().main, copy(), stream(), cells) &&
-            is_ordered_on<edm::silicon_cell_collection::const_device>(
-                channel0_major_cell_order_relation(), mr().main, copy(),
-                stream(), cells));
+    return is_contiguous_on<edm::silicon_cell_collection::const_device>(
+        cell_module_projection(), mr().main, copy(), stream(), cells);
+}
+
+bool clusterization_algorithm::input_is_sorted(
+    const edm::silicon_cell_collection::const_view& cells) const {
+
+    return is_ordered_on<edm::silicon_cell_collection::const_device>(
+        channel0_major_cell_order_relation(), mr().main, copy(), stream(),
+        cells);
+}
+
+void clusterization_algorithm::sort_cells_kernel(
+    const unsigned int num_cells,
+    const edm::silicon_cell_collection::const_view& cells,
+    edm::silicon_cell_collection::view& new_cells,
+    vecmem::data::vector_view<unsigned int>& permutation_map_view,
+    const bool write_permutation) const {
+
+    static constexpr std::size_t SORT_THREADS_PER_BLOCK = 512;
+
+    const unsigned blockSize = SORT_THREADS_PER_BLOCK;
+    const unsigned int cellsPerThread = 4;
+    const unsigned int numBlocks =
+        (num_cells + (blockSize * cellsPerThread) - 1) /
+        (blockSize * cellsPerThread);
+
+    kernels::sort_cells<SORT_THREADS_PER_BLOCK, 8>
+        <<<numBlocks, blockSize, 0, details::get_stream(stream())>>>(
+            cellsPerThread, num_cells, cells, new_cells, permutation_map_view,
+            write_permutation);
+    TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 }
 
 void clusterization_algorithm::ccl_kernel(
@@ -54,19 +86,30 @@ void clusterization_algorithm::ccl_kernel(
         payload.adjc_backup, payload.adjv_backup, payload.backup_mutex,
         payload.disjoint_set, payload.cluster_sizes);
     TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+    // With sorting enabled, the kernel reads from sorted cell and permutation
+    // map buffers that the base class destroys without any further
+    // synchronization, so the kernel must finish before returning.
+    if (payload.config.sort_cells) {
+        stream().synchronize();
+    }
 }
 
 void clusterization_algorithm::cluster_maker_kernel(
     unsigned int num_cells,
     const vecmem::data::vector_view<unsigned int>& disjoint_set,
-    edm::silicon_cluster_collection::view& cluster_data) const {
+    edm::silicon_cluster_collection::view& cluster_data,
+    const vecmem::data::vector_view<const unsigned int>& permutation_map_view)
+    const {
 
     const unsigned int num_threads = warp_size() * 16u;
     const unsigned int num_blocks = (num_cells + num_threads - 1) / num_threads;
     kernels::reify_cluster_data<<<num_blocks, num_threads, 0,
                                   details::get_stream(stream())>>>(
-        disjoint_set, cluster_data);
+        disjoint_set, permutation_map_view, cluster_data);
     TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+    // The base class destroys the input buffers right after this call, so
+    // the kernel must finish before returning.
+    stream().synchronize();
 }
 
 }  // namespace traccc::cuda

--- a/device/cuda/src/clusterization/kernels/reify_cluster_data.cu
+++ b/device/cuda/src/clusterization/kernels/reify_cluster_data.cu
@@ -15,9 +15,11 @@
 namespace traccc::cuda::kernels {
 __global__ void reify_cluster_data(
     vecmem::data::vector_view<const unsigned int> disjoint_set_view,
+    vecmem::data::vector_view<const unsigned int> permutation_map_view,
     traccc::edm::silicon_cluster_collection::view cluster_view) {
 
     device::reify_cluster_data(details::thread_id1{}.getGlobalThreadId(),
-                               disjoint_set_view, cluster_view);
+                               disjoint_set_view, permutation_map_view,
+                               cluster_view);
 }
 }  // namespace traccc::cuda::kernels

--- a/device/cuda/src/clusterization/kernels/reify_cluster_data.cuh
+++ b/device/cuda/src/clusterization/kernels/reify_cluster_data.cuh
@@ -21,6 +21,7 @@ namespace traccc::cuda::kernels {
 ///
 __global__ void reify_cluster_data(
     vecmem::data::vector_view<const unsigned int> disjoint_set_view,
+    vecmem::data::vector_view<const unsigned int> permutation_map_view,
     traccc::edm::silicon_cluster_collection::view cluster_view);
 
 }  // namespace traccc::cuda::kernels

--- a/device/cuda/src/clusterization/kernels/sort_cells.cuh
+++ b/device/cuda/src/clusterization/kernels/sort_cells.cuh
@@ -1,0 +1,402 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cub/cub.cuh>
+
+#include "traccc/device/sort.hpp"
+
+namespace traccc::cuda {
+namespace kernels {
+/**
+ * @brief Sort the cells that will serve as the input to the clustering
+ * algorithm.
+ *
+ * @note This performs a sort per module, and while the sorting might
+ * reorder modules within the input, there is no guarantee that the indices
+ * of the modules will be sorted in any particular way.
+ *
+ * @note The permutation map may be filled even if `write_permutation` is
+ * false.
+ *
+ * @tparam SORT_THREADS_PER_BLOCK The number of threads to use per block when
+ *     launching this kernel.
+ * @tparam PER_THREAD_MAX The maximum number of cells to sort per thread.
+ *
+ * @param[in] cells_per_thread The target number of cells to allocate per
+ *     thread.
+ * @param[in] num_cells The number of cells to sort.
+ * @param[in] cells The original, potentially unordered cells.
+ * @param[out] new_cells The new, sorted vector of cells.
+ * @param[out] permutation_map_view The permutation map between new and old
+ *     indices.
+ * @param[in] write_permutation Boolean flag to enforce writing to the
+ *     `permutation_map_view` vector.
+ */
+template <std::size_t SORT_THREADS_PER_BLOCK, std::size_t PER_THREAD_MAX>
+__global__ __launch_bounds__(SORT_THREADS_PER_BLOCK) void sort_cells(
+    const unsigned int cells_per_thread, const unsigned int num_cells,
+    const edm::silicon_cell_collection::const_view cells,
+    edm::silicon_cell_collection::view new_cells,
+    vecmem::data::vector_view<unsigned int> permutation_map_view,
+    const bool write_permutation) {
+
+    /*
+     * We start off defining some types which we will use in sorting. In
+     * particular, we will be doing a key-value sort where the key is composed
+     * of the channel0 and channel1 coordinates, as well as the module index.
+     * Although this can, for many use cases, fit into 32 bits, we use 64 bits
+     * to be sure. The value, then, is simply the index of the cell within the
+     * block-local frame, which easily fits into 32 bits.
+     */
+    using key_t = std::uint64_t;
+    using value_t = std::uint32_t;
+    static_assert(sizeof(key_t) == 8);
+    static_assert(sizeof(value_t) == 4);
+
+    /*
+     * The meat of the pudding here is CUB's block radix sort algorithm, which
+     * is an exact fit for the job we are trying to do here. This struct
+     * defines the thread allocation as well as the shared memory sizing.
+     */
+    using sort_t = cub::BlockRadixSort<key_t, SORT_THREADS_PER_BLOCK,
+                                       PER_THREAD_MAX, value_t>;
+
+    /*
+     * Compute the partition target size based on the cells per thread
+     * parameter and the block dimension. Note that we routinely overshoot
+     * or undershoot this value because the partitioning algorithm is greedy.
+     */
+    unsigned int partition_target_size = cells_per_thread * blockDim.x;
+
+    /*
+     * Define a sum type of the storage that we will need in shared memory,
+     * which will hold either the CUB sorting scratch space or a small cache
+     * of cell coordinates and module indices. Throughout the computation, we
+     * use the software cache first and then evict it to repurpose it as the
+     * CUB scratchpad.
+     *
+     * Note that the cache always has size SORT_THREADS_PER_BLOCK times
+     * PER_THREAD_MAX, which is also the maximum partition size that can be
+     * sorted with the CUB algorithm.
+     */
+    union smem_union {
+        typename sort_t::TempStorage cub_sorting_tmp;
+        struct {
+            unsigned short channel0[SORT_THREADS_PER_BLOCK * PER_THREAD_MAX];
+            unsigned short channel1[SORT_THREADS_PER_BLOCK * PER_THREAD_MAX];
+            unsigned int module_index[SORT_THREADS_PER_BLOCK * PER_THREAD_MAX];
+        } cell_attribute_cache;
+    };
+
+    /*
+     * Shared memory allocations. The union type is by far the largest, but we
+     * also keep some integers for administrative purposes.
+     */
+    __shared__ smem_union smem;
+    __shared__ unsigned int partition_start, partition_end;
+    __shared__ unsigned int min_module_index, max_module_index, max_channel0,
+        max_channel1;
+
+    vecmem::device_vector<unsigned int> permutation_map(permutation_map_view);
+    const edm::silicon_cell_collection::const_device cells_device(cells);
+    edm::silicon_cell_collection::device new_cells_device(new_cells);
+
+    /*
+     * Compute the beginning and end of the partition boundary search. Note
+     * that this employs a greedy algorithm similar to the CCL algorithm
+     * (albeit with different partition points). The actual partition edges
+     * will always be equal to or greater than these, never smaller.
+     */
+    const unsigned int search_start = blockIdx.x * partition_target_size;
+    const unsigned int search_end =
+        std::min(num_cells, search_start + partition_target_size);
+
+    if (threadIdx.x == 0) {
+        /*
+         * We'll find the partition point using a parallel algorithm and rely
+         * on atomic min operations, so we initialize the partition
+         * boundaries by some sentinel values.
+         */
+        partition_start = std::numeric_limits<unsigned int>::max();
+        partition_end = num_cells;
+
+        /*
+         * Similarly, the minimum and maximum module indices and channels are
+         * initialized to reasonable sentinels.
+         */
+        min_module_index = std::numeric_limits<unsigned int>::max();
+        max_module_index = 0;
+        max_channel0 = 0;
+        max_channel1 = 0;
+    }
+
+    __syncthreads();
+
+    /*
+     * First, perform the boundary search for the upper limit of the
+     * partition. Simple parallel marching algorithm which modifies the
+     * boundary using an atomic minimum operation in shared memory. Computing
+     * the end first allows us to find a reasonable upper bound on the start.
+     */
+    {
+        unsigned int i = search_end + threadIdx.x;
+        bool valid_split = false;
+
+        do {
+            valid_split = (i > 0 && i < num_cells)
+                              ? cells_device.module_index().at(i - 1) !=
+                                    cells_device.module_index().at(i)
+                              : true;
+
+            if (valid_split) {
+                atomicMin(&partition_end, i);
+            }
+
+            i += blockDim.x;
+        } while (!__syncthreads_or(valid_split));
+    }
+
+    /*
+     * And then the same algorithm to find a reasonable cut-off point for the
+     * start of the partition.
+     *
+     * NOTE: No synchronization is necessary here, the previous do-while loop
+     * synchronizes as part of its loop condition.
+     */
+    {
+        unsigned int i = search_start + threadIdx.x;
+        bool valid_split = false;
+
+        do {
+            valid_split = (i > 0 && i < partition_end)
+                              ? (cells_device.module_index().at(i - 1) !=
+                                 cells_device.module_index().at(i))
+                              : true;
+
+            if (valid_split) {
+                atomicMin(&partition_start, i);
+            }
+
+            i += blockDim.x;
+        } while (!__syncthreads_or(valid_split));
+    }
+
+    __syncthreads();
+
+    /*
+     * With the partition boundaries found, compute the partition size and
+     * exit if it is 0, in which case there is no sorting to be done.
+     */
+    assert(partition_start <= partition_end);
+
+    const unsigned int partition_size = partition_end - partition_start;
+
+    if (partition_size == 0) {
+        return;
+    }
+
+    /*
+     * Recall that SORT_THREADS_PER_BLOCK * PER_THREAD_MAX is the maximum
+     * number of cells that we can sort in one block, so we need a slow path
+     * for larger partitions.
+     */
+    if (partition_size > SORT_THREADS_PER_BLOCK * PER_THREAD_MAX) [[unlikely]] {
+        /*
+         * We are unlikely to hit the slow path, but if we do we _need_ the
+         * permutation map even if we don't explicitly need it as an output,
+         * so we populate its values.
+         */
+        for (unsigned int i = partition_start + threadIdx.x; i < partition_end;
+             i += blockDim.x) {
+            permutation_map.at(i) = i;
+        }
+
+        __syncthreads();
+
+        /*
+         * Simple comparison function of cells that will put them in the
+         * desired order.
+         */
+        auto compare_cells = [&cells_device](const unsigned int idx_a,
+                                             const unsigned int idx_b) {
+            const auto& a = cells_device.at(idx_a);
+            const auto& b = cells_device.at(idx_b);
+            if (a.module_index() < b.module_index()) {
+                return true;
+            } else if (a.module_index() == b.module_index()) {
+                if (a.channel1() < b.channel1()) {
+                    return true;
+                } else if (a.channel1() == b.channel1()) {
+                    return a.channel0() < b.channel0();
+                } else {
+                    return false;
+                }
+
+            } else {
+                return false;
+            }
+        };
+
+        /*
+         * Launch the (slow) odd-even sort to sort the indices.
+         */
+        traccc::cuda::details::thread_id1 thread_id;
+        traccc::cuda::barrier barrier;
+        device::blockOddEvenSort(thread_id, barrier,
+                                 &permutation_map.at(partition_start),
+                                 partition_size, compare_cells);
+
+        /*
+         * Using the permutation map which we have now written, put the cells
+         * into the output vector.
+         */
+        for (unsigned int i = partition_start + threadIdx.x; i < partition_end;
+             i += blockDim.x) {
+            new_cells_device.at(i) = cells_device.at(permutation_map.at(i));
+        }
+    } else {
+        /*
+         * Then the fast path. Here, we will compute the maximum channel0 and
+         * channel1 values, as well as the range of module indices, to find
+         * the number of bits we need to radix sort over.
+         *
+         * We first compute the limits per thread to reduce atomic contention.
+         */
+        unsigned int local_max_channel_0 = 0;
+        unsigned int local_max_channel_1 = 0;
+        unsigned int local_min_module_index =
+            std::numeric_limits<unsigned int>::max();
+        unsigned int local_max_module_index = 0;
+
+        /*
+         * Perform a parallel march over the partition, recording the values
+         * into our shared memory cache and then computing the minima and
+         * maxima per thread.
+         */
+        for (unsigned int i = threadIdx.x; i < partition_size;
+             i += blockDim.x) {
+            const auto& cell = cells_device.at(partition_start + i);
+            const auto channel0 = cell.channel0();
+            const auto channel1 = cell.channel1();
+            const auto module_index = cell.module_index();
+
+            local_max_channel_0 = std::max(local_max_channel_0, channel0);
+            local_max_channel_1 = std::max(local_max_channel_1, channel1);
+            local_min_module_index =
+                std::min(local_min_module_index, module_index);
+            local_max_module_index =
+                std::max(local_max_module_index, module_index);
+
+            assert(channel0 <= 0xFFFF);
+            smem.cell_attribute_cache.channel0[i] = channel0;
+            assert(channel1 <= 0xFFFF);
+            smem.cell_attribute_cache.channel1[i] = channel1;
+            smem.cell_attribute_cache.module_index[i] = module_index;
+        }
+
+        /*
+         * Aggregate the boundary values to find the partition-wide minima and
+         * maxima.
+         */
+        atomicMax(&max_channel0, local_max_channel_0);
+        atomicMax(&max_channel1, local_max_channel_1);
+        atomicMin(&min_module_index, local_min_module_index);
+        atomicMax(&max_module_index, local_max_module_index);
+
+        __syncthreads();
+
+        /*
+         * Use the CLZ (count leading zero) operation to find the number of
+         * bits required to store the range of module indices, channel0, and
+         * channel1 values. Then add these up to compute the total key size.
+         */
+        const auto module_index_clz =
+            __clz(max_module_index - min_module_index);
+        const unsigned int module_index_bits =
+            CHAR_BIT * sizeof(std::decay_t<decltype(module_index_clz)>) -
+            module_index_clz;
+
+        const auto channel0_clz = __clz(max_channel0);
+        const unsigned int channel0_bits =
+            CHAR_BIT * sizeof(std::decay_t<decltype(channel0_clz)>) -
+            channel0_clz;
+
+        const auto channel1_clz = __clz(max_channel1);
+        const unsigned int channel1_bits =
+            CHAR_BIT * sizeof(std::decay_t<decltype(channel1_clz)>) -
+            channel1_clz;
+
+        const unsigned int total_bits =
+            module_index_bits + channel0_bits + channel1_bits;
+
+        /*
+         * Accounting for a single sentinel bit, these bits should fit into
+         * the chosen key type.
+         *
+         * Note that the added bit (which any valid cell cannot write to and
+         * leaves at 0) serves as the sentinel bit; only invalid cells set
+         * this to 1 and are thus automatically sorted past valid cells.
+         */
+        assert((total_bits + 1) <= (CHAR_BIT * sizeof(key_t)));
+
+        /*
+         * Now, extract the cell values from the shared memory cache and use
+         * them to populate thread-local arrays.
+         */
+        key_t keys[PER_THREAD_MAX];
+        value_t values[PER_THREAD_MAX];
+
+        for (unsigned int i = 0; i < PER_THREAD_MAX; ++i) {
+            unsigned int eff = i * blockDim.x + threadIdx.x;
+            if (eff < partition_size) {
+                const auto module_index =
+                    smem.cell_attribute_cache.module_index[eff] -
+                    min_module_index;
+                const auto channel0 = smem.cell_attribute_cache.channel0[eff];
+                const auto channel1 = smem.cell_attribute_cache.channel1[eff];
+
+                keys[i] = static_cast<key_t>(module_index)
+                              << (channel0_bits + channel1_bits) |
+                          static_cast<key_t>(channel1) << (channel0_bits) |
+                          static_cast<key_t>(channel0);
+                values[i] = eff;
+            } else {
+                keys[i] = std::numeric_limits<key_t>::max();
+                values[i] = std::numeric_limits<value_t>::max();
+            }
+        }
+
+        __syncthreads();
+
+        /*
+         * Finally, perform the sorting on the keys and values using an
+         * algorithm provided by CUB.
+         */
+        sort_t(smem.cub_sorting_tmp)
+            .SortBlockedToStriped(keys, values, 0, total_bits + 1);
+
+        /*
+         * Now, with the values (original indices) sorted, we can populate a
+         * new, sorted cell vector.
+         */
+        for (unsigned int i = 0; i < PER_THREAD_MAX; ++i) {
+            unsigned int eff = i * blockDim.x + threadIdx.x;
+            if (eff < partition_size) {
+                new_cells_device.at(partition_start + eff) =
+                    cells_device.at(partition_start + values[i]);
+                if (write_permutation) {
+                    permutation_map.at(partition_start + eff) =
+                        partition_start + values[i];
+                }
+            }
+        }
+    }
+}
+}  // namespace kernels
+}  // namespace traccc::cuda

--- a/device/hip/include/traccc/hip/clusterization/clusterization_algorithm.hpp
+++ b/device/hip/include/traccc/hip/clusterization/clusterization_algorithm.hpp
@@ -50,8 +50,20 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     /// @param cells     All cells in an event
     /// @return @c true if the input data is valid, @c false otherwise
     ///
-    bool input_is_valid(
+    bool input_is_contiguous(
         const edm::silicon_cell_collection::const_view& cells) const override;
+
+    /// Function that asserts the inputs are sorted.
+    bool input_is_sorted(
+        const edm::silicon_cell_collection::const_view& cells) const override;
+
+    /// Cell sorting algorithm
+    void sort_cells_kernel(
+        const unsigned int num_cells,
+        const edm::silicon_cell_collection::const_view& cells,
+        edm::silicon_cell_collection::view& new_cells,
+        vecmem::data::vector_view<unsigned int>& permutation_map_view,
+        bool write_permutation) const override;
 
     /// Main CCL kernel launcher
     void ccl_kernel(const ccl_kernel_payload& payload) const override;
@@ -65,7 +77,9 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     void cluster_maker_kernel(
         unsigned int num_cells,
         const vecmem::data::vector_view<unsigned int>& disjoint_set,
-        edm::silicon_cluster_collection::view& cluster_data) const override;
+        edm::silicon_cluster_collection::view& cluster_data,
+        const vecmem::data::vector_view<const unsigned int>&
+            permutation_map_view) const override;
 
     /// @}
 

--- a/device/hip/src/clusterization/clusterization_algorithm.hip
+++ b/device/hip/src/clusterization/clusterization_algorithm.hip
@@ -15,6 +15,9 @@
 // HIP include(s).
 #include <hip/hip_runtime.h>
 
+// System include(s).
+#include <stdexcept>
+
 namespace traccc::hip {
 
 clusterization_algorithm::clusterization_algorithm(
@@ -24,11 +27,27 @@ clusterization_algorithm::clusterization_algorithm(
     : device::clusterization_algorithm(mr, copy, config, std::move(logger)),
       hip::algorithm_base(str) {}
 
-bool clusterization_algorithm::input_is_valid(
+bool clusterization_algorithm::input_is_contiguous(
     const edm::silicon_cell_collection::const_view& /*cells*/) const {
 
     /// TODO: implement input checks
     return true;
+}
+
+bool clusterization_algorithm::input_is_sorted(
+    const edm::silicon_cell_collection::const_view& /*cells*/) const {
+
+    /// TODO: implement input checks
+    return true;
+}
+
+void clusterization_algorithm::sort_cells_kernel(
+    const unsigned int, const edm::silicon_cell_collection::const_view&,
+    edm::silicon_cell_collection::view&,
+    vecmem::data::vector_view<unsigned int>&, const bool) const {
+
+    throw std::runtime_error(
+        "Cell sorting is not yet implemented for the HIP backend.");
 }
 
 void clusterization_algorithm::ccl_kernel(
@@ -53,14 +72,19 @@ void clusterization_algorithm::ccl_kernel(
 void clusterization_algorithm::cluster_maker_kernel(
     unsigned int num_cells,
     const vecmem::data::vector_view<unsigned int>& disjoint_set,
-    edm::silicon_cluster_collection::view& cluster_data) const {
+    edm::silicon_cluster_collection::view& cluster_data,
+    const vecmem::data::vector_view<const unsigned int>& permutation_map_view)
+    const {
 
     const unsigned int num_threads = warp_size() * 16u;
     const unsigned int num_blocks = (num_cells + num_threads - 1) / num_threads;
     hipLaunchKernelGGL(kernels::reify_cluster_data, num_blocks, num_threads, 0,
                        details::get_stream(stream()), disjoint_set,
-                       cluster_data);
+                       permutation_map_view, cluster_data);
     TRACCC_HIP_ERROR_CHECK(hipGetLastError());
+    // The base class destroys the input buffers right after this call, so
+    // the kernel must finish before returning.
+    stream().synchronize();
 }
 
 }  // namespace traccc::hip

--- a/device/hip/src/clusterization/kernels/reify_cluster_data.hip
+++ b/device/hip/src/clusterization/kernels/reify_cluster_data.hip
@@ -16,10 +16,12 @@ namespace traccc::hip::kernels {
 
 __global__ void reify_cluster_data(
     vecmem::data::vector_view<const unsigned int> disjoint_set_view,
+    vecmem::data::vector_view<const unsigned int> permutation_map_view,
     traccc::edm::silicon_cluster_collection::view cluster_view) {
 
     device::reify_cluster_data(details::thread_id1{}.getGlobalThreadId(),
-                               disjoint_set_view, cluster_view);
+                               disjoint_set_view, permutation_map_view,
+                               cluster_view);
 }
 
 }  // namespace traccc::hip::kernels

--- a/device/hip/src/clusterization/kernels/reify_cluster_data.hpp
+++ b/device/hip/src/clusterization/kernels/reify_cluster_data.hpp
@@ -18,10 +18,12 @@ namespace traccc::hip::kernels {
 /// Fill the cluster collection with the cell indices
 ///
 /// @param disjoint_set_view The cluster/measurement index of each cell
+/// @param permutation_map_view Maps sorted cell positions back to input indices
 /// @param cluster_view The collection to fill
 ///
 __global__ void reify_cluster_data(
     vecmem::data::vector_view<const unsigned int> disjoint_set_view,
+    vecmem::data::vector_view<const unsigned int> permutation_map_view,
     traccc::edm::silicon_cluster_collection::view cluster_view);
 
 }  // namespace traccc::hip::kernels

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -49,8 +49,20 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     /// @param cells     All cells in an event
     /// @return @c true if the input data is valid, @c false otherwise
     ///
-    bool input_is_valid(
+    bool input_is_contiguous(
         const edm::silicon_cell_collection::const_view& cells) const override;
+
+    /// Function that asserts the inputs are sorted.
+    bool input_is_sorted(
+        const edm::silicon_cell_collection::const_view& cells) const override;
+
+    /// Cell sorting algorithm
+    void sort_cells_kernel(
+        const unsigned int num_cells,
+        const edm::silicon_cell_collection::const_view& cells,
+        edm::silicon_cell_collection::view& new_cells,
+        vecmem::data::vector_view<unsigned int>& permutation_map_view,
+        bool write_permutation) const override;
 
     /// Main CCL kernel launcher
     void ccl_kernel(const ccl_kernel_payload& payload) const override;
@@ -64,7 +76,9 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     void cluster_maker_kernel(
         unsigned int num_cells,
         const vecmem::data::vector_view<unsigned int>& disjoint_set,
-        edm::silicon_cluster_collection::view& cluster_data) const override;
+        edm::silicon_cluster_collection::view& cluster_data,
+        const vecmem::data::vector_view<const unsigned int>&
+            permutation_map_view) const override;
 
     /// @}
 

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -26,6 +26,9 @@
 // Vecmem include(s).
 #include <vecmem/utils/sycl/local_accessor.hpp>
 
+// System include(s).
+#include <stdexcept>
+
 namespace traccc::sycl {
 namespace kernels {
 
@@ -43,15 +46,29 @@ clusterization_algorithm::clusterization_algorithm(
     : device::clusterization_algorithm(mr, copy, config, std::move(logger)),
       sycl::algorithm_base(queue) {}
 
-bool clusterization_algorithm::input_is_valid(
+bool clusterization_algorithm::input_is_contiguous(
     const edm::silicon_cell_collection::const_view& cells) const {
 
-    return (is_contiguous_on<edm::silicon_cell_collection::const_device>(
-                cell_module_projection(), mr().main, copy(),
-                details::get_queue(queue()), cells) &&
-            is_ordered_on<edm::silicon_cell_collection::const_device>(
-                channel0_major_cell_order_relation(), mr().main, copy(),
-                details::get_queue(queue()), cells));
+    return is_contiguous_on<edm::silicon_cell_collection::const_device>(
+        cell_module_projection(), mr().main, copy(),
+        details::get_queue(queue()), cells);
+}
+
+bool clusterization_algorithm::input_is_sorted(
+    const edm::silicon_cell_collection::const_view& cells) const {
+
+    return is_ordered_on<edm::silicon_cell_collection::const_device>(
+        channel0_major_cell_order_relation(), mr().main, copy(),
+        details::get_queue(queue()), cells);
+}
+
+void clusterization_algorithm::sort_cells_kernel(
+    const unsigned int, const edm::silicon_cell_collection::const_view&,
+    edm::silicon_cell_collection::view&,
+    vecmem::data::vector_view<unsigned int>&, const bool) const {
+
+    throw std::runtime_error(
+        "Cell sorting is not yet implemented for the SYCL backend.");
 }
 
 void clusterization_algorithm::ccl_kernel(
@@ -126,17 +143,20 @@ void clusterization_algorithm::ccl_kernel(
 void clusterization_algorithm::cluster_maker_kernel(
     unsigned int num_cells,
     const vecmem::data::vector_view<unsigned int>& disjoint_set,
-    edm::silicon_cluster_collection::view& cluster_data) const {
+    edm::silicon_cluster_collection::view& cluster_data,
+    const vecmem::data::vector_view<const unsigned int>& permutation_map_view)
+    const {
 
     const ::sycl::nd_range range =
         details::calculate1DimNdRange(num_cells, warp_size() * 8u);
     details::get_queue(queue())
         .submit([&](::sycl::handler& h) {
             h.parallel_for<kernels::reify_cluster_data>(
-                range, [disjoint_set, cluster_data](::sycl::nd_item<1> item) {
+                range, [disjoint_set, permutation_map_view,
+                        cluster_data](::sycl::nd_item<1> item) {
                     device::reify_cluster_data(
                         static_cast<unsigned int>(item.get_global_linear_id()),
-                        disjoint_set, cluster_data);
+                        disjoint_set, permutation_map_view, cluster_data);
                 });
         })
         .wait_and_throw();

--- a/tests/cuda/test_clusterization.cpp
+++ b/tests/cuda/test_clusterization.cpp
@@ -179,3 +179,49 @@ TEST(CUDAClustering, SingleModule) {
 
     run_clustering_test(cells, references, reference_disjoint_set, mng_mr, cfg);
 }
+
+TEST(CUDAClustering, SingleModuleUnsorted) {
+
+    // Memory resource used by the EDM.
+    vecmem::cuda::managed_memory_resource mng_mr;
+
+    // Create cell collection
+    traccc::edm::silicon_cell_collection::host cells{mng_mr};
+    cells.reserve(8u);
+    cells.push_back({7u, 5u, 1.f, 0.f, 0u});
+    cells.push_back({3u, 2u, 1.f, 0.f, 0u});
+    cells.push_back({5u, 5u, 1.f, 0.f, 0u});
+    cells.push_back({6u, 5u, 1.f, 0.f, 0u});
+    cells.push_back({2u, 2u, 1.f, 0.f, 0u});
+    cells.push_back({1u, 2u, 1.f, 0.f, 0u});
+    cells.push_back({6u, 6u, 1.f, 0.f, 0u});
+    cells.push_back({6u, 4u, 1.f, 0.f, 0u});
+
+    edm::measurement_collection::host references{mng_mr};
+    references.push_back({{2.5f, 2.5f},
+                          {0.75f, 0.0833333f},
+                          2u,
+                          0.f,
+                          0.f,
+                          0u,
+                          detray::geometry::identifier{0u},
+                          {1u, 1u},
+                          0u});
+    references.push_back({{6.5f, 5.5f},
+                          {0.483333f, 0.483333f},
+                          2u,
+                          0.f,
+                          0.f,
+                          0u,
+                          detray::geometry::identifier{0u},
+                          {1u, 1u},
+                          1u});
+
+    std::vector<std::vector<unsigned int>> reference_disjoint_set{
+        {5, 4, 1}, {7, 2, 3, 0, 6}};
+
+    auto cfg = default_ccl_test_config();
+    cfg.sort_cells = true;
+
+    run_clustering_test(cells, references, reference_disjoint_set, mng_mr, cfg);
+}


### PR DESCRIPTION
This commit adds a cell sorting option to the clustering algorithm which allows the code to accept cells for which modules are contiguous but for which cells are not necessarily ordered within each module.