### PR TITLE
Add seed quality to EDM

### DIFF
--- a/core/include/traccc/edm/seed_collection.hpp
+++ b/core/include/traccc/edm/seed_collection.hpp
@@ -128,7 +128,7 @@ using seed_collection =
     vecmem::edm::container<seed, vecmem::edm::type::vector<unsigned int>,
                            vecmem::edm::type::vector<unsigned int>,
                            vecmem::edm::type::vector<unsigned int>,
-						   vecmem::edm::type::vector<float> >;
+                           vecmem::edm::type::vector<float> >;
 
 }  // namespace traccc::edm
 

--- a/core/include/traccc/edm/seed_collection.hpp
+++ b/core/include/traccc/edm/seed_collection.hpp
@@ -77,6 +77,18 @@ class seed : public BASE {
     ///
     TRACCC_HOST_DEVICE
     const auto& top_index() const { return BASE::template get<2>(); }
+    /// Quality of the seed (const)
+    ///
+    /// @return A (const) vector of <tt>float</tt> values
+    ///
+    TRACCC_HOST_DEVICE
+    const auto& quality() const { return BASE::template get<3>(); }
+    /// Quality of the seed (non-const)
+    ///
+    /// @return A (non-const) vector of <tt>float</tt> values
+    ///
+    TRACCC_HOST_DEVICE
+    auto& quality() { return BASE::template get<3>(); }
 
     /// @}
 
@@ -115,7 +127,8 @@ class seed : public BASE {
 using seed_collection =
     vecmem::edm::container<seed, vecmem::edm::type::vector<unsigned int>,
                            vecmem::edm::type::vector<unsigned int>,
-                           vecmem::edm::type::vector<unsigned int> >;
+                           vecmem::edm::type::vector<unsigned int>,
+						   vecmem::edm::type::vector<float> >;
 
 }  // namespace traccc::edm
 

--- a/core/src/seeding/seed_filtering.cpp
+++ b/core/src/seeding/seed_filtering.cpp
@@ -118,7 +118,7 @@ void seed_filtering::operator()(
         seeds.push_back({sp_grid.bin(triplet.sp1.bin_idx)[triplet.sp1.sp_idx],
                          sp_grid.bin(triplet.sp2.bin_idx)[triplet.sp2.sp_idx],
                          sp_grid.bin(triplet.sp3.bin_idx)[triplet.sp3.sp_idx],
-                         triplet.weight});
+                         static_cast<float>(triplet.weight)});
     }
 }
 

--- a/core/src/seeding/seed_filtering.cpp
+++ b/core/src/seeding/seed_filtering.cpp
@@ -117,7 +117,8 @@ void seed_filtering::operator()(
         }
         seeds.push_back({sp_grid.bin(triplet.sp1.bin_idx)[triplet.sp1.sp_idx],
                          sp_grid.bin(triplet.sp2.bin_idx)[triplet.sp2.sp_idx],
-                         sp_grid.bin(triplet.sp3.bin_idx)[triplet.sp3.sp_idx]});
+                         sp_grid.bin(triplet.sp3.bin_idx)[triplet.sp3.sp_idx],
+						 triplet.weight});
     }
 }
 

--- a/core/src/seeding/seed_filtering.cpp
+++ b/core/src/seeding/seed_filtering.cpp
@@ -118,7 +118,7 @@ void seed_filtering::operator()(
         seeds.push_back({sp_grid.bin(triplet.sp1.bin_idx)[triplet.sp1.sp_idx],
                          sp_grid.bin(triplet.sp2.bin_idx)[triplet.sp2.sp_idx],
                          sp_grid.bin(triplet.sp3.bin_idx)[triplet.sp3.sp_idx],
-						 triplet.weight});
+                         triplet.weight});
     }
 }
 

--- a/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
+++ b/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
@@ -182,7 +182,7 @@ inline void select_seeds(
             n_seeds_per_spM++;
 
             seeds_device.push_back(
-                {aTriplet.spB, aTriplet.spM, aTriplet.spT, aTriplet.weight});
+                {aTriplet.spB, aTriplet.spM, aTriplet.spT, static_cast<float>(aTriplet.weight)});
         }
     }
 }

--- a/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
+++ b/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
@@ -181,7 +181,8 @@ inline void select_seeds(
 
             n_seeds_per_spM++;
 
-            seeds_device.push_back({aTriplet.spB, aTriplet.spM, aTriplet.spT, aTriplet.weight});
+            seeds_device.push_back(
+                {aTriplet.spB, aTriplet.spM, aTriplet.spT, aTriplet.weight});
         }
     }
 }

