### PR TITLE
Revert vecmem update to v1.23.0

### DIFF
--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -40,7 +40,20 @@ full_chain_algorithm::full_chain_algorithm(
       m_field(make_magnetic_field(field, m_queue)),
       m_det_descr(det_descr),
       m_device_det_descr(
-          vecmem::edm::get_capacities(vecmem::get_data(m_det_descr.get())),
+          [&]() {
+              // number of elements in the detector design description
+              std::vector<unsigned int> sizes(det_descr.size());
+              for (std::size_t i = 0; i < det_descr.size(); ++i) {
+                  auto this_design = det_descr.at(i);
+                  // now for each element, set the size to the largest size of
+                  // that element across all modules
+                  sizes[i] = std::max(static_cast<unsigned int>(
+                                          ((this_design.bin_edges_x()).size())),
+                                      static_cast<unsigned int>((
+                                          (this_design.bin_edges_y()).size())));
+              }
+              return sizes;
+          }(),
           m_cached_device_mr, &m_cached_pinned_host_mr,
           vecmem::data::buffer_type::resizable),
       m_det_cond(det_cond),
@@ -105,7 +118,21 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
       m_field(parent.m_field),
       m_det_descr(parent.m_det_descr),
       m_device_det_descr(
-          vecmem::edm::get_capacities(vecmem::get_data(m_det_descr.get())),
+          [&]() {
+              // number of elements in the detector design description
+              std::vector<unsigned int> sizes(parent.m_det_descr.get().size());
+              for (std::size_t i = 0; i < parent.m_det_descr.get().size();
+                   ++i) {
+                  auto this_design = parent.m_det_descr.get().at(i);
+                  // now for each element, set the size to the largest size of
+                  // that element across all modules
+                  sizes[i] = std::max(static_cast<unsigned int>(
+                                          ((this_design.bin_edges_x()).size())),
+                                      static_cast<unsigned int>((
+                                          (this_design.bin_edges_y()).size())));
+              }
+              return sizes;
+          }(),
           m_cached_device_mr, &m_cached_pinned_host_mr,
           vecmem::data::buffer_type::resizable),
       m_det_cond(parent.m_det_cond),

--- a/examples/run/alpaka/seq_example_alpaka.cpp
+++ b/examples/run/alpaka/seq_example_alpaka.cpp
@@ -91,7 +91,18 @@ int seq_run(const traccc::opts::detector& detector_opts,
     traccc::detector_conditions_description::data host_det_cond_data{
         vecmem::get_data(host_det_cond)};
     traccc::detector_design_description::buffer device_det_descr{
-        vecmem::edm::get_capacities(vecmem::get_data(host_det_descr)),
+        [&]() {
+            std::vector<unsigned int> sizes(host_det_descr.size());
+            for (std::size_t i = 0; i < host_det_descr.size(); ++i) {
+                auto this_design = host_det_descr.at(i);
+
+                sizes[i] = std::max(static_cast<unsigned int>(
+                                        ((this_design.bin_edges_x()).size())),
+                                    static_cast<unsigned int>(
+                                        ((this_design.bin_edges_y()).size())));
+            }
+            return sizes;
+        }(),
         device_mr, &host_mr, vecmem::data::buffer_type::resizable};
     copy.setup(device_det_descr)->wait();
     copy(vecmem::get_data(host_det_descr), device_det_descr)->wait();

--- a/examples/run/cuda/full_chain_algorithm.cpp
+++ b/examples/run/cuda/full_chain_algorithm.cpp
@@ -57,7 +57,20 @@ full_chain_algorithm::full_chain_algorithm(
       m_det_descr(det_descr),
       m_det_cond(det_cond),
       m_device_det_descr(
-          vecmem::edm::get_capacities(vecmem::get_data(m_det_descr.get())),
+          [&]() {
+              // number of elements in the detector design description
+              std::vector<unsigned int> sizes(det_descr.size());
+              for (std::size_t i = 0; i < det_descr.size(); ++i) {
+                  auto this_design = det_descr.at(i);
+                  // now for each element, set the size to the largest size of
+                  // that element across all modules
+                  sizes[i] = std::max(static_cast<unsigned int>(
+                                          ((this_design.bin_edges_x()).size())),
+                                      static_cast<unsigned int>((
+                                          (this_design.bin_edges_y()).size())));
+              }
+              return sizes;
+          }(),
           m_device_mr, &m_host_mr, vecmem::data::buffer_type::resizable),
       m_device_det_cond(
           static_cast<detector_conditions_description::buffer::size_type>(
@@ -124,7 +137,21 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
       m_det_descr(parent.m_det_descr),
       m_det_cond(parent.m_det_cond),
       m_device_det_descr(
-          vecmem::edm::get_capacities(vecmem::get_data(m_det_descr.get())),
+          [&]() {
+              // number of elements in the detector design description
+              std::vector<unsigned int> sizes(parent.m_det_descr.get().size());
+              for (std::size_t i = 0; i < parent.m_det_descr.get().size();
+                   ++i) {
+                  auto this_design = parent.m_det_descr.get().at(i);
+                  // now for each element, set the size to the largest size of
+                  // that element across all modules
+                  sizes[i] = std::max(static_cast<unsigned int>(
+                                          ((this_design.bin_edges_x()).size())),
+                                      static_cast<unsigned int>((
+                                          (this_design.bin_edges_y()).size())));
+              }
+              return sizes;
+          }(),
           m_device_mr, &m_host_mr, vecmem::data::buffer_type::resizable),
       m_device_det_cond(
           static_cast<detector_conditions_description::buffer::size_type>(

--- a/examples/run/cuda/seq_example_cuda.cpp
+++ b/examples/run/cuda/seq_example_cuda.cpp
@@ -102,7 +102,20 @@ int seq_run(const traccc::opts::detector& detector_opts,
     traccc::detector_conditions_description::data host_det_cond_data{
         vecmem::get_data(host_det_cond)};
     traccc::detector_design_description::buffer device_det_descr{
-        vecmem::edm::get_capacities(vecmem::get_data(host_det_descr)),
+        [&]() {
+            // number of elements in the detector design description
+            std::vector<unsigned int> sizes(host_det_descr.size());
+            for (std::size_t i = 0; i < host_det_descr.size(); ++i) {
+                auto this_design = host_det_descr.at(i);
+                // now for each element, set the size to the largest size of
+                // that element across all modules
+                sizes[i] = std::max(static_cast<unsigned int>(
+                                        ((this_design.bin_edges_x()).size())),
+                                    static_cast<unsigned int>(
+                                        ((this_design.bin_edges_y()).size())));
+            }
+            return sizes;
+        }(),
         device_mr, &host_mr, vecmem::data::buffer_type::resizable};
     copy.setup(device_det_descr)->wait();
     copy(host_det_descr_data, device_det_descr)->wait();

--- a/examples/run/sycl/full_chain_algorithm.cpp
+++ b/examples/run/sycl/full_chain_algorithm.cpp
@@ -49,7 +49,20 @@ full_chain_algorithm::full_chain_algorithm(
       m_det_descr(det_descr),
       m_det_cond(det_cond),
       m_device_det_descr(
-          vecmem::edm::get_capacities(vecmem::get_data(m_det_descr.get())),
+          [&]() {
+              // number of elements in the detector design description
+              std::vector<unsigned int> sizes(det_descr.size());
+              for (std::size_t i = 0; i < det_descr.size(); ++i) {
+                  auto this_design = det_descr.at(i);
+                  // now for each element, set the size to the largest size of
+                  // that element across all modules
+                  sizes[i] = std::max(static_cast<unsigned int>(
+                                          ((this_design.bin_edges_x()).size())),
+                                      static_cast<unsigned int>((
+                                          (this_design.bin_edges_y()).size())));
+              }
+              return sizes;
+          }(),
           m_cached_device_mr, &m_cached_pinned_host_mr,
           vecmem::data::buffer_type::resizable),
       m_device_det_cond(
@@ -126,7 +139,21 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
       m_det_descr(parent.m_det_descr),
       m_det_cond(parent.m_det_cond),
       m_device_det_descr(
-          vecmem::edm::get_capacities(vecmem::get_data(m_det_descr.get())),
+          [&]() {
+              // number of elements in the detector design description
+              std::vector<unsigned int> sizes(parent.m_det_descr.get().size());
+              for (std::size_t i = 0; i < parent.m_det_descr.get().size();
+                   ++i) {
+                  auto this_design = parent.m_det_descr.get().at(i);
+                  // now for each element, set the size to the largest size of
+                  // that element across all modules
+                  sizes[i] = std::max(static_cast<unsigned int>(
+                                          ((this_design.bin_edges_x()).size())),
+                                      static_cast<unsigned int>((
+                                          (this_design.bin_edges_y()).size())));
+              }
+              return sizes;
+          }(),
           m_cached_device_mr, &m_cached_pinned_host_mr,
           vecmem::data::buffer_type::resizable),
       m_device_det_cond(

--- a/examples/run/sycl/seq_example_sycl.cpp
+++ b/examples/run/sycl/seq_example_sycl.cpp
@@ -106,7 +106,20 @@ int seq_run(const traccc::opts::detector& detector_opts,
     traccc::detector_conditions_description::data host_det_cond_data{
         vecmem::get_data(host_det_cond)};
     traccc::detector_design_description::buffer device_det_descr{
-        vecmem::edm::get_capacities(vecmem::get_data(host_det_descr)),
+        [&]() {
+            // number of elements in the detector design description
+            std::vector<unsigned int> sizes(host_det_descr.size());
+            for (std::size_t i = 0; i < host_det_descr.size(); ++i) {
+                auto this_design = host_det_descr.at(i);
+                // now for each element, set the size to the largest size of
+                // that element across all modules
+                sizes[i] = std::max(static_cast<unsigned int>(
+                                        ((this_design.bin_edges_x()).size())),
+                                    static_cast<unsigned int>(
+                                        ((this_design.bin_edges_y()).size())));
+            }
+            return sizes;
+        }(),
         device_mr, &host_mr, vecmem::data::buffer_type::resizable};
     copy.setup(device_det_descr)->wait();
     copy(host_det_descr_data, device_det_descr)->wait();

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the TRACCC project" )
 
 # Declare where to get VecMem from.
 set( TRACCC_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.24.0.tar.gz;URL_MD5;4ca66bf822528e0880581ad107efa911"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.23.0.tar.gz;URL_MD5;c4b87f88856b5273b89373d880bdc0fd"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( TRACCC_VECMEM_SOURCE )
 FetchContent_Declare( VecMem SYSTEM ${TRACCC_VECMEM_SOURCE} )

--- a/tests/alpaka/test_cca.cpp
+++ b/tests/alpaka/test_cca.cpp
@@ -55,7 +55,19 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
                 {device_mr, &pinned_host_mr}, copy, queue, cfg);
 
             traccc::detector_design_description::buffer det_desc_buffer{
-                vecmem::edm::get_capacities(vecmem::get_data(det_desc)),
+                [&]() {
+                    std::vector<unsigned int> sizes(det_desc.size());
+                    for (std::size_t i = 0; i < det_desc.size(); ++i) {
+                        auto this_design = det_desc.at(i);
+
+                        sizes[i] =
+                            std::max(static_cast<unsigned int>(
+                                         ((this_design.bin_edges_x()).size())),
+                                     static_cast<unsigned int>(
+                                         ((this_design.bin_edges_y()).size())));
+                    }
+                    return sizes;
+                }(),
                 device_mr, &host_mr, vecmem::data::buffer_type::resizable};
             copy.setup(det_desc_buffer)->wait();
             copy(vecmem::get_data(det_desc), det_desc_buffer)->wait();

--- a/tests/cuda/test_cca.cpp
+++ b/tests/cuda/test_cca.cpp
@@ -40,8 +40,21 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
                                                   stream, cfg);
 
         traccc::detector_design_description::buffer det_descr_buffer{
-            vecmem::edm::get_capacities(vecmem::get_data(det_desc)), device_mr,
-            &host_mr, vecmem::data::buffer_type::fixed_size};
+            [&]() {
+                std::vector<unsigned int> sizes(det_desc.size());
+                for (std::size_t i = 0; i < det_desc.size(); ++i) {
+                    auto this_design = det_desc.at(i);
+                    // now for each element, set the size to the largest size of
+                    // that element across all modules
+                    sizes[i] =
+                        std::max(static_cast<unsigned int>(
+                                     ((this_design.bin_edges_x()).size())),
+                                 static_cast<unsigned int>(
+                                     ((this_design.bin_edges_y()).size())));
+                }
+                return sizes;
+            }(),
+            device_mr, &host_mr, vecmem::data::buffer_type::fixed_size};
         copy.setup(det_descr_buffer)->wait();
         copy(vecmem::get_data(det_desc), det_descr_buffer)->wait();
         traccc::detector_conditions_description::buffer det_cond_buffer{

--- a/tests/sycl/test_cca.cpp
+++ b/tests/sycl/test_cca.cpp
@@ -49,7 +49,20 @@ cca_function_t get_f_with(traccc::clustering_config cfg) {
                                                       copy, traccc_queue, cfg);
 
             traccc::detector_design_description::buffer det_descr_buffer{
-                vecmem::edm::get_capacities(vecmem::get_data(det_desc)),
+                [&]() {
+                    std::vector<unsigned int> sizes(det_desc.size());
+                    for (std::size_t i = 0; i < det_desc.size(); ++i) {
+                        auto this_design = det_desc.at(i);
+                        // now for each element, set the size to the largest
+                        // size of that element across all modules
+                        sizes[i] =
+                            std::max(static_cast<unsigned int>(
+                                         ((this_design.bin_edges_x()).size())),
+                                     static_cast<unsigned int>(
+                                         ((this_design.bin_edges_y()).size())));
+                    }
+                    return sizes;
+                }(),
                 device_mr, &host_mr, vecmem::data::buffer_type::fixed_size};
             copy.setup(det_descr_buffer)->wait();
             copy(vecmem::get_data(det_desc), det_descr_buffer)->wait();


### PR DESCRIPTION
Reverts acts-project/traccc#1291

Update to newer VecMem version is ok however, get_capacities() fails to correctly retrieve the sizes (appears to only be faulty for for ITk digitization)