### PR TITLE
Fix CUDA greedy ambiguity resolver correctness bug

### DIFF
--- a/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
+++ b/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
@@ -429,6 +429,7 @@ greedy_ambiguity_resolution_algorithm::operator()(
     int terminate = 0;
     vecmem::unique_alloc_ptr<int> terminate_device =
         vecmem::make_unique_alloc<int>(m_mr.main);
+    cudaMemsetAsync(terminate_device.get(), 0, sizeof(int), stream);
     auto max_shared = thrust::max_element(thrust::device, n_shared_buffer.ptr(),
                                           n_shared_buffer.ptr() + n_tracks);
 
@@ -437,7 +438,7 @@ greedy_ambiguity_resolution_algorithm::operator()(
     vecmem::unique_alloc_ptr<unsigned int> max_shared_device =
         vecmem::make_unique_alloc<unsigned int>(m_mr.main);
     cudaMemcpyAsync(max_shared_device.get(), max_shared, sizeof(unsigned int),
-                    cudaMemcpyHostToDevice, stream);
+                    cudaMemcpyDeviceToDevice, stream);
 
     // The number of tracks whose number of share measurements is updated
     vecmem::unique_alloc_ptr<unsigned int> n_updated_tracks_device =
@@ -485,7 +486,7 @@ greedy_ambiguity_resolution_algorithm::operator()(
     m_copy.get().setup(block_offsets_buffer)->ignore();
     vecmem::data::vector_buffer<int> scanned_block_offsets_buffer{nBlocks_scan,
                                                                   m_mr.main};
-    m_copy.get().setup(block_offsets_buffer)->ignore();
+    m_copy.get().setup(scanned_block_offsets_buffer)->ignore();
 
     // Start the iteration
     while (!terminate && n_accepted > 0) {
@@ -667,6 +668,7 @@ greedy_ambiguity_resolution_algorithm::operator()(
                         cudaMemcpyDeviceToHost, stream);
         cudaMemcpyAsync(&n_accepted, n_accepted_device.get(),
                         sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        m_stream.get().synchronize();
     }
 
     cudaMemcpyAsync(&n_accepted, n_accepted_device.get(), sizeof(unsigned int),

--- a/tests/cuda/test_ambiguity_resolution.cpp
+++ b/tests/cuda/test_ambiguity_resolution.cpp
@@ -894,10 +894,8 @@ TEST_P(CUDAGreedyResolutionCompareToCPU, Comparison) {
     }
 };
 
-// The following tests are not working for some not fully understood reason.
-// We are blaming the ambiguity resolution algorithm for now.
 INSTANTIATE_TEST_SUITE_P(
-    DISABLED_CUDAStandard, CUDAGreedyResolutionCompareToCPU,
+    CUDAStandard, CUDAGreedyResolutionCompareToCPU,
     ::testing::Values(std::make_tuple(5u, 50000u,
                                       std::array<std::size_t, 2u>{1u, 10u},
                                       20000u, true),


### PR DESCRIPTION
# Summary

This PR fixes correctness bugs in the CUDA greedy ambiguity resolver and re-enables the previously disabled CPU-vs-CUDA tests.

The core issue was that the CUDA resolver could silently return incorrect outputs on some workloads, often by removing no tracks at all and returning the full input unchanged.

## Problem (how it was observed)

During a synthetic GPU benchmark sweep, the CUDA resolver produced incorrect results in 8 of 9 configurations. The dominant failure mode was:

* `n_removed = 0`
* GPU output = all input candidates
* CPU and GPU selected-track sets did not match

## Root Cause

The CUDA resolver had four correctness bugs:

* `terminate_device` was allocated but never initialized to `0`, so reused device memory could start with `terminate=1` and cause the removal kernel to exit immediately.
* `scanned_block_offsets_buffer` was allocated but never passed through `setup()`, corrupting the prefix-sum metadata used to maintain sorted track order during iterative removals.
* `max_shared_device` was initialized with the wrong `cudaMemcpy` direction (`HostToDevice` instead of `DeviceToDevice`) even though the source pointer came from device memory.
* The outer loop copied `terminate` and `n_accepted` back to host asynchronously but did not synchronize before checking the loop condition, so host-side control flow could observe stale values.

_This PR applies the minimal correctness fixes necessary_