--- a/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
+++ b/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
@@ -181,7 +181,7 @@ inline void select_seeds(
 
             n_seeds_per_spM++;
 
-            seeds_device.push_back({aTriplet.spB, aTriplet.spM, aTriplet.spT});
+            seeds_device.push_back({aTriplet.spB, aTriplet.spM, aTriplet.spT, aTriplet.weight});
         }
     }
 }

--- a/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
+++ b/device/common/include/traccc/seeding/device/impl/select_seeds.ipp
@@ -181,8 +181,8 @@ inline void select_seeds(
 
             n_seeds_per_spM++;
 
-            seeds_device.push_back(
-                {aTriplet.spB, aTriplet.spM, aTriplet.spT, static_cast<float>(aTriplet.weight)});
+            seeds_device.push_back({aTriplet.spB, aTriplet.spM, aTriplet.spT,
+                                    static_cast<float>(aTriplet.weight)});
         }
     }
 }

--- a/device/cuda/src/gbts_seeding/kernels/GbtsGraphProcessingKernels.cuh
+++ b/device/cuda/src/gbts_seeding/kernels/GbtsGraphProcessingKernels.cuh
@@ -847,6 +847,7 @@ void __global__ gbts_seed_conversion_kernel(
                               3.0f * tight_bid_cot_threshold) &
                              diff_code == 0;
         }
+		float quality = static_cast<float>(prop.x);
         // use one seed from a consistant pair/set + the inconsistant one
         // sample spacepoints from tracklet to create seeds
         // include 1st order unless either 2 or 3 are consitant with the other
@@ -854,21 +855,21 @@ void __global__ gbts_seed_conversion_kernel(
         if (diff_code != 3 & diff_code != 6 | force_dropout) {
             seeds_device.push_back({seed.nodes[seed.size - 1],
                                     seed.nodes[(seed.size - 1) / 2 + 1],
-                                    seed.nodes[0]});
+                                    seed.nodes[0], quality});
         }
         // include 2nd order if it consistant with 1 and 3 or only 1 and 3 are
         // consistant
         if (diff_code == 1 | diff_code == 6) {
             seeds_device.push_back({seed.nodes[seed.size - 1],
                                     seed.nodes[(seed.size - 1) / 2],
-                                    seed.nodes[0]});
+                                    seed.nodes[0], quality});
         }
         // include 3rd order if it is consistant with 1 and 2 or only 1 and 2
         // are consistant or if only 2 and 3 are consistant
         if (diff_code == 2 | diff_code == 3 | diff_code == 4 | force_dropout) {
             seeds_device.push_back({seed.nodes[seed.size - 2],
                                     seed.nodes[(seed.size - 1) / 2],
-                                    seed.nodes[0]});
+                                    seed.nodes[0], quality});
         }
     }
 }

--- a/device/cuda/src/gbts_seeding/kernels/GbtsGraphProcessingKernels.cuh
+++ b/device/cuda/src/gbts_seeding/kernels/GbtsGraphProcessingKernels.cuh
@@ -847,7 +847,7 @@ void __global__ gbts_seed_conversion_kernel(
                               3.0f * tight_bid_cot_threshold) &
                              diff_code == 0;
         }
-		float quality = static_cast<float>(prop.x);
+        float quality = static_cast<float>(prop.x);
         // use one seed from a consistant pair/set + the inconsistant one
         // sample spacepoints from tracklet to create seeds
         // include 1st order unless either 2 or 3 are consitant with the other

--- a/tests/cpu/test_track_params_estimation.cpp
+++ b/tests/cpu/test_track_params_estimation.cpp
@@ -126,7 +126,7 @@ TEST(track_params_estimation, helix_positive_charge) {
 
     // Make a seed from the three spacepoints
     edm::seed_collection::host seeds{host_mr};
-    seeds.push_back({0, 1, 2});
+    seeds.push_back({0, 1, 2, 0.0f});
 
     // Run track parameter estimation
     traccc::track_params_estimation_config track_params_estimation_config;

--- a/tests/cpu/test_track_params_estimation.cpp
+++ b/tests/cpu/test_track_params_estimation.cpp
@@ -70,7 +70,7 @@ TEST(track_params_estimation, helix_negative_charge) {
 
     // Make a seed from the three spacepoints
     edm::seed_collection::host seeds{host_mr};
-    seeds.push_back({0, 1, 2});
+    seeds.push_back({0, 1, 2, 0.0f});
 
     // Run track parameter estimation
     traccc::track_params_estimation_config track_params_estimation_config;


### PR DESCRIPTION
Adds seed quality to the seed EDM:
Used to sort seeds by quality for CPU ACTS track following for an improvement in efficiency and consistency.
Quality is seed weight for the triplet seeder and fit quality for GBTS.