### PR TITLE
Refactor subspace storage and handling

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
+++ b/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
@@ -59,22 +59,22 @@ struct measurement_selector {
         const bool is_line) {
 
         // Oservation model: Subspace of measurement space for this measurement
-        const subspace<algebra_t, e_bound_size> subs(measurement.subspace());
-        detray::dmatrix<algebra_t, D, e_bound_size> H =
-            subs.template projector<D>();
+        subspace<algebra_t, e_bound_size> subs(measurement.subspace());
 
         // Flip the sign of projector matrix element in case the first element
         // of a line measurement is negative
         if (is_line && bound_params.bound_local()[e_bound_loc0] < 0) {
-            getter::element(H, 0u, e_bound_loc0) = -1;
+            subs.set_sign(0, true);
         }
 
         detray::dmatrix<algebra_t, D, 1> meas_local;
         edm::get_measurement_local<algebra_t>(measurement, meas_local);
         if (measurement.dimensions() == 1) {
-            getter::element(H, 1u, 0u) = 0.f;
-            getter::element(H, 1u, 1u) = 0.f;
+            subs.set_invalid(1);
         }
+
+        const detray::dmatrix<algebra_t, D, e_bound_size> H =
+            subs.template projector<D>();
 
         TRACCC_DEBUG_HOST("--> Observation model (H):\n" << H);
 

--- a/core/include/traccc/utils/subspace.hpp
+++ b/core/include/traccc/utils/subspace.hpp
@@ -27,6 +27,31 @@ struct subspace {
     public:
     // Type declarations
     using size_type = detray::dindex_type<algebra_t>;
+
+    // Define the number of bits we use to represent a single index;
+    // currently, we hardcode to be three plus one sign bit so that the full
+    // size of the subspace is limited to 8. Note that we also reserve one
+    // element (all ones) as invalid.
+    //
+    // TODO: Find a nicer, automated solution to this.
+    static constexpr size_type BITS_PER_INDEX = 4;
+    static_assert(BITS_PER_INDEX >= 2);
+
+    // Compute the total number of bits necessary to represent a subspace.
+    static constexpr size_type TOTAL_BITS = BITS_PER_INDEX * kSize;
+    static_assert(
+        TOTAL_BITS <= 64,
+        "Subspaces with more than 64 necessary bits are not supported");
+    using axes_type = std::conditional_t<TOTAL_BITS <= 32, std::uint_least32_t,
+                                         std::uint_least64_t>;
+
+    static constexpr axes_type SIGN_BIT_MASK = 1 << (BITS_PER_INDEX - 1);
+    static constexpr axes_type VALUE_BITS_MASK =
+        (1 << (BITS_PER_INDEX - 1)) - 1;
+    static constexpr axes_type ELEMENT_BITS_MASK = (1 << BITS_PER_INDEX) - 1;
+    static_assert(((1 << (BITS_PER_INDEX - 1)) - 1) >= kFullSize);
+    static_assert(ELEMENT_BITS_MASK == (SIGN_BIT_MASK | VALUE_BITS_MASK));
+
     template <size_type ROWS, size_type COLS>
     using matrix_type = detray::dmatrix<algebra_t, ROWS, COLS>;
 
@@ -43,28 +68,64 @@ struct subspace {
     /// @param indices Unique, ordered indices
     template <typename SIZE_TYPE>
     TRACCC_HOST_DEVICE constexpr subspace(
-        const std::array<SIZE_TYPE, kSize>& indices) {
+        const std::array<SIZE_TYPE, kSize>& indices)
+        : m_axes(0) {
         for (size_type i = 0u; i < kSize; ++i) {
             assert((indices[i] < kFullSize) and
                    "Axis indices must be within the full space");
-            m_axes[i] = static_cast<size_type>(indices[i]);
+            set_index(i, static_cast<axes_type>(indices[i]));
         }
     }
 
-    /// Axis indices that comprise the subspace.
-    ///
-    /// The specific container and index type should be considered an
-    /// implementation detail. Users should treat the return type as a generic
-    /// container whose elements are convertible to `size_t`.
+    /// Get the projection index for a given element of the subspace.
     TRACCC_HOST_DEVICE
-    constexpr const std::array<size_type, kSize>& get_indices() const {
-        return m_axes;
+    constexpr size_type get_index(const size_type& i) const {
+        const size_type sr = i * BITS_PER_INDEX;
+        return (m_axes >> sr) & VALUE_BITS_MASK;
     }
 
-    /// Function that sets the m_axes
+    /// Check whether a given element of the subspace is valid or not.
+    ///
+    /// Invalid elements are not projected at all and result in an empty
+    /// row or column in the projection and expansion matrix.
     TRACCC_HOST_DEVICE
-    void set_indices(const std::array<size_type, kSize>& indices) {
-        m_axes = indices;
+    constexpr bool get_valid(const size_type& i) const {
+        const size_type sr = i * BITS_PER_INDEX;
+        return ((m_axes >> sr) & VALUE_BITS_MASK) != VALUE_BITS_MASK;
+    }
+
+    /// Retrieve the sign of an element of the subspace; if a true value is
+    /// returned, the element will be projected in the negative.
+    TRACCC_HOST_DEVICE
+    constexpr bool get_sign(const size_type& i) const {
+        const size_type sr = i * BITS_PER_INDEX;
+        return (m_axes >> sr) & SIGN_BIT_MASK;
+    }
+
+    /// Set the projection index for a given element.
+    TRACCC_HOST_DEVICE
+    constexpr void set_index(const size_type& i, const axes_type& j) {
+        assert(j == (j & ELEMENT_BITS_MASK));
+        const size_type sl = i * BITS_PER_INDEX;
+        m_axes = (m_axes & static_cast<axes_type>(~(VALUE_BITS_MASK << sl))) |
+                 static_cast<axes_type>(j << sl);
+    }
+
+    /// Set an element to be invalid so that it is not projected.
+    TRACCC_HOST_DEVICE
+    constexpr void set_invalid(const size_type& i) {
+        // HACK: For reasons not understood by the author, the
+        // `VALUE_BITS_MASK` variable cannot be used here.
+        set_index(i, ((1 << (BITS_PER_INDEX - 1)) - 1));
+    }
+
+    /// Set the sign of an element, where trueish values indicate negative
+    /// projection and falseish values indicate positive values.
+    TRACCC_HOST_DEVICE
+    constexpr void set_sign(const size_type& i, const bool s) {
+        const size_type sl = i * BITS_PER_INDEX;
+        m_axes = (m_axes & static_cast<axes_type>(~(SIGN_BIT_MASK << sl))) |
+                 static_cast<axes_type>((s ? SIGN_BIT_MASK : 0) << sl);
     }
 
     /// Projection matrix that maps from the full space into the subspace.
@@ -77,7 +138,10 @@ struct subspace {
         auto proj = matrix::zero<matrix_type<D, kFullSize>>();
 
         for (size_type i = 0u; i < D; ++i) {
-            getter::element(proj, i, m_axes[i]) = 1;
+            if (get_index(i) < kFullSize) {
+                getter::element(proj, i, get_index(i)) =
+                    (get_sign(i) ? -1.f : 1.f);
+            }
         }
         return proj;
     }
@@ -92,13 +156,16 @@ struct subspace {
         auto expn = matrix::zero<matrix_type<kFullSize, D>>();
 
         for (size_type i = 0u; i < kSize; ++i) {
-            getter::element(expn, m_axes[i], i) = 1;
+            if (get_index(i) < kFullSize) {
+                getter::element(expn, get_index(i), i) =
+                    (get_sign(i) ? -1.f : 1.f);
+            }
         }
         return expn;
     }
 
     private:
-    std::array<size_type, kSize> m_axes;
+    axes_type m_axes;
 };
 
 }  // namespace traccc

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -9,6 +9,7 @@ traccc_add_test(core
    "test_algorithm.cpp"
    "test_module_map.cpp"
    "test_pvalue.cpp"
+   "test_subspace.cpp"
    "particle.cpp"
    LINK_LIBRARIES GTest::gtest_main traccc_tests_common
    traccc::core traccc::io)

--- a/tests/core/test_subspace.cpp
+++ b/tests/core/test_subspace.cpp
@@ -1,0 +1,209 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include "traccc/utils/subspace.hpp"
+
+using namespace traccc;
+
+TEST(subspace, init) {
+    const std::array<detray::dindex_type<default_algebra>, 2> indices{1, 2};
+    subspace<default_algebra, 6, 2> s{indices};
+
+    ASSERT_EQ(s.get_index(0), indices[0]);
+    ASSERT_EQ(s.get_index(1), indices[1]);
+    ASSERT_EQ(s.get_sign(0), false);
+    ASSERT_EQ(s.get_sign(1), false);
+    ASSERT_EQ(s.get_valid(0), true);
+    ASSERT_EQ(s.get_valid(1), true);
+
+    const auto H = s.projector<2>();
+
+    ASSERT_EQ(getter::element(H, 0, 0), 0);
+    ASSERT_EQ(getter::element(H, 0, 1), 1);
+    ASSERT_EQ(getter::element(H, 0, 2), 0);
+    ASSERT_EQ(getter::element(H, 0, 3), 0);
+    ASSERT_EQ(getter::element(H, 0, 4), 0);
+    ASSERT_EQ(getter::element(H, 0, 5), 0);
+    ASSERT_EQ(getter::element(H, 1, 0), 0);
+    ASSERT_EQ(getter::element(H, 1, 1), 0);
+    ASSERT_EQ(getter::element(H, 1, 2), 1);
+    ASSERT_EQ(getter::element(H, 1, 3), 0);
+    ASSERT_EQ(getter::element(H, 1, 4), 0);
+    ASSERT_EQ(getter::element(H, 1, 5), 0);
+}
+
+TEST(subspace, set_index) {
+    const std::array<detray::dindex_type<default_algebra>, 2> indices{1, 2};
+    subspace<default_algebra, 6, 2> s{indices};
+
+    s.set_index(0, 5);
+
+    ASSERT_EQ(s.get_index(0), 5);
+    ASSERT_EQ(s.get_index(1), indices[1]);
+    ASSERT_EQ(s.get_sign(0), false);
+    ASSERT_EQ(s.get_sign(1), false);
+    ASSERT_EQ(s.get_valid(0), true);
+    ASSERT_EQ(s.get_valid(1), true);
+
+    s.set_index(1, 4);
+
+    ASSERT_EQ(s.get_index(0), 5);
+    ASSERT_EQ(s.get_index(1), 4);
+    ASSERT_EQ(s.get_sign(0), false);
+    ASSERT_EQ(s.get_sign(1), false);
+    ASSERT_EQ(s.get_valid(0), true);
+    ASSERT_EQ(s.get_valid(1), true);
+
+    s.set_index(0, 3);
+
+    ASSERT_EQ(s.get_index(0), 3);
+    ASSERT_EQ(s.get_index(1), 4);
+    ASSERT_EQ(s.get_sign(0), false);
+    ASSERT_EQ(s.get_sign(1), false);
+    ASSERT_EQ(s.get_valid(0), true);
+    ASSERT_EQ(s.get_valid(1), true);
+
+    s.set_index(1, 0);
+
+    ASSERT_EQ(s.get_index(0), 3);
+    ASSERT_EQ(s.get_index(1), 0);
+    ASSERT_EQ(s.get_sign(0), false);
+    ASSERT_EQ(s.get_sign(1), false);
+    ASSERT_EQ(s.get_valid(0), true);
+    ASSERT_EQ(s.get_valid(1), true);
+
+    const auto H = s.projector<2>();
+
+    ASSERT_EQ(getter::element(H, 0, 0), 0);
+    ASSERT_EQ(getter::element(H, 0, 1), 0);
+    ASSERT_EQ(getter::element(H, 0, 2), 0);
+    ASSERT_EQ(getter::element(H, 0, 3), 1);
+    ASSERT_EQ(getter::element(H, 0, 4), 0);
+    ASSERT_EQ(getter::element(H, 0, 5), 0);
+    ASSERT_EQ(getter::element(H, 1, 0), 1);
+    ASSERT_EQ(getter::element(H, 1, 1), 0);
+    ASSERT_EQ(getter::element(H, 1, 2), 0);
+    ASSERT_EQ(getter::element(H, 1, 3), 0);
+    ASSERT_EQ(getter::element(H, 1, 4), 0);
+    ASSERT_EQ(getter::element(H, 1, 5), 0);
+}
+
+TEST(subspace, set_sign) {
+    const std::array<detray::dindex_type<default_algebra>, 2> indices{1, 2};
+    subspace<default_algebra, 6, 2> s{indices};
+
+    s.set_sign(0, true);
+
+    ASSERT_EQ(s.get_index(0), 1);
+    ASSERT_EQ(s.get_index(1), 2);
+    ASSERT_EQ(s.get_sign(0), true);
+    ASSERT_EQ(s.get_sign(1), false);
+    ASSERT_EQ(s.get_valid(0), true);
+    ASSERT_EQ(s.get_valid(1), true);
+
+    s.set_sign(1, true);
+
+    ASSERT_EQ(s.get_index(0), 1);
+    ASSERT_EQ(s.get_index(1), 2);
+    ASSERT_EQ(s.get_sign(0), true);
+    ASSERT_EQ(s.get_sign(1), true);
+    ASSERT_EQ(s.get_valid(0), true);
+    ASSERT_EQ(s.get_valid(1), true);
+
+    const auto H1 = s.projector<2>();
+
+    ASSERT_EQ(getter::element(H1, 0, 0), 0);
+    ASSERT_EQ(getter::element(H1, 0, 1), -1);
+    ASSERT_EQ(getter::element(H1, 0, 2), 0);
+    ASSERT_EQ(getter::element(H1, 0, 3), 0);
+    ASSERT_EQ(getter::element(H1, 0, 4), 0);
+    ASSERT_EQ(getter::element(H1, 0, 5), 0);
+    ASSERT_EQ(getter::element(H1, 1, 0), 0);
+    ASSERT_EQ(getter::element(H1, 1, 1), 0);
+    ASSERT_EQ(getter::element(H1, 1, 2), -1);
+    ASSERT_EQ(getter::element(H1, 1, 3), 0);
+    ASSERT_EQ(getter::element(H1, 1, 4), 0);
+    ASSERT_EQ(getter::element(H1, 1, 5), 0);
+
+    s.set_sign(0, false);
+
+    ASSERT_EQ(s.get_index(0), 1);
+    ASSERT_EQ(s.get_index(1), 2);
+    ASSERT_EQ(s.get_sign(0), false);
+    ASSERT_EQ(s.get_sign(1), true);
+    ASSERT_EQ(s.get_valid(0), true);
+    ASSERT_EQ(s.get_valid(1), true);
+
+    const auto H2 = s.projector<2>();
+
+    ASSERT_EQ(getter::element(H2, 0, 0), 0);
+    ASSERT_EQ(getter::element(H2, 0, 1), 1);
+    ASSERT_EQ(getter::element(H2, 0, 2), 0);
+    ASSERT_EQ(getter::element(H2, 0, 3), 0);
+    ASSERT_EQ(getter::element(H2, 0, 4), 0);
+    ASSERT_EQ(getter::element(H2, 0, 5), 0);
+    ASSERT_EQ(getter::element(H2, 1, 0), 0);
+    ASSERT_EQ(getter::element(H2, 1, 1), 0);
+    ASSERT_EQ(getter::element(H2, 1, 2), -1);
+    ASSERT_EQ(getter::element(H2, 1, 3), 0);
+    ASSERT_EQ(getter::element(H2, 1, 4), 0);
+    ASSERT_EQ(getter::element(H2, 1, 5), 0);
+}
+
+TEST(subspace, set_invalid) {
+    const std::array<detray::dindex_type<default_algebra>, 2> indices{1, 2};
+    subspace<default_algebra, 6, 2> s{indices};
+
+    s.set_invalid(1);
+
+    ASSERT_EQ(s.get_index(0), 1);
+    ASSERT_EQ(s.get_sign(0), false);
+    ASSERT_EQ(s.get_valid(0), true);
+    ASSERT_EQ(s.get_valid(1), false);
+
+    const auto H1 = s.projector<2>();
+
+    ASSERT_EQ(getter::element(H1, 0, 0), 0);
+    ASSERT_EQ(getter::element(H1, 0, 1), 1);
+    ASSERT_EQ(getter::element(H1, 0, 2), 0);
+    ASSERT_EQ(getter::element(H1, 0, 3), 0);
+    ASSERT_EQ(getter::element(H1, 0, 4), 0);
+    ASSERT_EQ(getter::element(H1, 0, 5), 0);
+    ASSERT_EQ(getter::element(H1, 1, 0), 0);
+    ASSERT_EQ(getter::element(H1, 1, 1), 0);
+    ASSERT_EQ(getter::element(H1, 1, 2), 0);
+    ASSERT_EQ(getter::element(H1, 1, 3), 0);
+    ASSERT_EQ(getter::element(H1, 1, 4), 0);
+    ASSERT_EQ(getter::element(H1, 1, 5), 0);
+
+    s.set_index(1, 5);
+
+    ASSERT_EQ(s.get_index(0), 1);
+    ASSERT_EQ(s.get_index(1), 5);
+    ASSERT_EQ(s.get_sign(0), false);
+    ASSERT_EQ(s.get_sign(1), false);
+    ASSERT_EQ(s.get_valid(0), true);
+    ASSERT_EQ(s.get_valid(1), true);
+
+    const auto H2 = s.projector<2>();
+
+    ASSERT_EQ(getter::element(H2, 0, 0), 0);
+    ASSERT_EQ(getter::element(H2, 0, 1), 1);
+    ASSERT_EQ(getter::element(H2, 0, 2), 0);
+    ASSERT_EQ(getter::element(H2, 0, 3), 0);
+    ASSERT_EQ(getter::element(H2, 0, 4), 0);
+    ASSERT_EQ(getter::element(H2, 0, 5), 0);
+    ASSERT_EQ(getter::element(H2, 1, 0), 0);
+    ASSERT_EQ(getter::element(H2, 1, 1), 0);
+    ASSERT_EQ(getter::element(H2, 1, 2), 0);
+    ASSERT_EQ(getter::element(H2, 1, 3), 0);
+    ASSERT_EQ(getter::element(H2, 1, 4), 0);
+    ASSERT_EQ(getter::element(H2, 1, 5), 1);
+}


### PR DESCRIPTION
This commit refactors the subspace representation to become more compact, and also adds additional member functions to elegantly model some of the operations performed on the projection matrix in the Kálmán filter code. Specifically, it packs the indices using a single bit field rather than an array of integers. Furthermore, it allows for the subspace to store signed projections (used for line surfaces) as well as invalid projections (used for 1D measurements).