### PR TITLE
Improve performance of CCA cluster aggregation

### DIFF
--- a/device/common/include/traccc/clusterization/device/aggregate_cluster.hpp
+++ b/device/common/include/traccc/clusterization/device/aggregate_cluster.hpp
@@ -29,8 +29,7 @@ namespace traccc::device {
 ///
 /// @param[in] cells     collection of cells
 /// @param[in] det_descr The detector description
-/// @param[in] f         array of "parent" indices for all cells in this
-///                      partition
+/// @param[in] fll       linked list of all cells in this partition
 /// @param[in] start     partition start point this cell belongs to
 /// @param[in] end       partition end point this cell belongs to
 /// @param[in] cid       current cell id

--- a/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/aggregate_cluster.ipp
@@ -20,7 +20,7 @@ TRACCC_HOST_DEVICE inline void aggregate_cluster(
     const edm::silicon_cell_collection::const_device& cells,
     const detector_design_description::const_device& det_desc,
     const detector_conditions_description::const_device& det_cond,
-    const vecmem::device_vector<index_t>& f, const unsigned int start,
+    const vecmem::device_vector<index_t>& fll, const unsigned int start,
     const unsigned int end, const unsigned int cid,
     edm::measurement_collection::device::proxy_type out,
     vecmem::data::vector_view<unsigned int> cell_links, const unsigned int link,
@@ -75,82 +75,59 @@ TRACCC_HOST_DEVICE inline void aggregate_cluster(
 
     const unsigned int partition_size = end - start;
 
-    bool first_processed = false;
+    index_t j = static_cast<index_t>(cid);
 
-    channel_id maxChannel1 = std::numeric_limits<channel_id>::min();
-
-    for (unsigned int j = cid; j < partition_size; j++) {
-
+    while (j < partition_size) {
         const unsigned int pos = j + start;
         const edm::silicon_cell cell = cells.at(pos);
+        const channel_id c0 = cell.channel0();
+        const channel_id c1 = cell.channel1();
+        const scalar activation = cell.activation();
 
-        /*
-         * Terminate the process earlier if we have reached a cell sufficiently
-         * in a different module.
-         */
-        if (cell.module_index() != module_idx) {
+        totalWeight += activation;
+        scalar weight_factor = activation / totalWeight;
+
+        point2 cell_position =
+            traccc::details::position_from_cell(cell, module_dd);
+
+        min_channel0 = std::min(min_channel0, c0);
+        min_channel1 = std::min(min_channel1, c1);
+        max_channel0 = std::max(max_channel0, c0);
+        max_channel1 = std::max(max_channel1, c1);
+
+        if (j == cid) {
+            offset = cell_position;
+        }
+
+        cell_position = cell_position - offset;
+
+        const point2 diff_old = cell_position - mean;
+        mean = mean + diff_old * weight_factor;
+        const point2 diff_new = cell_position - mean;
+
+        var[0] = (1.f - weight_factor) * var[0] +
+                 weight_factor * (diff_old[0] * diff_new[0]);
+        var[1] = (1.f - weight_factor) * var[1] +
+                 weight_factor * (diff_old[1] * diff_new[1]);
+
+        cell_links_device.at(pos) = link;
+        tmp_cluster_size++;
+
+        if (disjoint_set.capacity()) {
+            disjoint_set.at(pos) = link;
+        }
+
+        const auto next_j = fll.at(j);
+
+        if (j == next_j) {
             break;
+        } else {
+            j = next_j;
         }
+    }
 
-        /*
-         * If the value of this cell is equal to our, that means it
-         * is part of our cluster. In that case, we take its values
-         * for position and add them to our accumulators.
-         */
-        if (f.at(j) == cid) {
-
-            if (cell.channel1() > maxChannel1) {
-                maxChannel1 = cell.channel1();
-            }
-
-            const scalar weight = cell.activation();
-
-            totalWeight += weight;
-            scalar weight_factor = weight / totalWeight;
-
-            point2 cell_position =
-                traccc::details::position_from_cell(cell, module_dd);
-
-            min_channel0 = std::min(min_channel0, cell.channel0());
-            min_channel1 = std::min(min_channel1, cell.channel1());
-            max_channel0 = std::max(max_channel0, cell.channel0());
-            max_channel1 = std::max(max_channel1, cell.channel1());
-
-            if (!first_processed) {
-                offset = cell_position;
-                first_processed = true;
-            }
-
-            cell_position = cell_position - offset;
-
-            const point2 diff_old = cell_position - mean;
-            mean = mean + diff_old * weight_factor;
-            const point2 diff_new = cell_position - mean;
-
-            var[0] = (1.f - weight_factor) * var[0] +
-                     weight_factor * (diff_old[0] * diff_new[0]);
-            var[1] = (1.f - weight_factor) * var[1] +
-                     weight_factor * (diff_old[1] * diff_new[1]);
-
-            cell_links_device.at(pos) = link;
-            tmp_cluster_size++;
-
-            if (disjoint_set.capacity()) {
-                disjoint_set.at(pos) = link;
-            }
-        }
-
-        /*
-         * Terminate the process earlier if we have reached a cell sufficiently
-         * far away from the cluster in the dominant axis.
-         */
-        if (cell.channel1() > maxChannel1 + 1) {
-            break;
-        }
-
-        if (cluster_size.has_value()) {
-            (*cluster_size).get() = tmp_cluster_size;
-        }
+    if (cluster_size.has_value()) {
+        (*cluster_size).get() = tmp_cluster_size;
     }
 
     unsigned int delta0 = (max_channel0 - min_channel0) + 1;

--- a/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
@@ -195,9 +195,66 @@ TRACCC_DEVICE inline void ccl_core(
 
     barrier.blockBarrier();
 
-    for (unsigned int tst = 0; tst < thread_cell_count; ++tst) {
-        const unsigned int cid =
-            tst * thread_id.getBlockDimX() + thread_id.getLocalThreadIdX();
+    /*
+     * We'll now convert the parent array `f` into a linked list equivalent
+     * stored in array `gf`. The point of this linked list is that the ID of
+     * each cell is either:
+     *
+     * - An out-of-bounds value if there is no later cell in the same
+     *   cluster; or
+     * - An in-bounds index pointing to the next cell belonging to the same
+     *   cluster.
+     *
+     * If, for example, f would look like this:
+     *
+     *        0  1  2  3  4  5  6  7  8
+     * f  = [ 0, 0, 2, 0, 2, 5, 2, 5, 8]
+     *
+     * We would compute:
+     *
+     * gf = [ 1, 3, 4, 9, 6, 7, 9, 9, 9]
+     *
+     * This makes aggregating the clusters trivial.
+     *
+     * WARNING: After this point, the `gf` vector no longer contains the
+     * grandparent information it held before. Do not use it as such!
+     *
+     * First, we start out by setting out-of-bounds values for all cells...
+     */
+    for (unsigned int i = thread_id.getLocalThreadIdX(); i < size;
+         i += thread_id.getBlockDimX()) {
+        gf.at(i) = static_cast<index_t>(partition_end - partition_start);
+    }
+
+    barrier.blockBarrier();
+
+    /*
+     * Now we construct the actual linked list. We move backwards here,
+     * because we are much more likely to be able to exit our loop early
+     * compared to looping forwards.
+     */
+    for (unsigned int i = thread_id.getLocalThreadIdX(); i < size;
+         i += thread_id.getBlockDimX()) {
+        const index_t effi =
+            static_cast<index_t>((partition_end - partition_start) - (i + 1));
+
+        const auto fid = f.at(effi);
+
+        if (fid != effi) {
+            for (unsigned int j = effi - 1; j < size; --j) {
+                if (fid == f.at(j)) {
+                    gf.at(j) = effi;
+                    break;
+                }
+            }
+        }
+    }
+
+    barrier.blockBarrier();
+
+    for (details::index_t tst = 0; tst < thread_cell_count; ++tst) {
+        const auto cid = static_cast<details::index_t>(
+            tst * thread_id.getBlockDimX() + thread_id.getLocalThreadIdX());
 
         if (f.at(cid) == cid) {
             // Add a new measurement to the output buffer. Remembering its
@@ -206,7 +263,7 @@ TRACCC_DEVICE inline void ccl_core(
                 measurements_device.push_back_default();
             // Set up the measurement under the appropriate index.
             aggregate_cluster(
-                cfg, cells_device, det_desc, det_cond, f,
+                cfg, cells_device, det_desc, det_cond, gf,
                 static_cast<unsigned int>(partition_start),
                 static_cast<unsigned int>(partition_end), cid,
                 measurements_device.at(meas_pos), cell_links, meas_pos,


### PR DESCRIPTION
This commit improves the performance of the CCA cluster aggregation by moving away from a model of computation where each parent cell iterates over the _entire_ parentage array. Instead, we first convert this array into a linked list which can then be more efficiently iterated over.