### PR TITLE
EDM De-Algebraification #1, main branch (2026.04.08.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2025 CERN for the benefit of the ACTS project
+# (c) 2021-2026 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -59,6 +59,8 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/geometry/detector_conditions_description.hpp"
   # Utilities.
   "include/traccc/utils/algorithm.hpp"
+  "include/traccc/utils/detray_conversion.hpp"
+  "include/traccc/utils/impl/detray_conversion.ipp"
   "include/traccc/utils/type_traits.hpp"
   "include/traccc/utils/memory_resource.hpp"
   "include/traccc/utils/seed_generator.hpp"

--- a/core/include/traccc/clusterization/clusterization_algorithm.hpp
+++ b/core/include/traccc/clusterization/clusterization_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -32,7 +32,7 @@ namespace traccc::host {
 /// module from the cells of the modules.
 ///
 class clusterization_algorithm
-    : public algorithm<edm::measurement_collection<default_algebra>::host(
+    : public algorithm<edm::measurement_collection::host(
           const edm::silicon_cell_collection::const_view&,
           const detector_design_description::const_view&,
           const detector_conditions_description::const_view&)>,

--- a/core/include/traccc/clusterization/impl/measurement_creation.ipp
+++ b/core/include/traccc/clusterization/impl/measurement_creation.ipp
@@ -7,6 +7,10 @@
 
 #pragma once
 
+// Library include(s).
+#include "traccc/utils/detray_conversion.hpp"
+
+// System include(s).
 #include <cassert>
 
 namespace traccc::details {
@@ -155,11 +159,11 @@ TRACCC_HOST_DEVICE inline void fill_measurement(
     measurement.surface_link() = module_cd.geometry_id();
 
     // apply lorentz shift to the cell position
-    measurement.template set_local_position_in<default_algebra>(
+    measurement.local_position() = utils::to_float_array<default_algebra>(
         mean + module_cd.measurement_translation());
 
     // plus pitch^2 / 12
-    measurement.template set_local_variance_in<default_algebra>(var);
+    measurement.local_variance() = utils::to_float_array<default_algebra>(var);
 
     // For the ambiguity resolution algorithm, give a unique measurement ID
     measurement.identifier() = index;

--- a/core/include/traccc/clusterization/impl/measurement_creation.ipp
+++ b/core/include/traccc/clusterization/impl/measurement_creation.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -155,12 +155,11 @@ TRACCC_HOST_DEVICE inline void fill_measurement(
     measurement.surface_link() = module_cd.geometry_id();
 
     // apply lorentz shift to the cell position
-    std::array<scalar, 2> shift = module_cd.measurement_translation();
-    measurement.local_position() = {static_cast<float>(mean[0]) + shift[0],
-                                    static_cast<float>(mean[1]) + shift[1]};
+    measurement.template set_local_position_in<default_algebra>(
+        mean + module_cd.measurement_translation());
 
     // plus pitch^2 / 12
-    measurement.local_variance() = var;
+    measurement.template set_local_variance_in<default_algebra>(var);
 
     // For the ambiguity resolution algorithm, give a unique measurement ID
     measurement.identifier() = index;
@@ -170,7 +169,7 @@ TRACCC_HOST_DEVICE inline void fill_measurement(
     measurement.dimensions() = module_dd.dimensions();
 
     // Set the measurement's subspace.
-    measurement.subspace() = module_dd.subspace();
+    measurement.set_subspace(module_dd.subspace());
 
     // Save the index of the cluster that produced this measurement
     measurement.cluster_index() = static_cast<unsigned int>(index);

--- a/core/include/traccc/clusterization/measurement_creation_algorithm.hpp
+++ b/core/include/traccc/clusterization/measurement_creation_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -31,7 +31,7 @@ namespace traccc::host {
 /// module.
 ///
 class measurement_creation_algorithm
-    : public algorithm<edm::measurement_collection<default_algebra>::host(
+    : public algorithm<edm::measurement_collection::host(
           const edm::silicon_cell_collection::const_view &,
           const edm::silicon_cluster_collection::const_view &,
           const detector_design_description::const_view &,

--- a/core/include/traccc/clusterization/measurement_sorting_algorithm.hpp
+++ b/core/include/traccc/clusterization/measurement_sorting_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,8 +30,8 @@ namespace traccc::host {
 /// measurements "correctly" in place.
 ///
 class measurement_sorting_algorithm
-    : public algorithm<edm::measurement_collection<default_algebra>::host(
-          const edm::measurement_collection<default_algebra>::const_view&)>,
+    : public algorithm<edm::measurement_collection::host(
+          const edm::measurement_collection::const_view&)>,
       public messaging {
 
     public:
@@ -49,8 +49,8 @@ class measurement_sorting_algorithm
     /// @param measurements The measurements to sort
     ///
     [[nodiscard]] output_type operator()(
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements) const override;
+        const edm::measurement_collection::const_view& measurements)
+        const override;
 
     private:
     /// The memory resource to use

--- a/core/include/traccc/edm/impl/measurement_collection.ipp
+++ b/core/include/traccc/edm/impl/measurement_collection.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,6 +12,59 @@
 #include "traccc/definitions/math.hpp"
 
 namespace traccc::edm {
+
+template <typename BASE>
+template <detray::concepts::algebra ALGEBRA_TYPE>
+TRACCC_HOST_DEVICE detray::dpoint2D<ALGEBRA_TYPE>
+measurement<BASE>::local_position_in() const {
+
+    detray::dpoint2D<ALGEBRA_TYPE> result;
+    getter::element(result, 0) =
+        static_cast<typename ALGEBRA_TYPE::value_type>(local_position()[0]);
+    getter::element(result, 1) =
+        static_cast<typename ALGEBRA_TYPE::value_type>(local_position()[1]);
+    return result;
+}
+
+template <typename BASE>
+template <detray::concepts::algebra ALGEBRA_TYPE>
+TRACCC_HOST_DEVICE void measurement<BASE>::set_local_position_in(
+    const detray::dpoint2D<ALGEBRA_TYPE>& pos) {
+
+    local_position()[0] = static_cast<float>(getter::element(pos, 0));
+    local_position()[1] = static_cast<float>(getter::element(pos, 1));
+}
+
+template <typename BASE>
+template <detray::concepts::algebra ALGEBRA_TYPE>
+TRACCC_HOST_DEVICE detray::dpoint2D<ALGEBRA_TYPE>
+measurement<BASE>::local_variance_in() const {
+
+    detray::dpoint2D<ALGEBRA_TYPE> result;
+    getter::element(result, 0) =
+        static_cast<typename ALGEBRA_TYPE::value_type>(local_variance()[0]);
+    getter::element(result, 1) =
+        static_cast<typename ALGEBRA_TYPE::value_type>(local_variance()[1]);
+    return result;
+}
+
+template <typename BASE>
+template <detray::concepts::algebra ALGEBRA_TYPE>
+TRACCC_HOST_DEVICE void measurement<BASE>::set_local_variance_in(
+    const detray::dpoint2D<ALGEBRA_TYPE>& var) {
+
+    local_variance()[0] = static_cast<float>(getter::element(var, 0));
+    local_variance()[1] = static_cast<float>(getter::element(var, 1));
+}
+
+template <typename BASE>
+template <std::integral TYPE>
+TRACCC_HOST_DEVICE void measurement<BASE>::set_subspace(
+    const std::array<TYPE, 2u>& subs) {
+
+    subspace()[0] = static_cast<unsigned int>(subs[0]);
+    subspace()[1] = static_cast<unsigned int>(subs[1]);
+}
 
 template <typename BASE>
 template <typename T>

--- a/core/include/traccc/edm/impl/measurement_collection.ipp
+++ b/core/include/traccc/edm/impl/measurement_collection.ipp
@@ -14,56 +14,12 @@
 namespace traccc::edm {
 
 template <typename BASE>
-template <detray::concepts::algebra ALGEBRA_TYPE>
-TRACCC_HOST_DEVICE detray::dpoint2D<ALGEBRA_TYPE>
-measurement<BASE>::local_position_in() const {
-
-    detray::dpoint2D<ALGEBRA_TYPE> result;
-    getter::element(result, 0) =
-        static_cast<typename ALGEBRA_TYPE::value_type>(local_position()[0]);
-    getter::element(result, 1) =
-        static_cast<typename ALGEBRA_TYPE::value_type>(local_position()[1]);
-    return result;
-}
-
-template <typename BASE>
-template <detray::concepts::algebra ALGEBRA_TYPE>
-TRACCC_HOST_DEVICE void measurement<BASE>::set_local_position_in(
-    const detray::dpoint2D<ALGEBRA_TYPE>& pos) {
-
-    local_position()[0] = static_cast<float>(getter::element(pos, 0));
-    local_position()[1] = static_cast<float>(getter::element(pos, 1));
-}
-
-template <typename BASE>
-template <detray::concepts::algebra ALGEBRA_TYPE>
-TRACCC_HOST_DEVICE detray::dpoint2D<ALGEBRA_TYPE>
-measurement<BASE>::local_variance_in() const {
-
-    detray::dpoint2D<ALGEBRA_TYPE> result;
-    getter::element(result, 0) =
-        static_cast<typename ALGEBRA_TYPE::value_type>(local_variance()[0]);
-    getter::element(result, 1) =
-        static_cast<typename ALGEBRA_TYPE::value_type>(local_variance()[1]);
-    return result;
-}
-
-template <typename BASE>
-template <detray::concepts::algebra ALGEBRA_TYPE>
-TRACCC_HOST_DEVICE void measurement<BASE>::set_local_variance_in(
-    const detray::dpoint2D<ALGEBRA_TYPE>& var) {
-
-    local_variance()[0] = static_cast<float>(getter::element(var, 0));
-    local_variance()[1] = static_cast<float>(getter::element(var, 1));
-}
-
-template <typename BASE>
 template <std::integral TYPE>
 TRACCC_HOST_DEVICE void measurement<BASE>::set_subspace(
     const std::array<TYPE, 2u>& subs) {
 
-    subspace()[0] = static_cast<unsigned int>(subs[0]);
-    subspace()[1] = static_cast<unsigned int>(subs[1]);
+    subspace()[0] = static_cast<std::uint8_t>(subs[0]);
+    subspace()[1] = static_cast<std::uint8_t>(subs[1]);
 }
 
 template <typename BASE>

--- a/core/include/traccc/edm/impl/measurement_helpers.ipp
+++ b/core/include/traccc/edm/impl/measurement_helpers.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,19 +21,20 @@ TRACCC_HOST_DEVICE void get_measurement_local(
     assert((meas.subspace()[0] == e_bound_loc0) ||
            (meas.subspace()[0] == e_bound_loc1));
 
-    const point2& local = meas.local_position();
+    const detray::dpoint2D<algebra_t> local =
+        meas.template local_position_in<algebra_t>();
 
     switch (meas.subspace()[0]) {
         case e_bound_loc0:
-            getter::element(pos, 0, 0) = local[0];
+            getter::element(pos, 0, 0) = getter::element(local, 0);
             if constexpr (D == 2u) {
-                getter::element(pos, 1, 0) = local[1];
+                getter::element(pos, 1, 0) = getter::element(local, 1);
             }
             break;
         case e_bound_loc1:
-            getter::element(pos, 0, 0) = local[1];
+            getter::element(pos, 0, 0) = getter::element(local, 1);
             if constexpr (D == 2u) {
-                getter::element(pos, 1, 0) = local[0];
+                getter::element(pos, 1, 0) = getter::element(local, 0);
             }
             break;
         default:
@@ -55,23 +56,24 @@ TRACCC_HOST_DEVICE void get_measurement_covariance(
     assert((meas.subspace()[0] == e_bound_loc0) ||
            (meas.subspace()[0] == e_bound_loc1));
 
-    const variance2& variance = meas.local_variance();
+    const detray::dpoint2D<algebra_t> variance =
+        meas.template local_variance_in<algebra_t>();
 
     switch (meas.subspace()[0]) {
         case e_bound_loc0:
-            getter::element(cov, 0, 0) = variance[0];
+            getter::element(cov, 0, 0) = getter::element(variance, 0);
             if constexpr (D == 2u) {
                 getter::element(cov, 0, 1) = 0.f;
                 getter::element(cov, 1, 0) = 0.f;
-                getter::element(cov, 1, 1) = variance[1];
+                getter::element(cov, 1, 1) = getter::element(variance, 1);
             }
             break;
         case e_bound_loc1:
-            getter::element(cov, 0, 0) = variance[1];
+            getter::element(cov, 0, 0) = getter::element(variance, 1);
             if constexpr (D == 2u) {
                 getter::element(cov, 0, 1) = 0.f;
                 getter::element(cov, 1, 0) = 0.f;
-                getter::element(cov, 1, 1) = variance[0];
+                getter::element(cov, 1, 1) = getter::element(variance, 0);
             }
             break;
         default:

--- a/core/include/traccc/edm/impl/measurement_helpers.ipp
+++ b/core/include/traccc/edm/impl/measurement_helpers.ipp
@@ -7,7 +7,17 @@
 
 #pragma once
 
+// Local include(s).
+#include "traccc/utils/detray_conversion.hpp"
+
 namespace traccc::edm {
+
+template <detray::concepts::algebra algebra_t, typename measurement_backend_t>
+TRACCC_HOST_DEVICE detray::dpoint2D<algebra_t> get_measurement_local(
+    const edm::measurement<measurement_backend_t>& meas) {
+
+    return utils::to_dpoint2D<algebra_t>(meas.local_position());
+}
 
 template <detray::concepts::algebra algebra_t, typename measurement_backend_t,
           std::integral size_t, size_t D>
@@ -18,23 +28,28 @@ TRACCC_HOST_DEVICE void get_measurement_local(
     static_assert(((D == 1u) || (D == 2u)),
                   "The measurement dimension must be 1 or 2");
 
-    assert((meas.subspace()[0] == e_bound_loc0) ||
-           (meas.subspace()[0] == e_bound_loc1));
-
-    const detray::dpoint2D<algebra_t> local =
-        meas.template local_position_in<algebra_t>();
+    assert((meas.subspace()[0] == detray::e_bound_loc0) ||
+           (meas.subspace()[0] == detray::e_bound_loc1));
 
     switch (meas.subspace()[0]) {
-        case e_bound_loc0:
-            getter::element(pos, 0, 0) = getter::element(local, 0);
+        case detray::e_bound_loc0:
+            getter::element(pos, 0, 0) =
+                static_cast<typename algebra_t::value_type>(
+                    meas.local_position()[0]);
             if constexpr (D == 2u) {
-                getter::element(pos, 1, 0) = getter::element(local, 1);
+                getter::element(pos, 1, 0) =
+                    static_cast<typename algebra_t::value_type>(
+                        meas.local_position()[1]);
             }
             break;
-        case e_bound_loc1:
-            getter::element(pos, 0, 0) = getter::element(local, 1);
+        case detray::e_bound_loc1:
+            getter::element(pos, 0, 0) =
+                static_cast<typename algebra_t::value_type>(
+                    meas.local_position()[1]);
             if constexpr (D == 2u) {
-                getter::element(pos, 1, 0) = getter::element(local, 0);
+                getter::element(pos, 1, 0) =
+                    static_cast<typename algebra_t::value_type>(
+                        meas.local_position()[0]);
             }
             break;
         default:
@@ -42,6 +57,13 @@ TRACCC_HOST_DEVICE void get_measurement_local(
             __builtin_unreachable();
 #endif
     }
+}
+
+template <detray::concepts::algebra algebra_t, typename measurement_backend_t>
+TRACCC_HOST_DEVICE detray::dvector2D<algebra_t> get_measurement_variance(
+    const edm::measurement<measurement_backend_t>& meas) {
+
+    return utils::to_dpoint2D<algebra_t>(meas.local_variance());
 }
 
 template <detray::concepts::algebra algebra_t, typename measurement_backend_t,
@@ -53,27 +75,32 @@ TRACCC_HOST_DEVICE void get_measurement_covariance(
     static_assert(((D == 1u) || (D == 2u)),
                   "The measurement dimension must be 1 or 2");
 
-    assert((meas.subspace()[0] == e_bound_loc0) ||
-           (meas.subspace()[0] == e_bound_loc1));
-
-    const detray::dpoint2D<algebra_t> variance =
-        meas.template local_variance_in<algebra_t>();
+    assert((meas.subspace()[0] == detray::e_bound_loc0) ||
+           (meas.subspace()[0] == detray::e_bound_loc1));
 
     switch (meas.subspace()[0]) {
-        case e_bound_loc0:
-            getter::element(cov, 0, 0) = getter::element(variance, 0);
+        case detray::e_bound_loc0:
+            getter::element(cov, 0, 0) =
+                static_cast<typename algebra_t::value_type>(
+                    meas.local_variance()[0]);
             if constexpr (D == 2u) {
                 getter::element(cov, 0, 1) = 0.f;
                 getter::element(cov, 1, 0) = 0.f;
-                getter::element(cov, 1, 1) = getter::element(variance, 1);
+                getter::element(cov, 1, 1) =
+                    static_cast<typename algebra_t::value_type>(
+                        meas.local_variance()[1]);
             }
             break;
-        case e_bound_loc1:
-            getter::element(cov, 0, 0) = getter::element(variance, 1);
+        case detray::e_bound_loc1:
+            getter::element(cov, 0, 0) =
+                static_cast<typename algebra_t::value_type>(
+                    meas.local_variance()[1]);
             if constexpr (D == 2u) {
                 getter::element(cov, 0, 1) = 0.f;
                 getter::element(cov, 1, 0) = 0.f;
-                getter::element(cov, 1, 1) = getter::element(variance, 0);
+                getter::element(cov, 1, 1) =
+                    static_cast<typename algebra_t::value_type>(
+                        meas.local_variance()[0]);
             }
             break;
         default:

--- a/core/include/traccc/edm/impl/track_state_helpers.ipp
+++ b/core/include/traccc/edm/impl/track_state_helpers.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,8 +12,7 @@ namespace traccc::edm {
 template <typename algebra_t>
 TRACCC_HOST_DEVICE
     typename track_state_collection<algebra_t>::device::object_type
-    make_track_state(const typename measurement_collection<
-                         algebra_t>::const_device& measurements,
+    make_track_state(const measurement_collection::const_device& measurements,
                      unsigned int mindex) {
 
     // Create the result object.

--- a/core/include/traccc/edm/measurement_collection.hpp
+++ b/core/include/traccc/edm/measurement_collection.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,7 +12,6 @@
 #include "traccc/definitions/qualifiers.hpp"
 
 // Detray include(s).
-#include <detray/definitions/algebra.hpp>
 #include <detray/geometry/barcode.hpp>
 
 // VecMem include(s).
@@ -60,6 +59,28 @@ class measurement : public BASE {
     TRACCC_HOST_DEVICE
     const auto& local_position() const { return BASE::template get<0>(); }
 
+    /// Get the local position object in a specific (Detray) algebra
+    ///
+    /// @note This function must only be used on proxy objects, not on
+    ///       containers!
+    ///
+    /// @tparam ALGEBRA_TYPE The algebra to retrieve the local position in
+    /// @return An algebra specific 1D/2D point object
+    ///
+    template <detray::concepts::algebra ALGEBRA_TYPE>
+    TRACCC_HOST_DEVICE detray::dpoint2D<ALGEBRA_TYPE> local_position_in() const;
+    /// Set the local position expressed in a specific (Detray) algebra
+    ///
+    /// @note This function must only be used on proxy objects, not on
+    ///       containers!
+    ///
+    /// @tparam ALGEBRA_TYPE The algebra to set the local position in
+    /// @param pos The local position to set
+    ///
+    template <detray::concepts::algebra ALGEBRA_TYPE>
+    TRACCC_HOST_DEVICE void set_local_position_in(
+        const detray::dpoint2D<ALGEBRA_TYPE>& pos);
+
     /// Variance of the local position of the measurement (non-const)
     ///
     /// @return A (non-const) vector of 1D/2D variances
@@ -72,6 +93,28 @@ class measurement : public BASE {
     ///
     TRACCC_HOST_DEVICE
     const auto& local_variance() const { return BASE::template get<1>(); }
+
+    /// Get the local variance object in a specific (Detray) algebra
+    ///
+    /// @note This function must only be used on proxy objects, not on
+    ///       containers!
+    ///
+    /// @tparam ALGEBRA_TYPE The algebra to retrieve the local variance in
+    /// @return An algebra specific 1D/2D point object
+    ///
+    template <detray::concepts::algebra ALGEBRA_TYPE>
+    TRACCC_HOST_DEVICE detray::dpoint2D<ALGEBRA_TYPE> local_variance_in() const;
+    /// Set the local variance expressed in a specific (Detray) algebra
+    ///
+    /// @note This function must only be used on proxy objects, not on
+    ///       containers!
+    ///
+    /// @tparam ALGEBRA_TYPE The algebra to set the local variance in
+    /// @param var The local variance to set
+    ///
+    template <detray::concepts::algebra ALGEBRA_TYPE>
+    TRACCC_HOST_DEVICE void set_local_variance_in(
+        const detray::dpoint2D<ALGEBRA_TYPE>& var);
 
     /// Dimensionality of the measurement (non-const)
     ///
@@ -88,26 +131,26 @@ class measurement : public BASE {
 
     /// Time assigned to the measurement (non-const)
     ///
-    /// @return A (non-const) vector of scalar values
+    /// @return A (non-const) vector of @c float values
     ///
     TRACCC_HOST_DEVICE
     auto& time() { return BASE::template get<3>(); }
     /// Time assigned to the measurement (const)
     ///
-    /// @return A (const) vector of scalar values
+    /// @return A (const) vector of @c float values
     ///
     TRACCC_HOST_DEVICE
     const auto& time() const { return BASE::template get<3>(); }
 
     /// Diameter of the measurement (non-const)
     ///
-    /// @return A (non-const) vector of scalar values
+    /// @return A (non-const) vector of @c float values
     ///
     TRACCC_HOST_DEVICE
     auto& diameter() { return BASE::template get<4>(); }
     /// Diameter of the measurement (const)
     ///
-    /// @return A (const) vector of scalar values
+    /// @return A (const) vector of @c float values
     ///
     TRACCC_HOST_DEVICE
     const auto& diameter() const { return BASE::template get<4>(); }
@@ -150,6 +193,18 @@ class measurement : public BASE {
     ///
     TRACCC_HOST_DEVICE
     const auto& subspace() const { return BASE::template get<7>(); }
+    /// Set the subspace of the measurement
+    ///
+    /// Using a possibly slightly different array than the one used by the
+    /// object itself.
+    ///
+    /// @note This function must only be used on proxy objects, not on
+    ///       containers!
+    ///
+    /// @param subs The subspace to set
+    ///
+    template <std::integral TYPE>
+    TRACCC_HOST_DEVICE void set_subspace(const std::array<TYPE, 2u>& subs);
 
     /// Index of the cluster that the measurement was created from (non-const)
     ///
@@ -198,28 +253,26 @@ class measurement : public BASE {
 };  // class measurement
 
 /// SoA container of measurements
-template <detray::concepts::algebra ALGEBRA>
-using measurement_collection =
-    vecmem::edm::container<measurement,
-                           // local_position
-                           vecmem::edm::type::vector<detray::dpoint2D<ALGEBRA>>,
-                           // local_variance
-                           vecmem::edm::type::vector<detray::dpoint2D<ALGEBRA>>,
-                           // dimensions
-                           vecmem::edm::type::vector<unsigned int>,
-                           // time
-                           vecmem::edm::type::vector<detray::dscalar<ALGEBRA>>,
-                           // diameter
-                           vecmem::edm::type::vector<detray::dscalar<ALGEBRA>>,
-                           // identifier
-                           vecmem::edm::type::vector<unsigned int>,
-                           // surface_link
-                           vecmem::edm::type::vector<detray::geometry::barcode>,
-                           // subspace
-                           vecmem::edm::type::vector<std::array<
-                               detray::dindex_type<default_algebra>, 2u>>,
-                           // cluster_index
-                           vecmem::edm::type::vector<unsigned int>>;
+using measurement_collection = vecmem::edm::container<
+    measurement,
+    // local_position
+    vecmem::edm::type::vector<std::array<float, 2u>>,
+    // local_variance
+    vecmem::edm::type::vector<std::array<float, 2u>>,
+    // dimensions
+    vecmem::edm::type::vector<unsigned int>,
+    // time
+    vecmem::edm::type::vector<float>,
+    // diameter
+    vecmem::edm::type::vector<float>,
+    // identifier
+    vecmem::edm::type::vector<unsigned int>,
+    // surface_link
+    vecmem::edm::type::vector<detray::geometry::barcode>,
+    // subspace
+    vecmem::edm::type::vector<std::array<unsigned int, 2u>>,
+    // cluster_index
+    vecmem::edm::type::vector<unsigned int>>;
 
 }  // namespace traccc::edm
 

--- a/core/include/traccc/edm/measurement_collection.hpp
+++ b/core/include/traccc/edm/measurement_collection.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 // Local include(s).
-#include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 
 // Detray include(s).
@@ -20,6 +19,7 @@
 // System include(s).
 #include <array>
 #include <compare>
+#include <cstdint>
 
 namespace traccc::edm {
 
@@ -59,28 +59,6 @@ class measurement : public BASE {
     TRACCC_HOST_DEVICE
     const auto& local_position() const { return BASE::template get<0>(); }
 
-    /// Get the local position object in a specific (Detray) algebra
-    ///
-    /// @note This function must only be used on proxy objects, not on
-    ///       containers!
-    ///
-    /// @tparam ALGEBRA_TYPE The algebra to retrieve the local position in
-    /// @return An algebra specific 1D/2D point object
-    ///
-    template <detray::concepts::algebra ALGEBRA_TYPE>
-    TRACCC_HOST_DEVICE detray::dpoint2D<ALGEBRA_TYPE> local_position_in() const;
-    /// Set the local position expressed in a specific (Detray) algebra
-    ///
-    /// @note This function must only be used on proxy objects, not on
-    ///       containers!
-    ///
-    /// @tparam ALGEBRA_TYPE The algebra to set the local position in
-    /// @param pos The local position to set
-    ///
-    template <detray::concepts::algebra ALGEBRA_TYPE>
-    TRACCC_HOST_DEVICE void set_local_position_in(
-        const detray::dpoint2D<ALGEBRA_TYPE>& pos);
-
     /// Variance of the local position of the measurement (non-const)
     ///
     /// @return A (non-const) vector of 1D/2D variances
@@ -93,28 +71,6 @@ class measurement : public BASE {
     ///
     TRACCC_HOST_DEVICE
     const auto& local_variance() const { return BASE::template get<1>(); }
-
-    /// Get the local variance object in a specific (Detray) algebra
-    ///
-    /// @note This function must only be used on proxy objects, not on
-    ///       containers!
-    ///
-    /// @tparam ALGEBRA_TYPE The algebra to retrieve the local variance in
-    /// @return An algebra specific 1D/2D point object
-    ///
-    template <detray::concepts::algebra ALGEBRA_TYPE>
-    TRACCC_HOST_DEVICE detray::dpoint2D<ALGEBRA_TYPE> local_variance_in() const;
-    /// Set the local variance expressed in a specific (Detray) algebra
-    ///
-    /// @note This function must only be used on proxy objects, not on
-    ///       containers!
-    ///
-    /// @tparam ALGEBRA_TYPE The algebra to set the local variance in
-    /// @param var The local variance to set
-    ///
-    template <detray::concepts::algebra ALGEBRA_TYPE>
-    TRACCC_HOST_DEVICE void set_local_variance_in(
-        const detray::dpoint2D<ALGEBRA_TYPE>& var);
 
     /// Dimensionality of the measurement (non-const)
     ///
@@ -270,7 +226,7 @@ using measurement_collection = vecmem::edm::container<
     // surface_link
     vecmem::edm::type::vector<detray::geometry::barcode>,
     // subspace
-    vecmem::edm::type::vector<std::array<unsigned int, 2u>>,
+    vecmem::edm::type::vector<std::array<std::uint8_t, 2u>>,
     // cluster_index
     vecmem::edm::type::vector<unsigned int>>;
 

--- a/core/include/traccc/edm/measurement_helpers.hpp
+++ b/core/include/traccc/edm/measurement_helpers.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,6 +13,17 @@
 #include "traccc/edm/measurement_collection.hpp"
 
 namespace traccc::edm {
+
+/// Get the local position of a measurement as a 2D point
+///
+/// @tparam algebra_t The algebra type used to describe the tracks
+///
+/// @param meas The measurement to extract the local position from
+/// @param pos The 2D point to fill with the local position of the measurement
+///
+template <detray::concepts::algebra algebra_t, typename measurement_backend_t>
+TRACCC_HOST_DEVICE detray::dpoint2D<algebra_t> get_measurement_local(
+    const edm::measurement<measurement_backend_t>& meas);
 
 /// Get the local position of a measurement as a matrix
 ///
@@ -28,6 +39,17 @@ template <detray::concepts::algebra algebra_t, typename measurement_backend_t,
 TRACCC_HOST_DEVICE void get_measurement_local(
     const edm::measurement<measurement_backend_t>& meas,
     detray::dmatrix<algebra_t, D, 1>& pos);
+
+/// Get the local position variance of a measurement as a 2D vector
+///
+/// @tparam algebra_t The algebra type used to describe the tracks
+///
+/// @param meas The measurement to extract the local position from
+/// @param pos The 2D vector to fill with the local variance of the measurement
+///
+template <detray::concepts::algebra algebra_t, typename measurement_backend_t>
+TRACCC_HOST_DEVICE detray::dvector2D<algebra_t> get_measurement_variance(
+    const edm::measurement<measurement_backend_t>& meas);
 
 /// Get the covariance of a measurement as a matrix
 ///

--- a/core/include/traccc/edm/silicon_cell_collection.hpp
+++ b/core/include/traccc/edm/silicon_cell_collection.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -73,26 +73,26 @@ class silicon_cell : public BASE {
 
     /// The "activation" of the cell / strip (non-const)
     ///
-    /// @return A (non-const) vector of @c traccc::scalar values
+    /// @return A (non-const) vector of @c float values
     ///
     TRACCC_HOST_DEVICE
     auto& activation() { return BASE::template get<2>(); }
     /// The "activation" of the cell / strip (const)
     ///
-    /// @return A (const) vector of @c traccc::scalar values
+    /// @return A (const) vector of @c float values
     ///
     TRACCC_HOST_DEVICE
     const auto& activation() const { return BASE::template get<2>(); }
 
     /// The time associated with the cell / strip (non-const)
     ///
-    /// @return A (non-const) vector of @c traccc::scalar values
+    /// @return A (non-const) vector of @c float values
     ///
     TRACCC_HOST_DEVICE
     auto& time() { return BASE::template get<3>(); }
     /// The time associated with the cell / strip (const)
     ///
-    /// @return A (const) vector of @c traccc::scalar values
+    /// @return A (const) vector of @c float values
     ///
     TRACCC_HOST_DEVICE
     const auto& time() const { return BASE::template get<3>(); }
@@ -165,10 +165,16 @@ class silicon_cell : public BASE {
 
 /// SoA container describing silicon detector hits
 using silicon_cell_collection =
-    vecmem::edm::container<silicon_cell, vecmem::edm::type::vector<channel_id>,
+    vecmem::edm::container<silicon_cell,
+                           // channel0
                            vecmem::edm::type::vector<channel_id>,
-                           vecmem::edm::type::vector<scalar>,
-                           vecmem::edm::type::vector<scalar>,
+                           // channel1
+                           vecmem::edm::type::vector<channel_id>,
+                           // activation
+                           vecmem::edm::type::vector<float>,
+                           // time
+                           vecmem::edm::type::vector<float>,
+                           // module_index
                            vecmem::edm::type::vector<unsigned int> >;
 
 }  // namespace traccc::edm

--- a/core/include/traccc/edm/track_container.hpp
+++ b/core/include/traccc/edm/track_container.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -25,7 +25,7 @@ struct track_container {
     struct host {
         /// Constructor using a memory resource
         explicit host(vecmem::memory_resource& mr,
-                      measurement_collection<ALGEBRA>::const_view meas = {})
+                      measurement_collection::const_view meas = {})
             : tracks{mr}, states{mr}, measurements{meas} {}
 
         /// The tracks
@@ -33,7 +33,7 @@ struct track_container {
         /// The track states used by the tracks
         track_state_collection<ALGEBRA>::host states;
         /// The measurements used by the tracks
-        measurement_collection<ALGEBRA>::const_view measurements;
+        measurement_collection::const_view measurements;
     };
 
     struct buffer {
@@ -42,7 +42,7 @@ struct track_container {
         /// The track states used by the tracks
         track_state_collection<ALGEBRA>::buffer states;
         /// The measurements used by the tracks
-        measurement_collection<ALGEBRA>::const_view measurements;
+        measurement_collection::const_view measurements;
     };
 
     struct data {
@@ -56,7 +56,7 @@ struct track_container {
         /// The track states used by the tracks
         track_state_collection<ALGEBRA>::data states;
         /// The measurements used by the tracks
-        measurement_collection<ALGEBRA>::const_view measurements;
+        measurement_collection::const_view measurements;
     };
 
     struct const_data {
@@ -70,7 +70,7 @@ struct track_container {
         /// The track states used by the tracks
         track_state_collection<ALGEBRA>::const_data states;
         /// The measurements used by the tracks
-        measurement_collection<ALGEBRA>::const_view measurements;
+        measurement_collection::const_view measurements;
     };
 
     struct view {
@@ -91,7 +91,7 @@ struct track_container {
         /// The track states used by the tracks
         track_state_collection<ALGEBRA>::view states;
         /// The measurements used by the tracks
-        measurement_collection<ALGEBRA>::const_view measurements;
+        measurement_collection::const_view measurements;
     };
 
     struct const_view {
@@ -112,7 +112,7 @@ struct track_container {
         /// The track states used by the tracks
         track_state_collection<ALGEBRA>::const_view states;
         /// The measurements used by the tracks
-        measurement_collection<ALGEBRA>::const_view measurements;
+        measurement_collection::const_view measurements;
     };
 
     struct device {
@@ -127,7 +127,7 @@ struct track_container {
         /// The track states used by the tracks
         track_state_collection<ALGEBRA>::device states;
         /// The measurements used by the tracks
-        measurement_collection<ALGEBRA>::const_device measurements;
+        measurement_collection::const_device measurements;
     };
 
     struct const_device {
@@ -142,7 +142,7 @@ struct track_container {
         /// The track states used by the tracks
         track_state_collection<ALGEBRA>::const_device states;
         /// The measurements used by the tracks
-        measurement_collection<ALGEBRA>::const_device measurements;
+        measurement_collection::const_device measurements;
     };
 
 };  // struct track_container

--- a/core/include/traccc/edm/track_state_helpers.hpp
+++ b/core/include/traccc/edm/track_state_helpers.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -23,8 +23,7 @@ namespace traccc::edm {
 template <typename algebra_t>
 TRACCC_HOST_DEVICE
     typename track_state_collection<algebra_t>::device::object_type
-    make_track_state(const typename measurement_collection<
-                         algebra_t>::const_device& measurements,
+    make_track_state(const measurement_collection::const_device& measurements,
                      unsigned int mindex);
 
 }  // namespace traccc::edm

--- a/core/include/traccc/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/core/include/traccc/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -34,7 +34,7 @@ namespace traccc::host {
 class combinatorial_kalman_filter_algorithm
     : public algorithm<edm::track_container<default_algebra>::host(
           const host_detector&, const magnetic_field&,
-          const edm::measurement_collection<default_algebra>::const_view&,
+          const edm::measurement_collection::const_view&,
           const bound_track_parameters_collection_types::const_view&)>,
       public messaging {
 
@@ -59,8 +59,7 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const host_detector& det, const magnetic_field& bfield,
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements,
+        const edm::measurement_collection::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;
 

--- a/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -59,8 +59,7 @@ template <typename detector_t, typename bfield_t>
 edm::track_container<typename detector_t::algebra_type>::host
 combinatorial_kalman_filter(
     const detector_t& det, const bfield_t& field,
-    const typename edm::measurement_collection<
-        typename detector_t::algebra_type>::const_view& measurements_view,
+    const edm::measurement_collection::const_view& measurements_view,
     const bound_track_parameters_collection_types::const_view& seeds_view,
     const finding_config& config, vecmem::memory_resource& mr,
     const Logger& /*log*/) {
@@ -88,8 +87,7 @@ combinatorial_kalman_filter(
      *****************************************************************/
 
     // Create the measurement container.
-    typename edm::measurement_collection<algebra_type>::const_device
-        measurements{measurements_view};
+    edm::measurement_collection::const_device measurements{measurements_view};
 
     // Check contiguity of the measurements
     assert(is_contiguous_on([](const auto& value) { return value; },
@@ -120,8 +118,8 @@ combinatorial_kalman_filter(
             std::distance(measurements.surface_link().begin(), up)));
     }
 
-    const typename edm::measurement_collection<
-        algebra_type>::const_device::size_type n_meas = measurements.size();
+    const edm::measurement_collection::const_device::size_type n_meas =
+        measurements.size();
 
     std::vector<std::vector<candidate_link>> links;
     links.resize(config.max_track_candidates_per_track);

--- a/core/include/traccc/fitting/details/triplet_fitting.hpp
+++ b/core/include/traccc/fitting/details/triplet_fitting.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,8 +39,8 @@ typename edm::track_container<algebra_t>::host triplet_fitting(
     vecmem::memory_resource& mr, vecmem::copy& copy) {
 
     // Get the input collections(s).
-    const typename edm::measurement_collection<algebra_t>::const_device
-        measurements{track_container.measurements};
+    const edm::measurement_collection::const_device measurements{
+        track_container.measurements};
     const typename edm::track_collection<algebra_t>::const_device
         track_candidates{track_container.tracks};
 

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -46,8 +46,7 @@ struct gain_matrix_updater {
     template <typename track_state_backend_t>
     [[nodiscard]] TRACCC_HOST_DEVICE inline kalman_fitter_status operator()(
         typename edm::track_state<track_state_backend_t>& trk_state,
-        const edm::measurement_collection<default_algebra>::const_device&
-            measurements,
+        const edm::measurement_collection::const_device& measurements,
         const bound_track_parameters<algebra_t>& bound_params,
         const bool is_line) const {
 

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -49,8 +49,7 @@ struct kalman_actor_state {
             track,
         const typename edm::track_state_collection<algebra_t>::device&
             track_states,
-        const typename edm::measurement_collection<algebra_t>::const_device&
-            measurements,
+        const edm::measurement_collection::const_device& measurements,
         vecmem::device_vector<surface_t> sequence)
         : m_track{track},
           m_track_states{track_states},
@@ -307,8 +306,7 @@ struct kalman_actor_state {
     /// All track states in the event
     typename edm::track_state_collection<algebra_t>::device m_track_states;
     /// All measurements in the event
-    typename edm::measurement_collection<algebra_t>::const_device
-        m_measurements;
+    edm::measurement_collection::const_device m_measurements;
 
     /// The surface sequencer
     sequencer_t m_sequencer;

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -116,8 +116,7 @@ class kalman_fitter {
                 algebra_type>::device::proxy_type& track,
             const typename edm::track_state_collection<algebra_type>::device&
                 track_states,
-            const typename edm::measurement_collection<
-                algebra_type>::const_device& measurements,
+            const edm::measurement_collection::const_device& measurements,
             vecmem::data::vector_view<surface_type> sequence_buffer,
             const detray::propagation::config& prop_cfg)
             : m_updater_state{prop_cfg},

--- a/core/include/traccc/fitting/kalman_filter/statistics_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/statistics_updater.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -32,8 +32,7 @@ struct statistics_updater {
         typename edm::track_collection<algebra_t>::device::proxy_type& fit_res,
         const typename edm::track_state_collection<
             algebra_t>::const_device::const_proxy_type& trk_state,
-        const typename edm::measurement_collection<algebra_t>::const_device&
-            measurements) {
+        const edm::measurement_collection::const_device& measurements) {
 
         if (!trk_state.is_hole()) {
 

--- a/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,8 +39,7 @@ struct two_filters_smoother {
     [[nodiscard]] TRACCC_HOST_DEVICE inline kalman_fitter_status operator()(
         typename edm::track_state_collection<algebra_t>::device::proxy_type&
             trk_state,
-        const typename edm::measurement_collection<algebra_t>::const_device&
-            measurements,
+        const edm::measurement_collection::const_device& measurements,
         bound_track_parameters<algebra_t>& bound_params,
         const bool is_line) const {
 

--- a/core/include/traccc/fitting/triplet_fit/triplet_fitter.hpp
+++ b/core/include/traccc/fitting/triplet_fit/triplet_fitter.hpp
@@ -12,6 +12,7 @@
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/measurement_collection.hpp"
+#include "traccc/edm/measurement_helpers.hpp"
 #include "traccc/edm/track_container.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/edm/track_state_collection.hpp"
@@ -484,8 +485,8 @@ class triplet_fitter {
         scalar t_eff =
             mat_scatter /
             detray::cos_angle({}, scat_sf, tangent3D,
-                              measurements.at(t.m_meas_idx[1])
-                                  .template local_position_in<algebra_type>());
+                              edm::get_measurement_local<algebra_type>(
+                                  measurements.at(t.m_meas_idx[1])));
 
         auto scattering_unc = [](scalar curvature_3D, scalar eff_thickness,
                                  vector3 field_strength_vector) {

--- a/core/include/traccc/fitting/triplet_fit/triplet_fitter.hpp
+++ b/core/include/traccc/fitting/triplet_fit/triplet_fitter.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -144,12 +144,10 @@ class triplet_fitter {
         /// @param dir_idx direction index
         /// @param multipler multipler
         /// @param detector detector
-        void shiftHit(
-            const unsigned& hit_idx, const unsigned& dir_idx,
-            const scalar& multipler,
-            typename edm::measurement_collection<algebra_type>::const_device
-                measurements,
-            const detector_t& detector) {
+        void shiftHit(const unsigned& hit_idx, const unsigned& dir_idx,
+                      const scalar& multipler,
+                      edm::measurement_collection::const_device measurements,
+                      const detector_t& detector) {
             // The shifts are applied to the global
             // positions of the hits
 
@@ -222,10 +220,8 @@ class triplet_fitter {
     /// Makes triplets from consecutive measurements on the track
     ///
     TRACCC_HOST_DEVICE
-    void make_triplets(
-        const vecmem::vector<unsigned int>& in_measurements,
-        typename edm::measurement_collection<algebra_type>::const_device
-            measurements) {
+    void make_triplets(const vecmem::vector<unsigned int>& in_measurements,
+                       edm::measurement_collection::const_device measurements) {
 
         // Assuming no holes
         const size_t n_triplets = in_measurements.size() - 2;
@@ -373,9 +369,7 @@ class triplet_fitter {
     /// @param t Triplet to linearize
     ///
     TRACCC_HOST_DEVICE void linearize_triplet(
-        triplet& t,
-        typename edm::measurement_collection<algebra_type>::const_device
-            measurements) {
+        triplet& t, edm::measurement_collection::const_device measurements) {
 
         // Vectors joining hits
         vector3 x_01{t.m_hit_pos[1] - t.m_hit_pos[0]};
@@ -487,10 +481,11 @@ class triplet_fitter {
             m_detector, measurements.at(t.m_meas_idx[1]).surface_link());
 
         // effective thickness
-        scalar t_eff = mat_scatter /
-                       detray::cos_angle(
-                           {}, scat_sf, tangent3D,
-                           measurements.at(t.m_meas_idx[1]).local_position());
+        scalar t_eff =
+            mat_scatter /
+            detray::cos_angle({}, scat_sf, tangent3D,
+                              measurements.at(t.m_meas_idx[1])
+                                  .template local_position_in<algebra_type>());
 
         auto scattering_unc = [](scalar curvature_3D, scalar eff_thickness,
                                  vector3 field_strength_vector) {
@@ -569,9 +564,7 @@ class triplet_fitter {
     /// @param t Triplet
     ///
     TRACCC_HOST_DEVICE void calculate_pos_derivs(
-        triplet& t,
-        typename edm::measurement_collection<algebra_type>::const_device
-            measurements) {
+        triplet& t, edm::measurement_collection::const_device measurements) {
 
         // Hits shifted by multiplier * sigma in every direction
         scalar multiplier = 1.f;
@@ -648,8 +641,7 @@ class triplet_fitter {
     typename edm::track_state_collection<algebra_type>::host::object_type
     do_global_fit(
         typename edm::track_collection<algebra_type>::host::proxy_type& track,
-        typename edm::measurement_collection<algebra_type>::const_device
-            measurements) {
+        edm::measurement_collection::const_device measurements) {
 
         // Allocate matrices with max possible sizes
         constexpr size_t max_nhits =
@@ -1027,8 +1019,7 @@ class triplet_fitter {
     TRACCC_HOST_DEVICE
     typename edm::track_state_collection<algebra_type>::host::object_type fit(
         typename edm::track_collection<algebra_type>::host::proxy_type& track,
-        typename edm::measurement_collection<algebra_type>::const_device
-            measurements) {
+        edm::measurement_collection::const_device measurements) {
 
         for (triplet& t : m_triplets) {
 

--- a/core/include/traccc/seeding/impl/spacepoint_formation.ipp
+++ b/core/include/traccc/seeding/impl/spacepoint_formation.ipp
@@ -31,7 +31,10 @@ TRACCC_HOST_DEVICE inline void fill_pixel_spacepoint(
 
     // Get the global position of this silicon pixel measurement.
     const detray::tracking_surface sf{det, meas.surface_link()};
-    const point3 global = sf.local_to_global(gctx, meas.local_position(), {});
+    const point3 global = sf.local_to_global(
+        gctx,
+        meas.template local_position_in<typename detector_t::algebra_type>(),
+        {});
 
     // Fill the spacepoint with the global position and the measurement.
     sp.x() = global[0];

--- a/core/include/traccc/seeding/impl/spacepoint_formation.ipp
+++ b/core/include/traccc/seeding/impl/spacepoint_formation.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "traccc/definitions/primitives.hpp"
+#include "traccc/edm/measurement_helpers.hpp"
 
 // Detray include(s).
 #include <detray/geometry/tracking_surface.hpp>
@@ -31,15 +32,16 @@ TRACCC_HOST_DEVICE inline void fill_pixel_spacepoint(
 
     // Get the global position of this silicon pixel measurement.
     const detray::tracking_surface sf{det, meas.surface_link()};
-    const point3 global = sf.local_to_global(
-        gctx,
-        meas.template local_position_in<typename detector_t::algebra_type>(),
-        {});
+    const detray::dpoint3D<typename detector_t::algebra_type> global =
+        sf.local_to_global(
+            gctx,
+            edm::get_measurement_local<typename detector_t::algebra_type>(meas),
+            {});
 
     // Fill the spacepoint with the global position and the measurement.
-    sp.x() = global[0];
-    sp.y() = global[1];
-    sp.z() = global[2];
+    sp.x() = getter::element(global, 0u);
+    sp.y() = getter::element(global, 1u);
+    sp.z() = getter::element(global, 2u);
     sp.radius_variance() = 0.f;
     sp.z_variance() = 0.f;
 }

--- a/core/include/traccc/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp
+++ b/core/include/traccc/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -31,7 +31,7 @@ namespace traccc::host {
 class silicon_pixel_spacepoint_formation_algorithm
     : public algorithm<edm::spacepoint_collection::host(
           const host_detector&,
-          const edm::measurement_collection<default_algebra>::const_view&)>,
+          const edm::measurement_collection::const_view&)>,
       public messaging {
 
     public:
@@ -53,10 +53,9 @@ class silicon_pixel_spacepoint_formation_algorithm
     /// @return A spacepoint container, with one spacepoint for every
     ///         silicon pixel measurement
     ///
-    output_type operator()(
-        const host_detector& det,
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements) const override;
+    output_type operator()(const host_detector& det,
+                           const edm::measurement_collection::const_view&
+                               measurements) const override;
 
     private:
     /// Memory resource to use for the output container

--- a/core/include/traccc/seeding/track_params_estimation.hpp
+++ b/core/include/traccc/seeding/track_params_estimation.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,7 +30,7 @@ namespace traccc::host {
 ///
 class track_params_estimation
     : public algorithm<bound_track_parameters_collection_types::host(
-          const edm::measurement_collection<default_algebra>::const_view&,
+          const edm::measurement_collection::const_view&,
           const edm::spacepoint_collection::const_view&,
           const edm::seed_collection::const_view&, const vector3&)>,
       public messaging {
@@ -55,8 +55,7 @@ class track_params_estimation
     /// @return A vector of bound track parameters
     ///
     output_type operator()(
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements,
+        const edm::measurement_collection::const_view& measurements,
         const edm::spacepoint_collection::const_view& spacepoints,
         const edm::seed_collection::const_view& seeds,
         const vector3& bfield) const override;

--- a/core/include/traccc/seeding/track_params_estimation_helper.hpp
+++ b/core/include/traccc/seeding/track_params_estimation_helper.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -46,8 +46,7 @@ inline TRACCC_HOST_DEVICE vector2 uv_transform(const scalar& x,
 template <typename T>
 inline TRACCC_HOST_DEVICE void seed_to_bound_param_vector(
     bound_track_parameters<>& params,
-    const edm::measurement_collection<default_algebra>::const_device&
-        measurements,
+    const edm::measurement_collection::const_device& measurements,
     const edm::spacepoint_collection::const_device& spacepoints,
     const edm::seed<T>& seed, const vector3& bfield) {
 

--- a/core/include/traccc/utils/detray_conversion.hpp
+++ b/core/include/traccc/utils/detray_conversion.hpp
@@ -1,0 +1,44 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+
+// Detray include(s).
+#include <detray/definitions/algebra.hpp>
+
+// System include(s).
+#include <array>
+
+namespace traccc::utils {
+
+/// Convert an algebra specific 2D point to a float array of size 2
+///
+/// @tparam ALGEBRA_TYPE The algebra type of the input point
+/// @param point The input 2D point to be converted
+/// @return An @c std::array of size 2 containing the converted float values
+///
+template <detray::concepts::algebra ALGEBRA_TYPE>
+TRACCC_HOST_DEVICE std::array<float, 2u> to_float_array(
+    const detray::dpoint2D<ALGEBRA_TYPE>& point);
+
+/// Convert a float array of size 2 to an algebra specific 2D point
+///
+/// @tparam ALGEBRA_TYPE The algebra type of the output point
+/// @param arr The input @c std::array of size 2 containing the float values
+/// @return A 2D point of type @c detray::dpoint2D with the converted values
+///
+template <detray::concepts::algebra ALGEBRA_TYPE>
+TRACCC_HOST_DEVICE detray::dpoint2D<ALGEBRA_TYPE> to_dpoint2D(
+    const std::array<float, 2u>& arr);
+
+}  // namespace traccc::utils
+
+// Implementation include(s).
+#include "traccc/utils/impl/detray_conversion.ipp"

--- a/core/include/traccc/utils/impl/detray_conversion.ipp
+++ b/core/include/traccc/utils/impl/detray_conversion.ipp
@@ -1,0 +1,32 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace traccc::utils {
+
+template <detray::concepts::algebra ALGEBRA_TYPE>
+TRACCC_HOST_DEVICE std::array<float, 2u> to_float_array(
+    const detray::dpoint2D<ALGEBRA_TYPE>& point) {
+
+    return {static_cast<float>(getter::element(point, 0u)),
+            static_cast<float>(getter::element(point, 1u))};
+}
+
+template <detray::concepts::algebra ALGEBRA_TYPE>
+TRACCC_HOST_DEVICE detray::dpoint2D<ALGEBRA_TYPE> to_dpoint2D(
+    const std::array<float, 2u>& arr) {
+
+    detray::dpoint2D<ALGEBRA_TYPE> point;
+    getter::element(point, 0u) =
+        static_cast<typename ALGEBRA_TYPE::value_type>(arr[0u]);
+    getter::element(point, 1u) =
+        static_cast<typename ALGEBRA_TYPE::value_type>(arr[1u]);
+    return point;
+}
+
+}  // namespace traccc::utils

--- a/core/include/traccc/utils/subspace.hpp
+++ b/core/include/traccc/utils/subspace.hpp
@@ -41,13 +41,12 @@ struct subspace {
     /// Construct from a container of axis indices.
     ///
     /// @param indices Unique, ordered indices
-    TRACCC_HOST_DEVICE
-    constexpr subspace(const std::array<size_type, kSize>& indices) {
+    template <typename SIZE_TYPE>
+    TRACCC_HOST_DEVICE constexpr subspace(
+        const std::array<SIZE_TYPE, kSize>& indices) {
         for (size_type i = 0u; i < kSize; ++i) {
             assert((indices[i] < kFullSize) and
                    "Axis indices must be within the full space");
-        }
-        for (size_type i = 0; i < kSize; ++i) {
             m_axes[i] = static_cast<size_type>(indices[i]);
         }
     }

--- a/core/src/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.cpp
+++ b/core/src/ambiguity_resolution/legacy/greedy_ambiguity_resolution_algorithm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -63,8 +63,8 @@ void greedy_ambiguity_resolution_algorithm::compute_initial_state(
     state_t& state) const {
 
     // Create a measurement collection to interact with.
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements(track_states.measurements);
+    const edm::measurement_collection::const_device measurements(
+        track_states.measurements);
 
     // For each track of the input container
     std::size_t n_track_states = track_states.tracks.size();

--- a/core/src/clusterization/measurement_creation_algorithm.cpp
+++ b/core/src/clusterization/measurement_creation_algorithm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -36,8 +36,7 @@ measurement_creation_algorithm::operator()(
     // Create the result object.
     output_type result(m_mr.get());
     result.resize(clusters.size());
-    edm::measurement_collection<default_algebra>::device measurements{
-        vecmem::get_data(result)};
+    edm::measurement_collection::device measurements{vecmem::get_data(result)};
 
     // Process the clusters one-by-one.
     for (decltype(clusters)::size_type i = 0; i < clusters.size(); ++i) {

--- a/core/src/clusterization/measurement_sorting_algorithm.cpp
+++ b/core/src/clusterization/measurement_sorting_algorithm.cpp
@@ -20,12 +20,11 @@ measurement_sorting_algorithm::measurement_sorting_algorithm(
 
 measurement_sorting_algorithm::output_type
 measurement_sorting_algorithm::operator()(
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements_view) const {
+    const edm::measurement_collection::const_view& measurements_view) const {
 
     // Create a device container on top of the view.
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements{measurements_view};
+    const edm::measurement_collection::const_device measurements{
+        measurements_view};
 
     // Create a vector of measurement indices, which would be sorted.
     vecmem::vector<unsigned int> indices(measurements.size(), &(m_mr.get()));
@@ -38,7 +37,7 @@ measurement_sorting_algorithm::operator()(
               });
 
     // Fill an output container with the sorted measurements.
-    edm::measurement_collection<default_algebra>::host result{m_mr.get()};
+    edm::measurement_collection::host result{m_mr.get()};
     for (unsigned int i : indices) {
         result.push_back(measurements.at(i));
     }

--- a/core/src/finding/combinatorial_kalman_filter_algorithm.cpp
+++ b/core/src/finding/combinatorial_kalman_filter_algorithm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -33,8 +33,7 @@ combinatorial_kalman_filter_algorithm::combinatorial_kalman_filter_algorithm(
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
     const host_detector& det, const magnetic_field& bfield,
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements,
+    const edm::measurement_collection::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
     // Perform the track finding using the appropriate templated implementation.

--- a/core/src/seeding/silicon_pixel_spacepoint_formation.hpp
+++ b/core/src/seeding/silicon_pixel_spacepoint_formation.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,13 +30,11 @@ namespace traccc::host::details {
 template <typename detector_t>
 edm::spacepoint_collection::host silicon_pixel_spacepoint_formation(
     const detector_t& det,
-    const typename edm::measurement_collection<
-        typename detector_t::algebra_type>::const_view& measurements_view,
+    const edm::measurement_collection::const_view& measurements_view,
     vecmem::memory_resource& mr) {
 
     // Create a device container for the input.
-    const typename edm::measurement_collection<
-        typename detector_t::algebra_type>::const_device measurements{
+    const typename edm::measurement_collection::const_device measurements{
         measurements_view};
 
     // Create the result container.

--- a/core/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cpp
+++ b/core/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -20,8 +20,7 @@ silicon_pixel_spacepoint_formation_algorithm::
 silicon_pixel_spacepoint_formation_algorithm::output_type
 silicon_pixel_spacepoint_formation_algorithm::operator()(
     const host_detector& det,
-    const edm::measurement_collection<default_algebra>::const_view& meas)
-    const {
+    const edm::measurement_collection::const_view& meas) const {
 
     return host_detector_visitor<detector_type_list>(
         det, [&]<typename detector_traits_t>(

--- a/core/src/seeding/track_params_estimation.cpp
+++ b/core/src/seeding/track_params_estimation.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,15 +21,14 @@ track_params_estimation::track_params_estimation(
     : messaging(std::move(logger)), m_config(config), m_mr(mr) {}
 
 track_params_estimation::output_type track_params_estimation::operator()(
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements_view,
+    const edm::measurement_collection::const_view& measurements_view,
     const edm::spacepoint_collection::const_view& spacepoints_view,
     const edm::seed_collection::const_view& seeds_view,
     const vector3& bfield) const {
 
     // Set up the input / output objects.
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements(measurements_view);
+    const edm::measurement_collection::const_device measurements(
+        measurements_view);
     const edm::spacepoint_collection::const_device spacepoints(
         spacepoints_view);
     const edm::seed_collection::const_device seeds(seeds_view);

--- a/device/alpaka/include/traccc/alpaka/clusterization/measurement_sorting_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/clusterization/measurement_sorting_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -35,8 +35,8 @@ namespace traccc::alpaka {
 /// to the rescue.
 ///
 class measurement_sorting_algorithm
-    : public algorithm<edm::measurement_collection<default_algebra>::buffer(
-          const edm::measurement_collection<default_algebra>::const_view&)>,
+    : public algorithm<edm::measurement_collection::buffer(
+          const edm::measurement_collection::const_view&)>,
       public messaging {
 
     public:
@@ -54,8 +54,8 @@ class measurement_sorting_algorithm
     /// @param measurements The measurements to sort
     ///
     [[nodiscard]] output_type operator()(
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements) const override;
+        const edm::measurement_collection::const_view& measurements)
+        const override;
 
     private:
     // The memory resource(s) to use

--- a/device/alpaka/include/traccc/alpaka/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -34,7 +34,7 @@ namespace traccc::alpaka {
 class combinatorial_kalman_filter_algorithm
     : public algorithm<edm::track_container<default_algebra>::buffer(
           const detector_buffer&, const magnetic_field&,
-          const edm::measurement_collection<default_algebra>::const_view&,
+          const edm::measurement_collection::const_view&,
           const bound_track_parameters_collection_types::const_view&)>,
       public messaging {
 
@@ -60,8 +60,7 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const detector_buffer& det, const magnetic_field& bfield,
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements,
+        const edm::measurement_collection::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;
 

--- a/device/alpaka/src/clusterization/clusterization_algorithm.cpp
+++ b/device/alpaka/src/clusterization/clusterization_algorithm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,7 +39,7 @@ struct ccl_kernel {
         uint32_t* backup_mutex_ptr,
         vecmem::data::vector_view<unsigned int> disjoint_set_view,
         vecmem::data::vector_view<unsigned int> cluster_size_view,
-        edm::measurement_collection<default_algebra>::view measurements_view,
+        edm::measurement_collection::view measurements_view,
         vecmem::data::vector_view<unsigned int> cell_links) const {
 
         details::thread_id1 thread_id(acc);

--- a/device/alpaka/src/clusterization/measurement_sorting_algorithm.cpp
+++ b/device/alpaka/src/clusterization/measurement_sorting_algorithm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -32,17 +32,14 @@ struct fill_sorted_measurements {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(
         TAcc const& acc,
-        const edm::measurement_collection<default_algebra>::const_view
-            input_view,
-        edm::measurement_collection<default_algebra>::view output_view,
+        const edm::measurement_collection::const_view input_view,
+        edm::measurement_collection::view output_view,
         const vecmem::data::vector_view<const unsigned int> sorted_indices_view)
         const {
 
         // Create the device objects.
-        const edm::measurement_collection<default_algebra>::const_device input{
-            input_view};
-        edm::measurement_collection<default_algebra>::device output{
-            output_view};
+        const edm::measurement_collection::const_device input{input_view};
+        edm::measurement_collection::device output{output_view};
         const vecmem::device_vector<const unsigned int> sorted_indices{
             sorted_indices_view};
 
@@ -66,8 +63,7 @@ measurement_sorting_algorithm::measurement_sorting_algorithm(
 
 measurement_sorting_algorithm::output_type
 measurement_sorting_algorithm::operator()(
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements_view) const {
+    const edm::measurement_collection::const_view& measurements_view) const {
 
     // Exit early if there are no measurements.
     if (measurements_view.capacity() == 0) {
@@ -78,8 +74,8 @@ measurement_sorting_algorithm::operator()(
     auto queue = details::get_queue(m_queue);
 
     // Create a device container on top of the view.
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements{measurements_view};
+    const edm::measurement_collection::const_device measurements{
+        measurements_view};
 
     // Create a vector of measurement indices, which would be sorted.
     vecmem::data::vector_buffer<unsigned int> indices(

--- a/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
@@ -170,14 +170,12 @@ template <typename detector_t, typename bfield_t>
 edm::track_container<typename detector_t::algebra_type>::buffer
 combinatorial_kalman_filter(
     const typename detector_t::const_view_type& det, const bfield_t& field,
-    const typename edm::measurement_collection<
-        typename detector_t::algebra_type>::const_view& measurements_view,
+    const edm::measurement_collection::const_view& measurements_view,
     const bound_track_parameters_collection_types::const_view& seeds,
     const finding_config& config, const memory_resource& mr, vecmem::copy& copy,
     const Logger& log, Queue& queue) {
 
-    const typename edm::measurement_collection<
-        typename detector_t::algebra_type>::const_device measurements{
+    const edm::measurement_collection::const_device measurements{
         measurements_view};
 
     assert(config.min_step_length_for_next_surface >

--- a/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp
+++ b/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -28,8 +28,7 @@ combinatorial_kalman_filter_algorithm::combinatorial_kalman_filter_algorithm(
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
     const detector_buffer& det, const magnetic_field& bfield,
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements,
+    const edm::measurement_collection::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
     // Perform the track finding using the templated implementation.

--- a/device/alpaka/src/seeding/seed_parameter_estimation_algorithm.cpp
+++ b/device/alpaka/src/seeding/seed_parameter_estimation_algorithm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,22 +19,20 @@ namespace traccc::alpaka {
 namespace kernels {
 
 /// Alpaka kernel for running @c traccc::device::estimate_track_params
-template <typename algebra_t, typename bfield_t>
+template <typename bfield_t>
 struct estimate_track_params {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(
         TAcc const& acc, const track_params_estimation_config config,
-        typename edm::measurement_collection<algebra_t>::const_view
-            measurements,
+        typename edm::measurement_collection::const_view measurements,
         edm::spacepoint_collection::const_view spacepoints,
         edm::seed_collection::const_view seeds, const bfield_t bfield,
         bound_track_parameters_collection_types::view params) const {
         auto const globalThreadIdx =
             ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0u];
 
-        device::estimate_track_params<algebra_t>(globalThreadIdx, config,
-                                                 measurements, spacepoints,
-                                                 seeds, bfield, params);
+        device::estimate_track_params(globalThreadIdx, config, measurements,
+                                      spacepoints, seeds, bfield, params);
     }
 };  // struct estimate_track_params
 
@@ -58,8 +56,7 @@ void seed_parameter_estimation_algorithm::estimate_seed_params_kernel(
         [&]<typename bfield_view_t>(const bfield_view_t& bfield) {
             ::alpaka::exec<Acc>(details::get_queue(queue()),
                                 makeWorkDiv<Acc>(n_blocks, n_threads),
-                                kernels::estimate_track_params<default_algebra,
-                                                               bfield_view_t>{},
+                                kernels::estimate_track_params<bfield_view_t>{},
                                 payload.config, payload.measurements,
                                 payload.spacepoints, payload.seeds, bfield,
                                 payload.params);

--- a/device/alpaka/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cpp
+++ b/device/alpaka/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cpp
@@ -25,7 +25,7 @@ struct form_spacepoints {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(
         TAcc const& acc, const typename detector_t::view* detector,
-        edm::measurement_collection<default_algebra>::const_view measurements,
+        edm::measurement_collection::const_view measurements,
         edm::spacepoint_collection::view spacepoints) const {
 
         auto const globalThreadIdx =

--- a/device/common/include/traccc/clusterization/device/aggregate_cluster.hpp
+++ b/device/common/include/traccc/clusterization/device/aggregate_cluster.hpp
@@ -49,7 +49,7 @@ TRACCC_HOST_DEVICE inline void aggregate_cluster(
     const detector_conditions_description::const_device& det_cond,
     const vecmem::device_vector<details::index_t>& f, unsigned int start,
     unsigned int end, unsigned short cid,
-    edm::measurement_collection<default_algebra>::device::proxy_type out,
+    edm::measurement_collection::device::proxy_type out,
     vecmem::data::vector_view<unsigned int> cell_links, unsigned int link,
     vecmem::device_vector<unsigned int>& disjoint_set,
     std::optional<std::reference_wrapper<unsigned int>> cluster_size);

--- a/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
+++ b/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -80,7 +80,7 @@ TRACCC_DEVICE inline void ccl_kernel(
     vecmem::data::vector_view<unsigned int> disjoint_set_view,
     vecmem::data::vector_view<unsigned int> cluster_size_view,
     const barrier_t& barrier,
-    edm::measurement_collection<default_algebra>::view measurements_view,
+    edm::measurement_collection::view measurements_view,
     vecmem::data::vector_view<unsigned int> cell_links);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/clusterization/device/clusterization_algorithm.hpp
+++ b/device/common/include/traccc/clusterization/device/clusterization_algorithm.hpp
@@ -42,22 +42,21 @@ namespace traccc::device {
 /// synchronisation statement is required before destroying the buffer.
 ///
 class clusterization_algorithm
-    : public algorithm<edm::measurement_collection<default_algebra>::buffer(
+    : public algorithm<edm::measurement_collection::buffer(
           const edm::silicon_cell_collection::const_view&,
           const detector_design_description::const_view&,
           const detector_conditions_description::const_view&)>,
-      public algorithm<edm::measurement_collection<default_algebra>::buffer(
+      public algorithm<edm::measurement_collection::buffer(
           const edm::silicon_cell_collection::const_view&,
           const detector_design_description::const_view&,
           const detector_conditions_description::const_view&,
           clustering_discard_disjoint_set&&)>,
-      public algorithm<
-          std::pair<edm::measurement_collection<default_algebra>::buffer,
-                    edm::silicon_cluster_collection::buffer>(
-              const edm::silicon_cell_collection::const_view&,
-              const detector_design_description::const_view&,
-              const detector_conditions_description::const_view&,
-              clustering_keep_disjoint_set&&)>,
+      public algorithm<std::pair<edm::measurement_collection::buffer,
+                                 edm::silicon_cluster_collection::buffer>(
+          const edm::silicon_cell_collection::const_view&,
+          const detector_design_description::const_view&,
+          const detector_conditions_description::const_view&,
+          clustering_keep_disjoint_set&&)>,
       public messaging,
       public algorithm_base {
 
@@ -86,19 +85,19 @@ class clusterization_algorithm
     /// @return a measurement collection (buffer)
     ///
     /// @{
-    edm::measurement_collection<default_algebra>::buffer operator()(
+    edm::measurement_collection::buffer operator()(
         const edm::silicon_cell_collection::const_view& cells,
         const detector_design_description::const_view& det_descr,
         const detector_conditions_description::const_view& det_cond)
         const override;
 
-    edm::measurement_collection<default_algebra>::buffer operator()(
+    edm::measurement_collection::buffer operator()(
         const edm::silicon_cell_collection::const_view& cells,
         const detector_design_description::const_view& det_descr,
         const detector_conditions_description::const_view& det_cond,
         clustering_discard_disjoint_set&&) const override;
 
-    std::pair<edm::measurement_collection<default_algebra>::buffer,
+    std::pair<edm::measurement_collection::buffer,
               edm::silicon_cluster_collection::buffer>
     operator()(const edm::silicon_cell_collection::const_view& cells,
                const detector_design_description::const_view& det_descr,
@@ -131,7 +130,7 @@ class clusterization_algorithm
         /// The detector conditions description
         const detector_conditions_description::const_view& det_cond;
         /// The measurement collection to fill
-        edm::measurement_collection<default_algebra>::view& measurements;
+        edm::measurement_collection::view& measurements;
         /// Buffer for linking cells to measurements
         vecmem::data::vector_view<unsigned int>& cell_links;
         /// Buffer for backup of the first element links
@@ -171,7 +170,7 @@ class clusterization_algorithm
 
     private:
     /// Main algorithmic implementation of the clusterization algorithm
-    std::pair<edm::measurement_collection<default_algebra>::buffer,
+    std::pair<edm::measurement_collection::buffer,
               std::optional<edm::silicon_cluster_collection::buffer>>
     execute_impl(const edm::silicon_cell_collection::const_view& cells,
                  const detector_design_description::const_view& det_descr,

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,7 +19,7 @@ TRACCC_HOST_DEVICE inline void aggregate_cluster(
     const detector_conditions_description::const_device& det_cond,
     const vecmem::device_vector<details::index_t>& f, const unsigned int start,
     const unsigned int end, const unsigned short cid,
-    edm::measurement_collection<default_algebra>::device::proxy_type out,
+    edm::measurement_collection::device::proxy_type out,
     vecmem::data::vector_view<unsigned int> cell_links, const unsigned int link,
     vecmem::device_vector<unsigned int>& disjoint_set,
     std::optional<std::reference_wrapper<unsigned int>> cluster_size) {
@@ -173,28 +173,30 @@ TRACCC_HOST_DEVICE inline void aggregate_cluster(
     /*
      * Fill output vector with calculated cluster properties
      */
-    out.local_position() = mean + offset + module_cd.measurement_translation();
-    out.local_variance() = var;
+    const auto position = mean + offset + module_cd.measurement_translation();
+    out.template set_local_position_in<default_algebra>(position);
+    out.template set_local_variance_in<default_algebra>(var);
     out.surface_link() = module_cd.geometry_id();
     // Set a unique identifier for the measurement.
     out.identifier() = link;
     // Set the dimensionality of the measurement.
     out.dimensions() = module_dd.dimensions();
     // Set the measurement's subspace.
-    out.subspace() = module_dd.subspace();
+    out.set_subspace(module_dd.subspace());
     // Set the index of the cluster that would be created for this measurement
     out.cluster_index() = link;
 
     if (cfg.diameter_strategy == clustering_diameter_strategy::CHANNEL0) {
-        out.diameter() = width[0];
+        out.diameter() = static_cast<float>(width[0]);
     } else if (cfg.diameter_strategy ==
                clustering_diameter_strategy::CHANNEL1) {
-        out.diameter() = width[1];
+        out.diameter() = static_cast<float>(width[1]);
     } else if (cfg.diameter_strategy == clustering_diameter_strategy::MAXIMUM) {
-        out.diameter() = std::max(width[0], width[1]);
+        out.diameter() = static_cast<float>(std::max(width[0], width[1]));
     } else if (cfg.diameter_strategy ==
                clustering_diameter_strategy::DIAGONAL) {
-        out.diameter() = math::sqrt(width[0] * width[0] + width[1] * width[1]);
+        out.diameter() = static_cast<float>(
+            math::sqrt(width[0] * width[0] + width[1] * width[1]));
     }
 }
 

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "traccc/clusterization/details/measurement_creation.hpp"
+#include "traccc/utils/detray_conversion.hpp"
 
 namespace traccc::device {
 
@@ -174,8 +175,8 @@ TRACCC_HOST_DEVICE inline void aggregate_cluster(
      * Fill output vector with calculated cluster properties
      */
     const auto position = mean + offset + module_cd.measurement_translation();
-    out.template set_local_position_in<default_algebra>(position);
-    out.template set_local_variance_in<default_algebra>(var);
+    out.local_position() = utils::to_float_array<default_algebra>(position);
+    out.local_variance() = utils::to_float_array<default_algebra>(var);
     out.surface_link() = module_cd.geometry_id();
     // Set a unique identifier for the measurement.
     out.identifier() = link;

--- a/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -145,7 +145,7 @@ TRACCC_DEVICE inline void ccl_core(
     const edm::silicon_cell_collection::const_device& cells_device,
     const detector_design_description::const_device& det_desc,
     const detector_conditions_description::const_device& det_cond,
-    edm::measurement_collection<default_algebra>::device measurements_device,
+    edm::measurement_collection::device measurements_device,
     const barrier_t& barrier, vecmem::device_vector<unsigned int>& disjoint_set,
     vecmem::device_vector<unsigned int>& cluster_size) {
     const auto size =
@@ -196,8 +196,7 @@ TRACCC_DEVICE inline void ccl_core(
         if (f.at(cid) == cid) {
             // Add a new measurement to the output buffer. Remembering its
             // position inside of the container.
-            const edm::measurement_collection<
-                default_algebra>::device::size_type meas_pos =
+            const edm::measurement_collection::device::size_type meas_pos =
                 measurements_device.push_back_default();
             // Set up the measurement under the appropriate index.
             aggregate_cluster(
@@ -232,15 +231,14 @@ TRACCC_DEVICE inline void ccl_kernel(
     vecmem::data::vector_view<unsigned int> disjoint_set_view,
     vecmem::data::vector_view<unsigned int> cluster_size_view,
     const barrier_t& barrier,
-    edm::measurement_collection<default_algebra>::view measurements_view,
+    edm::measurement_collection::view measurements_view,
     vecmem::data::vector_view<unsigned int> cell_links) {
 
     // Construct device containers around the views.
     const edm::silicon_cell_collection::const_device cells_device(cells_view);
     const detector_design_description::const_device det_desc(det_desc_view);
     const detector_conditions_description::const_device det_cond(det_cond_view);
-    edm::measurement_collection<default_algebra>::device measurements_device(
-        measurements_view);
+    edm::measurement_collection::device measurements_device(measurements_view);
     vecmem::device_vector<details::index_t> f_primary(f_view);
     vecmem::device_vector<details::index_t> gf_primary(gf_view);
     vecmem::device_vector<details::index_t> f_backup(f_backup_view);

--- a/device/common/include/traccc/finding/device/find_tracks.hpp
+++ b/device/common/include/traccc/finding/device/find_tracks.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -41,7 +41,7 @@ struct find_tracks_payload {
      *
      * @warning Measurements on the same surface must be adjacent
      */
-    edm::measurement_collection<default_algebra>::const_view measurements_view;
+    edm::measurement_collection::const_view measurements_view;
 
     /**
      * @brief View object to the vector of track parameters

--- a/device/common/include/traccc/finding/device/gather_best_tips_per_measurement.hpp
+++ b/device/common/include/traccc/finding/device/gather_best_tips_per_measurement.hpp
@@ -26,7 +26,7 @@ template <typename algebra_t>
 struct gather_best_tips_per_measurement_payload {
     vecmem::data::vector_view<const unsigned int> tips;
     vecmem::data::vector_view<const candidate_link> links;
-    typename edm::measurement_collection<algebra_t>::const_view measurements;
+    edm::measurement_collection::const_view measurements;
     vecmem::data::vector_view<unsigned long long int> insertion_mutex;
     vecmem::data::vector_view<unsigned int> tip_index;
     vecmem::data::vector_view<typename algebra_t::scalar> tip_pval;

--- a/device/common/include/traccc/finding/device/impl/build_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/build_tracks.ipp
@@ -22,8 +22,8 @@ TRACCC_HOST_DEVICE inline void build_tracks(
     const global_index_t globalIndex, bool run_mbf,
     const build_tracks_payload& payload) {
 
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements(payload.tracks_view.measurements);
+    const edm::measurement_collection::const_device measurements(
+        payload.tracks_view.measurements);
 
     const bound_track_parameters_collection_types::const_device seeds(
         payload.seeds_view);

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -52,7 +52,7 @@ TRACCC_HOST_DEVICE inline void find_tracks(
      * Initialize all of the device vectors from their vecmem views.
      */
     detector_t det(payload.det_data);
-    edm::measurement_collection<default_algebra>::const_device measurements(
+    edm::measurement_collection::const_device measurements(
         payload.measurements_view);
     bound_track_parameters_collection_types::const_device in_params(
         payload.in_params_view);

--- a/device/common/include/traccc/finding/device/impl/gather_best_tips_per_measurement.ipp
+++ b/device/common/include/traccc/finding/device/impl/gather_best_tips_per_measurement.ipp
@@ -30,8 +30,8 @@ TRACCC_HOST_DEVICE inline void gather_best_tips_per_measurement(
 
     const vecmem::device_vector<const unsigned int> tips(payload.tips);
     const vecmem::device_vector<const candidate_link> links(payload.links);
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements(payload.measurements);
+    const edm::measurement_collection::const_device measurements(
+        payload.measurements);
     vecmem::device_vector<unsigned long long int> insertion_mutex(
         payload.insertion_mutex);
     vecmem::device_vector<unsigned int> tip_index(payload.tip_index);

--- a/device/common/include/traccc/fitting/device/fit_prelude.hpp
+++ b/device/common/include/traccc/fitting/device/fit_prelude.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -50,8 +50,8 @@ TRACCC_HOST_DEVICE inline void fit_prelude(
     const edm::track track_candidate = track_candidates.at(param_id);
     const auto track_candidate_constituent_links =
         track_candidate.constituent_links();
-    const typename edm::measurement_collection<algebra_t>::const_device
-        measurements{track_candidates_view.measurements};
+    const edm::measurement_collection::const_device measurements{
+        track_candidates_view.measurements};
     for (const edm::track_constituent_link& link :
          track_candidate_constituent_links) {
         assert(link.type == edm::track_constituent_link::measurement);

--- a/device/common/include/traccc/seeding/device/estimate_track_params.hpp
+++ b/device/common/include/traccc/seeding/device/estimate_track_params.hpp
@@ -28,11 +28,10 @@ namespace traccc::device {
 /// @param[in] bfield           B field
 /// @param[out] params_view     Collection storing the bound track parameters
 ///
-template <typename algebra_t, typename bfield_t>
+template <typename bfield_t>
 TRACCC_HOST_DEVICE inline void estimate_track_params(
     global_index_t globalIndex, const track_params_estimation_config& config,
-    const typename edm::measurement_collection<algebra_t>::const_view&
-        measurements_view,
+    const edm::measurement_collection::const_view& measurements_view,
     const edm::spacepoint_collection::const_view& spacepoints_view,
     const edm::seed_collection::const_view& seeds_view, const bfield_t& bfield,
     bound_track_parameters_collection_types::view params_view);

--- a/device/common/include/traccc/seeding/device/form_spacepoints.hpp
+++ b/device/common/include/traccc/seeding/device/form_spacepoints.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,8 +29,7 @@ namespace traccc::device {
 template <typename detector_t>
 TRACCC_HOST_DEVICE inline void form_spacepoints(
     global_index_t globalIndex, typename detector_t::view det_view,
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements_view,
+    const edm::measurement_collection::const_view& measurements_view,
     edm::spacepoint_collection::view spacepoints_view);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/seeding/device/impl/estimate_track_params.ipp
+++ b/device/common/include/traccc/seeding/device/impl/estimate_track_params.ipp
@@ -17,12 +17,11 @@
 
 namespace traccc::device {
 
-template <typename algebra_t, typename bfield_t>
+template <typename bfield_t>
 TRACCC_HOST_DEVICE inline void estimate_track_params(
     const global_index_t globalIndex,
     const track_params_estimation_config& config,
-    const typename edm::measurement_collection<algebra_t>::const_view&
-        measurements_view,
+    const edm::measurement_collection::const_view& measurements_view,
     const edm::spacepoint_collection::const_view& spacepoints_view,
     const edm::seed_collection::const_view& seeds_view, const bfield_t& bfield,
     bound_track_parameters_collection_types::view params_view) {
@@ -34,8 +33,8 @@ TRACCC_HOST_DEVICE inline void estimate_track_params(
     }
 
     // Create the rest of the device objects.
-    const typename edm::measurement_collection<algebra_t>::const_device
-        measurements(measurements_view);
+    const edm::measurement_collection::const_device measurements(
+        measurements_view);
     const edm::spacepoint_collection::const_device spacepoints(
         spacepoints_view);
     bound_track_parameters_collection_types::device params(params_view);

--- a/device/common/include/traccc/seeding/device/impl/form_spacepoints.ipp
+++ b/device/common/include/traccc/seeding/device/impl/form_spacepoints.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,13 +18,12 @@ namespace traccc::device {
 template <typename detector_t>
 TRACCC_HOST_DEVICE inline void form_spacepoints(
     const global_index_t globalIndex, typename detector_t::view det_view,
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements_view,
+    const edm::measurement_collection::const_view& measurements_view,
     edm::spacepoint_collection::view spacepoints_view) {
 
     // Set up the input container(s).
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements(measurements_view);
+    const edm::measurement_collection::const_device measurements(
+        measurements_view);
 
     // Check if anything needs to be done
     if (globalIndex >= measurements.size()) {
@@ -43,7 +42,7 @@ TRACCC_HOST_DEVICE inline void form_spacepoints(
     if (details::is_valid_measurement(meas)) {
         const edm::spacepoint_collection::device::size_type i =
             spacepoints.push_back_default();
-        edm::spacepoint_collection::device::proxy_type sp = spacepoints.at(i);
+        edm::spacepoint sp = spacepoints.at(i);
         traccc::details::fill_pixel_spacepoint(sp, det, meas);
         sp.measurement_index_1() = globalIndex;
         sp.measurement_index_2() =

--- a/device/common/include/traccc/seeding/device/seed_parameter_estimation_algorithm.hpp
+++ b/device/common/include/traccc/seeding/device/seed_parameter_estimation_algorithm.hpp
@@ -30,8 +30,7 @@ namespace traccc::device {
 ///
 struct seed_parameter_estimation_algorithm
     : public algorithm<bound_track_parameters_collection_types::buffer(
-          const magnetic_field&,
-          const edm::measurement_collection<default_algebra>::const_view&,
+          const magnetic_field&, const edm::measurement_collection::const_view&,
           const edm::spacepoint_collection::const_view&,
           const edm::seed_collection::const_view&)>,
       public messaging,
@@ -63,8 +62,7 @@ struct seed_parameter_estimation_algorithm
     ///
     output_type operator()(
         const magnetic_field& bfield,
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements,
+        const edm::measurement_collection::const_view& measurements,
         const edm::spacepoint_collection::const_view& spacepoints,
         const edm::seed_collection::const_view& seeds) const override;
 
@@ -81,8 +79,7 @@ struct seed_parameter_estimation_algorithm
         /// The magnetic field object
         const magnetic_field& bfield;
         /// All measurements of the event
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements;
+        const edm::measurement_collection::const_view& measurements;
         /// All spacepoints of the event
         const edm::spacepoint_collection::const_view& spacepoints;
         /// The reconstructed track seeds of the event

--- a/device/common/include/traccc/seeding/device/silicon_pixel_spacepoint_formation_algorithm.hpp
+++ b/device/common/include/traccc/seeding/device/silicon_pixel_spacepoint_formation_algorithm.hpp
@@ -28,7 +28,7 @@ namespace traccc::device {
 class silicon_pixel_spacepoint_formation_algorithm
     : public algorithm<edm::spacepoint_collection::buffer(
           const detector_buffer&,
-          const edm::measurement_collection<default_algebra>::const_view&)>,
+          const edm::measurement_collection::const_view&)>,
       public messaging,
       public algorithm_base {
 
@@ -51,10 +51,9 @@ class silicon_pixel_spacepoint_formation_algorithm
     /// @return A spacepoint buffer, with one spacepoint for every
     ///         silicon pixel measurement
     ///
-    output_type operator()(
-        const detector_buffer& det,
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements) const override;
+    output_type operator()(const detector_buffer& det,
+                           const edm::measurement_collection::const_view&
+                               measurements) const override;
 
     protected:
     /// @name Function(s) to be implemented by derived classes
@@ -63,13 +62,11 @@ class silicon_pixel_spacepoint_formation_algorithm
     /// Payload for the @c form_spacepoints_kernel function
     struct form_spacepoints_kernel_payload {
         /// The number of measurements in the event
-        edm::measurement_collection<default_algebra>::const_view::size_type
-            n_measurements;
+        edm::measurement_collection::const_view::size_type n_measurements;
         /// The detector object
         const detector_buffer& detector;
         /// The input measurements
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements;
+        const edm::measurement_collection::const_view& measurements;
         /// The output spacepoints
         edm::spacepoint_collection::view& spacepoints;
     };

--- a/device/common/src/clusterization/clusterization_algorithm.cpp
+++ b/device/common/src/clusterization/clusterization_algorithm.cpp
@@ -32,8 +32,7 @@ clusterization_algorithm::clusterization_algorithm(
         ->wait();
 }
 
-edm::measurement_collection<default_algebra>::buffer
-clusterization_algorithm::operator()(
+edm::measurement_collection::buffer clusterization_algorithm::operator()(
     const edm::silicon_cell_collection::const_view& cells,
     const detector_design_description::const_view& det_descr,
     const detector_conditions_description::const_view& det_cond) const {
@@ -42,8 +41,7 @@ clusterization_algorithm::operator()(
                             clustering_discard_disjoint_set{});
 }
 
-edm::measurement_collection<default_algebra>::buffer
-clusterization_algorithm::operator()(
+edm::measurement_collection::buffer clusterization_algorithm::operator()(
     const edm::silicon_cell_collection::const_view& cells,
     const detector_design_description::const_view& det_descr,
     const detector_conditions_description::const_view& det_cond,
@@ -56,7 +54,7 @@ clusterization_algorithm::operator()(
     return std::move(res);
 }
 
-std::pair<edm::measurement_collection<default_algebra>::buffer,
+std::pair<edm::measurement_collection::buffer,
           edm::silicon_cluster_collection::buffer>
 clusterization_algorithm::operator()(
     const edm::silicon_cell_collection::const_view& cells,
@@ -71,7 +69,7 @@ clusterization_algorithm::operator()(
     return {std::move(res), std::move(*djs)};
 }
 
-std::pair<edm::measurement_collection<default_algebra>::buffer,
+std::pair<edm::measurement_collection::buffer,
           std::optional<edm::silicon_cluster_collection::buffer>>
 clusterization_algorithm::execute_impl(
     const edm::silicon_cell_collection::const_view& cells,
@@ -96,7 +94,7 @@ clusterization_algorithm::execute_impl(
     // If there are no cells, return right away.
     if (num_cells == 0) {
         if (keep_disjoint_set) {
-            return {edm::measurement_collection<default_algebra>::buffer{},
+            return {edm::measurement_collection::buffer{},
                     edm::silicon_cluster_collection::buffer{}};
         } else {
             return {};
@@ -104,7 +102,7 @@ clusterization_algorithm::execute_impl(
     }
 
     // Create the result object, overestimating the number of measurements.
-    edm::measurement_collection<default_algebra>::buffer measurements{
+    edm::measurement_collection::buffer measurements{
         num_cells, mr().main, vecmem::data::buffer_type::resizable};
     copy().setup(measurements)->ignore();
 
@@ -131,16 +129,15 @@ clusterization_algorithm::execute_impl(
                 m_adjv_backup, m_backup_mutex.get(), disjoint_set,
                 cluster_sizes});
 
-    std::optional<traccc::edm::silicon_cluster_collection::buffer>
-        cluster_data = std::nullopt;
+    std::optional<edm::silicon_cluster_collection::buffer> cluster_data =
+        std::nullopt;
 
     // Create the cluster data if requested.
     if (keep_disjoint_set) {
 
         // Get the number of reconstructed measurements, in an asynchronous way
         // if possible.
-        edm::measurement_collection<default_algebra>::buffer::size_type
-            num_measurements = 0u;
+        edm::measurement_collection::buffer::size_type num_measurements = 0u;
         if (mr().host) {
             const vecmem::async_size size =
                 copy().get_size(measurements, *(mr().host));

--- a/device/common/src/seeding/seed_parameter_estimation_algorithm.cpp
+++ b/device/common/src/seeding/seed_parameter_estimation_algorithm.cpp
@@ -30,8 +30,7 @@ seed_parameter_estimation_algorithm::~seed_parameter_estimation_algorithm() =
 
 auto seed_parameter_estimation_algorithm::operator()(
     const magnetic_field& bfield,
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements,
+    const edm::measurement_collection::const_view& measurements,
     const edm::spacepoint_collection::const_view& spacepoints,
     const edm::seed_collection::const_view& seeds) const -> output_type {
 

--- a/device/common/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cpp
+++ b/device/common/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cpp
@@ -18,12 +18,11 @@ silicon_pixel_spacepoint_formation_algorithm::
 
 auto silicon_pixel_spacepoint_formation_algorithm::operator()(
     const detector_buffer& det,
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements) const -> output_type {
+    const edm::measurement_collection::const_view& measurements) const
+    -> output_type {
 
     // Get the number of measurements. In an asynchronous way if possible.
-    edm::measurement_collection<default_algebra>::const_view::size_type
-        n_measurements = 0u;
+    edm::measurement_collection::const_view::size_type n_measurements = 0u;
     if (mr().host) {
         vecmem::async_size size = copy().get_size(measurements, *(mr().host));
         // Here we could give control back to the caller, once our code allows

--- a/device/cuda/include/traccc/cuda/clusterization/measurement_sorting_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/clusterization/measurement_sorting_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -33,8 +33,8 @@ namespace traccc::cuda {
 /// to the rescue.
 ///
 class measurement_sorting_algorithm
-    : public algorithm<edm::measurement_collection<default_algebra>::buffer(
-          const edm::measurement_collection<default_algebra>::const_view&)>,
+    : public algorithm<edm::measurement_collection::buffer(
+          const edm::measurement_collection::const_view&)>,
       public messaging {
 
     public:
@@ -52,8 +52,8 @@ class measurement_sorting_algorithm
     /// @param measurements The measurements to sort
     ///
     [[nodiscard]] output_type operator()(
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements) const override;
+        const edm::measurement_collection::const_view& measurements)
+        const override;
 
     private:
     /// The memory resource(s) to use

--- a/device/cuda/include/traccc/cuda/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -34,7 +34,7 @@ namespace traccc::cuda {
 class combinatorial_kalman_filter_algorithm
     : public algorithm<edm::track_container<default_algebra>::buffer(
           const detector_buffer&, const magnetic_field&,
-          const edm::measurement_collection<default_algebra>::const_view&,
+          const edm::measurement_collection::const_view&,
           const bound_track_parameters_collection_types::const_view&)>,
       public messaging {
 
@@ -60,8 +60,7 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const detector_buffer& det, const magnetic_field& bfield,
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements,
+        const edm::measurement_collection::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;
 

--- a/device/cuda/include/traccc/cuda/gbts_seeding/gbts_seeding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/gbts_seeding/gbts_seeding_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -37,8 +37,7 @@ namespace traccc::cuda {
 class gbts_seeding_algorithm
     : public algorithm<edm::seed_collection::buffer(
           const edm::spacepoint_collection::const_view&,
-          const edm::measurement_collection<default_algebra>::const_view&
-              measurements)>,
+          const edm::measurement_collection::const_view&)>,
       public messaging {
 
     public:
@@ -59,8 +58,7 @@ class gbts_seeding_algorithm
     ///
     output_type operator()(
         const edm::spacepoint_collection::const_view& spacepoints,
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements) const;
+        const edm::measurement_collection::const_view& measurements) const;
 
     private:
     gbts_seedfinder_config m_config;

--- a/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
+++ b/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -85,8 +85,8 @@ greedy_ambiguity_resolution_algorithm::operator()(
     const edm::track_container<default_algebra>::const_view& tracks_view)
     const {
 
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements(tracks_view.measurements);
+    const edm::measurement_collection::const_device measurements(
+        tracks_view.measurements);
 
     auto n_meas_total = m_copy.get().get_size(tracks_view.measurements);
 

--- a/device/cuda/src/clusterization/kernels/ccl_kernel.cu
+++ b/device/cuda/src/clusterization/kernels/ccl_kernel.cu
@@ -23,7 +23,7 @@ __global__ void ccl_kernel(
     const edm::silicon_cell_collection::const_view cells_view,
     const detector_design_description::const_view det_desc_view,
     const detector_conditions_description::const_view det_cond_view,
-    edm::measurement_collection<default_algebra>::view measurements_view,
+    edm::measurement_collection::view measurements_view,
     vecmem::data::vector_view<unsigned int> cell_links,
     vecmem::data::vector_view<device::details::index_t> f_backup_view,
     vecmem::data::vector_view<device::details::index_t> gf_backup_view,

--- a/device/cuda/src/clusterization/kernels/ccl_kernel.cuh
+++ b/device/cuda/src/clusterization/kernels/ccl_kernel.cuh
@@ -26,7 +26,7 @@ __global__ void ccl_kernel(
     const edm::silicon_cell_collection::const_view cells_view,
     const detector_design_description::const_view det_descr_view,
     const detector_conditions_description::const_view det_cond_view,
-    edm::measurement_collection<default_algebra>::view measurements_view,
+    edm::measurement_collection::view measurements_view,
     vecmem::data::vector_view<unsigned int> cell_links,
     vecmem::data::vector_view<device::details::index_t> f_backup_view,
     vecmem::data::vector_view<device::details::index_t> gf_backup_view,

--- a/device/cuda/src/clusterization/measurement_sorting_algorithm.cu
+++ b/device/cuda/src/clusterization/measurement_sorting_algorithm.cu
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -35,14 +35,13 @@ namespace kernels {
 /// @param[in] sorted_indices_view View of the sorted measurement indices
 ///
 __global__ void fill_sorted_measurements(
-    const edm::measurement_collection<default_algebra>::const_view input_view,
-    edm::measurement_collection<default_algebra>::view output_view,
+    const edm::measurement_collection::const_view input_view,
+    edm::measurement_collection::view output_view,
     const vecmem::data::vector_view<const unsigned int> sorted_indices_view) {
 
     // Create the device objects.
-    const edm::measurement_collection<default_algebra>::const_device input{
-        input_view};
-    edm::measurement_collection<default_algebra>::device output{output_view};
+    const edm::measurement_collection::const_device input{input_view};
+    edm::measurement_collection::device output{output_view};
     const vecmem::device_vector<const unsigned int> sorted_indices{
         sorted_indices_view};
 
@@ -65,8 +64,7 @@ measurement_sorting_algorithm::measurement_sorting_algorithm(
 
 measurement_sorting_algorithm::output_type
 measurement_sorting_algorithm::operator()(
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements_view) const {
+    const edm::measurement_collection::const_view& measurements_view) const {
 
     // Exit early if there are no measurements.
     if (measurements_view.capacity() == 0) {
@@ -81,8 +79,8 @@ measurement_sorting_algorithm::operator()(
             .on(stream);
 
     // Create a device container on top of the view.
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements{measurements_view};
+    const edm::measurement_collection::const_device measurements{
+        measurements_view};
 
     // Create a vector of measurement indices, which would be sorted.
     vecmem::data::vector_buffer<unsigned int> indices(

--- a/device/cuda/src/finding/combinatorial_kalman_filter.cuh
+++ b/device/cuda/src/finding/combinatorial_kalman_filter.cuh
@@ -78,14 +78,12 @@ template <typename detector_t, typename bfield_t>
 edm::track_container<typename detector_t::algebra_type>::buffer
 combinatorial_kalman_filter(
     const typename detector_t::const_view_type& det, const bfield_t& field,
-    const typename edm::measurement_collection<
-        typename detector_t::algebra_type>::const_view& measurements_view,
+    const edm::measurement_collection::const_view& measurements_view,
     const bound_track_parameters_collection_types::const_view& seeds,
     const finding_config& config, const memory_resource& mr, vecmem::copy& copy,
     const Logger& log, stream& str, unsigned int warp_size) {
 
-    const typename edm::measurement_collection<
-        typename detector_t::algebra_type>::const_device measurements{
+    const edm::measurement_collection::const_device measurements{
         measurements_view};
 
     assert(config.min_step_length_for_next_surface >

--- a/device/cuda/src/finding/combinatorial_kalman_filter_algorithm.cu
+++ b/device/cuda/src/finding/combinatorial_kalman_filter_algorithm.cu
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -22,8 +22,7 @@ namespace traccc::cuda {
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
     const detector_buffer& det, const magnetic_field& field,
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements,
+    const edm::measurement_collection::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
     // Perform the track finding using the appropriate templated implementation.

--- a/device/cuda/src/gbts_seeding/gbts_seeding_algorithm.cu
+++ b/device/cuda/src/gbts_seeding/gbts_seeding_algorithm.cu
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -121,8 +121,7 @@ gbts_seeding_algorithm::gbts_seeding_algorithm(
 
 gbts_seeding_algorithm::output_type gbts_seeding_algorithm::operator()(
     const traccc::edm::spacepoint_collection::const_view& spacepoints,
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements) const {
+    const edm::measurement_collection::const_view& measurements) const {
 
     gbts_ctx ctx;
 

--- a/device/cuda/src/gbts_seeding/kernels/GbtsNodesMakingKernels.cuh
+++ b/device/cuda/src/gbts_seeding/kernels/GbtsNodesMakingKernels.cuh
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -25,16 +25,15 @@ namespace traccc::cuda::kernels {
 
 __global__ void count_sp_by_layer(
     const traccc::edm::spacepoint_collection::const_view spacepoints_view,
-    const edm::measurement_collection<default_algebra>::const_view
-        measurements_view,
+    const edm::measurement_collection::const_view measurements_view,
     const short* volumeToLayerMap, const uint2* surfaceToLayerMap,
     const char* d_layerType, float4* reducedSP, int* d_layerCounts,
     short* spacepointsLayer, const float type1_max_width,
     const unsigned int nSp, const long unsigned int volumeMapSize,
     const long unsigned int surfaceMapSize, bool doTauCut = true) {
 
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements(measurements_view);
+    const edm::measurement_collection::const_device measurements(
+        measurements_view);
     const traccc::edm::spacepoint_collection::const_device spacepoints(
         spacepoints_view);
 

--- a/device/cuda/src/seeding/seed_parameter_estimation_algorithm.cu
+++ b/device/cuda/src/seeding/seed_parameter_estimation_algorithm.cu
@@ -19,17 +19,17 @@ namespace traccc::cuda {
 namespace kernels {
 
 /// CUDA kernel for running @c traccc::device::estimate_track_params
-template <typename algebra_t, typename bfield_t>
+template <typename bfield_t>
 __global__ void estimate_track_params(
     const track_params_estimation_config config,
-    typename edm::measurement_collection<algebra_t>::const_view measurements,
+    edm::measurement_collection::const_view measurements,
     edm::spacepoint_collection::const_view spacepoints,
     edm::seed_collection::const_view seeds, const bfield_t bfield,
     bound_track_parameters_collection_types::view params_view) {
 
-    device::estimate_track_params<algebra_t>(details::global_index1(), config,
-                                             measurements, spacepoints, seeds,
-                                             bfield, params_view);
+    device::estimate_track_params(details::global_index1(), config,
+                                  measurements, spacepoints, seeds, bfield,
+                                  params_view);
 }
 
 }  // namespace kernels
@@ -50,10 +50,10 @@ void seed_parameter_estimation_algorithm::estimate_seed_params_kernel(
     magnetic_field_visitor<bfield_type_list<scalar>>(
         payload.bfield,
         [&]<typename bfield_view_t>(const bfield_view_t& bfield) {
-            kernels::estimate_track_params<default_algebra>
-                <<<n_blocks, n_threads, 0, details::get_stream(stream())>>>(
-                    payload.config, payload.measurements, payload.spacepoints,
-                    payload.seeds, bfield, payload.params);
+            kernels::estimate_track_params<<<n_blocks, n_threads, 0,
+                                             details::get_stream(stream())>>>(
+                payload.config, payload.measurements, payload.spacepoints,
+                payload.seeds, bfield, payload.params);
         });
     TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 }

--- a/device/cuda/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cu
+++ b/device/cuda/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cu
@@ -20,11 +20,10 @@ namespace kernels {
 
 /// Kernel wrapping @c device::form_spacepoints
 template <typename detector_t>
-__global__ void __launch_bounds__(1024, 1) form_spacepoints(
-    typename detector_t::view detector,
-    typename edm::measurement_collection<
-        typename detector_t::device::algebra_type>::const_view measurements,
-    edm::spacepoint_collection::view spacepoints)
+__global__ void __launch_bounds__(1024, 1)
+    form_spacepoints(typename detector_t::view detector,
+                     edm::measurement_collection::const_view measurements,
+                     edm::spacepoint_collection::view spacepoints)
     requires(traccc::is_detector_traits<detector_t>)
 {
     device::form_spacepoints<detector_t>(details::global_index1(), detector,

--- a/device/sycl/include/traccc/sycl/clusterization/measurement_sorting_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/measurement_sorting_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -33,8 +33,8 @@ namespace traccc::sycl {
 /// to the rescue.
 ///
 class measurement_sorting_algorithm
-    : public algorithm<edm::measurement_collection<default_algebra>::buffer(
-          const edm::measurement_collection<default_algebra>::const_view&)>,
+    : public algorithm<edm::measurement_collection::buffer(
+          const edm::measurement_collection::const_view&)>,
       public messaging {
 
     public:
@@ -54,8 +54,8 @@ class measurement_sorting_algorithm
     /// @param measurements The measurements to sort
     ///
     [[nodiscard]] output_type operator()(
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements) const override;
+        const edm::measurement_collection::const_view& measurements)
+        const override;
 
     private:
     /// Memory resource(s) to use

--- a/device/sycl/include/traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -34,7 +34,7 @@ namespace traccc::sycl {
 class combinatorial_kalman_filter_algorithm
     : public algorithm<edm::track_container<default_algebra>::buffer(
           const detector_buffer&, const magnetic_field&,
-          const edm::measurement_collection<default_algebra>::const_view&,
+          const edm::measurement_collection::const_view&,
           const bound_track_parameters_collection_types::const_view&)>,
       public messaging {
 
@@ -60,8 +60,7 @@ class combinatorial_kalman_filter_algorithm
     ///
     output_type operator()(
         const detector_buffer& det, const magnetic_field& bfield,
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements,
+        const edm::measurement_collection::const_view& measurements,
         const bound_track_parameters_collection_types::const_view& seeds)
         const override;
 

--- a/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
+++ b/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -33,8 +33,7 @@ measurement_sorting_algorithm::measurement_sorting_algorithm(
 
 measurement_sorting_algorithm::output_type
 measurement_sorting_algorithm::operator()(
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements_view) const {
+    const edm::measurement_collection::const_view& measurements_view) const {
 
     // Exit early if there are no measurements.
     if (measurements_view.capacity() == 0) {
@@ -49,8 +48,8 @@ measurement_sorting_algorithm::operator()(
     auto policy = oneapi::dpl::execution::device_policy{queue};
 
     // Create a device container on top of the view.
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements{measurements_view};
+    const edm::measurement_collection::const_device measurements{
+        measurements_view};
 
     // Create a vector of measurement indices, which would be sorted.
     vecmem::data::vector_buffer<unsigned int> indices(
@@ -82,10 +81,9 @@ measurement_sorting_algorithm::operator()(
                  sorted_indices_view =
                      vecmem::get_data(indices)](::sycl::nd_item<1> item) {
                     // Create the device objects.
-                    const edm::measurement_collection<
-                        default_algebra>::const_device input{measurements_view};
-                    edm::measurement_collection<default_algebra>::device output{
-                        output_view};
+                    const edm::measurement_collection::const_device input{
+                        measurements_view};
+                    edm::measurement_collection::device output{output_view};
                     const vecmem::device_vector<const unsigned int>
                         sorted_indices{sorted_indices_view};
 

--- a/device/sycl/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/sycl/src/finding/combinatorial_kalman_filter.hpp
@@ -94,14 +94,12 @@ template <typename kernel_t, typename detector_t, typename bfield_t>
 edm::track_container<typename detector_t::algebra_type>::buffer
 combinatorial_kalman_filter(
     const typename detector_t::const_view_type& det, const bfield_t& field,
-    const typename edm::measurement_collection<
-        typename detector_t::algebra_type>::const_view& measurements_view,
+    const edm::measurement_collection::const_view& measurements_view,
     const bound_track_parameters_collection_types::const_view& seeds,
     const finding_config& config, const memory_resource& mr, vecmem::copy& copy,
     ::sycl::queue& queue) {
 
-    const typename edm::measurement_collection<
-        typename detector_t::algebra_type>::const_device measurements{
+    const edm::measurement_collection::const_device measurements{
         measurements_view};
 
     assert(config.min_step_length_for_next_surface >

--- a/device/sycl/src/finding/combinatorial_kalman_filter_algorithm.sycl
+++ b/device/sycl/src/finding/combinatorial_kalman_filter_algorithm.sycl
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,8 +30,7 @@ struct combinatorial_kalman_filter;
 combinatorial_kalman_filter_algorithm::output_type
 combinatorial_kalman_filter_algorithm::operator()(
     const detector_buffer& detector, const magnetic_field& field,
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements,
+    const edm::measurement_collection::const_view& measurements,
     const bound_track_parameters_collection_types::const_view& seeds) const {
 
     // Perform the track finding using the templated implementation.

--- a/device/sycl/src/seeding/seed_parameter_estimation_algorithm.sycl
+++ b/device/sycl/src/seeding/seed_parameter_estimation_algorithm.sycl
@@ -42,7 +42,7 @@ void seed_parameter_estimation_algorithm::estimate_seed_params_kernel(
                      spacepoints = payload.spacepoints, seeds = payload.seeds,
                      bfield = bfield,
                      params = payload.params](::sycl::nd_item<1> item) {
-                        device::estimate_track_params<default_algebra>(
+                        device::estimate_track_params(
                             details::global_index(item), config, measurements,
                             spacepoints, seeds, bfield, params);
                     });

--- a/examples/io/create_binaries.cpp
+++ b/examples/io/create_binaries.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -54,8 +54,7 @@ int create_binaries(const traccc::opts::detector& detector_opts,
                           vecmem::get_data(det_cond));
 
         // Read the measurements and hits from the relevant event file
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements{host_mr};
+        traccc::edm::measurement_collection::host measurements{host_mr};
         traccc::edm::spacepoint_collection::host spacepoints{host_mr};
         traccc::io::read_spacepoints(spacepoints, measurements, event,
                                      input_opts.directory, nullptr, nullptr,

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -237,8 +237,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     else {
 
         // Copy the measurements back to the host.
-        edm::measurement_collection<default_algebra>::host measurements_host(
-            m_host_mr);
+        edm::measurement_collection::host measurements_host(m_host_mr);
         m_vecmem_objects.async_copy()(measurements, measurements_host)->wait();
 
         // Return an empty object.
@@ -286,8 +285,7 @@ bound_track_parameters_collection_types::host full_chain_algorithm::seeding(
     else {
 
         // Copy the measurements back to the host.
-        edm::measurement_collection<default_algebra>::host measurements_host(
-            m_host_mr);
+        edm::measurement_collection::host measurements_host(m_host_mr);
         m_vecmem_objects.async_copy()(measurements, measurements_host)->wait();
 
         // Return an empty object.

--- a/examples/run/alpaka/seeding_example_alpaka.cpp
+++ b/examples/run/alpaka/seeding_example_alpaka.cpp
@@ -193,8 +193,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
         // Instantiate host containers/collections
         traccc::edm::spacepoint_collection::host spacepoints_per_event{host_mr};
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::host::seeding_algorithm::output_type seeds{host_mr};
         traccc::host::track_params_estimation::output_type params;
         traccc::edm::track_container<traccc::default_algebra>::host
@@ -246,7 +246,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                        spacepoints_alpaka_buffer)
                 ->wait();
 
-            traccc::edm::measurement_collection<traccc::default_algebra>::buffer
+            traccc::edm::measurement_collection::buffer
                 measurements_alpaka_buffer(
                     static_cast<unsigned int>(measurements_per_event.size()),
                     mr.main);

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -225,8 +225,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
         host_fitting_algorithm::output_type track_states{host_mr};
 
         // Instantiate alpaka containers/collections
-        traccc::edm::measurement_collection<traccc::default_algebra>::buffer
-            measurements_alpaka_buffer;
+        traccc::edm::measurement_collection::buffer measurements_alpaka_buffer;
         traccc::edm::spacepoint_collection::buffer spacepoints_alpaka_buffer;
         traccc::edm::seed_collection::buffer seeds_alpaka_buffer;
         traccc::bound_track_parameters_collection_types::buffer
@@ -373,8 +372,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
           compare cpu and alpaka result
           ----------------------------------*/
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event_alpaka{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event_alpaka{
+            host_mr};
         traccc::edm::spacepoint_collection::host spacepoints_per_event_alpaka{
             host_mr};
         traccc::edm::seed_collection::host seeds_alpaka{host_mr};
@@ -400,8 +399,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
             TRACCC_INFO("===>>> Event " << event << " <<<===");
 
             // Compare the measurements made on the host and on the device.
-            traccc::soa_comparator<
-                traccc::edm::measurement_collection<traccc::default_algebra>>
+            traccc::soa_comparator<traccc::edm::measurement_collection>
                 compare_measurements{"measurements"};
             compare_measurements(
                 vecmem::get_data(measurements_per_event),

--- a/examples/run/cpu/full_chain_algorithm.cpp
+++ b/examples/run/cpu/full_chain_algorithm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -63,8 +63,8 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     if (m_detector != nullptr) {
 
         // Run the seed-finding.
-        const edm::measurement_collection<default_algebra>::const_data
-            measurements_view = vecmem::get_data(measurements);
+        const edm::measurement_collection::const_data measurements_view =
+            vecmem::get_data(measurements);
         const spacepoint_formation_algorithm::output_type spacepoints =
             m_spacepoint_formation(*m_detector, measurements_view);
         const edm::spacepoint_collection::const_data spacepoints_data =
@@ -114,8 +114,8 @@ bound_track_parameters_collection_types::host full_chain_algorithm::seeding(
     if (m_detector != nullptr) {
 
         // Run the seed-finding.
-        const edm::measurement_collection<default_algebra>::const_data
-            measurements_view = vecmem::get_data(measurements);
+        const edm::measurement_collection::const_data measurements_view =
+            vecmem::get_data(measurements);
         const spacepoint_formation_algorithm::output_type spacepoints =
             m_spacepoint_formation(*m_detector, measurements_view);
         const edm::spacepoint_collection::const_data spacepoints_data =

--- a/examples/run/cpu/misaligned_truth_fitting_example.cpp
+++ b/examples/run/cpu/misaligned_truth_fitting_example.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -148,8 +148,8 @@ int main(int argc, char* argv[]) {
 
         // For the first half of events run Alg0
         if ((event - input_opts.skip) / (input_opts.events / 2) == 0) {
-            traccc::edm::measurement_collection<traccc::default_algebra>::host
-                truth_measurements{host_mr};
+            traccc::edm::measurement_collection::host truth_measurements{
+                host_mr};
             traccc::edm::track_container<default_algebra>::host
                 truth_track_candidates{host_mr};
             evt_data.generate_truth_candidates(
@@ -177,8 +177,8 @@ int main(int argc, char* argv[]) {
                 }
             }
         } else {
-            traccc::edm::measurement_collection<traccc::default_algebra>::host
-                truth_measurements{host_mr};
+            traccc::edm::measurement_collection::host truth_measurements{
+                host_mr};
             traccc::edm::track_container<default_algebra>::host
                 truth_track_candidates{host_mr};
             evt_data.generate_truth_candidates(

--- a/examples/run/cpu/seeding_example.cpp
+++ b/examples/run/cpu/seeding_example.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -163,8 +163,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
          event < input_opts.events + input_opts.skip; ++event) {
 
         // Read the hits from the relevant event file
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::edm::spacepoint_collection::host spacepoints_per_event{host_mr};
         traccc::io::read_spacepoints(
             spacepoints_per_event, measurements_per_event, event,

--- a/examples/run/cpu/truth_finding_example.cpp
+++ b/examples/run/cpu/truth_finding_example.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -127,8 +127,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
                                     &polymorphic_detector, input_opts.format,
                                     false);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            truth_measurements{host_mr};
+        traccc::edm::measurement_collection::host truth_measurements{host_mr};
         traccc::edm::track_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
 
@@ -156,8 +155,8 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
         std::cout << "Number of seeds: " << seeds.size() << std::endl;
 
         // Read measurements
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::io::read_measurements(
             measurements_per_event, event, input_opts.directory,
             (input_opts.use_acts_geom_source ? &polymorphic_detector : nullptr),

--- a/examples/run/cpu/truth_fitting_example.cpp
+++ b/examples/run/cpu/truth_fitting_example.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -114,8 +114,7 @@ int main(int argc, char* argv[]) {
                                     &polymorphic_detector, input_opts.format,
                                     false);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            truth_measurements{host_mr};
+        traccc::edm::measurement_collection::host truth_measurements{host_mr};
         traccc::edm::track_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
 

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -241,8 +241,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     else {
 
         // Copy the measurements back to the host.
-        edm::measurement_collection<default_algebra>::host measurements_host(
-            m_host_mr);
+        edm::measurement_collection::host measurements_host(m_host_mr);
         m_copy(measurements, measurements_host)->wait();
 
         // Return an empty object.
@@ -288,8 +287,7 @@ bound_track_parameters_collection_types::host full_chain_algorithm::seeding(
     else {
 
         // Copy the measurements back to the host.
-        edm::measurement_collection<default_algebra>::host measurements_host(
-            m_host_mr);
+        edm::measurement_collection::host measurements_host(m_host_mr);
         m_copy(measurements, measurements_host)->wait();
 
         // Return an empty object.

--- a/examples/run/cuda/seeding_example_cuda.cpp
+++ b/examples/run/cuda/seeding_example_cuda.cpp
@@ -205,8 +205,8 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
 
         // Instantiate host containers/collections
         traccc::edm::spacepoint_collection::host spacepoints_per_event{host_mr};
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::host::seeding_algorithm::output_type seeds{host_mr};
         traccc::host::track_params_estimation::output_type params;
         traccc::edm::track_container<traccc::default_algebra>::host
@@ -252,7 +252,7 @@ int seq_run(const traccc::opts::track_seeding& seeding_opts,
                        spacepoints_cuda_buffer)
                 ->wait();
 
-            traccc::edm::measurement_collection<traccc::default_algebra>::buffer
+            traccc::edm::measurement_collection::buffer
                 measurements_cuda_buffer(
                     static_cast<unsigned int>(measurements_per_event.size()),
                     mr.main);

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -254,8 +254,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
         host_fitting_algorithm::output_type track_states{host_mr};
 
         // Instantiate cuda containers/collections
-        traccc::edm::measurement_collection<traccc::default_algebra>::buffer
-            measurements_cuda_buffer;
+        traccc::edm::measurement_collection::buffer measurements_cuda_buffer;
         traccc::edm::spacepoint_collection::buffer spacepoints_cuda_buffer;
         traccc::edm::seed_collection::buffer seeds_cuda_buffer;
         traccc::bound_track_parameters_collection_types::buffer
@@ -422,8 +421,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
           compare cpu and cuda result
           ----------------------------------*/
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event_cuda{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event_cuda{
+            host_mr};
         traccc::edm::spacepoint_collection::host spacepoints_per_event_cuda{
             host_mr};
         traccc::edm::seed_collection::host seeds_cuda{host_mr};
@@ -461,8 +460,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
             TRACCC_INFO("===>>> Event " << event << " <<<===");
 
             // Compare the measurements made on the host and on the device.
-            traccc::soa_comparator<
-                traccc::edm::measurement_collection<traccc::default_algebra>>
+            traccc::soa_comparator<traccc::edm::measurement_collection>
                 compare_measurements{"measurements"};
             compare_measurements(vecmem::get_data(measurements_per_event),
                                  vecmem::get_data(measurements_per_event_cuda));

--- a/examples/run/cuda/truth_finding_example_cuda.cpp
+++ b/examples/run/cuda/truth_finding_example_cuda.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -165,8 +165,7 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
                                     &polymorphic_detector, input_opts.format,
                                     false);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            truth_measurements{host_mr};
+        traccc::edm::measurement_collection::host truth_measurements{host_mr};
         traccc::edm::track_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
 
@@ -201,17 +200,15 @@ int seq_run(const traccc::opts::track_finding& finding_opts,
             ->wait();
 
         // Read measurements
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::io::read_measurements(
             measurements_per_event, event, input_opts.directory,
             (input_opts.use_acts_geom_source ? &polymorphic_detector : nullptr),
             nullptr, nullptr, input_opts.format);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::buffer
-            measurements_cuda_buffer(
-                static_cast<unsigned int>(measurements_per_event.size()),
-                mr.main);
+        traccc::edm::measurement_collection::buffer measurements_cuda_buffer(
+            static_cast<unsigned int>(measurements_per_event.size()), mr.main);
         async_copy.setup(measurements_cuda_buffer)->wait();
         async_copy(vecmem::get_data(measurements_per_event),
                    measurements_cuda_buffer)

--- a/examples/run/cuda/truth_fitting_example_cuda.cpp
+++ b/examples/run/cuda/truth_fitting_example_cuda.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -147,8 +147,7 @@ int main(int argc, char* argv[]) {
                                     &polymorphic_detector, input_opts.format,
                                     false);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            truth_measurements{host_mr};
+        traccc::edm::measurement_collection::host truth_measurements{host_mr};
         traccc::edm::track_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
 

--- a/examples/run/sycl/full_chain_algorithm.cpp
+++ b/examples/run/sycl/full_chain_algorithm.cpp
@@ -262,8 +262,7 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     else {
 
         // Copy the measurements back to the host.
-        edm::measurement_collection<default_algebra>::host measurements_host(
-            m_host_mr.get());
+        edm::measurement_collection::host measurements_host(m_host_mr.get());
         m_copy(measurements, measurements_host)->wait();
 
         // Return an empty object.
@@ -310,8 +309,7 @@ bound_track_parameters_collection_types::host full_chain_algorithm::seeding(
     else {
 
         // Copy the measurements back to the host.
-        edm::measurement_collection<default_algebra>::host measurements_host(
-            m_host_mr.get());
+        edm::measurement_collection::host measurements_host(m_host_mr.get());
         m_copy(measurements, measurements_host)->wait();
 
         // Return an empty object.

--- a/examples/run/sycl/seeding_example_sycl.cpp
+++ b/examples/run/sycl/seeding_example_sycl.cpp
@@ -137,8 +137,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
          event < input_opts.events + input_opts.skip; ++event) {
 
         // Instantiate host containers/collections
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::edm::spacepoint_collection::host spacepoints_per_event{host_mr};
         traccc::host::seeding_algorithm::output_type seeds{host_mr};
         traccc::host::track_params_estimation::output_type params{&host_mr};
@@ -175,7 +175,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
 
             // Copy the measurements and spacepoint and module data to the
             // device.
-            traccc::edm::measurement_collection<traccc::default_algebra>::buffer
+            traccc::edm::measurement_collection::buffer
                 measurements_sycl_buffer(
                     static_cast<unsigned int>(measurements_per_event.size()),
                     mr.main);

--- a/examples/run/sycl/seq_example_sycl.cpp
+++ b/examples/run/sycl/seq_example_sycl.cpp
@@ -219,8 +219,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
             track_candidates{host_mr};
 
         // Instantiate SYCL containers/collections
-        traccc::edm::measurement_collection<traccc::default_algebra>::buffer
-            measurements_sycl_buffer;
+        traccc::edm::measurement_collection::buffer measurements_sycl_buffer;
         traccc::sycl::silicon_pixel_spacepoint_formation_algorithm::output_type
             spacepoints_sycl_buffer;
         traccc::sycl::triplet_seeding_algorithm::output_type seeds_sycl_buffer;
@@ -349,8 +348,8 @@ int seq_run(const traccc::opts::detector& detector_opts,
           compare cpu and sycl result
           ----------------------------------*/
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event_sycl{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event_sycl{
+            host_mr};
         traccc::edm::spacepoint_collection::host spacepoints_per_event_sycl{
             host_mr};
         traccc::edm::seed_collection::host seeds_sycl{host_mr};
@@ -373,8 +372,7 @@ int seq_run(const traccc::opts::detector& detector_opts,
             TRACCC_INFO("===>>> Event " << event << " <<<===");
 
             // Compare the measurements made on the host and on the device.
-            traccc::soa_comparator<
-                traccc::edm::measurement_collection<traccc::default_algebra>>
+            traccc::soa_comparator<traccc::edm::measurement_collection>
                 compare_measurements{"measurements"};
             compare_measurements(vecmem::get_data(measurements_per_event),
                                  vecmem::get_data(measurements_per_event_sycl));

--- a/io/include/traccc/io/csv/make_measurement_edm.hpp
+++ b/io/include/traccc/io/csv/make_measurement_edm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -26,7 +26,7 @@ namespace traccc::io::csv {
 ///
 void make_measurement_edm(
     const traccc::io::csv::measurement& csv_meas,
-    edm::measurement_collection<default_algebra>::host::proxy_type& meas,
+    edm::measurement_collection::host::proxy_type& meas,
     const std::map<geometry_id, geometry_id>* acts_to_detray_id,
     const traccc::detector_design_description::host* det_desc = nullptr,
     const std::map<geometry_id, std::size_t>*

--- a/io/include/traccc/io/read_measurements.hpp
+++ b/io/include/traccc/io/read_measurements.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -36,9 +36,8 @@ namespace traccc::io {
 /// @param[in]  format    The format of the measurement data files (to read)
 ///
 std::vector<measurement_id_type> read_measurements(
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::size_t event, std::string_view directory,
-    const traccc::host_detector* detector = nullptr,
+    edm::measurement_collection::host& measurements, std::size_t event,
+    std::string_view directory, const traccc::host_detector* detector = nullptr,
     const traccc::detector_design_description::host* det_desc = nullptr,
     const traccc::detector_conditions_description::host* det_cond = nullptr,
     const bool sort_measurements = true, data_format format = data_format::csv);
@@ -53,8 +52,8 @@ std::vector<measurement_id_type> read_measurements(
 /// @param[in]  format   The format of the measurement data files (to read)
 ///
 std::vector<measurement_id_type> read_measurements(
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::string_view filename, const traccc::host_detector* detector = nullptr,
+    edm::measurement_collection::host& measurements, std::string_view filename,
+    const traccc::host_detector* detector = nullptr,
     const traccc::detector_design_description::host* det_desc = nullptr,
     const traccc::detector_conditions_description::host* det_cond = nullptr,
     const bool sort_measurements = true, data_format format = data_format::csv);

--- a/io/include/traccc/io/read_particles.hpp
+++ b/io/include/traccc/io/read_particles.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -63,13 +63,12 @@ void read_particles(particle_collection_types::host &particles,
 /// @param[in]  detector  detray detector
 /// @param[in]  filename_postfix Postfix for the particle file name(s)
 ///
-void read_particles(
-    particle_container_types::host &particles,
-    edm::measurement_collection<default_algebra>::host &measurements,
-    std::size_t event, std::string_view directory,
-    const traccc::host_detector *detector = nullptr,
-    data_format format = data_format::csv,
-    std::string_view filename_postfix = "-particles_initial");
+void read_particles(particle_container_types::host &particles,
+                    edm::measurement_collection::host &measurements,
+                    std::size_t event, std::string_view directory,
+                    const traccc::host_detector *detector = nullptr,
+                    data_format format = data_format::csv,
+                    std::string_view filename_postfix = "-particles_initial");
 
 /// Read full truth particle data into memory
 ///
@@ -84,12 +83,12 @@ void read_particles(
 /// @param[in]  detector  detray detector
 /// @param[in]  format        The format of the particle data files (to read)
 ///
-void read_particles(
-    particle_container_types::host &particles,
-    edm::measurement_collection<default_algebra>::host &measurements,
-    std::string_view particles_file, std::string_view hits_file,
-    std::string_view measurements_file, std::string_view hit_map_file,
-    const traccc::host_detector *detector = nullptr,
-    data_format format = data_format::csv);
+void read_particles(particle_container_types::host &particles,
+                    edm::measurement_collection::host &measurements,
+                    std::string_view particles_file, std::string_view hits_file,
+                    std::string_view measurements_file,
+                    std::string_view hit_map_file,
+                    const traccc::host_detector *detector = nullptr,
+                    data_format format = data_format::csv);
 
 }  // namespace traccc::io

--- a/io/include/traccc/io/read_spacepoints.hpp
+++ b/io/include/traccc/io/read_spacepoints.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -38,16 +38,15 @@ namespace traccc::io {
 /// @param[in]  conditions_description The detector conditions description
 /// @param[in]  format    The format of the data files (to read)
 ///
-void read_spacepoints(
-    edm::spacepoint_collection::host& spacepoints,
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::size_t event, std::string_view directory,
-    const traccc::host_detector* detector = nullptr,
-    const traccc::detector_design_description::host*
-        detector_design_description = nullptr,
-    const traccc::detector_conditions_description::host*
-        detector_conditions_description = nullptr,
-    data_format format = data_format::csv);
+void read_spacepoints(edm::spacepoint_collection::host& spacepoints,
+                      edm::measurement_collection::host& measurements,
+                      std::size_t event, std::string_view directory,
+                      const traccc::host_detector* detector = nullptr,
+                      const traccc::detector_design_description::host*
+                          detector_design_description = nullptr,
+                      const traccc::detector_conditions_description::host*
+                          detector_conditions_description = nullptr,
+                      data_format format = data_format::csv);
 
 /// Read spacepoint data into memory
 ///
@@ -62,16 +61,16 @@ void read_spacepoints(
 /// @param[in]  detector  detray detector
 /// @param[in]  format The format of the data files (to read)
 ///
-void read_spacepoints(
-    edm::spacepoint_collection::host& spacepoints,
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::string_view hit_filename, std::string_view meas_filename,
-    std::string_view meas_hit_map_filename,
-    const traccc::host_detector* detector = nullptr,
-    const traccc::detector_design_description::host*
-        detector_design_description = nullptr,
-    const traccc::detector_conditions_description::host*
-        detector_conditions_description = nullptr,
-    data_format format = data_format::csv);
+void read_spacepoints(edm::spacepoint_collection::host& spacepoints,
+                      edm::measurement_collection::host& measurements,
+                      std::string_view hit_filename,
+                      std::string_view meas_filename,
+                      std::string_view meas_hit_map_filename,
+                      const traccc::host_detector* detector = nullptr,
+                      const traccc::detector_design_description::host*
+                          detector_design_description = nullptr,
+                      const traccc::detector_conditions_description::host*
+                          detector_conditions_description = nullptr,
+                      data_format format = data_format::csv);
 
 }  // namespace traccc::io

--- a/io/include/traccc/io/write.hpp
+++ b/io/include/traccc/io/write.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -51,10 +51,10 @@ void write(std::size_t event, std::string_view directory,
 /// @param spacepoints is the spacepoint collection to write
 /// @param measurements is the measurement collection to write
 ///
-void write(
-    std::size_t event, std::string_view directory, traccc::data_format format,
-    edm::spacepoint_collection::const_view spacepoints,
-    edm::measurement_collection<default_algebra>::const_view measurements);
+void write(std::size_t event, std::string_view directory,
+           traccc::data_format format,
+           edm::spacepoint_collection::const_view spacepoints,
+           edm::measurement_collection::const_view measurements);
 
 /// Function for measurement file writing
 ///
@@ -63,9 +63,9 @@ void write(
 /// @param format is the data format (e.g. csv or binary) of output file
 /// @param measurements is the measurement collection to write
 ///
-void write(
-    std::size_t event, std::string_view directory, traccc::data_format format,
-    edm::measurement_collection<default_algebra>::const_view measurements);
+void write(std::size_t event, std::string_view directory,
+           traccc::data_format format,
+           edm::measurement_collection::const_view measurements);
 
 /// Function for seed writing
 ///

--- a/io/src/csv/make_measurement_edm.cpp
+++ b/io/src/csv/make_measurement_edm.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,7 +18,7 @@ namespace traccc::io::csv {
 
 void make_measurement_edm(
     const traccc::io::csv::measurement& csv_meas,
-    edm::measurement_collection<default_algebra>::host::proxy_type& meas,
+    edm::measurement_collection::host::proxy_type& meas,
     const std::map<geometry_id, geometry_id>* acts_to_detray_id,
     const traccc::detector_design_description::host* det_desc,
     const std::map<geometry_id, std::size_t>*
@@ -63,9 +63,9 @@ void make_measurement_edm(
         std::size_t dd_idx = geometry_id_to_detector_description_index->at(
             meas.surface_link().value());
         meas.dimensions() = det_desc->dimensions().at(dd_idx);
-        meas.subspace() = det_desc->subspace().at(dd_idx);
+        meas.set_subspace(det_desc->subspace().at(dd_idx));
     } else {
-        meas.subspace() = indices;
+        meas.set_subspace(indices);
     }
 }
 

--- a/io/src/csv/read_measurements.cpp
+++ b/io/src/csv/read_measurements.cpp
@@ -18,8 +18,8 @@
 namespace traccc::io::csv {
 
 std::vector<measurement_id_type> read_measurements(
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::string_view filename, const traccc::host_detector* detector,
+    edm::measurement_collection::host& measurements, std::string_view filename,
+    const traccc::host_detector* detector,
     const traccc::detector_design_description::host* det_desc,
     const traccc::detector_conditions_description::host* det_cond,
     const bool do_sort) {
@@ -80,7 +80,7 @@ std::vector<measurement_id_type> read_measurements(
                           });
 
         // Create a sorted measurement collection.
-        edm::measurement_collection<default_algebra>::host sorted_measurements(
+        edm::measurement_collection::host sorted_measurements(
             measurements.resource());
         sorted_measurements.resize(measurements.size());
 

--- a/io/src/csv/read_measurements.hpp
+++ b/io/src/csv/read_measurements.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,8 +29,8 @@ namespace traccc::io::csv {
 /// @param[in]  do_sort      Whether to sort the measurements or not
 ///
 std::vector<measurement_id_type> read_measurements(
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::string_view filename, const traccc::host_detector* detector = nullptr,
+    edm::measurement_collection::host& measurements, std::string_view filename,
+    const traccc::host_detector* detector = nullptr,
     const traccc::detector_design_description::host* detector_description =
         nullptr,
     const traccc::detector_conditions_description::host* detector_conditions =

--- a/io/src/csv/read_particles.cpp
+++ b/io/src/csv/read_particles.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -42,7 +42,7 @@ void read_particles(particle_collection_types::host& particles,
 
 void read_particles(
     particle_container_types::host& particles,
-    edm::measurement_collection<default_algebra>::host& measurements,
+    edm::measurement_collection::host& measurements,
     std::string_view particles_file, std::string_view hits_file,
     std::string_view measurements_file, std::string_view hit_map_file,
     const traccc::host_detector* detector,

--- a/io/src/csv/read_particles.hpp
+++ b/io/src/csv/read_particles.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -38,16 +38,16 @@ void read_particles(particle_collection_types::host& particles,
 /// @param[in]  hit_map_file  The file to read the hit->measurement mapping from
 /// @param[in]  detector  detray detector
 ///
-void read_particles(
-    particle_container_types::host& particles,
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::string_view particles_file, std::string_view hits_file,
-    std::string_view measurements_file, std::string_view hit_map_file,
-    const traccc::host_detector* detector,
-    const traccc::detector_design_description::host*
-        detector_design_description = nullptr,
-    const traccc::detector_conditions_description::host*
-        detector_conditions_description = nullptr,
-    const bool sort_measurements = true);
+void read_particles(particle_container_types::host& particles,
+                    edm::measurement_collection::host& measurements,
+                    std::string_view particles_file, std::string_view hits_file,
+                    std::string_view measurements_file,
+                    std::string_view hit_map_file,
+                    const traccc::host_detector* detector,
+                    const traccc::detector_design_description::host*
+                        detector_design_description = nullptr,
+                    const traccc::detector_conditions_description::host*
+                        detector_conditions_description = nullptr,
+                    const bool sort_measurements = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/csv/read_spacepoints.cpp
+++ b/io/src/csv/read_spacepoints.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -24,7 +24,7 @@ namespace traccc::io::csv {
 
 void read_spacepoints(
     edm::spacepoint_collection::host& spacepoints,
-    edm::measurement_collection<default_algebra>::host& measurements,
+    edm::measurement_collection::host& measurements,
     std::string_view hit_filename, std::string_view meas_filename,
     std::string_view meas_hit_map_filename,
     const traccc::host_detector* detector,

--- a/io/src/csv/read_spacepoints.hpp
+++ b/io/src/csv/read_spacepoints.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,16 +30,16 @@ namespace traccc::io::csv {
 ///                                   measurements to hits from
 /// @param[in]  detector  detray detector
 ///
-void read_spacepoints(
-    edm::spacepoint_collection::host& spacepoints,
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::string_view hit_filename, std::string_view meas_filename,
-    std::string_view meas_hit_map_filename,
-    const traccc::host_detector* detector = nullptr,
-    const traccc::detector_design_description::host* detector_description =
-        nullptr,
-    const traccc::detector_conditions_description::host*
-        detector_conditions_description = nullptr,
-    const bool sort_measurements = true);
+void read_spacepoints(edm::spacepoint_collection::host& spacepoints,
+                      edm::measurement_collection::host& measurements,
+                      std::string_view hit_filename,
+                      std::string_view meas_filename,
+                      std::string_view meas_hit_map_filename,
+                      const traccc::host_detector* detector = nullptr,
+                      const traccc::detector_design_description::host*
+                          detector_description = nullptr,
+                      const traccc::detector_conditions_description::host*
+                          detector_conditions_description = nullptr,
+                      const bool sort_measurements = true);
 
 }  // namespace traccc::io::csv

--- a/io/src/obj/write_tracks.cpp
+++ b/io/src/obj/write_tracks.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -48,8 +48,7 @@ void write_tracks(std::string_view filename,
              tracks.tracks.constituent_links().at(i)) {
 
             // Find the measurement of this constituent.
-            edm::measurement_collection<
-                default_algebra>::const_device::object_type meas;
+            edm::measurement_collection::const_device::object_type meas;
             if (type == edm::track_constituent_link::measurement) {
                 meas = tracks.measurements.at(idx);
             } else if (type == edm::track_constituent_link::track_state) {
@@ -66,8 +65,8 @@ void write_tracks(std::string_view filename,
                 detector, [meas]<typename detector_traits_t>(
                               const typename detector_traits_t::host& d) {
                     detray::tracking_surface surface{d, meas.surface_link()};
-                    return surface.local_to_global({}, meas.local_position(),
-                                                   {});
+                    return surface.local_to_global(
+                        {}, meas.local_position_in<default_algebra>(), {});
                 });
 
             // Write the 3D coordinates of the measurement / spacepoint.

--- a/io/src/obj/write_tracks.cpp
+++ b/io/src/obj/write_tracks.cpp
@@ -8,6 +8,9 @@
 // Local include(s).
 #include "write_tracks.hpp"
 
+// Project include(s).
+#include "traccc/edm/measurement_helpers.hpp"
+
 // Detray include(s)
 #include <detray/geometry/tracking_surface.hpp>
 
@@ -66,13 +69,18 @@ void write_tracks(std::string_view filename,
                               const typename detector_traits_t::host& d) {
                     detray::tracking_surface surface{d, meas.surface_link()};
                     return surface.local_to_global(
-                        {}, meas.local_position_in<default_algebra>(), {});
+                        {},
+                        edm::get_measurement_local<
+                            typename detector_traits_t::host::algebra_type>(
+                            meas),
+                        {});
                 });
 
             // Write the 3D coordinates of the measurement / spacepoint.
             assert(global.size() == 3);
-            file << "v " << global[0] << " " << global[1] << " " << global[2]
-                 << "\n";
+            file << "v " << getter::element(global, 0u) << " "
+                 << getter::element(global, 1u) << " "
+                 << getter::element(global, 2u) << "\n";
         }
     }
 

--- a/io/src/read_measurements.cpp
+++ b/io/src/read_measurements.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,9 +18,8 @@
 namespace traccc::io {
 
 std::vector<measurement_id_type> read_measurements(
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::size_t event, std::string_view directory,
-    const traccc::host_detector* detector,
+    edm::measurement_collection::host& measurements, std::size_t event,
+    std::string_view directory, const traccc::host_detector* detector,
     const traccc::detector_design_description::host* det_desc,
     const traccc::detector_conditions_description::host* det_cond,
     const bool sort_measurements, data_format format) {
@@ -50,8 +49,8 @@ std::vector<measurement_id_type> read_measurements(
 }
 
 std::vector<measurement_id_type> read_measurements(
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::string_view filename, const traccc::host_detector* detector,
+    edm::measurement_collection::host& measurements, std::string_view filename,
+    const traccc::host_detector* detector,
     const traccc::detector_design_description::host* det_desc,
     const traccc::detector_conditions_description::host* det_cond,
     const bool sort_measurements, data_format format) {

--- a/io/src/read_particles.cpp
+++ b/io/src/read_particles.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -48,12 +48,11 @@ void read_particles(particle_collection_types::host& particles,
     }
 }
 
-void read_particles(
-    particle_container_types::host& particles,
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::size_t event, std::string_view directory,
-    const traccc::host_detector* detector, data_format format,
-    std::string_view filename_postfix) {
+void read_particles(particle_container_types::host& particles,
+                    edm::measurement_collection::host& measurements,
+                    std::size_t event, std::string_view directory,
+                    const traccc::host_detector* detector, data_format format,
+                    std::string_view filename_postfix) {
 
     switch (format) {
         case data_format::csv:
@@ -83,12 +82,12 @@ void read_particles(
     }
 }
 
-void read_particles(
-    particle_container_types::host& particles,
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::string_view particles_file, std::string_view hits_file,
-    std::string_view measurements_file, std::string_view hit_map_file,
-    const traccc::host_detector* detector, data_format format) {
+void read_particles(particle_container_types::host& particles,
+                    edm::measurement_collection::host& measurements,
+                    std::string_view particles_file, std::string_view hits_file,
+                    std::string_view measurements_file,
+                    std::string_view hit_map_file,
+                    const traccc::host_detector* detector, data_format format) {
 
     switch (format) {
         case data_format::csv:

--- a/io/src/read_spacepoints.cpp
+++ b/io/src/read_spacepoints.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,9 +19,8 @@ namespace traccc::io {
 
 void read_spacepoints(
     edm::spacepoint_collection::host& spacepoints,
-    edm::measurement_collection<default_algebra>::host& measurements,
-    std::size_t event, std::string_view directory,
-    const traccc::host_detector* detector,
+    edm::measurement_collection::host& measurements, std::size_t event,
+    std::string_view directory, const traccc::host_detector* detector,
     const traccc::detector_design_description::host* det_desc,
     const traccc::detector_conditions_description::host* det_cond,
     data_format format) {
@@ -66,7 +65,7 @@ void read_spacepoints(
 
 void read_spacepoints(
     edm::spacepoint_collection::host& spacepoints,
-    edm::measurement_collection<default_algebra>::host& measurements,
+    edm::measurement_collection::host& measurements,
     std::string_view hit_filename, std::string_view meas_filename,
     std::string_view meas_hit_map_filename,
     const traccc::host_detector* detector,

--- a/io/src/write.cpp
+++ b/io/src/write.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -52,10 +52,10 @@ void write(std::size_t event, std::string_view directory,
     }
 }
 
-void write(
-    std::size_t event, std::string_view directory, traccc::data_format format,
-    edm::spacepoint_collection::const_view spacepoints,
-    edm::measurement_collection<default_algebra>::const_view measurements) {
+void write(std::size_t event, std::string_view directory,
+           traccc::data_format format,
+           edm::spacepoint_collection::const_view spacepoints,
+           edm::measurement_collection::const_view measurements) {
 
     switch (format) {
         case data_format::binary:
@@ -70,8 +70,7 @@ void write(
                                    std::filesystem::path(get_event_filename(
                                        event, "-measurements.dat")))
                                       .native()),
-                edm::measurement_collection<default_algebra>::const_device{
-                    measurements});
+                edm::measurement_collection::const_device{measurements});
             break;
         case data_format::obj:
             obj::write_spacepoints(
@@ -86,9 +85,9 @@ void write(
     }
 }
 
-void write(
-    std::size_t event, std::string_view directory, traccc::data_format format,
-    edm::measurement_collection<default_algebra>::const_view measurements) {
+void write(std::size_t event, std::string_view directory,
+           traccc::data_format format,
+           edm::measurement_collection::const_view measurements) {
 
     switch (format) {
         case data_format::binary:
@@ -97,8 +96,7 @@ void write(
                                    std::filesystem::path(get_event_filename(
                                        event, "-measurements.dat")))
                                       .native()),
-                edm::measurement_collection<default_algebra>::const_device{
-                    measurements});
+                edm::measurement_collection::const_device{measurements});
             break;
         default:
             throw std::invalid_argument("Unsupported data format");

--- a/performance/include/traccc/efficiency/nseed_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/nseed_performance_writer.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -44,8 +44,7 @@ class nseed_performance_writer {
     void register_event(
         std::size_t ev, const SeedIt sb, const SeedIt se,
         const edm::spacepoint_collection::const_view& spacepoints_view,
-        const edm::measurement_collection<default_algebra>::const_view&
-            measurements_view,
+        const edm::measurement_collection::const_view& measurements_view,
         const event_data& em) {
 
         std::size_t seed_id = 0;
@@ -54,8 +53,8 @@ class nseed_performance_writer {
 
         const edm::spacepoint_collection::const_device spacepoints{
             spacepoints_view};
-        const edm::measurement_collection<default_algebra>::const_device
-            measurements{measurements_view};
+        const edm::measurement_collection::const_device measurements{
+            measurements_view};
 
         for (SeedIt s = sb; s != se; ++s) {
             std::vector<std::vector<uint64_t>> particle_ids;
@@ -69,9 +68,8 @@ class nseed_performance_writer {
                                INVALID_MEASUREMENT_INDEX);
                     const edm::measurement meas = measurements.at(
                         spacepoints
-                            .at(static_cast<edm::measurement_collection<
-                                    default_algebra>::const_device::size_type>(
-                                l))
+                            .at(static_cast<edm::measurement_collection::
+                                                const_device::size_type>(l))
                             .measurement_index_1());
 
                     const auto& ptcs = em.m_meas_to_ptc_map.find(meas)->second;

--- a/performance/include/traccc/efficiency/seeding_performance_writer.hpp
+++ b/performance/include/traccc/efficiency/seeding_performance_writer.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -68,8 +68,7 @@ class seeding_performance_writer : public messaging {
 
     void write(const edm::seed_collection::const_view& seeds_view,
                const edm::spacepoint_collection::const_view& spacepoints_view,
-               const edm::measurement_collection<default_algebra>::const_view&
-                   measurements_view,
+               const edm::measurement_collection::const_view& measurements_view,
                const event_data& evt_data);
 
     void finalize();

--- a/performance/include/traccc/performance/impl/is_same_track.ipp
+++ b/performance/include/traccc/performance/impl/is_same_track.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -28,10 +28,8 @@ class is_same_object<edm::track<T>> {
     public:
     /// Constructor with a reference object, and an allowed uncertainty
     is_same_object(
-        const edm::measurement_collection<default_algebra>::const_view&
-            ref_meas,
-        const edm::measurement_collection<default_algebra>::const_view&
-            test_meas,
+        const edm::measurement_collection::const_view& ref_meas,
+        const edm::measurement_collection::const_view& test_meas,
         const edm::track_state_collection<default_algebra>::const_view&
             ref_states,
         const edm::track_state_collection<default_algebra>::const_view&
@@ -75,10 +73,8 @@ class is_same_object<edm::track<T>> {
         }
 
         // Now compare the constituents one by one.
-        const edm::measurement_collection<default_algebra>::const_device
-            ref_meas{m_ref_meas};
-        const edm::measurement_collection<default_algebra>::const_device
-            test_meas{m_test_meas};
+        const edm::measurement_collection::const_device ref_meas{m_ref_meas};
+        const edm::measurement_collection::const_device test_meas{m_test_meas};
         const edm::track_state_collection<default_algebra>::const_device
             ref_states{m_ref_states};
         const edm::track_state_collection<default_algebra>::const_device
@@ -94,8 +90,8 @@ class is_same_object<edm::track<T>> {
             if (obj.constituent_links()[i].type ==
                 edm::track_constituent_link::measurement) {
 
-                if (!is_same_object<edm::measurement_collection<
-                        default_algebra>::const_device::const_proxy_type>(
+                if (!is_same_object<edm::measurement_collection::const_device::
+                                        const_proxy_type>(
                         ref_meas.at(m_ref.constituent_links()[i].index), m_unc)(
                         test_meas.at(obj.constituent_links()[i].index))) {
                     return false;
@@ -126,9 +122,9 @@ class is_same_object<edm::track<T>> {
 
     private:
     /// Measurements for the reference object
-    const edm::measurement_collection<default_algebra>::const_view m_ref_meas;
+    const edm::measurement_collection::const_view m_ref_meas;
     /// Measurements for the test object
-    const edm::measurement_collection<default_algebra>::const_view m_test_meas;
+    const edm::measurement_collection::const_view m_test_meas;
     /// States for the reference object
     const edm::track_state_collection<default_algebra>::const_view m_ref_states;
     /// States for the test object

--- a/performance/include/traccc/performance/impl/is_same_track_state.ipp
+++ b/performance/include/traccc/performance/impl/is_same_track_state.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -23,12 +23,9 @@ class is_same_object<edm::track_state<T>> {
 
     public:
     /// Constructor with a reference object, and an allowed uncertainty
-    is_same_object(
-        const edm::measurement_collection<default_algebra>::const_view&
-            ref_meas,
-        const edm::measurement_collection<default_algebra>::const_view&
-            test_meas,
-        const edm::track_state<T>& ref, scalar unc = float_epsilon)
+    is_same_object(const edm::measurement_collection::const_view& ref_meas,
+                   const edm::measurement_collection::const_view& test_meas,
+                   const edm::track_state<T>& ref, scalar unc = float_epsilon)
         : m_ref_meas(ref_meas),
           m_test_meas(test_meas),
           m_ref(ref),
@@ -58,12 +55,10 @@ class is_same_object<edm::track_state<T>> {
             return false;
         }
         // Compare the measurements that they point at.
-        const edm::measurement_collection<default_algebra>::const_device
-            ref_meas{m_ref_meas};
-        const edm::measurement_collection<default_algebra>::const_device
-            test_meas{m_test_meas};
-        if (!is_same_object<edm::measurement_collection<
-                default_algebra>::const_device::const_proxy_type>(
+        const edm::measurement_collection::const_device ref_meas{m_ref_meas};
+        const edm::measurement_collection::const_device test_meas{m_test_meas};
+        if (!is_same_object<
+                edm::measurement_collection::const_device::const_proxy_type>(
                 ref_meas.at(m_ref.measurement_index()),
                 m_unc)(test_meas.at(obj.measurement_index()))) {
             return false;
@@ -75,9 +70,9 @@ class is_same_object<edm::track_state<T>> {
 
     private:
     /// Measurements for the reference object
-    const edm::measurement_collection<default_algebra>::const_view m_ref_meas;
+    const edm::measurement_collection::const_view m_ref_meas;
     /// Measurements for the test object
-    const edm::measurement_collection<default_algebra>::const_view m_test_meas;
+    const edm::measurement_collection::const_view m_test_meas;
     /// The reference object
     const edm::track_state<T> m_ref;
     /// The uncertainty

--- a/performance/include/traccc/performance/impl/track_comparator_factory.ipp
+++ b/performance/include/traccc/performance/impl/track_comparator_factory.ipp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -25,10 +25,8 @@ class comparator_factory<edm::track<T>> {
     public:
     /// Constructor with all necessary arguments
     comparator_factory(
-        const edm::measurement_collection<default_algebra>::const_view&
-            ref_meas,
-        const edm::measurement_collection<default_algebra>::const_view&
-            test_meas,
+        const edm::measurement_collection::const_view& ref_meas,
+        const edm::measurement_collection::const_view& test_meas,
         const edm::track_state_collection<default_algebra>::const_view&
             ref_states,
         const edm::track_state_collection<default_algebra>::const_view&
@@ -48,9 +46,9 @@ class comparator_factory<edm::track<T>> {
 
     private:
     /// Measurement container for the reference track candidates
-    const edm::measurement_collection<default_algebra>::const_view m_ref_meas;
+    const edm::measurement_collection::const_view m_ref_meas;
     /// Measurement container for the test track candidates
-    const edm::measurement_collection<default_algebra>::const_view m_test_meas;
+    const edm::measurement_collection::const_view m_test_meas;
     /// States for the reference object
     const edm::track_state_collection<default_algebra>::const_view m_ref_states;
     /// States for the test object

--- a/performance/include/traccc/resolution/fitting_performance_writer.hpp
+++ b/performance/include/traccc/resolution/fitting_performance_writer.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -65,8 +65,7 @@ class fitting_performance_writer : public messaging {
                    traccc::default_algebra>::host::proxy_type track,
                const edm::track_state_collection<traccc::default_algebra>::host&
                    track_states,
-               const edm::measurement_collection<traccc::default_algebra>::host&
-                   measurements,
+               const edm::measurement_collection::host& measurements,
                const detector_t& det, event_data& evt_data,
                const detector_t::geometry_context& ctx = {}) {
 
@@ -149,7 +148,7 @@ class fitting_performance_writer : public messaging {
             track,
         const edm::track_state_collection<traccc::default_algebra>::host&
             track_states,
-        const edm::measurement_collection<default_algebra>::host& measurements);
+        const edm::measurement_collection::host& measurements);
 
     /// Configuration for the tool
     config m_cfg;

--- a/performance/include/traccc/utils/event_data.hpp
+++ b/performance/include/traccc/utils/event_data.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -66,8 +66,7 @@ struct event_data {
     void fill_cca_result(
         const edm::silicon_cell_collection::host& cells,
         const edm::silicon_cluster_collection::host& cca_clusters,
-        const edm::measurement_collection<default_algebra>::host&
-            cca_measurements,
+        const edm::measurement_collection::host& cca_measurements,
         const detector_conditions_description::host& det_cond);
 
     /// Generate truth candidate used for truth fitting
@@ -79,7 +78,7 @@ struct event_data {
     template <typename detector_type>
     void generate_truth_candidates(
         edm::track_container<default_algebra>::host& truth_candidates,
-        edm::measurement_collection<default_algebra>::host& truth_measurements,
+        edm::measurement_collection::host& truth_measurements,
         seed_generator<detector_type>& sg, vecmem::memory_resource& resource,
         float pt_cut = 0.f) {
         for (auto const& [ptc, measurements] : m_ptc_to_meas_map) {
@@ -123,10 +122,9 @@ struct event_data {
     }
 
     /// All internally defined measurements
-    edm::measurement_collection<default_algebra>::host m_measurements;
+    edm::measurement_collection::host m_measurements;
     /// Proxy type for the following maps
-    using measurement_proxy =
-        edm::measurement_collection<default_algebra>::host::object_type;
+    using measurement_proxy = edm::measurement_collection::host::object_type;
 
     // Measurement map
     std::map<measurement_id_type, measurement_proxy> m_measurement_map;

--- a/performance/src/efficiency/seeding_performance_writer.cpp
+++ b/performance/src/efficiency/seeding_performance_writer.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -65,8 +65,7 @@ seeding_performance_writer::~seeding_performance_writer() {}
 void seeding_performance_writer::write(
     const edm::seed_collection::const_view& seeds_view,
     const edm::spacepoint_collection::const_view& spacepoints_view,
-    const edm::measurement_collection<default_algebra>::const_view&
-        measurements_view,
+    const edm::measurement_collection::const_view& measurements_view,
     const event_data& evt_data) {
 
     std::map<particle_id, std::size_t> match_counter;
@@ -75,8 +74,8 @@ void seeding_performance_writer::write(
     const edm::seed_collection::const_device seeds(seeds_view);
     const edm::spacepoint_collection::const_device spacepoints(
         spacepoints_view);
-    const edm::measurement_collection<default_algebra>::const_device
-        measurements(measurements_view);
+    const edm::measurement_collection::const_device measurements(
+        measurements_view);
 
     const std::size_t n_seeds = seeds.size();
 

--- a/performance/src/resolution/fitting_performance_writer.cpp
+++ b/performance/src/resolution/fitting_performance_writer.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -87,7 +87,7 @@ void fitting_performance_writer::write_stat(
         track,
     const edm::track_state_collection<traccc::default_algebra>::host&
         track_states,
-    const edm::measurement_collection<default_algebra>::host& measurements) {
+    const edm::measurement_collection::host& measurements) {
 
     m_data->m_stat_plot_tool.fill(m_data->m_stat_plot_cache, track);
 

--- a/performance/src/resolution/stat_plot_tool.hpp
+++ b/performance/src/resolution/stat_plot_tool.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -76,8 +76,7 @@ class stat_plot_tool {
     template <typename track_state_backend_t>
     void fill(stat_plot_cache& cache,
               const edm::track_state<track_state_backend_t>& trk_state,
-              const edm::measurement_collection<default_algebra>::host&
-                  measurements) const;
+              const edm::measurement_collection::host& measurements) const;
 
     /// @brief fill the cache
     /// @param cache the cache for statistics plots

--- a/performance/src/resolution/stat_plot_tool.ipp
+++ b/performance/src/resolution/stat_plot_tool.ipp
@@ -34,8 +34,7 @@ template <typename track_state_backend_t>
 void stat_plot_tool::fill(
     stat_plot_cache& cache,
     const edm::track_state<track_state_backend_t>& trk_state,
-    const edm::measurement_collection<default_algebra>::host& measurements)
-    const {
+    const edm::measurement_collection::host& measurements) const {
 
     // Avoid unused variable warnings when building the code without ROOT.
     (void)cache;

--- a/performance/src/utils/event_data.cpp
+++ b/performance/src/utils/event_data.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -288,7 +288,7 @@ void event_data::setup_csv(bool use_acts_geom_source, const host_detector* det,
 void event_data::fill_cca_result(
     const edm::silicon_cell_collection::host& cells,
     const edm::silicon_cluster_collection::host& cca_clusters,
-    const edm::measurement_collection<default_algebra>::host& cca_measurements,
+    const edm::measurement_collection::host& cca_measurements,
     const detector_conditions_description::host& det_cond) {
 
     const std::size_t n_cca_clusters = cca_measurements.size();

--- a/tests/alpaka/test_cca.cpp
+++ b/tests/alpaka/test_cca.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -38,11 +38,10 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
 
             -> std::pair<
                 std::map<traccc::geometry_id,
-                         traccc::edm::measurement_collection<
-                             traccc::default_algebra>::host>,
+                         traccc::edm::measurement_collection::host>,
                 std::optional<traccc::edm::silicon_cluster_collection::host>> {
-            std::map<traccc::geometry_id, traccc::edm::measurement_collection<
-                                              traccc::default_algebra>::host>
+            std::map<traccc::geometry_id,
+                     traccc::edm::measurement_collection::host>
                 result;
 
             traccc::alpaka::queue queue;
@@ -94,8 +93,8 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
                 cc(cells_buffer, det_desc_buffer, det_cond_buffer,
                    traccc::device::clustering_keep_disjoint_set{});
             queue.synchronize();
-            traccc::edm::measurement_collection<traccc::default_algebra>::host
-                measurements{pinned_host_mr};
+            traccc::edm::measurement_collection::host measurements{
+                pinned_host_mr};
             copy(measurements_buffer, measurements)->wait();
 
             traccc::edm::silicon_cluster_collection::host clusters{host_mr};
@@ -106,8 +105,7 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
                         measurements.at(i).surface_link().value()) == false) {
                     result.insert(
                         {measurements.at(i).surface_link().value(),
-                         traccc::edm::measurement_collection<
-                             traccc::default_algebra>::host{host_mr}});
+                         traccc::edm::measurement_collection::host{host_mr}});
                 }
                 result.at(measurements.at(i).surface_link().value())
                     .push_back(measurements.at(i));

--- a/tests/common/tests/cca_test.hpp
+++ b/tests/common/tests/cca_test.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -38,13 +38,12 @@
 #include <sstream>
 #include <string>
 
-using cca_function_t = std::function<
-    std::pair<std::map<traccc::geometry_id, traccc::edm::measurement_collection<
-                                                traccc::default_algebra>::host>,
-              std::optional<traccc::edm::silicon_cluster_collection::host>>(
-        const traccc::edm::silicon_cell_collection::host &,
-        const traccc::detector_design_description::host &,
-        const traccc::detector_conditions_description::host &)>;
+using cca_function_t = std::function<std::pair<
+    std::map<traccc::geometry_id, traccc::edm::measurement_collection::host>,
+    std::optional<traccc::edm::silicon_cluster_collection::host>>(
+    const traccc::edm::silicon_cell_collection::host &,
+    const traccc::detector_design_description::host &,
+    const traccc::detector_conditions_description::host &)>;
 
 inline traccc::clustering_config default_ccl_test_config() {
     traccc::clustering_config rv;
@@ -195,8 +194,7 @@ class ConnectedComponentAnalysisTests
         while (truth_reader.read(io_truth)) {
             ASSERT_TRUE(result.find(io_truth.geometry_id) != result.end());
 
-            const traccc::edm::measurement_collection<
-                traccc::default_algebra>::host &meas =
+            const traccc::edm::measurement_collection::host &meas =
                 result.at(io_truth.geometry_id);
 
             const traccc::scalar tol = 0.0001f;

--- a/tests/common/tests/kalman_fitting_test.cpp
+++ b/tests/common/tests/kalman_fitting_test.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -136,7 +136,7 @@ void KalmanFittingTests::p_value_tests(
 void KalmanFittingTests::ndf_tests(
     const edm::track_collection<default_algebra>::host::const_proxy_type& track,
     const edm::track_state_collection<default_algebra>::host& track_states,
-    const edm::measurement_collection<default_algebra>::host& measurements) {
+    const edm::measurement_collection::host& measurements) {
 
     scalar dim_sum = 0;
     std::size_t n_effective_states = 0;

--- a/tests/common/tests/kalman_fitting_test.hpp
+++ b/tests/common/tests/kalman_fitting_test.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -82,7 +82,7 @@ class KalmanFittingTests : public testing::Test {
         const edm::track_collection<default_algebra>::host::const_proxy_type&
             track,
         const edm::track_state_collection<default_algebra>::host& track_states,
-        const edm::measurement_collection<default_algebra>::host& measurements);
+        const edm::measurement_collection::host& measurements);
 
     /// Count the number of tracks that were successfully fitted
     ///

--- a/tests/common/tests/triplet_fitting_test.cpp
+++ b/tests/common/tests/triplet_fitting_test.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -136,7 +136,7 @@ void TripletFittingTests::p_value_tests(
 void TripletFittingTests::ndf_tests(
     const edm::track_collection<default_algebra>::host::const_proxy_type& track,
     const edm::track_state_collection<default_algebra>::host& track_states,
-    const edm::measurement_collection<default_algebra>::host& measurements) {
+    const edm::measurement_collection::host& measurements) {
 
     scalar dim_sum = 0;
     std::size_t n_effective_states = 0;

--- a/tests/common/tests/triplet_fitting_test.hpp
+++ b/tests/common/tests/triplet_fitting_test.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -87,7 +87,7 @@ class TripletFittingTests : public testing::Test {
         const edm::track_collection<default_algebra>::host::const_proxy_type&
             track,
         const edm::track_state_collection<default_algebra>::host& track_states,
-        const edm::measurement_collection<default_algebra>::host& measurements);
+        const edm::measurement_collection::host& measurements);
 
     /// Count the number of tracks that were successfully fitted
     ///

--- a/tests/cpu/compare_with_acts_seeding.cpp
+++ b/tests/cpu/compare_with_acts_seeding.cpp
@@ -81,8 +81,7 @@ TEST_P(CompareWithActsSeedingTests, Run) {
 
     // Read the hits from the relevant event file
     traccc::edm::spacepoint_collection::host spacepoints_per_event{host_mr};
-    traccc::edm::measurement_collection<traccc::default_algebra>::host
-        measurements_per_event{host_mr};
+    traccc::edm::measurement_collection::host measurements_per_event{host_mr};
     traccc::io::read_spacepoints(spacepoints_per_event, measurements_per_event,
                                  event, hits_dir);
 

--- a/tests/cpu/test_ambiguity_resolution.cpp
+++ b/tests/cpu/test_ambiguity_resolution.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -26,9 +26,8 @@ namespace {
 vecmem::host_memory_resource host_mr;
 }  // namespace
 
-void fill_measurements(
-    edm::measurement_collection<default_algebra>::host& measurements,
-    const measurement_id_type max_meas_id) {
+void fill_measurements(edm::measurement_collection::host& measurements,
+                       const measurement_id_type max_meas_id) {
 
     measurements.reserve(max_meas_id + 1);
     for (measurement_id_type i = 0; i <= max_meas_id; i++) {
@@ -44,7 +43,7 @@ void fill_pattern(edm::track_container<default_algebra>::host& track_candidates,
     track_candidates.tracks.resize(track_candidates.tracks.size() + 1u);
     track_candidates.tracks.pval().back() = pval;
 
-    edm::measurement_collection<default_algebra>::const_device measurements{
+    edm::measurement_collection::const_device measurements{
         track_candidates.measurements};
 
     for (const auto& meas_id : pattern) {
@@ -64,7 +63,7 @@ std::vector<std::size_t> get_pattern(
     const edm::track_container<default_algebra>::host& track_candidates,
     const std::size_t idx) {
 
-    edm::measurement_collection<default_algebra>::const_device measurements{
+    edm::measurement_collection::const_device measurements{
         track_candidates.measurements};
     std::vector<std::size_t> ret;
     // A const reference would be fine here. But GCC fears that that would lead
@@ -80,7 +79,7 @@ std::vector<std::size_t> get_pattern(
 
 TEST(AmbiguitySolverTests, GreedyResolverTest0) {
 
-    edm::measurement_collection<default_algebra>::host measurements{host_mr};
+    edm::measurement_collection::host measurements{host_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -157,7 +156,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest0) {
 
 TEST(AmbiguitySolverTests, GreedyResolverTest1) {
 
-    edm::measurement_collection<default_algebra>::host measurements{host_mr};
+    edm::measurement_collection::host measurements{host_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -205,7 +204,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest1) {
 
 TEST(AmbiguitySolverTests, GreedyResolverTest2) {
 
-    edm::measurement_collection<default_algebra>::host measurements{host_mr};
+    edm::measurement_collection::host measurements{host_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -232,7 +231,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest2) {
 
 TEST(AmbiguitySolverTests, GreedyResolverTest3) {
 
-    edm::measurement_collection<default_algebra>::host measurements{host_mr};
+    edm::measurement_collection::host measurements{host_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -280,7 +279,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest3) {
 // Comparison to the legacy algorithm.
 TEST(AmbiguitySolverTests, GreedyResolverTest4) {
 
-    edm::measurement_collection<default_algebra>::host measurements{host_mr};
+    edm::measurement_collection::host measurements{host_mr};
     const measurement_id_type max_meas_id = 10000;
     fill_measurements(measurements, max_meas_id);
 
@@ -365,7 +364,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest4) {
 
 TEST(AmbiguitySolverTests, GreedyResolverTest5) {
 
-    edm::measurement_collection<default_algebra>::host measurements{host_mr};
+    edm::measurement_collection::host measurements{host_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -395,7 +394,7 @@ TEST(AmbiguitySolverTests, GreedyResolverTest5) {
 
 TEST(AmbiguitySolverTests, GreedyResolverTest6) {
 
-    edm::measurement_collection<default_algebra>::host measurements{host_mr};
+    edm::measurement_collection::host measurements{host_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{

--- a/tests/cpu/test_cca.cpp
+++ b/tests/cpu/test_cca.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -34,12 +34,10 @@ cca_function_t f =
     [](const traccc::edm::silicon_cell_collection::host& cells,
        const traccc::detector_design_description::host& det_desc,
        const traccc::detector_conditions_description::host& det_cond)
-    -> std::pair<
-        std::map<traccc::geometry_id, traccc::edm::measurement_collection<
-                                          traccc::default_algebra>::host>,
-        std::optional<traccc::edm::silicon_cluster_collection::host>> {
-    std::map<traccc::geometry_id,
-             traccc::edm::measurement_collection<traccc::default_algebra>::host>
+    -> std::pair<std::map<traccc::geometry_id,
+                          traccc::edm::measurement_collection::host>,
+                 std::optional<traccc::edm::silicon_cluster_collection::host>> {
+    std::map<traccc::geometry_id, traccc::edm::measurement_collection::host>
         result;
 
     const traccc::edm::silicon_cell_collection::const_data cells_data =
@@ -56,9 +54,9 @@ cca_function_t f =
     for (std::size_t i = 0; i < measurements.size(); i++) {
         if (result.contains(measurements.at(i).surface_link().value()) ==
             false) {
-            result.insert({measurements.at(i).surface_link().value(),
-                           traccc::edm::measurement_collection<
-                               traccc::default_algebra>::host{resource}});
+            result.insert(
+                {measurements.at(i).surface_link().value(),
+                 traccc::edm::measurement_collection::host{resource}});
         }
         result.at(measurements.at(i).surface_link().value())
             .push_back(measurements.at(i));

--- a/tests/cpu/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cpu/test_ckf_combinatorics_telescope.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -140,8 +140,7 @@ TEST_P(CpuCkfCombinatoricsTelescopeTests, Run) {
         // Truth Track Candidates
         traccc::event_data evt_data(path, i_evt, host_mr);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            truth_measurements{host_mr};
+        traccc::edm::measurement_collection::host truth_measurements{host_mr};
         traccc::edm::track_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
         evt_data.generate_truth_candidates(truth_track_candidates,
@@ -161,12 +160,11 @@ TEST_P(CpuCkfCombinatoricsTelescopeTests, Run) {
             seeds_view = vecmem::get_data(seeds);
 
         // Read measurements
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::io::read_measurements(measurements_per_event, i_evt, path);
-        const traccc::edm::measurement_collection<
-            traccc::default_algebra>::const_view measurements_view =
-            vecmem::get_data(measurements_per_event);
+        const traccc::edm::measurement_collection::const_view
+            measurements_view = vecmem::get_data(measurements_per_event);
 
         // Run finding
         auto track_candidates =

--- a/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
+++ b/tests/cpu/test_ckf_sparse_tracks_telescope.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -149,8 +149,7 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
         // Truth Track Candidates
         traccc::event_data evt_data(path, i_evt, host_mr);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            truth_measurements{host_mr};
+        traccc::edm::measurement_collection::host truth_measurements{host_mr};
         traccc::edm::track_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
         evt_data.generate_truth_candidates(truth_track_candidates,
@@ -168,8 +167,8 @@ TEST_P(CkfSparseTrackTelescopeTests, Run) {
         ASSERT_EQ(seeds.size(), n_truth_tracks);
 
         // Read measurements
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::io::read_measurements(measurements_per_event, i_evt, path);
 
         // Run finding

--- a/tests/cpu/test_clusterization_resolution.cpp
+++ b/tests/cpu/test_clusterization_resolution.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -69,8 +69,7 @@ TEST_P(SurfaceBinningTests, Run) {
 
     // Read the hits from the relevant event file
     traccc::edm::spacepoint_collection::host spacepoints_truth{host_mr};
-    traccc::edm::measurement_collection<traccc::default_algebra>::host
-        measurements_truth{host_mr};
+    traccc::edm::measurement_collection::host measurements_truth{host_mr};
     traccc::io::read_spacepoints(spacepoints_truth, measurements_truth, event,
                                  data_dir, &detector);
 

--- a/tests/cpu/test_kalman_fitter_hole_count.cpp
+++ b/tests/cpu/test_kalman_fitter_hole_count.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -132,8 +132,7 @@ TEST_P(KalmanFittingHoleCountTests, Run) {
     traccc::event_data evt_data(path, 0u, host_mr);
 
     // Truth Track Candidates
-    traccc::edm::measurement_collection<traccc::default_algebra>::host
-        measurements(host_mr);
+    traccc::edm::measurement_collection::host measurements(host_mr);
     traccc::edm::track_container<traccc::default_algebra>::host
         track_candidates{host_mr};
     evt_data.generate_truth_candidates(track_candidates, measurements, sg,

--- a/tests/cpu/test_kalman_fitter_momentum_resolution.cpp
+++ b/tests/cpu/test_kalman_fitter_momentum_resolution.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -153,8 +153,7 @@ TEST_P(KalmanFittingMomentumResolutionTests, Run) {
         // Event map
         traccc::event_data evt_data(path, i_evt, host_mr);
         // Truth Track Candidates
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements(host_mr);
+        traccc::edm::measurement_collection::host measurements(host_mr);
         traccc::edm::track_container<traccc::default_algebra>::host
             track_candidates{host_mr};
         evt_data.generate_truth_candidates(track_candidates, measurements, sg,

--- a/tests/cpu/test_kalman_fitter_telescope.cpp
+++ b/tests/cpu/test_kalman_fitter_telescope.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -134,8 +134,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
         // Event map
         traccc::event_data evt_data(path, i_evt, host_mr);
         // Truth Track Candidates
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements(host_mr);
+        traccc::edm::measurement_collection::host measurements(host_mr);
         traccc::edm::track_container<traccc::default_algebra>::host
             track_candidates{host_mr};
         evt_data.generate_truth_candidates(track_candidates, measurements, sg,

--- a/tests/cpu/test_kalman_fitter_wire_chamber.cpp
+++ b/tests/cpu/test_kalman_fitter_wire_chamber.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -141,8 +141,7 @@ TEST_P(KalmanFittingWireChamberTests, Run) {
         // Event map
         traccc::event_data evt_data(path, i_evt, host_mr);
         // Truth Track Candidates
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements(host_mr);
+        traccc::edm::measurement_collection::host measurements(host_mr);
         traccc::edm::track_container<traccc::default_algebra>::host
             track_candidates{host_mr};
         evt_data.generate_truth_candidates(track_candidates, measurements, sg,

--- a/tests/cpu/test_seeding.cpp
+++ b/tests/cpu/test_seeding.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -45,7 +45,7 @@ TEST(seeding, case1) {
     traccc::host::seeding_algorithm sa(finder_config, grid_config,
                                        filter_config, host_mr);
 
-    edm::measurement_collection<default_algebra>::host measurements(host_mr);
+    edm::measurement_collection::host measurements(host_mr);
     edm::spacepoint_collection::host spacepoints{host_mr};
 
     // Spacepoints from 16.62 GeV muon
@@ -119,7 +119,7 @@ TEST(seeding, case2) {
     traccc::host::seeding_algorithm sa(finder_config, grid_config,
                                        filter_config, host_mr);
 
-    edm::measurement_collection<default_algebra>::host measurements(host_mr);
+    edm::measurement_collection::host measurements(host_mr);
     edm::spacepoint_collection::host spacepoints{host_mr};
 
     // Spacepoints from 1.85 GeV muon

--- a/tests/cpu/test_spacepoint_formation.cpp
+++ b/tests/cpu/test_spacepoint_formation.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -50,8 +50,7 @@ TEST(spacepoint_formation, cpu) {
     // Surface lookup
 
     // Prepare measurement collection
-    typename edm::measurement_collection<default_algebra>::host measurements{
-        host_mr};
+    edm::measurement_collection::host measurements{host_mr};
 
     // Add a measurement at the first plane
     measurements.push_back({{7.f, 2.f},

--- a/tests/cpu/test_track_params_estimation.cpp
+++ b/tests/cpu/test_track_params_estimation.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -47,7 +47,7 @@ TEST(track_params_estimation, helix_negative_charge) {
         pos, time, vector::normalize(mom), q / vector::norm(mom), B);
 
     // Make three spacepoints with the helix
-    edm::measurement_collection<default_algebra>::host measurements(host_mr);
+    edm::measurement_collection::host measurements(host_mr);
     edm::spacepoint_collection::host spacepoints{host_mr};
     measurements.resize(3);
     spacepoints.reserve(3);
@@ -97,7 +97,7 @@ TEST(track_params_estimation, helix_positive_charge) {
         pos, time, vector::normalize(mom), q / vector::norm(mom), B);
 
     // Make three spacepoints with the helix
-    edm::measurement_collection<default_algebra>::host measurements(host_mr);
+    edm::measurement_collection::host measurements(host_mr);
     edm::spacepoint_collection::host spacepoints{host_mr};
     measurements.resize(3);
     spacepoints.reserve(3);

--- a/tests/cpu/test_triplet_fitter_telescope.cpp
+++ b/tests/cpu/test_triplet_fitter_telescope.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -137,8 +137,7 @@ TEST_P(TripletFittingTelescopeTests, Run) {
         // Event map
         traccc::event_data evt_data(path, i_evt, host_mr);
         // Truth Track Candidates
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements(host_mr);
+        traccc::edm::measurement_collection::host measurements(host_mr);
         traccc::edm::track_container<traccc::default_algebra>::host
             track_candidates{host_mr};
         evt_data.generate_truth_candidates(track_candidates, measurements, sg,

--- a/tests/cuda/test_ambiguity_resolution.cpp
+++ b/tests/cuda/test_ambiguity_resolution.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,9 +29,8 @@
 
 using namespace traccc;
 
-void fill_measurements(
-    edm::measurement_collection<default_algebra>::host& measurements,
-    const measurement_id_type max_meas_id) {
+void fill_measurements(edm::measurement_collection::host& measurements,
+                       const measurement_id_type max_meas_id) {
 
     measurements.reserve(max_meas_id + 1);
     for (measurement_id_type i = 0; i <= max_meas_id; i++) {
@@ -47,7 +46,7 @@ void fill_pattern(edm::track_container<default_algebra>::host& track_candidates,
     track_candidates.tracks.resize(track_candidates.tracks.size() + 1u);
     track_candidates.tracks.pval().back() = pval;
 
-    edm::measurement_collection<default_algebra>::const_device measurements{
+    edm::measurement_collection::const_device measurements{
         track_candidates.measurements};
 
     for (const auto& meas_id : pattern) {
@@ -86,7 +85,7 @@ std::vector<measurement_id_type> get_pattern(
     const edm::track_container<default_algebra>::host& track_candidates,
     const std::size_t idx) {
 
-    edm::measurement_collection<default_algebra>::const_device measurements{
+    edm::measurement_collection::const_device measurements{
         track_candidates.measurements};
     std::vector<measurement_id_type> ret;
     // A const reference would be fine here. But GCC fears that that would lead
@@ -111,7 +110,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest0) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -163,7 +162,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest1) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -203,7 +202,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest2) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -239,7 +238,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest3) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -278,7 +277,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest5) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -315,7 +314,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest6) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -353,7 +352,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest7) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -388,7 +387,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest8) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -427,7 +426,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest9) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -462,7 +461,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest10) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -501,7 +500,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest11) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -536,7 +535,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest12) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -574,7 +573,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest13) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -616,7 +615,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest14) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -653,7 +652,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest15) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -690,7 +689,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest16) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -730,7 +729,7 @@ TEST(CUDAAmbiguitySolverTests, GreedyResolverTest17) {
     // Cuda copy objects
     vecmem::cuda::async_copy copy{stream.cudaStream()};
 
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
     fill_measurements(measurements, 100);
 
     edm::track_container<default_algebra>::host trk_cands{
@@ -789,8 +788,7 @@ TEST_P(CUDAGreedyResolutionCompareToCPU, Comparison) {
         std::mt19937 gen(sd);
         std::cout << "Event: " << i_evt << " Seed: " << sd << std::endl;
 
-        edm::measurement_collection<default_algebra>::host measurements{
-            host_mr};
+        edm::measurement_collection::host measurements{host_mr};
         fill_measurements(measurements, max_meas_id);
         edm::track_container<default_algebra>::host trk_cands{
             host_mr, vecmem::get_data(measurements)};
@@ -853,10 +851,9 @@ TEST_P(CUDAGreedyResolutionCompareToCPU, Comparison) {
             resolution_config, mr, copy, stream);
 
         // H2D transfer
-        edm::measurement_collection<default_algebra>::buffer
-            measurements_buffer =
-                copy.to(vecmem::get_data(measurements), device_mr, &host_mr,
-                        vecmem::copy::type::host_to_device);
+        edm::measurement_collection::buffer measurements_buffer =
+            copy.to(vecmem::get_data(measurements), device_mr, &host_mr,
+                    vecmem::copy::type::host_to_device);
         traccc::edm::track_container<default_algebra>::buffer trk_cands_buffer{
             copy.to(vecmem::get_data(trk_cands.tracks), device_mr, &host_mr,
                     vecmem::copy::type::host_to_device),

--- a/tests/cuda/test_cca.cpp
+++ b/tests/cuda/test_cca.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -27,11 +27,9 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
                  const traccc::detector_design_description::host& det_desc,
                  const traccc::detector_conditions_description::host& det_cond)
                -> std::pair<std::map<traccc::geometry_id,
-                                     traccc::edm::measurement_collection<
-                                         traccc::default_algebra>::host>,
+                                     traccc::edm::measurement_collection::host>,
                             traccc::edm::silicon_cluster_collection::host> {
-        std::map<traccc::geometry_id, traccc::edm::measurement_collection<
-                                          traccc::default_algebra>::host>
+        std::map<traccc::geometry_id, traccc::edm::measurement_collection::host>
             geom_to_meas_map;
 
         traccc::cuda::stream stream;
@@ -79,8 +77,7 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
         auto [measurements_buffer, cluster_buffer] =
             cc(cells_buffer, det_descr_buffer, det_cond_buffer,
                traccc::device::clustering_keep_disjoint_set{});
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements{host_mr};
+        traccc::edm::measurement_collection::host measurements{host_mr};
         copy(measurements_buffer, measurements)->wait();
 
         traccc::edm::silicon_cluster_collection::host clusters{host_mr};
@@ -91,8 +88,7 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
                     measurements.at(i).surface_link().value()) == false) {
                 geom_to_meas_map.insert(
                     {measurements.at(i).surface_link().value(),
-                     traccc::edm::measurement_collection<
-                         traccc::default_algebra>::host{host_mr}});
+                     traccc::edm::measurement_collection::host{host_mr}});
             }
             geom_to_meas_map.at(measurements.at(i).surface_link().value())
                 .push_back(measurements.at(i));

--- a/tests/cuda/test_ckf_combinatorics_telescope.cpp
+++ b/tests/cuda/test_ckf_combinatorics_telescope.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -159,8 +159,7 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
         // Truth Track Candidates
         traccc::event_data evt_data(path, i_evt, host_mr);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            truth_measurements{host_mr};
+        traccc::edm::measurement_collection::host truth_measurements{host_mr};
         traccc::edm::track_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
         evt_data.generate_truth_candidates(truth_track_candidates,
@@ -185,14 +184,12 @@ TEST_P(CudaCkfCombinatoricsTelescopeTests, Run) {
             ->wait();
 
         // Read measurements
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::io::read_measurements(measurements_per_event, i_evt, path);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::buffer
-            measurements_buffer(
-                static_cast<unsigned int>(measurements_per_event.size()),
-                mr.main);
+        traccc::edm::measurement_collection::buffer measurements_buffer(
+            static_cast<unsigned int>(measurements_per_event.size()), mr.main);
         copy.setup(measurements_buffer)->wait();
         copy(vecmem::get_data(measurements_per_event), measurements_buffer)
             ->wait();

--- a/tests/cuda/test_ckf_toy_detector.cpp
+++ b/tests/cuda/test_ckf_toy_detector.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -157,8 +157,7 @@ TEST_P(CkfToyDetectorTests, Run) {
         // Truth Track Candidates
         traccc::event_data evt_data(path, i_evt, host_mr);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            truth_measurements{host_mr};
+        traccc::edm::measurement_collection::host truth_measurements{host_mr};
         traccc::edm::track_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
         evt_data.generate_truth_candidates(truth_track_candidates,
@@ -183,14 +182,12 @@ TEST_P(CkfToyDetectorTests, Run) {
             ->wait();
 
         // Prepare the measurements
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::io::read_measurements(measurements_per_event, i_evt, path);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::buffer
-            measurements_buffer(
-                static_cast<unsigned int>(measurements_per_event.size()),
-                mr.main);
+        traccc::edm::measurement_collection::buffer measurements_buffer(
+            static_cast<unsigned int>(measurements_per_event.size()), mr.main);
         copy.setup(measurements_buffer)->wait();
         copy(vecmem::get_data(measurements_per_event), measurements_buffer)
             ->wait();

--- a/tests/cuda/test_clusterization.cpp
+++ b/tests/cuda/test_clusterization.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -64,13 +64,12 @@ TEST(CUDAClustering, SingleModule) {
     auto measurements_buffer =
         ca_cuda(vecmem::get_data(cells), vecmem::get_data(det_desc),
                 vecmem::get_data(det_cond));
-    edm::measurement_collection<default_algebra>::const_device measurements(
-        measurements_buffer);
+    edm::measurement_collection::const_device measurements(measurements_buffer);
 
     // Check the results
     ASSERT_EQ(copy.get_size(measurements_buffer), 2u);
 
-    edm::measurement_collection<default_algebra>::host references{mng_mr};
+    edm::measurement_collection::host references{mng_mr};
     references.push_back({{2.5f, 2.5f},
                           {0.75f, 0.0833333f},
                           2u,
@@ -93,8 +92,9 @@ TEST(CUDAClustering, SingleModule) {
     for (unsigned int i = 0; i < measurements.size(); ++i) {
         const auto test = measurements.at(i);
         // 0.01 % uncertainty
-        auto iso = traccc::details::is_same_object<edm::measurement_collection<
-            default_algebra>::const_device::object_type>(test, 0.0001f);
+        auto iso = traccc::details::is_same_object<
+            edm::measurement_collection::const_device::object_type>(test,
+                                                                    0.0001f);
         bool matched = false;
 
         for (std::size_t j = 0; j < references.size(); ++j) {

--- a/tests/cuda/test_kalman_fitter_telescope.cpp
+++ b/tests/cuda/test_kalman_fitter_telescope.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -154,8 +154,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
         traccc::event_data evt_data(path, i_evt, host_mr);
 
         // Truth Track Candidates
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements(host_mr);
+        traccc::edm::measurement_collection::host measurements(host_mr);
         traccc::edm::track_container<traccc::default_algebra>::host
             track_candidates{host_mr};
         evt_data.generate_truth_candidates(track_candidates, measurements, sg,
@@ -166,10 +165,9 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
         ASSERT_EQ(track_candidates.tracks.size(), n_truth_tracks);
 
         // track candidates buffer
-        traccc::edm::measurement_collection<traccc::default_algebra>::buffer
-            measurements_buffer =
-                copy.to(track_candidates.measurements, mr.main, mr.host,
-                        vecmem::copy::type::host_to_device);
+        traccc::edm::measurement_collection::buffer measurements_buffer =
+            copy.to(track_candidates.measurements, mr.main, mr.host,
+                    vecmem::copy::type::host_to_device);
         traccc::edm::track_container<traccc::default_algebra>::buffer
             track_candidates_buffer{
                 copy.to(vecmem::get_data(track_candidates.tracks), mr.main,

--- a/tests/cuda/test_spacepoint_formation.cpp
+++ b/tests/cuda/test_spacepoint_formation.cpp
@@ -67,7 +67,7 @@ TEST(CUDASpacepointFormation, cuda) {
         traccc::buffer_from_host_detector(host_det, mng_mr, copy);
 
     // Prepare measurement collection
-    edm::measurement_collection<default_algebra>::host measurements{mng_mr};
+    edm::measurement_collection::host measurements{mng_mr};
 
     // Add a measurement at the first plane
     measurements.push_back({{7.f, 2.f},

--- a/tests/io/test_csv.cpp
+++ b/tests/io/test_csv.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -102,8 +102,7 @@ TEST_F(io, csv_read_odd_single_muon) {
 
     // Read the truth particles for the first event.
     traccc::particle_container_types::host particles{&mr};
-    traccc::edm::measurement_collection<traccc::default_algebra>::host
-        measurements{mr};
+    traccc::edm::measurement_collection::host measurements{mr};
     traccc::io::read_particles(particles, measurements, 0u,
                                "odd/geant4_1muon_1GeV/", &detector,
                                traccc::data_format::csv);

--- a/tests/sycl/test_cca.cpp
+++ b/tests/sycl/test_cca.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -34,11 +34,10 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
               const traccc::detector_conditions_description::host& det_cond)
             -> std::pair<
                 std::map<traccc::geometry_id,
-                         traccc::edm::measurement_collection<
-                             traccc::default_algebra>::host>,
+                         traccc::edm::measurement_collection::host>,
                 std::optional<traccc::edm::silicon_cluster_collection::host>> {
-            std::map<traccc::geometry_id, traccc::edm::measurement_collection<
-                                              traccc::default_algebra>::host>
+            std::map<traccc::geometry_id,
+                     traccc::edm::measurement_collection::host>
                 result;
 
             vecmem::sycl::queue_wrapper vecmem_queue;
@@ -87,8 +86,7 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
             auto [measurements_buffer, cluster_buffer] =
                 cc(cells_buffer, det_descr_buffer, det_cond_buffer,
                    traccc::device::clustering_keep_disjoint_set{});
-            traccc::edm::measurement_collection<traccc::default_algebra>::host
-                measurements{host_mr};
+            traccc::edm::measurement_collection::host measurements{host_mr};
             copy(measurements_buffer, measurements)->wait();
 
             traccc::edm::silicon_cluster_collection::host clusters{host_mr};
@@ -99,8 +97,7 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
                         measurements.at(i).surface_link().value()) == false) {
                     result.insert(
                         {measurements.at(i).surface_link().value(),
-                         traccc::edm::measurement_collection<
-                             traccc::default_algebra>::host{host_mr}});
+                         traccc::edm::measurement_collection::host{host_mr}});
                 }
                 result.at(measurements.at(i).surface_link().value())
                     .push_back(measurements.at(i));

--- a/tests/sycl/test_ckf_combinatorics_telescope.cpp
+++ b/tests/sycl/test_ckf_combinatorics_telescope.cpp
@@ -165,8 +165,7 @@ TEST_P(CkfCombinatoricsTelescopeTests, Run) {
         // Truth Track Candidates
         traccc::event_data evt_data(path, i_evt, host_mr);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            truth_measurements{host_mr};
+        traccc::edm::measurement_collection::host truth_measurements{host_mr};
         traccc::edm::track_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
         evt_data.generate_truth_candidates(truth_track_candidates,
@@ -191,15 +190,13 @@ TEST_P(CkfCombinatoricsTelescopeTests, Run) {
             ->wait();
 
         // Read measurements
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::io::read_measurements(measurements_per_event, i_evt,
                                       path.native());
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::buffer
-            measurements_buffer(
-                static_cast<unsigned int>(measurements_per_event.size()),
-                mr.main);
+        traccc::edm::measurement_collection::buffer measurements_buffer(
+            static_cast<unsigned int>(measurements_per_event.size()), mr.main);
         copy.setup(measurements_buffer)->wait();
         copy(vecmem::get_data(measurements_per_event), measurements_buffer)
             ->wait();

--- a/tests/sycl/test_ckf_toy_detector.cpp
+++ b/tests/sycl/test_ckf_toy_detector.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -157,8 +157,7 @@ TEST_P(CkfToyDetectorTests, Run) {
         // Truth Track Candidates
         traccc::event_data evt_data(path.native(), i_evt, host_mr);
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            truth_measurements{host_mr};
+        traccc::edm::measurement_collection::host truth_measurements{host_mr};
         traccc::edm::track_container<traccc::default_algebra>::host
             truth_track_candidates{host_mr};
         evt_data.generate_truth_candidates(truth_track_candidates,
@@ -183,15 +182,13 @@ TEST_P(CkfToyDetectorTests, Run) {
             ->wait();
 
         // Read measurements
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements_per_event{host_mr};
+        traccc::edm::measurement_collection::host measurements_per_event{
+            host_mr};
         traccc::io::read_measurements(measurements_per_event, i_evt,
                                       path.native());
 
-        traccc::edm::measurement_collection<traccc::default_algebra>::buffer
-            measurements_buffer(
-                static_cast<unsigned int>(measurements_per_event.size()),
-                mr.main);
+        traccc::edm::measurement_collection::buffer measurements_buffer(
+            static_cast<unsigned int>(measurements_per_event.size()), mr.main);
         copy.setup(measurements_buffer)->wait();
         copy(vecmem::get_data(measurements_per_event), measurements_buffer)
             ->wait();

--- a/tests/sycl/test_clusterization.cpp
+++ b/tests/sycl/test_clusterization.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -67,13 +67,12 @@ TEST(SYCLClustering, SingleModule) {
         ca_sycl(vecmem::get_data(cells), vecmem::get_data(det_desc),
                 vecmem::get_data(det_cond));
 
-    edm::measurement_collection<default_algebra>::device measurements(
-        measurements_buffer);
+    edm::measurement_collection::device measurements(measurements_buffer);
 
     // Check the results
     EXPECT_EQ(copy.get_size(measurements_buffer), 2u);
 
-    edm::measurement_collection<default_algebra>::host references{shared_mr};
+    edm::measurement_collection::host references{shared_mr};
     references.push_back({{2.5f, 2.5f},
                           {0.75f, 0.0833333f},
                           2u,
@@ -96,8 +95,9 @@ TEST(SYCLClustering, SingleModule) {
     for (unsigned int i = 0; i < measurements.size(); ++i) {
         const auto test = measurements.at(i);
         // 0.01 % uncertainty
-        auto iso = traccc::details::is_same_object<edm::measurement_collection<
-            default_algebra>::const_device::object_type>(test, 0.0001f);
+        auto iso = traccc::details::is_same_object<
+            edm::measurement_collection::const_device::object_type>(test,
+                                                                    0.0001f);
         bool matched = false;
 
         for (std::size_t j = 0; j < references.size(); ++j) {

--- a/tests/sycl/test_kalman_fitter_telescope.cpp
+++ b/tests/sycl/test_kalman_fitter_telescope.cpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -164,8 +164,7 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
         traccc::event_data evt_data(path, i_evt, host_mr);
 
         // Truth Track Candidates
-        traccc::edm::measurement_collection<traccc::default_algebra>::host
-            measurements{host_mr};
+        traccc::edm::measurement_collection::host measurements{host_mr};
         traccc::edm::track_container<traccc::default_algebra>::host
             track_candidates{host_mr};
         evt_data.generate_truth_candidates(track_candidates, measurements, sg,
@@ -176,10 +175,9 @@ TEST_P(KalmanFittingTelescopeTests, Run) {
         ASSERT_EQ(track_candidates.tracks.size(), n_truth_tracks);
 
         // track candidates buffer
-        traccc::edm::measurement_collection<traccc::default_algebra>::buffer
-            measurements_buffer =
-                copy.to(track_candidates.measurements, mr.main, mr.host,
-                        vecmem::copy::type::host_to_device);
+        traccc::edm::measurement_collection::buffer measurements_buffer =
+            copy.to(track_candidates.measurements, mr.main, mr.host,
+                    vecmem::copy::type::host_to_device);
         traccc::edm::track_container<traccc::default_algebra>::buffer
             track_candidates_buffer{
                 copy.to(vecmem::get_data(track_candidates.tracks), mr.main,

--- a/tests/sycl/test_spacepoint_formation.cpp
+++ b/tests/sycl/test_spacepoint_formation.cpp
@@ -65,7 +65,7 @@ TEST(SYCLSpacepointFormation, sycl) {
                                           copy);
 
     // Prepare measurement collection
-    edm::measurement_collection<default_algebra>::host measurements{shared_mr};
+    edm::measurement_collection::host measurements{shared_mr};
 
     // Add a measurement at the first plane
     measurements.push_back({{7.f, 2.f},


### PR DESCRIPTION
With this let me start yet another big rewrite / redesign. :thinking:

It's been bugging me for a long time that the data model we use depends on the algebra that we use. Which in my mind is not a workable API. The data itself needs to be fixed somehow.

So I started by making `traccc::edm::silicon_cell` and `traccc::edm::measurement` not be dependent on the build setup of the project. As these seemed technically the easiest to do, and since `edm::measurement` is used pretty much everywhere, I thought that this would be a good stress-test for the rewrite.

Making `edm::silicon_cell` always use `float` values for its "activation" and "time" properties was a trivial change, that didn't actually necessitate any code changes. So that was surprisingly easy.

But of course `edm::measurement` was a bit more tricky. What we do currently is that we use the `detray::point2D` type for storing the local coordinates and the variances of those local coordinates. But I believe it's a lot better idea to just store plain `std::array<float, 2>` objects. Independent of what algebra we want to use for our calculations.

To help with this, I added a couple of additional functions to `edm::measurement`. Which would help with both retrieving and setting the `local_position` and `local_variance` variables using Detray objects directly. Just so that the actual algorithmic code would look a bit more "natural". Like:

```c++
    const point3 global = sf.local_to_global(
        gctx,
        meas.template local_position_in<typename detector_t::algebra_type>(),
        {});
```

(Okay, maybe "natural" is a bit over-selling it. :thinking:)

I see this all as one step towards hiding the whole algebra business behind the scenes. As the API of the GPU tools should really not reveal what algebra is being used underneath. In case we end up using array and Eigen algebras interchangeably in the end after all. :thinking:

I assume there will be plenty of discussion around this. Especially around what we'll do with `edm::track_state` afterwards. (As there I do have some worries about what we actually want to do.) But let's see how this goes...