### PR TITLE
AdaptiveCpp Compatibility, main branch (2026.04.24.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,15 +248,17 @@ if( TRACCC_SETUP_DPL )
       set(_sycl_support ON)
       set(SYCL_SUPPORT ON)
       find_package( oneDPL REQUIRED )
-      # OneDPL attaches the `-fsycl` flag to the C++ compiler, which causes
-      # it to incorrectly trigger some preprocessor definitions, thereby
-      # loading SYCL-specific header files which do not exist for e.g. a
-      # generic clang installation. Therefore, we have to manually wipe the
-      # compile flags that OneDPL sets.
-      set_target_properties(oneDPL PROPERTIES INTERFACE_COMPILE_OPTIONS "")
    else()
       add_subdirectory( extern/dpl )
    endif()
+   # OneDPL attaches the `-fsycl` flag to the C++ compiler, which causes
+   # it to incorrectly trigger some preprocessor definitions, thereby
+   # loading SYCL-specific header files which do not exist for e.g. a
+   # generic clang installation. Therefore, we have to manually wipe the
+   # compile flags that OneDPL sets.
+   set_target_properties(oneDPL PROPERTIES
+      INTERFACE_COMPILE_OPTIONS ""
+      INTERFACE_LINK_LIBRARIES "" )
 endif()
 
 # Set up Alpaka.

--- a/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
+++ b/device/common/include/traccc/clusterization/device/ccl_kernel.hpp
@@ -64,7 +64,7 @@ namespace traccc::device {
 /// put into
 template <device::concepts::barrier barrier_t,
           device::concepts::thread_id1 thread_id_t>
-TRACCC_DEVICE inline void ccl_kernel(
+TRACCC_HOST_DEVICE inline void ccl_kernel(
     const clustering_config cfg, const thread_id_t& thread_id,
     const edm::silicon_cell_collection::const_view& cells_view,
     const detector_design_description::const_view& det_descr_view,

--- a/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
+++ b/device/common/include/traccc/clusterization/device/impl/ccl_kernel.ipp
@@ -44,12 +44,13 @@ namespace traccc::device {
 ///
 template <device::concepts::barrier barrier_t,
           device::concepts::thread_id1 thread_id_t, typename index_t>
-TRACCC_DEVICE void fast_sv_1(const thread_id_t& thread_id,
-                             vecmem::device_vector<index_t>& f,
-                             vecmem::device_vector<index_t>& gf,
-                             unsigned char* adjc, index_t* adjv,
-                             unsigned int thread_cell_count,
-                             barrier_t& barrier) {
+TRACCC_HOST_DEVICE void fast_sv_1(const thread_id_t& thread_id,
+                                  vecmem::device_vector<index_t>& f,
+                                  vecmem::device_vector<index_t>& gf,
+                                  unsigned char* adjc, index_t* adjv,
+                                  unsigned int thread_cell_count,
+                                  barrier_t& barrier) {
+
     /*
      * The algorithm finishes if an iteration leaves the arrays unchanged.
      * This varible will be set if a change is made, and dictates if another
@@ -142,7 +143,7 @@ TRACCC_DEVICE void fast_sv_1(const thread_id_t& thread_id,
 
 template <device::concepts::barrier barrier_t,
           device::concepts::thread_id1 thread_id_t, typename index_t>
-TRACCC_DEVICE inline void ccl_core(
+TRACCC_HOST_DEVICE inline void ccl_core(
     const clustering_config& cfg, const thread_id_t& thread_id,
     std::size_t& partition_start, std::size_t& partition_end,
     vecmem::device_vector<index_t> f, vecmem::device_vector<index_t> gf,
@@ -221,7 +222,7 @@ TRACCC_DEVICE inline void ccl_core(
 
 template <device::concepts::barrier barrier_t,
           device::concepts::thread_id1 thread_id_t>
-TRACCC_DEVICE inline void ccl_kernel(
+TRACCC_HOST_DEVICE inline void ccl_kernel(
     const clustering_config cfg, const thread_id_t& thread_id,
     const edm::silicon_cell_collection::const_view& cells_view,
     const detector_design_description::const_view& det_desc_view,

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// SYCL include(s).
+#include <sycl/sycl.hpp>
+
 // Local include(s).
 #include "../sanity/contiguous_on.hpp"
 #include "../sanity/ordered_on.hpp"

--- a/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
+++ b/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// SYCL include(s).
+#include <sycl/sycl.hpp>
+
 // Local include(s).
 #include "../utils/calculate1DimNdRange.hpp"
 #include "../utils/get_queue.hpp"
@@ -14,9 +17,6 @@
 // Project include(s).
 #include "traccc/clusterization/device/geo_id_based_sorter.hpp"
 #include "traccc/clusterization/device/sorting_index_filler.hpp"
-
-// SYCL include(s).
-#include <sycl/sycl.hpp>
 
 namespace traccc::sycl {
 namespace kernels {

--- a/device/sycl/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/sycl/src/finding/combinatorial_kalman_filter.hpp
@@ -66,6 +66,14 @@ template <typename T>
 struct update_tip_length_buffer {};
 template <typename T>
 struct build_tracks {};
+
+template <typename T>
+struct upper_bound {};
+template <typename T>
+struct sort_by_key_1 {};
+template <typename T>
+struct sort_by_key_2 {};
+
 }  // namespace kernels
 
 /// Templated implementation of the track finding algorithm.
@@ -112,10 +120,6 @@ combinatorial_kalman_filter(
         device::identity_projector{}, mr.main, copy, queue,
         measurements_view.template get<6>()));
 
-    // oneDPL policy to use, forcing execution onto the same device that the
-    // hand-written kernels would run on.
-    auto policy = oneapi::dpl::execution::device_policy{queue};
-
     /*****************************************************************
      * Measurement Operations
      *****************************************************************/
@@ -133,7 +137,9 @@ combinatorial_kalman_filter(
     vecmem::device_vector<unsigned int> measurement_ranges(meas_ranges_buffer);
 
     oneapi::dpl::upper_bound(
-        policy, measurements.surface_link().begin(),
+        oneapi::dpl::execution::device_policy<kernels::upper_bound<kernel_t>>{
+            queue},
+        measurements.surface_link().begin(),
         // We have to use this ugly form here, because if the
         // measurement collection is resizable (which it often
         // is), the end() function cannot be used in host code.
@@ -433,9 +439,11 @@ combinatorial_kalman_filter(
                 link_last_measurement_buffer);
             vecmem::device_vector<unsigned int> param_ids_device(
                 param_ids_buffer);
-            oneapi::dpl::sort_by_key(policy, keys_device.begin(),
-                                     keys_device.end(),
-                                     param_ids_device.begin());
+            oneapi::dpl::sort_by_key(
+                oneapi::dpl::execution::device_policy<
+                    kernels::sort_by_key_1<kernel_t>>{queue},
+                keys_device.begin(), keys_device.end(),
+                param_ids_device.begin());
             queue.wait_and_throw();
 
             /*
@@ -513,9 +521,11 @@ combinatorial_kalman_filter(
                     keys_buffer);
                 vecmem::device_vector<unsigned int> param_ids_device(
                     param_ids_buffer);
-                oneapi::dpl::sort_by_key(policy, keys_device.begin(),
-                                         keys_device.end(),
-                                         param_ids_device.begin());
+                oneapi::dpl::sort_by_key(
+                    oneapi::dpl::execution::device_policy<
+                        kernels::sort_by_key_2<kernel_t>>{queue},
+                    keys_device.begin(), keys_device.end(),
+                    param_ids_device.begin());
                 queue.wait_and_throw();
             }
 

--- a/device/sycl/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/sycl/src/finding/combinatorial_kalman_filter.hpp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// SYCL include(s).
+#include <sycl/sycl.hpp>
+
 // Local include(s).
 #include "../sanity/contiguous_on.hpp"
 #include "../utils/barrier.hpp"
@@ -40,9 +43,6 @@
 // VecMem include(s).
 #include <vecmem/utils/copy.hpp>
 #include <vecmem/utils/sycl/local_accessor.hpp>
-
-// SYCL include(s).
-#include <sycl/sycl.hpp>
 
 namespace traccc::sycl::details {
 namespace kernels {

--- a/device/sycl/src/finding/combinatorial_kalman_filter_algorithm.sycl
+++ b/device/sycl/src/finding/combinatorial_kalman_filter_algorithm.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// SYCL include(s).
+#include <sycl/sycl.hpp>
+
 // Local include(s).
 #include "../utils/detector_types.hpp"
 #include "../utils/get_queue.hpp"

--- a/device/sycl/src/fitting/kalman_fitting_algorithm.sycl
+++ b/device/sycl/src/fitting/kalman_fitting_algorithm.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// SYCL include(s).
+#include <sycl/sycl.hpp>
+
 // Local include(s).
 #include "../utils/detector_types.hpp"
 #include "../utils/get_queue.hpp"

--- a/device/sycl/src/seeding/seed_parameter_estimation_algorithm.sycl
+++ b/device/sycl/src/seeding/seed_parameter_estimation_algorithm.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// SYCL include
+#include <sycl/sycl.hpp>
+
 // Local include(s).
 #include "../utils/calculate1DimNdRange.hpp"
 #include "../utils/get_queue.hpp"

--- a/device/sycl/src/seeding/silicon_pixel_spacepoint_formation_algorithm.sycl
+++ b/device/sycl/src/seeding/silicon_pixel_spacepoint_formation_algorithm.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// SYCL include
+#include <sycl/sycl.hpp>
+
 // Local include(s).
 #include "../utils/calculate1DimNdRange.hpp"
 #include "../utils/get_queue.hpp"

--- a/device/sycl/src/seeding/triplet_seeding_algorithm.sycl
+++ b/device/sycl/src/seeding/triplet_seeding_algorithm.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// SYCL include
+#include <sycl/sycl.hpp>
+
 // Library include(s).
 #include "../utils/calculate1DimNdRange.hpp"
 #include "../utils/get_queue.hpp"

--- a/device/sycl/src/utils/algorithm_base.sycl
+++ b/device/sycl/src/utils/algorithm_base.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// SYCL include
+#include <sycl/sycl.hpp>
+
 // Local include(s).
 #include "get_queue.hpp"
 #include "traccc/sycl/utils/algorithm_base.hpp"

--- a/extern/dpl/CMakeLists.txt
+++ b/extern/dpl/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2024-2025 CERN for the benefit of the ACTS project
+# (c) 2024-2026 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,7 +13,7 @@ message( STATUS "Building oneDPL as part of the TRACCC project" )
 
 # Declare where to get DPL from.
 set( TRACCC_DPL_SOURCE
-   "URL;https://github.com/oneapi-src/oneDPL/archive/refs/tags/oneDPL-2022.7.1-release.tar.gz;URL_MD5;21d45dc27ba3133bfb282ec7383177f4"
+   "URL;https://github.com/uxlfoundation/oneDPL/archive/refs/tags/oneDPL-2022.11.0-release.tar.gz;URL_MD5;d42f971a7fb53574e511e207b22151cd;PATCH_COMMAND;patch;-p1;-i;${CMAKE_CURRENT_SOURCE_DIR}/oneDPL-2022.11.0.patch"
    CACHE STRING "Source for DPL, when built as part of this project" )
 mark_as_advanced( TRACCC_DPL_SOURCE )
 # Must not use SYSTEM here, as the oneAPI compiler then ignores this version
@@ -22,6 +22,7 @@ FetchContent_Declare( DPL ${TRACCC_DPL_SOURCE} )
 
 # Set the default oneDPL threading backend.
 set( ONEDPL_BACKEND "dpcpp" CACHE STRING "oneDPL threading backend" )
+set( SYCL_SUPPORT ON )
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( DPL )

--- a/extern/dpl/oneDPL-2022.11.0.patch
+++ b/extern/dpl/oneDPL-2022.11.0.patch
@@ -1,0 +1,34 @@
+diff -ur oneDPL-oneDPL-2022.11.0-release-orig/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h oneDPL-oneDPL-2022.11.0-release-fixed/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+--- oneDPL-oneDPL-2022.11.0-release-orig/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h	2025-12-19 17:56:53.000000000 +0100
++++ oneDPL-oneDPL-2022.11.0-release-fixed/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h	2026-04-29 14:16:28.013957292 +0200
+@@ -736,7 +736,7 @@
+     std::size_t
+     __fill_data(_Args&&...) const
+     {
+-        assert(!"Unsupported return type");
++        assert(false && "Unsupported return type");
+         return 0;
+     }
+ 
+diff -ur oneDPL-oneDPL-2022.11.0-release-orig/include/oneapi/dpl/pstl/parallel_backend_utils.h oneDPL-oneDPL-2022.11.0-release-fixed/include/oneapi/dpl/pstl/parallel_backend_utils.h
+--- oneDPL-oneDPL-2022.11.0-release-orig/include/oneapi/dpl/pstl/parallel_backend_utils.h	2025-12-19 17:56:53.000000000 +0100
++++ oneDPL-oneDPL-2022.11.0-release-fixed/include/oneapi/dpl/pstl/parallel_backend_utils.h	2026-04-29 14:12:54.596311509 +0200
+@@ -390,14 +390,14 @@
+     get_for_current_thread()
+     {
+         const std::size_t __i = _Derived::get_thread_num();
+-        std::optional<_ValueType>& __local = __thread_specific_storage[__i];
+-        if (!__local)
++        std::optional<_ValueType>& __current = __thread_specific_storage[__i];
++        if (!__current)
+         {
+             // create temporary storage on first usage to avoid extra parallel region and unnecessary instantiation
+-            std::apply([&__local](_Args... __arg_pack) { __local.emplace(__arg_pack...); }, __args);
++            std::apply([&__current](_Args... __arg_pack) { __current.emplace(__arg_pack...); }, __args);
+             __num_elements.fetch_add(1, std::memory_order_relaxed);
+         }
+-        return *__local;
++        return *__current;
+     }
+ 
+     std::vector<std::optional<_ValueType>> __thread_specific_storage;

--- a/tests/sycl/test_barrier.sycl
+++ b/tests/sycl/test_barrier.sycl
@@ -1,7 +1,7 @@
 /**
  * traccc library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -26,7 +26,7 @@ TEST(SYCLBarrier, BarrierAnd) {
     ::sycl::nd_range test_range(::sycl::range<1>(128), ::sycl::range<1>(128));
 
     queue
-        .submit([&, out = out.get()](::sycl::handler &h) {
+        .submit([&, out = out.get()](::sycl::handler& h) {
             h.parallel_for<class BarrierAndTest>(
                 test_range, [=](::sycl::nd_item<1> item) {
                     const traccc::sycl::details::barrier bar{item};
@@ -34,22 +34,22 @@ TEST(SYCLBarrier, BarrierAnd) {
                     bool v;
 
                     v = bar.blockAnd(false);
-                    if (item.get_local_id() == 0) {
+                    if (item.get_local_id()[0] == 0) {
                         out[0] = v;
                     }
 
                     v = bar.blockAnd(true);
-                    if (item.get_local_id() == 0) {
+                    if (item.get_local_id()[0] == 0) {
                         out[1] = v;
                     }
 
-                    v = bar.blockAnd(item.get_local_id() % 2 == 0);
-                    if (item.get_local_id() == 0) {
+                    v = bar.blockAnd(item.get_local_id()[0] % 2 == 0);
+                    if (item.get_local_id()[0] == 0) {
                         out[2] = v;
                     }
 
-                    v = bar.blockAnd(item.get_local_id() < 32);
-                    if (item.get_local_id() == 0) {
+                    v = bar.blockAnd(item.get_local_id()[0] < 32);
+                    if (item.get_local_id()[0] == 0) {
                         out[3] = v;
                     }
                 });
@@ -74,7 +74,7 @@ TEST(SYCLBarrier, BarrierOr) {
     ::sycl::nd_range test_range(::sycl::range<1>(128), ::sycl::range<1>(128));
 
     queue
-        .submit([&, out = out.get()](::sycl::handler &h) {
+        .submit([&, out = out.get()](::sycl::handler& h) {
             h.parallel_for<class BarrierOrTest>(
                 test_range, [=](::sycl::nd_item<1> item) {
                     const traccc::sycl::details::barrier bar{item};
@@ -82,22 +82,22 @@ TEST(SYCLBarrier, BarrierOr) {
                     bool v;
 
                     v = bar.blockOr(false);
-                    if (item.get_local_id() == 0) {
+                    if (item.get_local_id()[0] == 0) {
                         out[0] = v;
                     }
 
                     v = bar.blockOr(true);
-                    if (item.get_local_id() == 0) {
+                    if (item.get_local_id()[0] == 0) {
                         out[1] = v;
                     }
 
-                    v = bar.blockOr(item.get_local_id() % 2 == 0);
-                    if (item.get_local_id() == 0) {
+                    v = bar.blockOr(item.get_local_id()[0] % 2 == 0);
+                    if (item.get_local_id()[0] == 0) {
                         out[2] = v;
                     }
 
-                    v = bar.blockOr(item.get_local_id() < 32);
-                    if (item.get_local_id() == 0) {
+                    v = bar.blockOr(item.get_local_id()[0] < 32);
+                    if (item.get_local_id()[0] == 0) {
                         out[3] = v;
                     }
                 });
@@ -122,7 +122,7 @@ TEST(SYCLBarrier, BarrierCount) {
     ::sycl::nd_range test_range(::sycl::range<1>(128), ::sycl::range<1>(128));
 
     queue
-        .submit([&, out = out.get()](::sycl::handler &h) {
+        .submit([&, out = out.get()](::sycl::handler& h) {
             h.parallel_for<class BarrierCountTest>(
                 test_range, [=](::sycl::nd_item<1> item) {
                     const traccc::sycl::details::barrier bar{item};
@@ -130,22 +130,22 @@ TEST(SYCLBarrier, BarrierCount) {
                     unsigned int v;
 
                     v = bar.blockCount(false);
-                    if (item.get_local_id() == 0) {
+                    if (item.get_local_id()[0] == 0) {
                         out[0] = v;
                     }
 
                     v = bar.blockCount(true);
-                    if (item.get_local_id() == 0) {
+                    if (item.get_local_id()[0] == 0) {
                         out[1] = v;
                     }
 
-                    v = bar.blockCount(item.get_local_id() % 2 == 0);
-                    if (item.get_local_id() == 0) {
+                    v = bar.blockCount(item.get_local_id()[0] % 2 == 0);
+                    if (item.get_local_id()[0] == 0) {
                         out[2] = v;
                     }
 
-                    v = bar.blockCount(item.get_local_id() < 32);
-                    if (item.get_local_id() == 0) {
+                    v = bar.blockCount(item.get_local_id()[0] < 32);
+                    if (item.get_local_id()[0] == 0) {
                         out[3] = v;
                     }
                 });

--- a/tests/sycl/test_barrier.sycl
+++ b/tests/sycl/test_barrier.sycl
@@ -6,13 +6,18 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// SYCL include(s).
 #include <sycl/sycl.hpp>
+
+// Project include(s).
+#include "../../device/sycl/src/utils/barrier.hpp"
+
+// VecMem include(s).
 #include <vecmem/memory/sycl/shared_memory_resource.hpp>
 #include <vecmem/memory/unique_ptr.hpp>
 
-#include "../../device/sycl/src/utils/barrier.hpp"
+// GoogleTest include(s).
+#include <gtest/gtest.h>
 
 TEST(SYCLBarrier, BarrierAnd) {
     vecmem::sycl::shared_memory_resource mr;

--- a/tests/sycl/test_dpl.sycl
+++ b/tests/sycl/test_dpl.sycl
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -66,7 +66,7 @@ TEST(dpl, sort) {
 
     vecmem::device_vector<unsigned int> device_vector(device_buffer);
 
-    oneapi::dpl::sort(oneapi::dpl::execution::dpcpp_default,
+    oneapi::dpl::sort(oneapi::dpl::execution::device_policy{q},
                       device_vector.begin(), device_vector.end());
 
     copy(device_buffer, host_buffer, vecmem::copy::type::device_to_host)
@@ -94,7 +94,7 @@ TEST(dpl, scan) {
 
     vecmem::device_vector<unsigned int> device_vector(device_buffer);
 
-    oneapi::dpl::inclusive_scan(oneapi::dpl::execution::dpcpp_default,
+    oneapi::dpl::inclusive_scan(oneapi::dpl::execution::device_policy{q},
                                 device_vector.begin(), device_vector.end(),
                                 device_vector.begin());
 
@@ -124,7 +124,7 @@ TEST(dpl, fill) {
 
     vecmem::device_vector<unsigned int> device_vector(device_buffer);
 
-    oneapi::dpl::fill(oneapi::dpl::execution::dpcpp_default,
+    oneapi::dpl::fill(oneapi::dpl::execution::device_policy{q},
                       device_vector.begin(), device_vector.end(), 112);
 
     copy(device_buffer, host_buffer, vecmem::copy::type::device_to_host)

--- a/tests/sycl/test_dpl.sycl
+++ b/tests/sycl/test_dpl.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// SYCL include(s).
+#include <sycl/sycl.hpp>
+
 // DPL include(s).
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshadow"
@@ -21,9 +24,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
 #pragma clang diagnostic pop
-
-// SYCL include(s).
-#include <sycl/sycl.hpp>
 
 // VecMem include(s).
 #include <vecmem/containers/data/vector_buffer.hpp>

--- a/tests/sycl/test_mutex.sycl
+++ b/tests/sycl/test_mutex.sycl
@@ -1,7 +1,7 @@
 /**
  * traccc library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -41,7 +41,7 @@ TEST(SYCLMutex, MassAdditionKernel) {
                 test_range, [=](::sycl::nd_item<1> item) {
                     traccc::device::mutex m(*lock);
 
-                    if (item.get_local_id() == 0) {
+                    if (item.get_local_id()[0] == 0) {
                         m.lock();
                         uint32_t tmp = *out;
                         tmp += 1;

--- a/tests/sycl/test_mutex.sycl
+++ b/tests/sycl/test_mutex.sycl
@@ -6,14 +6,19 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// SYCL include(s).
 #include <sycl/sycl.hpp>
+
+// Project include(s).
+#include "traccc/device/mutex.hpp"
+
+// VecMem include(s).
 #include <vecmem/memory/sycl/device_memory_resource.hpp>
 #include <vecmem/memory/sycl/shared_memory_resource.hpp>
 #include <vecmem/memory/unique_ptr.hpp>
 
-#include "traccc/device/mutex.hpp"
+// GoogleTest include(s).
+#include <gtest/gtest.h>
 
 TEST(SYCLMutex, MassAdditionKernel) {
 

--- a/tests/sycl/test_sanity_contiguous_on.sycl
+++ b/tests/sycl/test_sanity_contiguous_on.sycl
@@ -1,10 +1,13 @@
 /*
  * traccc library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
+
+// System include
+#include <sycl/sycl.hpp>
 
 // vecmem includes
 #include <vecmem/containers/device_vector.hpp>
@@ -16,9 +19,6 @@
 
 // GTest include(s).
 #include <gtest/gtest.h>
-
-// System include
-#include <sycl/sycl.hpp>
 
 struct int_identity_projection {
     int operator()(const int& v) const { return v; }

--- a/tests/sycl/test_sanity_ordered_on.sycl
+++ b/tests/sycl/test_sanity_ordered_on.sycl
@@ -1,10 +1,13 @@
 /*
  * traccc library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
+
+// System include
+#include <sycl/sycl.hpp>
 
 // vecmem includes
 #include <vecmem/containers/device_vector.hpp>
@@ -16,9 +19,6 @@
 
 // GTest include(s).
 #include <gtest/gtest.h>
-
-// System include
-#include <sycl/sycl.hpp>
 
 struct int_lt_relation {
     bool operator()(const int& a, const int& b) const { return a < b; }

--- a/tests/sycl/test_sort.sycl
+++ b/tests/sycl/test_sort.sycl
@@ -6,15 +6,20 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// SYCL include(s).
 #include <sycl/sycl.hpp>
-#include <vecmem/memory/sycl/shared_memory_resource.hpp>
-#include <vecmem/memory/unique_ptr.hpp>
 
+// Project include(s).
 #include "../../sycl/src/utils/barrier.hpp"
 #include "../../sycl/src/utils/thread_id.hpp"
 #include "traccc/device/sort.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/sycl/shared_memory_resource.hpp>
+#include <vecmem/memory/unique_ptr.hpp>
+
+// GTest include(s).
+#include <gtest/gtest.h>
 
 TEST(SYCLSort, BlockOddEvenSort) {
     vecmem::sycl::shared_memory_resource mr;
@@ -33,7 +38,7 @@ TEST(SYCLSort, BlockOddEvenSort) {
     ::sycl::nd_range test_range(::sycl::range<1>(128), ::sycl::range<1>(128));
 
     queue
-        .submit([&, keys = arr.get()](::sycl::handler &h) {
+        .submit([&, keys = arr.get()](::sycl::handler& h) {
             h.parallel_for<class BlockOddEvenSortKernel>(
                 test_range, [=](::sycl::nd_item<1> item) {
                     const traccc::sycl::details::thread_id thread_id{item};

--- a/tests/sycl/test_unique_lock.sycl
+++ b/tests/sycl/test_unique_lock.sycl
@@ -1,7 +1,7 @@
 /**
  * traccc library, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -37,12 +37,12 @@ TEST(SYCLUniqueLock, MassAdditionKernelTryLock) {
                                 ::sycl::range<1>(n_threads));
 
     queue
-        .submit([&, out = out.get(), _lock = lock.get()](::sycl::handler &h) {
+        .submit([&, out = out.get(), _lock = lock.get()](::sycl::handler& h) {
             h.parallel_for<class MassAdditionTryLockTest>(
                 test_range, [=](::sycl::nd_item<1> item) {
                     traccc::device::mutex m(*_lock);
 
-                    if (item.get_local_id() == 0) {
+                    if (item.get_local_id()[0] == 0) {
                         traccc::device::unique_lock lock(m, std::try_to_lock);
 
                         if (!lock.owns_lock()) {
@@ -81,13 +81,13 @@ TEST(SYCLUniqueLock, MassAdditionKernelDeferLock) {
                                 ::sycl::range<1>(n_threads));
 
     queue
-        .submit([&, out = out.get(), _lock = lock.get()](::sycl::handler &h) {
+        .submit([&, out = out.get(), _lock = lock.get()](::sycl::handler& h) {
             h.parallel_for<class MassAdditionDeferLockTest>(
                 test_range, [=](::sycl::nd_item<1> item) {
                     traccc::device::mutex m(*_lock);
                     traccc::device::unique_lock lock(m, std::defer_lock);
 
-                    if (item.get_local_id() == 0) {
+                    if (item.get_local_id()[0] == 0) {
                         lock.lock();
 
                         uint32_t tmp = *out;
@@ -122,12 +122,12 @@ TEST(SYCLUniqueLock, MassAdditionKernelAdoptLock) {
                                 ::sycl::range<1>(n_threads));
 
     queue
-        .submit([&, out = out.get(), _lock = lock.get()](::sycl::handler &h) {
+        .submit([&, out = out.get(), _lock = lock.get()](::sycl::handler& h) {
             h.parallel_for<class MassAdditionAdoptLockTest>(
                 test_range, [=](::sycl::nd_item<1> item) {
                     traccc::device::mutex m(*_lock);
 
-                    if (item.get_local_id() == 0) {
+                    if (item.get_local_id()[0] == 0) {
                         m.lock();
                         traccc::device::unique_lock lock(m, std::adopt_lock);
 

--- a/tests/sycl/test_unique_lock.sycl
+++ b/tests/sycl/test_unique_lock.sycl
@@ -6,15 +6,20 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// SYCL include(s).
 #include <sycl/sycl.hpp>
+
+// Project include(s).
+#include "traccc/device/mutex.hpp"
+#include "traccc/device/unique_lock.hpp"
+
+// VecMem include(s).
 #include <vecmem/memory/sycl/device_memory_resource.hpp>
 #include <vecmem/memory/sycl/shared_memory_resource.hpp>
 #include <vecmem/memory/unique_ptr.hpp>
 
-#include "traccc/device/mutex.hpp"
-#include "traccc/device/unique_lock.hpp"
+// GoogleTest include(s).
+#include <gtest/gtest.h>
 
 TEST(SYCLUniqueLock, MassAdditionKernelTryLock) {
 


### PR DESCRIPTION
With this I'm trying to make the project build successfully using [AdaptiveCpp](https://github.com/AdaptiveCpp/AdaptiveCpp). 😄 

The task is still not done, I'm still getting some issues from the unit tests, but this is where I'll stop for today. This setup is now able to do:

```
[bash][pcadp04]:build > ACPP_VISIBILITY_MASK=cuda ./bin/traccc_seq_example_sycl --finding-run-mbf-smoother=0 --compare-w
ith-cpu
17:30:09    TracccExampleSeqSyclOptions   INFO
17:30:09    TracccExampleSeqSyclOptions   INFO      Running Full Tracking Chain Using SYCL
17:30:09    TracccExampleSeqSyclOptions   INFO
...
17:30:10    TracccExampleSeqSycl          INFO      Running on device: NVIDIA RTX A5000
17:30:13    TracccExampleSeqSycl          WARNING   28 duplicate cells found in /mnt/hdd1/krasznaa/projects/traccc/traccc/data/odd/geant4_10muon_10GeV/event000000000-cells.csv
[AdaptiveCpp Warning] This application uses SYCL buffers; the SYCL buffer-accessor model is well-known to introduce unnecessary overheads. Please consider migrating to the SYCL2020 USM model, in particular device USM (sycl::malloc_device) combined with in-order queues for more performance. See the AdaptiveCpp performance guide for more information:
https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/doc/performance.md
17:30:14    TracccExampleSeqSycl          INFO      ===>>> Event 0 <<<===
Number of measurements: 631 (host), 631 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of spacepoints: 451 (host), 451 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of seeds: 121 (host), 121 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of track parameters: 121 (host), 121 (device)
  Matching rate(s):
    - 0% at 0.01% uncertainty
    - 0% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of track candidates: 87 (host), 87 (device)
  Matching rate(s):
    - 0% at 0.01% uncertainty
    - 0% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
17:30:14    TracccExampleSeqSycl          INFO      ==> Statistics ...
17:30:14    TracccExampleSeqSycl          INFO      - read    1515 cells
17:30:14    TracccExampleSeqSycl          INFO      - created (cpu)  631 measurements
17:30:14    TracccExampleSeqSycl          INFO      - created (cpu)  451 spacepoints
17:30:14    TracccExampleSeqSycl          INFO      - created (sycl) 451 spacepoints
17:30:14    TracccExampleSeqSycl          INFO      - created  (cpu) 121 seeds
17:30:14    TracccExampleSeqSycl          INFO      - created (sycl) 121 seeds
17:30:14    TracccExampleSeqSycl          INFO      - found (cpu)    87 tracks
17:30:14    TracccExampleSeqSycl          INFO      - found (sycl)   87 tracks
17:30:14    TracccExampleSeqSycl          INFO      ==>Elapsed times...
17:30:14    TracccExampleSeqSycl          INFO                 File reading  (cpu)  4 ms
17:30:14    TracccExampleSeqSycl          INFO               Clusterization (sycl)  6 ms
17:30:14    TracccExampleSeqSycl          INFO               Clusterization  (cpu)  0 ms
17:30:14    TracccExampleSeqSycl          INFO         Spacepoint formation (sycl)  3 ms
17:30:14    TracccExampleSeqSycl          INFO         Spacepoint formation  (cpu)  0 ms
17:30:14    TracccExampleSeqSycl          INFO                      Seeding (sycl)  5 ms
17:30:14    TracccExampleSeqSycl          INFO                      Seeding  (cpu)  0 ms
17:30:14    TracccExampleSeqSycl          INFO                 Track params (sycl)  3 ms
17:30:14    TracccExampleSeqSycl          INFO                 Track params  (cpu)  0 ms
17:30:14    TracccExampleSeqSycl          INFO                Track finding (sycl)  320 ms
17:30:14    TracccExampleSeqSycl          INFO                Track finding  (cpu)  6 ms
17:30:14    TracccExampleSeqSycl          INFO                           Wall time  352 ms
[bash][pcadp04]:build >
```

And:

```
[bash][pcadp04]:build > ACPP_VISIBILITY_MASK=hip ./bin/traccc_seq_example_sycl --finding-run-mbf-smoother=0 --compare-wi
th-cpu
17:31:13    TracccExampleSeqSyclOptions   INFO
17:31:13    TracccExampleSeqSyclOptions   INFO      Running Full Tracking Chain Using SYCL
17:31:13    TracccExampleSeqSyclOptions   INFO
...
17:31:13    TracccExampleSeqSycl          INFO      Running on device: AMD Radeon RX 6700 XT
17:31:16    TracccExampleSeqSycl          WARNING   28 duplicate cells found in /mnt/hdd1/krasznaa/projects/traccc/traccc/data/odd/geant4_10muon_10GeV/event000000000-cells.csv
[AdaptiveCpp Warning] This application uses SYCL buffers; the SYCL buffer-accessor model is well-known to introduce unnecessary overheads. Please consider migrating to the SYCL2020 USM model, in particular device USM (sycl::malloc_device) combined with in-order queues for more performance. See the AdaptiveCpp performance guide for more information:
https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/doc/performance.md
17:31:17    TracccExampleSeqSycl          INFO      ===>>> Event 0 <<<===
Number of measurements: 631 (host), 631 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of spacepoints: 451 (host), 451 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of seeds: 121 (host), 121 (device)
  Matching rate(s):
    - 100% at 0.01% uncertainty
    - 100% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of track parameters: 121 (host), 121 (device)
  Matching rate(s):
    - 0% at 0.01% uncertainty
    - 0% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
Number of track candidates: 87 (host), 87 (device)
  Matching rate(s):
    - 0% at 0.01% uncertainty
    - 0% at 0.1% uncertainty
    - 100% at 1% uncertainty
    - 100% at 5% uncertainty
17:31:17    TracccExampleSeqSycl          INFO      ==> Statistics ...
17:31:17    TracccExampleSeqSycl          INFO      - read    1515 cells
17:31:17    TracccExampleSeqSycl          INFO      - created (cpu)  631 measurements
17:31:17    TracccExampleSeqSycl          INFO      - created (cpu)  451 spacepoints
17:31:17    TracccExampleSeqSycl          INFO      - created (sycl) 451 spacepoints
17:31:17    TracccExampleSeqSycl          INFO      - created  (cpu) 121 seeds
17:31:17    TracccExampleSeqSycl          INFO      - created (sycl) 121 seeds
17:31:17    TracccExampleSeqSycl          INFO      - found (cpu)    87 tracks
17:31:17    TracccExampleSeqSycl          INFO      - found (sycl)   87 tracks
17:31:17    TracccExampleSeqSycl          INFO      ==>Elapsed times...
17:31:17    TracccExampleSeqSycl          INFO                 File reading  (cpu)  4 ms
17:31:17    TracccExampleSeqSycl          INFO               Clusterization (sycl)  5 ms
17:31:17    TracccExampleSeqSycl          INFO               Clusterization  (cpu)  0 ms
17:31:17    TracccExampleSeqSycl          INFO         Spacepoint formation (sycl)  2 ms
17:31:17    TracccExampleSeqSycl          INFO         Spacepoint formation  (cpu)  0 ms
17:31:17    TracccExampleSeqSycl          INFO                      Seeding (sycl)  3 ms
17:31:17    TracccExampleSeqSycl          INFO                      Seeding  (cpu)  0 ms
17:31:17    TracccExampleSeqSycl          INFO                 Track params (sycl)  0 ms
17:31:17    TracccExampleSeqSycl          INFO                 Track params  (cpu)  0 ms
17:31:17    TracccExampleSeqSycl          INFO                Track finding (sycl)  131 ms
17:31:17    TracccExampleSeqSycl          INFO                Track finding  (cpu)  6 ms
17:31:17    TracccExampleSeqSycl          INFO                           Wall time  158 ms
[bash][pcadp04]:build >
```

Though the OpenMP backend is not happy yet. 😛

```
[bash][pcadp04]:build > ACPP_VISIBILITY_MASK=omp ./bin/traccc_seq_example_sycl --finding-run-mbf-smoother=0 --compare-wi
th-cpu
17:32:31    TracccExampleSeqSyclOptions   INFO
17:32:31    TracccExampleSeqSyclOptions   INFO      Running Full Tracking Chain Using SYCL
17:32:31    TracccExampleSeqSyclOptions   INFO
...
17:32:31    TracccExampleSeqSycl          INFO      Running on device: AdaptiveCpp OpenMP host device
17:32:35    TracccExampleSeqSycl          WARNING   28 duplicate cells found in /mnt/hdd1/krasznaa/projects/traccc/traccc/data/odd/geant4_10muon_10GeV/event000000000-cells.csv
[AdaptiveCpp Warning] This application uses SYCL buffers; the SYCL buffer-accessor model is well-known to introduce unnecessary overheads. Please consider migrating to the SYCL2020 USM model, in particular device USM (sycl::malloc_device) combined with in-order queues for more performance. See the AdaptiveCpp performance guide for more information:
https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/doc/performance.md

 *** Break *** segmentation violation

 *** Break *** segmentation violation
[bash][pcadp04]:build >


===========================================================
There was a crash.
This is the entire stack trace of all threads:
===========================================================

Thread 50 (Thread 0x7f5d917f5000 (LWP 3179037) "traccc_seq_exam"):
#0  0x00007f5e8448688a in __futex_abstimed_wait_common () from /lib64/libc.so.6
#1  0x00007f5e84488de2 in pthread_cond_wait

GLIBC_2.3.2 () from /lib64/libc.so.6
#2  0x00007f5e847a6250 in void __kmp_suspend_64<false, true>(int, kmp_flag_64<false, true>*) () from /lib64/libomp.so
#3  0x00007f5e84773ca6 in kmp_flag_64<false, true>::wait(kmp_info*, int, void*) () from /lib64/libomp.so
#4  0x00007f5e8476ea69 in __kmp_hyper_barrier_release(barrier_type, kmp_info*, int, int, int, void*) [clone .llvm.2231712469945138702] () from /lib64/libomp.so
```

So, things are far from perfect. But I'm quite pleased with this already.