### PR TITLE
Reduce redundant computation in CCL kernel

### DIFF
--- a/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
@@ -75,13 +75,20 @@ TRACCC_DEVICE void fast_sv_1(const thread_id_t& thread_id,
             const auto cid = static_cast<details::index_t>(
                 tst * thread_id.getBlockDimX() + thread_id.getLocalThreadIdX());
 
-            TRACCC_ASSUME(adjc[tst] <= 8);
+            TRACCC_ASSUME(adjc[tst] <= 4);
             for (unsigned char k = 0; k < adjc[tst]; ++k) {
-                details::index_t q = gf.at(adjv[8 * tst + k]);
+                const auto cid2 = adjv[4 * tst + k];
 
-                if (gf.at(cid) > q) {
-                    f.at(f.at(cid)) = q;
-                    f.at(cid) = q;
+                details::index_t q2 = gf.at(cid2);
+                details::index_t q1 = gf.at(cid);
+
+                if (gf.at(cid) > q2) {
+                    f.at(f.at(cid)) = q2;
+                    f.at(cid) = q2;
+                }
+                if (gf.at(cid2) > q1) {
+                    f.at(f.at(cid2)) = q1;
+                    f.at(cid2) = q1;
                 }
             }
         }
@@ -169,7 +176,7 @@ TRACCC_DEVICE inline void ccl_core(
         reduce_problem_cell(cells_device, cid,
                             static_cast<unsigned int>(partition_start),
                             static_cast<unsigned int>(partition_end), adjc[tst],
-                            &adjv[8 * tst]);
+                            &adjv[4 * tst]);
 
         f.at(cid) = cid;
         gf.at(cid) = cid;
@@ -303,7 +310,7 @@ TRACCC_DEVICE inline void ccl_kernel(
     barrier.blockBarrier();
 
     // Vector of indices of the adjacent cells
-    details::index_t _adjv[details::CELLS_PER_THREAD_STACK_LIMIT * 8];
+    details::index_t _adjv[details::CELLS_PER_THREAD_STACK_LIMIT * 4];
 
     /*
      * The number of adjacent cells for each cell must start at zero, to
@@ -349,7 +356,7 @@ TRACCC_DEVICE inline void ccl_kernel(
                (thread_id.getLocalThreadIdX() * cfg.max_cells_per_thread *
                 cfg.backup_size_multiplier);
         adjv = adjv_backup.data() +
-               (thread_id.getLocalThreadIdX() * 8 * cfg.max_cells_per_thread *
+               (thread_id.getLocalThreadIdX() * 4 * cfg.max_cells_per_thread *
                 cfg.backup_size_multiplier);
         use_scratch = true;
     } else {

--- a/device/common/include/traccc/clusterization/device/impl/reduce_problem_cell.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/reduce_problem_cell.ipp
@@ -30,18 +30,18 @@ TRACCC_HOST_DEVICE inline void reduce_problem_cell(
     const edm::silicon_cell reference_cell = cells.at(pos);
 
     /*
-     * First, we traverse the cells backwards, starting from the current
+     * We traverse the cells backwards, starting from the current
      * cell and working back to the first, collecting adjacent cells
      * along the way.
      */
-    for (unsigned int j = pos - 1; j < pos; --j) {
+    for (unsigned int j = pos + 1; j < end; ++j) {
         /*
          * Since the data is sorted, we can assume that if we see a cell
          * sufficiently far away in both directions, it becomes
          * impossible for that cell to ever be adjacent to this one.
          * This is a small optimisation.
          */
-        if (traccc::details::is_far_enough(reference_cell, cells.at(j))) {
+        if (traccc::details::is_far_enough(cells.at(j), reference_cell)) {
             break;
         }
 
@@ -50,26 +50,7 @@ TRACCC_HOST_DEVICE inline void reduce_problem_cell(
          * in the current cell's adjacency set.
          */
         if (traccc::details::is_adjacent(reference_cell, cells.at(j))) {
-            assert(adjc < 8);
-            adjv[adjc++] = static_cast<unsigned short>(j - start);
-        }
-    }
-
-    /*
-     * Now we examine all the cells past the current one, using almost
-     * the same logic as in the backwards pass.
-     */
-    for (unsigned int j = pos + 1; j < end; ++j) {
-        /*
-         * Note that this check now looks in the opposite direction! An
-         * important difference.
-         */
-        if (traccc::details::is_far_enough(cells.at(j), reference_cell)) {
-            break;
-        }
-
-        if (traccc::details::is_adjacent(reference_cell, cells.at(j))) {
-            assert(adjc < 8);
+            assert(adjc < 4);
             adjv[adjc++] = static_cast<unsigned short>(j - start);
         }
     }

--- a/device/common/src/clusterization/clusterization_algorithm.cpp
+++ b/device/common/src/clusterization/clusterization_algorithm.cpp
@@ -20,7 +20,7 @@ clusterization_algorithm::clusterization_algorithm(
       m_gf_backup{m_config.backup_size(), mr.main},
       m_backup_mutex{vecmem::make_unique_alloc<unsigned int>(mr.main)},
       m_adjc_backup{m_config.backup_size(), mr.main},
-      m_adjv_backup{m_config.backup_size() * 8, mr.main} {
+      m_adjv_backup{m_config.backup_size() * 4, mr.main} {
 
     copy().setup(m_f_backup)->wait();
     copy().setup(m_gf_backup)->wait();


### PR DESCRIPTION
When converting the grid-based CCL kernel to a graph based one, we currently reify the definitionally symmetric adjacency relation in two directions which costs us additional compute as well as additional storage. This commit removes the redundant computation to increase the CCL performance.