### PR TITLE
fix: Remove barcode name

### DIFF
--- a/.github/check_taboos.sh
+++ b/.github/check_taboos.sh
@@ -10,6 +10,8 @@ INPUT="$@"
 
 INPUT_EX_THIS_FILE=${INPUT[@]/".github/check_taboos.sh"}
 
+${GREP} "barcode" ${INPUT_EX_THIS_FILE[@]} ; test $? -eq 1 || exit 1
+
 UNIT_CONSTANT_EXCUDE_FILE="core/include/traccc/definitions/common.hpp"
 INPUT_EX_UNIT_CONSTANT=${INPUT_EX_THIS_FILE[@]/$UNIT_CONSTANT_EXCUDE_FILE}
 

--- a/examples/options/src/track_gbts_seeding.cpp
+++ b/examples/options/src/track_gbts_seeding.cpp
@@ -163,27 +163,27 @@ void track_gbts_seeding::read(const boost::program_options::variables_map &) {
         return;
     }
     // config info from file
-    std::vector<std::pair<uint64_t, short>> barcodeBinning;
+    std::vector<std::pair<uint64_t, short>> geoidBinning;
     std::vector<std::pair<int, std::vector<int>>> binTables;
     traccc::device::gbts_layerInfo layerInfo;
 
-    auto barcodeBinningPath =
-        std::filesystem::path(config_dir + "/barcodeBinning.txt");
-    if (!std::filesystem::exists(barcodeBinningPath)) {
-        throw std::runtime_error("barcodeBinning.txt file not found");
+    auto geoidBinningPath =
+        std::filesystem::path(config_dir + "/geoidBinning.txt");
+    if (!std::filesystem::exists(geoidBinningPath)) {
+        throw std::runtime_error("geoidBinning.txt file not found");
     }
-    std::ifstream barcodeBinningFile(barcodeBinningPath);
+    std::ifstream geoidBinningFile(geoidBinningPath);
 
-    unsigned int nBarcodes = 0;
-    barcodeBinningFile >> nBarcodes;
-    barcodeBinning.reserve(nBarcodes);
+    unsigned int nGeoIDs = 0;
+    geoidBinningFile >> nGeoIDs;
+    geoidBinning.reserve(nGeoIDs);
 
-    std::pair<uint64_t, short> barcodeLayerPair;
-    for (; nBarcodes > 0u; --nBarcodes) {
-        barcodeBinningFile >> barcodeLayerPair.first;
-        barcodeBinningFile >> barcodeLayerPair.second;
+    std::pair<uint64_t, short> geoidLayerPair;
+    for (; nGeoIDs > 0u; --nGeoIDs) {
+        geoidBinningFile >> geoidLayerPair.first;
+        geoidBinningFile >> geoidLayerPair.second;
 
-        barcodeBinning.push_back(barcodeLayerPair);
+        geoidBinning.push_back(geoidLayerPair);
     }
 
     auto binTablesPath = std::filesystem::path(config_dir + "/binTables.txt");
@@ -223,7 +223,7 @@ void track_gbts_seeding::read(const boost::program_options::variables_map &) {
                            geo[1]);
     }
     // Set linking scheme
-    gbts_config.setLinkingScheme(binTables, layerInfo, barcodeBinning, min_pt,
+    gbts_config.setLinkingScheme(binTables, layerInfo, geoidBinning, min_pt,
                                  getDefaultLogger("GBTSconfig"));
 }
 


### PR DESCRIPTION
The barcode name is no longer used for detray geoids in order to avoid confusion with simulation barcodes. This PR removes the barcode name and adds it to the taboo script