### PR TITLE
Fix for alpaka after #1272

### DIFF
--- a/examples/run/alpaka/CMakeLists.txt
+++ b/examples/run/alpaka/CMakeLists.txt
@@ -46,3 +46,6 @@ traccc_add_executable( throughput_mt_alpaka "throughput_mt.cpp"
 
 add_test( NAME throughput_st_alpaka
           COMMAND traccc_throughput_st_alpaka --finding-run-mbf-smoother=0 --read-bfield-from-file --cold-run-events=1 --processed-events=1)
+
+add_test( NAME throughput_mt_alpaka
+          COMMAND traccc_throughput_mt_alpaka --finding-run-mbf-smoother=0 --read-bfield-from-file --cold-run-events=1 --processed-events=1)

--- a/examples/run/alpaka/CMakeLists.txt
+++ b/examples/run/alpaka/CMakeLists.txt
@@ -43,3 +43,6 @@ traccc_add_executable( throughput_st_alpaka "throughput_st.cpp"
 
 traccc_add_executable( throughput_mt_alpaka "throughput_mt.cpp"
    LINK_LIBRARIES TBB::tbb indicators::indicators ${LIBRARIES} ${DETRAY} traccc_examples_alpaka )
+
+add_test( throughput_st_alpaka
+                 ${CMAKE_BINARY_DIR}/bin/traccc_throughput_st_alpaka --finding-run-mbf-smoother=0 --read-bfield-from-file --cold-run-events=1 --processed-events=1)

--- a/examples/run/alpaka/CMakeLists.txt
+++ b/examples/run/alpaka/CMakeLists.txt
@@ -44,5 +44,5 @@ traccc_add_executable( throughput_st_alpaka "throughput_st.cpp"
 traccc_add_executable( throughput_mt_alpaka "throughput_mt.cpp"
    LINK_LIBRARIES TBB::tbb indicators::indicators ${LIBRARIES} ${DETRAY} traccc_examples_alpaka )
 
-add_test( throughput_st_alpaka
-                 ${CMAKE_BINARY_DIR}/bin/traccc_throughput_st_alpaka --finding-run-mbf-smoother=0 --read-bfield-from-file --cold-run-events=1 --processed-events=1)
+add_test( NAME throughput_st_alpaka
+          COMMAND traccc_throughput_st_alpaka --finding-run-mbf-smoother=0 --read-bfield-from-file --cold-run-events=1 --processed-events=1)

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -181,9 +181,13 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
       m_fitting_config(parent.m_fitting_config) {
 
     // Copy the detector (description) to the device.
+    m_vecmem_objects.async_copy().setup(m_device_det_descr)->wait();
     m_vecmem_objects
         .async_copy()(::vecmem::get_data(m_det_descr.get()), m_device_det_descr)
-        ->ignore();
+        ->wait();
+    m_vecmem_objects
+        .async_copy()(::vecmem::get_data(m_det_cond.get()), m_device_det_cond)
+        ->wait();
     if (m_detector != nullptr) {
         m_device_detector = traccc::buffer_from_host_detector(
             *m_detector, m_vecmem_objects.device_mr(),

--- a/examples/run/alpaka/full_chain_algorithm.cpp
+++ b/examples/run/alpaka/full_chain_algorithm.cpp
@@ -97,9 +97,13 @@ full_chain_algorithm::full_chain_algorithm(
     std::cout << traccc::alpaka::get_device_info() << std::endl;
 
     // Copy the detector (description) to the device.
+    m_vecmem_objects.async_copy().setup(m_device_det_descr)->wait();
     m_vecmem_objects
         .async_copy()(::vecmem::get_data(m_det_descr.get()), m_device_det_descr)
-        ->ignore();
+        ->wait();
+    m_vecmem_objects
+        .async_copy()(::vecmem::get_data(m_det_cond.get()), m_device_det_cond)
+        ->wait();
     if (m_detector != nullptr) {
         m_device_detector = traccc::buffer_from_host_detector(
             *m_detector, m_vecmem_objects.device_mr(),


### PR DESCRIPTION
Fixes the throughput executables on CPU. Have yet to test with CUDA/HIP backends.

Add a quick run of the throughput example to the unit tests. Possibly this could be done better in some way? I think it's useful though.