### PR TITLE
ref: use predicted chi2 in CKF and introduce measurement selector

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -96,6 +96,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/fitting/kalman_filter/kalman_actor.hpp"
   "include/traccc/fitting/kalman_filter/kalman_fitter.hpp"
   "include/traccc/fitting/kalman_filter/kalman_step_aborter.hpp"
+  "include/traccc/fitting/kalman_filter/measurement_selector.hpp"
   "include/traccc/fitting/kalman_filter/statistics_updater.hpp"
   "include/traccc/fitting/kalman_filter/two_filters_smoother.hpp"
   "include/traccc/fitting/details/kalman_fitting_types.hpp"

--- a/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -233,7 +233,6 @@ combinatorial_kalman_filter(
                 best_links;
 
             const bool is_line = detail::is_line(sf);
-            measurement_selector::config calib_cfg{};
 
             // Iterate over the measurements
             TRACCC_VERBOSE_HOST("No. measurements: " << (up - lo));
@@ -244,7 +243,7 @@ combinatorial_kalman_filter(
                 const edm::measurement meas = measurements.at(meas_id);
 
                 const scalar_type chi2 = measurement_selector::predicted_chi2(
-                    meas, in_param, calib_cfg, is_line);
+                    meas, in_param, config.meas_calibration, is_line);
 
                 // If the measurement is outside the chi2 cut, skip it
                 if (chi2 > config.chi2_max || chi2 < 0.f) {
@@ -258,8 +257,9 @@ combinatorial_kalman_filter(
 
                 // Run the Kalman update on a copy of the track parameters
                 const kalman_fitter_status res =
-                    gain_matrix_updater<algebra_type>{}(trk_state, measurements,
-                                                        in_param, is_line);
+                    gain_matrix_updater<algebra_type>{}(
+                        trk_state, meas, in_param, config.meas_calibration,
+                        is_line);
 
                 TRACCC_DEBUG_HOST("KF status: " << fitter_debug_msg{res}());
 

--- a/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,6 +16,7 @@
 #include "traccc/finding/finding_config.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
 #include "traccc/fitting/kalman_filter/is_line_visitor.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/sanity/contiguous_on.hpp"
 #include "traccc/utils/logging.hpp"
@@ -231,6 +232,9 @@ combinatorial_kalman_filter(
                                    bound_track_parameters<algebra_type>>>
                 best_links;
 
+            const bool is_line = detail::is_line(sf);
+            measurement_selector::config calib_cfg{};
+
             // Iterate over the measurements
             TRACCC_VERBOSE_HOST("No. measurements: " << (up - lo));
             for (unsigned int meas_id = lo; meas_id < up; meas_id++) {
@@ -239,24 +243,28 @@ combinatorial_kalman_filter(
                 // The measurement on surface to handle.
                 const edm::measurement meas = measurements.at(meas_id);
 
+                const scalar_type chi2 = measurement_selector::predicted_chi2(
+                    meas, in_param, calib_cfg, is_line);
+
+                // If the measurement is outside the chi2 cut, skip it
+                if (chi2 > config.chi2_max || chi2 < 0.f) {
+                    continue;
+                }
+
                 // Create a standalone track state object.
                 edm::track_state trk_state =
                     edm::make_track_state<algebra_type>(measurements, meas_id);
-
-                const bool is_line = detail::is_line(sf);
+                trk_state.filtered_chi2() = chi2;
 
                 // Run the Kalman update on a copy of the track parameters
                 const kalman_fitter_status res =
                     gain_matrix_updater<algebra_type>{}(trk_state, measurements,
                                                         in_param, is_line);
 
-                const traccc::scalar chi2 = trk_state.filtered_chi2();
-
                 TRACCC_DEBUG_HOST("KF status: " << fitter_debug_msg{res}());
 
                 // The chi2 from Kalman update should be less than chi2_max
-                if (res == kalman_fitter_status::SUCCESS &&
-                    (chi2 < config.chi2_max)) {
+                if (res == kalman_fitter_status::SUCCESS) {
 
                     TRACCC_VERBOSE_HOST("Found measurement: " << meas_id);
 

--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -10,6 +10,7 @@
 // traccc include(s).
 #include "traccc/definitions/common.hpp"
 #include "traccc/definitions/primitives.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/utils/particle.hpp"
 
 // detray include(s).
@@ -58,6 +59,8 @@ struct finding_config {
 
     /// Propagation configuration
     detray::propagation::config propagation{};
+    /// Measurement calibration configuration
+    measurement_selector::config meas_calibration{};
 
     /// Minimum momentum for reconstructed tracks
     float min_p = 100.f * traccc::unit<float>::MeV;

--- a/core/include/traccc/fitting/details/kalman_fitting.hpp
+++ b/core/include/traccc/fitting/details/kalman_fitting.hpp
@@ -86,7 +86,8 @@ typename edm::track_container<algebra_t>::host kalman_fitting(
             result_tracks_device.at(result_tracks_device.size() - 1),
             typename edm::track_state_collection<algebra_t>::device{
                 vecmem::get_data(result.states)},
-            tracks.measurements, seqs_buffer, fitter.config().propagation);
+            tracks.measurements, seqs_buffer, fitter.config().propagation,
+            fitter.config().meas_calibration);
 
         // Run the fitter. The status that it returns is not used here. The main
         // failure modes are saved onto the fitted track itself. Not sure what

--- a/core/include/traccc/fitting/fitting_config.hpp
+++ b/core/include/traccc/fitting/fitting_config.hpp
@@ -10,6 +10,7 @@
 // Local include(s).
 #include "traccc/definitions/common.hpp"
 #include "traccc/definitions/primitives.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/utils/particle.hpp"
 
 // detray include(s).
@@ -24,6 +25,8 @@ struct fitting_config {
 
     /// Propagation configuration
     detray::propagation::config propagation{};
+    /// Measurement calibration configuration
+    measurement_selector::config meas_calibration{};
 
     /// Minimum momentum for reconstructed tracks
     float min_p = 100.f * traccc::unit<float>::MeV;

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -15,6 +15,7 @@
 #include "traccc/edm/measurement_helpers.hpp"
 #include "traccc/edm/track_state_collection.hpp"
 #include "traccc/fitting/details/regularize_covariance.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/utils/logging.hpp"
 #include "traccc/utils/subspace.hpp"
@@ -43,17 +44,17 @@ struct gain_matrix_updater {
     /// @param bound_params bound parameter
     ///
     /// @return true if the update succeeds
-    template <typename track_state_backend_t>
+    template <typename track_state_backend_t, typename measurement_backend_t>
     [[nodiscard]] TRACCC_HOST_DEVICE inline kalman_fitter_status operator()(
         typename edm::track_state<track_state_backend_t>& trk_state,
-        const edm::measurement_collection::const_device& measurements,
+        const edm::measurement<measurement_backend_t>& measurement,
         const bound_track_parameters<algebra_t>& bound_params,
+        const measurement_selector::config& calib_cfg,
         const bool is_line) const {
 
         static constexpr unsigned int D = 2;
 
-        [[maybe_unused]] const unsigned int dim{
-            measurements.at(trk_state.measurement_index()).dimensions()};
+        [[maybe_unused]] const unsigned int dim{measurement.dimensions()};
 
         TRACCC_VERBOSE_HOST_DEVICE("Perform Kalman filtering...");
         TRACCC_VERBOSE_HOST_DEVICE("-> Measurement dim: %d", dim);
@@ -63,17 +64,6 @@ struct gain_matrix_updater {
         assert(!bound_params.is_invalid());
         assert(!bound_params.surface_link().is_invalid());
 
-        // Some identity matrices
-        // @TODO: Make constexpr work
-        const auto I66 = matrix::identity<bound_matrix_type>();
-
-        // Measurement data on surface
-        matrix_type<D, 1> meas_local;
-        edm::get_measurement_local<algebra_t>(
-            measurements.at(trk_state.measurement_index()), meas_local);
-
-        assert((dim > 1) || (getter::element(meas_local, 1u, 0u) == 0.f));
-
         TRACCC_DEBUG_HOST("Predicted param.: " << bound_params);
 
         // Predicted vector of bound track parameters
@@ -82,33 +72,21 @@ struct gain_matrix_updater {
         // Predicted covaraince of bound track parameters
         const bound_matrix_type& predicted_cov = bound_params.covariance();
 
-        const subspace<algebra_t, e_bound_size> subs(
-            measurements.at(trk_state.measurement_index()).subspace());
-        matrix_type<D, e_bound_size> H = subs.template projector<D>();
-
-        // Flip the sign of projector matrix element in case the first element
-        // of line measurement is negative
-        if (is_line && getter::element(predicted_vec, e_bound_loc0, 0u) < 0) {
-            getter::element(H, 0u, e_bound_loc0) = -1;
-        }
-
-        // @TODO: Fix properly
-        if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
-            getter::element(H, 1u, 0u) = 0.f;
-            getter::element(H, 1u, 1u) = 0.f;
-        }
+        // Measurement data on surface
+        const matrix_type<D, 1> meas_local =
+            measurement_selector::calibrated_measurement_position<algebra_t, D>(
+                measurement, calib_cfg);
 
         // Spatial resolution (Measurement covariance)
-        matrix_type<D, D> V;
-        edm::get_measurement_covariance<algebra_t>(
-            measurements.at(trk_state.measurement_index()), V);
-        // @TODO: Fix properly
-        if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
-            getter::element(V, 1u, 1u) = 1000.f;
-        }
+        const matrix_type<D, D> V =
+            measurement_selector::calibrated_measurement_covariance<algebra_t,
+                                                                    D>(
+                measurement, calib_cfg);
 
-        TRACCC_DEBUG_HOST("-> Measurement position:\n" << meas_local);
-        TRACCC_DEBUG_HOST("-> Measurement variance:\n" << V);
+        const matrix_type<D, e_bound_size> H =
+            measurement_selector::observation_model<algebra_t, D>(
+                measurement, bound_params, is_line);
+
         TRACCC_DEBUG_HOST("-> Predicted residual:\n"
                           << meas_local - H * predicted_vec);
 
@@ -149,6 +127,16 @@ struct gain_matrix_updater {
             return kalman_fitter_status::ERROR_QOP_ZERO;
         }
 
+        // Wrap the phi and theta angles in their valid ranges
+        if (!normalize_angles<algebra_t>(filtered_vec)) {
+            TRACCC_ERROR_HOST_DEVICE("Hit theta pole in filtering!");
+            return kalman_fitter_status::ERROR_THETA_POLE;
+        }
+
+        // Some identity matrices
+        // @TODO: Make constexpr work
+        const auto I66 = matrix::identity<bound_matrix_type>();
+
         const matrix_type<6, 6> i_minus_kh = I66 - K * H;
         matrix_type<6, 6> filtered_cov =
             i_minus_kh * predicted_cov * matrix::transpose(i_minus_kh) +
@@ -162,12 +150,6 @@ struct gain_matrix_updater {
             !details::regularize_covariance<algebra_t>(filtered_cov, min_var)) {
             TRACCC_ERROR_HOST_DEVICE("Negative variance after filtering");
             return kalman_fitter_status::ERROR_UPDATER_INVALID_COVARIANCE;
-        }
-
-        // Wrap the phi and theta angles in their valid ranges
-        if (!normalize_angles<algebra_t>(filtered_vec)) {
-            TRACCC_ERROR_HOST_DEVICE("Hit theta pole in filtering!");
-            return kalman_fitter_status::ERROR_THETA_POLE;
         }
 
         // Set the chi2 for this track and measurement

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -66,7 +66,6 @@ struct gain_matrix_updater {
         // Some identity matrices
         // @TODO: Make constexpr work
         const auto I66 = matrix::identity<bound_matrix_type>();
-        const auto I_m = matrix::identity<matrix_type<D, D>>();
 
         // Measurement data on surface
         matrix_type<D, 1> meas_local;
@@ -165,35 +164,6 @@ struct gain_matrix_updater {
             return kalman_fitter_status::ERROR_UPDATER_INVALID_COVARIANCE;
         }
 
-        // Residual between measurement and (projected) filtered vector
-        const matrix_type<D, 1> residual = meas_local - H * filtered_vec;
-
-        // Calculate the chi square
-        const matrix_type<D, D> R = (I_m - H * K) * V;
-        const matrix_type<1, 1> chi2 = matrix::transposed_product<true, false>(
-                                           residual, matrix::inverse(R)) *
-                                       residual;
-
-        const scalar chi2_val{getter::element(chi2, 0, 0)};
-
-        TRACCC_DEBUG_HOST("-> Filtered residual:\n" << residual);
-        TRACCC_DEBUG_HOST("-> R:\n" << R);
-        TRACCC_DEBUG_HOST("-> det(R): " << std::scientific
-                                        << matrix::determinant(R)
-                                        << std::defaultfloat);
-        TRACCC_DEBUG_HOST("-> R_inv:\n" << matrix::inverse(R));
-        TRACCC_VERBOSE_HOST_DEVICE("-> Chi2: %f", chi2_val);
-
-        if (chi2_val < 0.f) {
-            TRACCC_ERROR_HOST_DEVICE("Chi2 negative");
-            return kalman_fitter_status::ERROR_UPDATER_CHI2_NEGATIVE;
-        }
-
-        if (!std::isfinite(chi2_val)) {
-            TRACCC_ERROR_HOST_DEVICE("Chi2 infinite");
-            return kalman_fitter_status::ERROR_UPDATER_CHI2_NOT_FINITE;
-        }
-
         // Wrap the phi and theta angles in their valid ranges
         if (!normalize_angles<algebra_t>(filtered_vec)) {
             TRACCC_ERROR_HOST_DEVICE("Hit theta pole in filtering!");
@@ -203,7 +173,6 @@ struct gain_matrix_updater {
         // Set the chi2 for this track and measurement
         trk_state.filtered_params().set_vector(filtered_vec);
         trk_state.filtered_params().set_covariance(filtered_cov);
-        trk_state.filtered_chi2() = chi2_val;
 
         assert(!trk_state.filtered_params().is_invalid());
 

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -14,6 +14,7 @@
 #include "traccc/edm/track_state_collection.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
 #include "traccc/fitting/kalman_filter/is_line_visitor.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/fitting/kalman_filter/two_filters_smoother.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/utils/logging.hpp"
@@ -50,11 +51,13 @@ struct kalman_actor_state {
         const typename edm::track_state_collection<algebra_t>::device&
             track_states,
         const edm::measurement_collection::const_device& measurements,
-        vecmem::device_vector<surface_t> sequence)
+        vecmem::device_vector<surface_t> sequence,
+        const measurement_selector::config& calib_cfg)
         : m_track{track},
           m_track_states{track_states},
           m_measurements{measurements},
-          m_sequencer{sequence} {
+          m_sequencer{sequence},
+          m_calib_cfg{calib_cfg} {
 
         reset();
     }
@@ -311,6 +314,9 @@ struct kalman_actor_state {
     /// The surface sequencer
     sequencer_t m_sequencer;
 
+    /// Measurement calibration configuration
+    measurement_selector::config m_calib_cfg{};
+
     /// Index of the current track state
     int m_idx;
 
@@ -408,6 +414,9 @@ struct kalman_actor : detray::base_actor {
             const auto sf = navigation.current_surface();
             const bool is_line = detail::is_line(sf);
 
+            const auto measurement =
+                actor_state.m_measurements.at(trk_state.measurement_index());
+
             if (!actor_state.backward_mode) {
                 if constexpr (direction_e ==
                                   kalman_actor_direction::FORWARD_ONLY ||
@@ -419,11 +428,17 @@ struct kalman_actor : detray::base_actor {
                     // Forward filter
                     TRACCC_DEBUG_HOST_DEVICE("Run filtering...");
                     actor_state.fit_result = gain_matrix_updater<algebra_t>{}(
-                        trk_state, actor_state.m_measurements, bound_param,
-                        is_line);
+                        trk_state, measurement, bound_param,
+                        actor_state.m_calib_cfg, is_line);
 
                     // Update the propagation flow
                     bound_param = trk_state.filtered_params();
+
+                    // Calculate the chi2 on the filtered parameters
+                    trk_state.filtered_chi2() =
+                        measurement_selector::predicted_chi2(
+                            measurement, bound_param, actor_state.m_calib_cfg,
+                            is_line);
 
                     // Add this to the surface sequence for the backward fit
                     actor_state.add_to_sequence(
@@ -449,8 +464,8 @@ struct kalman_actor : detray::base_actor {
                     } else {
                         actor_state.fit_result =
                             two_filters_smoother<algebra_t>{}(
-                                trk_state, actor_state.m_measurements,
-                                bound_param, is_line);
+                                trk_state, measurement, bound_param,
+                                actor_state.m_calib_cfg, is_line);
                     }
                 } else {
                     assert(false);

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -17,6 +17,7 @@
 #include "traccc/fitting/fitting_config.hpp"
 #include "traccc/fitting/kalman_filter/kalman_actor.hpp"
 #include "traccc/fitting/kalman_filter/kalman_step_aborter.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/fitting/kalman_filter/statistics_updater.hpp"
 #include "traccc/fitting/kalman_filter/two_filters_smoother.hpp"
 #include "traccc/fitting/status_codes.hpp"
@@ -118,11 +119,13 @@ class kalman_fitter {
                 track_states,
             const edm::measurement_collection::const_device& measurements,
             vecmem::data::vector_view<surface_type> sequence_buffer,
-            const detray::propagation::config& prop_cfg)
+            const detray::propagation::config& prop_cfg,
+            const measurement_selector::config& calib_cfg)
             : m_updater_state{prop_cfg},
               m_fit_actor_state{
                   track, track_states, measurements,
-                  vecmem::device_vector<surface_type>(sequence_buffer)},
+                  vecmem::device_vector<surface_type>(sequence_buffer),
+                  calib_cfg},
               m_fit_res{track},
               m_sequence_buffer{sequence_buffer} {}
 

--- a/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
+++ b/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
@@ -1,0 +1,285 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/definitions/track_parametrization.hpp"
+#include "traccc/edm/measurement_collection.hpp"
+#include "traccc/edm/measurement_helpers.hpp"
+#include "traccc/utils/logging.hpp"
+#include "traccc/utils/subspace.hpp"
+
+// System include(s)
+#include <limits>
+
+namespace traccc {
+
+/// Potential next measurement to be added to track
+struct candidate_measurement {
+    unsigned int meas_idx{std::numeric_limits<unsigned int>::max()};
+    float chi2{std::numeric_limits<float>::max()};
+
+    /// Define comparisons
+    TRACCC_HOST_DEVICE
+    constexpr bool operator<=>(const candidate_measurement& other) const =
+        default;
+};
+/// @}
+
+/// Associate a measurement to a candidate track
+struct measurement_selector {
+
+    template <detray::concepts::algebra A, unsigned int ROWS, unsigned int COLS>
+    using matrix_t = detray::dmatrix<A, ROWS, COLS>;
+
+    // Where to get the calibration from
+    struct config { /*TODO: implement calibration handling*/
+    };
+
+    /// Get the observation model for a given measurement
+    ///
+    /// @param measurement the measurement
+    /// @param bound_params predicted bound track parameters
+    /// @param is_line whether the measurement belong to a line surface
+    ///
+    /// @returns the projection matrix H
+    template <detray::concepts::algebra algebra_t, unsigned int D,
+              typename measurement_backend_t>
+    TRACCC_HOST_DEVICE static detray::dmatrix<algebra_t, D, e_bound_size>
+    observation_model(
+        const edm::measurement<measurement_backend_t>& measurement,
+        const bound_track_parameters<algebra_t>& bound_params,
+        const bool is_line) {
+
+        // Oservation model: Subspace of measurement space for this measurement
+        const subspace<algebra_t, e_bound_size> subs(measurement.subspace());
+        detray::dmatrix<algebra_t, D, e_bound_size> H =
+            subs.template projector<D>();
+
+        // Flip the sign of projector matrix element in case the first element
+        // of a line measurement is negative
+        if (is_line && bound_params.bound_local()[e_bound_loc0] < 0) {
+            getter::element(H, 0u, e_bound_loc0) = -1;
+        }
+
+        detray::dmatrix<algebra_t, D, 1> meas_local;
+        edm::get_measurement_local<algebra_t>(measurement, meas_local);
+        if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
+            // if (measurement.dimensions() == 1) {
+            getter::element(H, 1u, 0u) = 0.f;
+            getter::element(H, 1u, 1u) = 0.f;
+        }
+
+        TRACCC_DEBUG_HOST("--> Observation model (H):\n" << H);
+
+        return H;
+    }
+
+    /// Get the calibrated measurement position
+    ///
+    /// @param measurement the measurement
+    /// @param cfg how to apply calibrations
+    ///
+    /// @returns the projection matrix H
+    template <detray::concepts::algebra algebra_t, unsigned int D,
+              typename measurement_backend_t>
+    TRACCC_HOST_DEVICE static detray::dmatrix<algebra_t, D, 1>
+    calibrated_measurement_position(
+        const edm::measurement<measurement_backend_t>& measurement,
+        const config& /*cfg*/) {
+
+        // Measurement data on surface
+        detray::dmatrix<algebra_t, D, 1> meas_local;
+        edm::get_measurement_local<algebra_t>(measurement, meas_local);
+
+        TRACCC_DEBUG_HOST("--> Measurement position (uncalibrated):\n"
+                          << meas_local);
+
+        assert((measurement.dimensions() > 1) ||
+               (getter::element(meas_local, 1u, 0u) == 0.f));
+
+        return meas_local;
+    }
+
+    /// Get the calibrated measurement covariance
+    ///
+    /// @param measurement the measurement
+    /// @param cfg how to apply calibrations
+    ///
+    /// @returns the projection matrix H
+    template <detray::concepts::algebra algebra_t, unsigned int D,
+              typename measurement_backend_t>
+    TRACCC_HOST_DEVICE static detray::dmatrix<algebra_t, D, D>
+    calibrated_measurement_covariance(
+        const edm::measurement<measurement_backend_t>& measurement,
+        const config& /*cfg*/) {
+
+        // Measurement covariance
+        detray::dmatrix<algebra_t, D, D> V;
+        edm::get_measurement_covariance<algebra_t>(measurement, V);
+
+        detray::dmatrix<algebra_t, D, 1> meas_local;
+        edm::get_measurement_local<algebra_t>(measurement, meas_local);
+        // @TODO: Fix properly
+        if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
+            // if (measurement.dimensions() == 1) {
+            getter::element(V, 1u, 1u) = 10000.f;
+        }
+
+        TRACCC_DEBUG_HOST("--> Measurement covariance (uncalibrated):\n" << V);
+
+        return V;
+    }
+
+    /// Calculate the predicted chi2
+    ///
+    /// @brief Based on "Application of Kalman filtering to track and vertex
+    /// fitting", R.Frühwirth, NIM A
+    ///
+    /// @param measurement the measurement
+    /// @param bound_params predicted bound track parameters
+    /// @param cfg the calibration configuration
+    /// @param is_line whether the measurement belong to a line surface
+    ///
+    /// @returns the predicted chi2 of the calibrated measurement
+    template <typename measurement_backend_t,
+              detray::concepts::algebra algebra_t>
+    TRACCC_HOST_DEVICE static detray::dscalar<algebra_t> predicted_chi2(
+        const edm::measurement<measurement_backend_t>& measurement,
+        const bound_track_parameters<algebra_t>& bound_params,
+        const config& cfg, const bool is_line) {
+
+        using scalar_t = detray::dscalar<algebra_t>;
+
+        // Measurement maximal dimension
+        constexpr unsigned int D = 2;
+
+        TRACCC_VERBOSE_HOST_DEVICE("--> dim: %d", measurement.dimensions());
+
+        assert(measurement.dimensions() == 1u ||
+               measurement.dimensions() == 2u);
+
+        assert(!bound_params.is_invalid());
+        assert(!bound_params.surface_link().is_invalid());
+
+        // Get calibrated measurement and covariance
+        const matrix_t<algebra_t, D, 1> meas_local =
+            calibrated_measurement_position<algebra_t, D>(measurement, cfg);
+
+        const matrix_t<algebra_t, D, D> V =
+            calibrated_measurement_covariance<algebra_t, D>(measurement, cfg);
+
+        // Project the predicted covariance to the observation
+        const matrix_t<algebra_t, D, e_bound_size> H =
+            observation_model<algebra_t, D>(measurement, bound_params, is_line);
+
+        const matrix_t<algebra_t, D, D> R =
+            H * matrix::transposed_product<false, true>(
+                    bound_params.covariance(), H) +
+            V;
+
+        TRACCC_DEBUG_HOST("--> R:\n" << R);
+        TRACCC_DEBUG_HOST_DEVICE("--> det(R): %.10e", matrix::determinant(R));
+        TRACCC_DEBUG_HOST("--> R_inv:\n" << matrix::inverse(R));
+
+        // Residual between measurement and (projected) vector (innovation)
+        const matrix_t<algebra_t, D, 1> residual =
+            meas_local - H * bound_params.vector();
+
+        TRACCC_DEBUG_HOST("--> Predicted residual:\n" << residual);
+
+        const matrix_t<algebra_t, 1, 1> pred_chi2 =
+            matrix::transposed_product<true, false>(
+                residual, traccc::matrix::inverse(R)) *
+            residual;
+
+        const scalar_t pred_chi2_val{getter::element(pred_chi2, 0, 0)};
+
+        TRACCC_VERBOSE_HOST_DEVICE("--> chi2: %.10e", pred_chi2_val);
+
+        return pred_chi2_val;
+    }
+
+    /// Measurement selection (optimal)
+    ///
+    /// @param bound_params predicted bound track parameters
+    /// @param measurements the measurement container
+    /// @param meas_range contains the index ranges into the measurements
+    /// @param cfg the calibration configuration
+    /// @param is_line whether the measurement belong to a line surface
+    ///
+    /// @returns the optimal candidate measurement for the input params
+    template <detray::concepts::algebra algebra_t>
+    TRACCC_HOST_DEVICE static candidate_measurement find_optimal_measurement(
+        const bound_track_parameters<algebra_t>& bound_params,
+        const typename edm::measurement_collection::const_device& measurements,
+        vecmem::device_vector<unsigned int> meas_ranges, const config& cfg,
+        const bool is_line) {
+
+        using scalar_t = detray::dscalar<algebra_t>;
+
+        // The optimal candidate
+        candidate_measurement cand{};
+
+        // Iterate over the measurements for this surface
+        const unsigned int sf_idx{bound_params.surface_link().index()};
+        const unsigned int lo{sf_idx == 0u ? 0u : meas_ranges[sf_idx - 1]};
+        const unsigned int up{meas_ranges[sf_idx]};
+
+        TRACCC_VERBOSE_HOST_DEVICE("Have %d measurement(s) on surface %d...",
+                                   up - lo, sf_idx);
+
+        // Find the best fitting measurement by prediced chi2
+        // TODO: Load balancing
+        for (unsigned int meas_idx = lo; meas_idx < up; meas_idx++) {
+
+            TRACCC_VERBOSE_HOST_DEVICE("-> measurement %d:", meas_idx);
+
+            // Predicted chi2
+            const scalar_t chi2 = measurement_selector::predicted_chi2(
+                measurements.at(meas_idx), bound_params, cfg, is_line);
+
+            // Check predicted chi2 cut
+            if (chi2 < cand.chi2) {
+                cand = {meas_idx, static_cast<float>(chi2)};
+                // Found optimal
+                if (cand.chi2 <= std::numeric_limits<scalar_t>::epsilon()) {
+                    return cand;
+                }
+            }
+        }
+
+        return cand;
+    }
+
+    /// Measurement selection (collection of compatible measurements)
+    ///
+    /// @param bound_params predicted bound track parameters
+    /// @param measurements the measurement container
+    /// @param meas_range contains the index ranges into the measurements
+    /// @param cfg the calibration configuration
+    /// @param is_line whether the measurement belong to a line surface
+    ///
+    /// @returns a collection of compatible measurements, sorted by pred. chi2
+    template <detray::concepts::algebra algebra_t>
+    TRACCC_HOST_DEVICE static vecmem::vector<candidate_measurement>
+    find_compatible_measurements(
+        const bound_track_parameters<algebra_t>& /*bound_params*/,
+        const typename edm::measurement_collection::const_device&
+        /*measurements*/,
+        vecmem::device_vector<unsigned int> /*meas_ranges*/,
+        const config& /*cfg*/, const bool /*is_line*/) {
+        /* TODO: Implement*/
+        assert(false);
+        return {};
+    }
+};
+
+}  // namespace traccc

--- a/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
+++ b/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
@@ -13,6 +13,7 @@
 #include "traccc/definitions/track_parametrization.hpp"
 #include "traccc/edm/measurement_collection.hpp"
 #include "traccc/edm/measurement_helpers.hpp"
+#include "traccc/edm/track_parameters.hpp"
 #include "traccc/utils/logging.hpp"
 #include "traccc/utils/subspace.hpp"
 
@@ -202,7 +203,13 @@ struct measurement_selector {
 
         const scalar_t pred_chi2_val{getter::element(pred_chi2, 0, 0)};
 
-        TRACCC_VERBOSE_HOST_DEVICE("--> chi2: %.10e", pred_chi2_val);
+        if (!std::isfinite(pred_chi2_val)) {
+            TRACCC_WARNING_HOST_DEVICE("Infinite predicted chi2 value!");
+        } else if (pred_chi2_val < 0.f) {
+            TRACCC_WARNING_HOST_DEVICE("Negative predicted chi2 value!");
+        } else {
+            TRACCC_VERBOSE_HOST_DEVICE("--> chi2: %.10e", pred_chi2_val);
+        }
 
         return pred_chi2_val;
     }
@@ -267,7 +274,8 @@ struct measurement_selector {
     /// @param cfg the calibration configuration
     /// @param is_line whether the measurement belong to a line surface
     ///
-    /// @returns a collection of compatible measurements, sorted by pred. chi2
+    /// @returns a collection of compatible measurements, sorted by pred.
+    /// chi2
     template <detray::concepts::algebra algebra_t>
     TRACCC_HOST_DEVICE static vecmem::vector<candidate_measurement>
     find_compatible_measurements(

--- a/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
@@ -14,6 +14,7 @@
 #include "traccc/edm/measurement_helpers.hpp"
 #include "traccc/edm/track_state_collection.hpp"
 #include "traccc/fitting/details/regularize_covariance.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/utils/logging.hpp"
 
@@ -36,17 +37,17 @@ struct two_filters_smoother {
     /// @param bound_params bound parameter
     ///
     /// @return true if the update succeeds
+    template <typename track_state_backend_t, typename measurement_backend_t>
     [[nodiscard]] TRACCC_HOST_DEVICE inline kalman_fitter_status operator()(
-        typename edm::track_state_collection<algebra_t>::device::proxy_type&
-            trk_state,
-        const edm::measurement_collection::const_device& measurements,
+        typename edm::track_state<track_state_backend_t>& trk_state,
+        const edm::measurement<measurement_backend_t>& measurement,
         bound_track_parameters<algebra_t>& bound_params,
+        const measurement_selector::config& calib_cfg,
         const bool is_line) const {
 
         static constexpr unsigned int D = 2;
 
-        [[maybe_unused]] const unsigned int dim{
-            measurements.at(trk_state.measurement_index()).dimensions()};
+        [[maybe_unused]] const unsigned int dim{measurement.dimensions()};
 
         assert(dim == 1u || dim == 2u);
 
@@ -61,13 +62,6 @@ struct two_filters_smoother {
             TRACCC_ERROR_HOST(trk_state.filtered_params());
             return kalman_fitter_status::ERROR_UPDATER_SKIPPED_STATE;
         }
-
-        // Measurement data on surface
-        matrix_type<D, 1> meas_local;
-        edm::get_measurement_local<algebra_t>(
-            measurements.at(trk_state.measurement_index()), meas_local);
-
-        assert((dim > 1) || (getter::element(meas_local, 1u, 0u) == 0.f));
 
         // Predicted vector of bound track parameters
         const matrix_type<e_bound_size, 1>& predicted_vec =
@@ -131,28 +125,23 @@ struct two_filters_smoother {
             return kalman_fitter_status::ERROR_THETA_POLE;
         }
 
-        const subspace<algebra_t, e_bound_size> subs(
-            measurements.at(trk_state.measurement_index()).subspace());
-        matrix_type<D, e_bound_size> H = subs.template projector<D>();
-        // @TODO: Fix properly
-        if (getter::element(meas_local, 1u, 0u) == 0.f /*dim == 1*/) {
-            getter::element(H, 1u, 0u) = 0.f;
-            getter::element(H, 1u, 1u) = 0.f;
-        }
+        // Measurement data on surface
+        const matrix_type<D, 1> meas_local =
+            measurement_selector::calibrated_measurement_position<algebra_t, D>(
+                measurement, calib_cfg);
+
+        // Spatial resolution (Measurement covariance)
+        const matrix_type<D, D> V =
+            measurement_selector::calibrated_measurement_covariance<algebra_t,
+                                                                    D>(
+                measurement, calib_cfg);
+
+        matrix_type<D, e_bound_size> H =
+            measurement_selector::observation_model<algebra_t, D>(
+                measurement, bound_params, is_line);
 
         const matrix_type<D, 1> residual_smt = meas_local - H * smoothed_vec;
 
-        // Spatial resolution (Measurement covariance)
-        matrix_type<D, D> V;
-        edm::get_measurement_covariance<algebra_t>(
-            measurements.at(trk_state.measurement_index()), V);
-        // @TODO: Fix properly
-        if (getter::element(meas_local, 1u, 0u) == 0.f /*dim == 1*/) {
-            getter::element(V, 1u, 1u) = 1000.f;
-        }
-
-        TRACCC_DEBUG_HOST("Measurement position: " << meas_local);
-        TRACCC_DEBUG_HOST("Measurement variance:\n" << V);
         TRACCC_DEBUG_HOST("Predicted residual: " << meas_local -
                                                         H * predicted_vec);
 
@@ -195,12 +184,6 @@ struct two_filters_smoother {
         /*************************************
          *  Set backward filtered parameter
          *************************************/
-
-        // Flip the sign of projector matrix element in case the first element
-        // of line measurement is negative
-        if (is_line && getter::element(predicted_vec, e_bound_loc0, 0u) < 0) {
-            getter::element(H, 0u, e_bound_loc0) = -1;
-        }
 
         const auto I66 =
             matrix::identity<matrix_type<e_bound_size, e_bound_size>>();

--- a/core/include/traccc/fitting/status_codes.hpp
+++ b/core/include/traccc/fitting/status_codes.hpp
@@ -20,14 +20,12 @@ enum class kalman_fitter_status : uint32_t {
     ERROR_SMOOTHER_CHI2_NOT_FINITE = 5u,
     ERROR_SMOOTHER_INVALID_COVARIANCE = 6u,
     ERROR_SMOOTHER_SKIPPED_STATE = 7u,
-    ERROR_UPDATER_CHI2_NEGATIVE = 8u,
-    ERROR_UPDATER_CHI2_NOT_FINITE = 9u,
-    ERROR_UPDATER_INVALID_COVARIANCE = 10u,
-    ERROR_UPDATER_SKIPPED_STATE = 11u,
-    ERROR_GEOID_SEQUENCE_OVERFLOW = 12u,
-    ERROR_PROPAGATION_FAILURE = 13u,
-    ERROR_OTHER = 14u,
-    MAX_STATUS = 15u
+    ERROR_UPDATER_INVALID_COVARIANCE = 8u,
+    ERROR_UPDATER_SKIPPED_STATE = 9u,
+    ERROR_GEOID_SEQUENCE_OVERFLOW = 10u,
+    ERROR_PROPAGATION_FAILURE = 11u,
+    ERROR_OTHER = 12u,
+    MAX_STATUS = 13u
 };
 
 /// Convert a status code into a human readable string
@@ -60,12 +58,6 @@ struct fitter_debug_msg {
             }
             case ERROR_SMOOTHER_SKIPPED_STATE: {
                 return msg + "Skipped track state during smoothing";
-            }
-            case ERROR_UPDATER_CHI2_NEGATIVE: {
-                return msg + "Negative chi2 in gain matrix updater";
-            }
-            case ERROR_UPDATER_CHI2_NOT_FINITE: {
-                return msg + "Invalid chi2 in gain matrix updater";
             }
             case ERROR_UPDATER_INVALID_COVARIANCE: {
                 return msg + "Invalid track covariance in forward fit";

--- a/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
@@ -135,11 +135,12 @@ struct build_tracks {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(
         TAcc const& acc, bool run_mbf,
+        const measurement_selector::config& calib_cfg,
         const device::build_tracks_payload payload) const {
 
         device::global_index_t globalThreadIdx =
             ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
-        device::build_tracks(globalThreadIdx, run_mbf, payload);
+        device::build_tracks(globalThreadIdx, run_mbf, calib_cfg, payload);
     }
 };
 
@@ -602,7 +603,7 @@ combinatorial_kalman_filter(
 
         ::alpaka::exec<Acc>(
             queue, workDiv, kernels::build_tracks{},
-            false && config.run_mbf_smoother,
+            false && config.run_mbf_smoother, config.meas_calibration,
             device::build_tracks_payload{
                 .seeds_view = seeds,
                 .links_view = links_buffer,

--- a/device/common/include/traccc/finding/device/build_tracks.hpp
+++ b/device/common/include/traccc/finding/device/build_tracks.hpp
@@ -16,6 +16,7 @@
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/finding/finding_config.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 
 // VecMem include(s).
 #include <vecmem/containers/data/jagged_vector_view.hpp>
@@ -65,6 +66,7 @@ struct build_tracks_payload {
 ///
 TRACCC_HOST_DEVICE inline void build_tracks(
     global_index_t globalIndex, bool run_mbf,
+    const measurement_selector::config calib_cfg,
     const build_tracks_payload& payload);
 
 }  // namespace traccc::device

--- a/device/common/include/traccc/finding/device/impl/build_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/build_tracks.ipp
@@ -13,6 +13,7 @@
 #include "traccc/edm/measurement_helpers.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/edm/track_state_helpers.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/utils/prob.hpp"
 #include "traccc/utils/subspace.hpp"
 
@@ -20,6 +21,7 @@ namespace traccc::device {
 
 TRACCC_HOST_DEVICE inline void build_tracks(
     const global_index_t globalIndex, bool run_mbf,
+    const measurement_selector::config calib_cfg,
     const build_tracks_payload& payload) {
 
     const edm::measurement_collection::const_device measurements(
@@ -132,31 +134,22 @@ TRACCC_HOST_DEVICE inline void build_tracks(
                                  big_lambda_tilde * accumulated_jacobian;
             }
 
+            const edm::measurement meas = measurements.at(L.meas_idx);
+
             // Measurement data on surface
-            detray::dmatrix<default_algebra, 2, 1> meas_local;
-            edm::get_measurement_local<default_algebra>(
-                measurements.at(L.meas_idx), meas_local);
-
-            // WARNING: This code doesn't currently work with line surfaces
-            const subspace<default_algebra, e_bound_size> subs(
-                measurements.at(L.meas_idx).subspace());
-            detray::dmatrix<default_algebra, 2, e_bound_size> H =
-                subs.template projector<2>();
-
-            // TODO: Fix properly
-            if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
-                getter::element(H, 1u, 0u) = 0.f;
-                getter::element(H, 1u, 1u) = 0.f;
-            }
+            const detray::dmatrix<default_algebra, 2, 1> meas_local =
+                measurement_selector::calibrated_measurement_position<
+                    default_algebra, 2>(meas, calib_cfg);
 
             // Spatial resolution (Measurement covariance)
-            detray::dmatrix<default_algebra, 2, 2> V;
-            edm::get_measurement_covariance<default_algebra>(
-                measurements.at(L.meas_idx), V);
-            // TODO: Fix properly
-            if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
-                getter::element(V, 1u, 1u) = 1000.f;
-            }
+            const detray::dmatrix<default_algebra, 2, 2> V =
+                measurement_selector::calibrated_measurement_covariance<
+                    default_algebra, 2>(meas, calib_cfg);
+
+            // TODO: Does not work for line surfaces!
+            const detray::dmatrix<default_algebra, 2, e_bound_size> H =
+                measurement_selector::observation_model<default_algebra, 2>(
+                    meas, predicted_params, false);
 
             const auto S = H * predicted_covariance * matrix::transpose(H) + V;
             const auto S_inv = matrix::inverse(S);

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -207,13 +207,11 @@ TRACCC_HOST_DEVICE inline void find_tracks(
                 const detray::tracking_surface sf{det, in_par.surface_link()};
                 const bool is_line = detail::is_line(sf);
 
-                measurement_selector::config calib_cfg{};
-
                 const edm::measurement meas = measurements.at(meas_idx);
 
                 const traccc::scalar chi2 =
-                    measurement_selector::predicted_chi2(meas, in_par,
-                                                         calib_cfg, is_line);
+                    measurement_selector::predicted_chi2(
+                        meas, in_par, cfg.meas_calibration, is_line);
 
                 if (chi2 <= cfg.chi2_max && chi2 >= 0.f) {
                     // The filtered track state
@@ -225,7 +223,8 @@ TRACCC_HOST_DEVICE inline void find_tracks(
                     // Run the Kalman update
                     const kalman_fitter_status res =
                         gain_matrix_updater<algebra_t>{}(
-                            trk_state, measurements, in_par, is_line);
+                            trk_state, meas, in_par, cfg.meas_calibration,
+                            is_line);
 
                     TRACCC_DEBUG_DEVICE("KF status: %d", res);
 

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -25,6 +25,7 @@
 #include "traccc/edm/track_state_helpers.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
 #include "traccc/fitting/kalman_filter/is_line_visitor.hpp"
+#include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/utils/logging.hpp"
 
@@ -43,6 +44,8 @@ TRACCC_HOST_DEVICE inline void find_tracks(
     const thread_id_t& thread_id, const barrier_t& barrier,
     const finding_config& cfg, const find_tracks_payload<detector_t>& payload,
     const find_tracks_shared_payload& shared_payload) {
+
+    using algebra_t = typename detector_t::algebra_type;
 
     const unsigned int in_param_id = thread_id.getGlobalThreadIdX();
     const bool last_step =
@@ -169,10 +172,9 @@ TRACCC_HOST_DEVICE inline void find_tracks(
 
         barrier.blockBarrier();
 
-        std::optional<std::tuple<
-            typename edm::track_state_collection<
-                typename detector_t::algebra_type>::device::object_type,
-            unsigned int, unsigned int>>
+        std::optional<std::tuple<typename edm::track_state_collection<
+                                     algebra_t>::device::object_type,
+                                 unsigned int, unsigned int>>
             result = std::nullopt;
 
         /*
@@ -199,52 +201,52 @@ TRACCC_HOST_DEVICE inline void find_tracks(
                                               ? links.at(prev_link_idx).seed_idx
                                               : owner_global_thread_id;
 
-            bool use_measurement = true;
-
-            if (use_measurement) {
-                if (n_tracks_per_seed.at(seed_idx) >=
-                    cfg.max_num_branches_per_seed) {
-                    use_measurement = false;
-                }
-            }
-
-            if (use_measurement) {
-
-                edm::track_state trk_state =
-                    edm::make_track_state<typename detector_t::algebra_type>(
-                        measurements, meas_idx);
+            if (n_tracks_per_seed.at(seed_idx) <
+                cfg.max_num_branches_per_seed) {
 
                 const detray::tracking_surface sf{det, in_par.surface_link()};
-
                 const bool is_line = detail::is_line(sf);
 
-                // Run the Kalman update
-                const kalman_fitter_status res =
-                    gain_matrix_updater<typename detector_t::algebra_type>{}(
-                        trk_state, measurements, in_par, is_line);
+                measurement_selector::config calib_cfg{};
 
-                TRACCC_DEBUG_DEVICE("KF status: %d", res);
+                const edm::measurement meas = measurements.at(meas_idx);
 
-                /*
-                 * The $\chi^2$ value from the Kalman update should be less than
-                 * `chi2_max`, and the fit should have succeeded. If both
-                 * conditions are true, we emplace the state, the measurement
-                 * index, and the thread ID into an optional value.
-                 *
-                 * NOTE: Using the optional value here allows us to remove the
-                 * depth of if-statements which is important for code quality
-                 * but, more importantly, allows us to more easily use
-                 * block-wide synchronization primitives.
-                 */
-                if (const traccc::scalar chi2 = trk_state.filtered_chi2();
-                    res != kalman_fitter_status::SUCCESS ||
-                    chi2 >= cfg.chi2_max) {
-                    use_measurement = false;
-                }
+                const traccc::scalar chi2 =
+                    measurement_selector::predicted_chi2(meas, in_par,
+                                                         calib_cfg, is_line);
 
-                if (use_measurement) {
-                    TRACCC_VERBOSE_DEVICE("Found measurement: %d", meas_idx);
-                    result.emplace(trk_state, meas_idx, owner_local_thread_id);
+                if (chi2 <= cfg.chi2_max && chi2 >= 0.f) {
+                    // The filtered track state
+                    edm::track_state trk_state =
+                        edm::make_track_state<algebra_t>(measurements,
+                                                         meas_idx);
+                    trk_state.filtered_chi2() = chi2;
+
+                    // Run the Kalman update
+                    const kalman_fitter_status res =
+                        gain_matrix_updater<algebra_t>{}(
+                            trk_state, measurements, in_par, is_line);
+
+                    TRACCC_DEBUG_DEVICE("KF status: %d", res);
+
+                    /*
+                     * The $\chi^2$ value from the Kalman update should be less
+                     * than `chi2_max`, and the fit should have succeeded. If
+                     * both conditions are true, we emplace the state, the
+                     * measurement index, and the thread ID into an optional
+                     * value.
+                     *
+                     * NOTE: Using the optional value here allows us to remove
+                     * the depth of if-statements which is important for code
+                     * quality but, more importantly, allows us to more easily
+                     * use block-wide synchronization primitives.
+                     */
+                    if (res == kalman_fitter_status::SUCCESS) {
+                        TRACCC_VERBOSE_DEVICE("Found measurement: %d",
+                                              meas_idx);
+                        result.emplace(trk_state, meas_idx,
+                                       owner_local_thread_id);
+                    }
                 }
             }
         }

--- a/device/common/include/traccc/fitting/device/fit_backward.hpp
+++ b/device/common/include/traccc/fitting/device/fit_backward.hpp
@@ -40,7 +40,7 @@ TRACCC_HOST_DEVICE inline void fit_backward(
         typename fitter_t::state fitter_state(
             track, tracks.states, tracks.measurements,
             *(payload.surfaces_view.ptr() + param_id),
-            fitter.config().propagation);
+            fitter.config().propagation, fitter.config().meas_calibration);
 
         kalman_fitter_status fit_status = fitter.smooth(fitter_state);
 

--- a/device/common/include/traccc/fitting/device/fit_forward.hpp
+++ b/device/common/include/traccc/fitting/device/fit_forward.hpp
@@ -42,7 +42,8 @@ TRACCC_HOST_DEVICE inline void fit_forward(
 
     typename fitter_t::state fitter_state(
         track, tracks.states, tracks.measurements,
-        *(payload.surfaces_view.ptr() + param_id), fitter.config().propagation);
+        *(payload.surfaces_view.ptr() + param_id), fitter.config().propagation,
+        fitter.config().meas_calibration);
 
     kalman_fitter_status fit_status = fitter.filter(params, fitter_state);
 

--- a/device/cuda/src/finding/combinatorial_kalman_filter.cuh
+++ b/device/cuda/src/finding/combinatorial_kalman_filter.cuh
@@ -689,7 +689,7 @@ combinatorial_kalman_filter(
             .link_filtered_parameter_view = link_filtered_parameter_buffer,
         };
         kernels::build_tracks<<<nBlocks, nThreads, 0, stream>>>(
-            config.run_mbf_smoother, payload);
+            config.run_mbf_smoother, config.meas_calibration, payload);
         TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 
         str.synchronize();

--- a/device/cuda/src/finding/kernels/build_tracks.cu
+++ b/device/cuda/src/finding/kernels/build_tracks.cu
@@ -19,8 +19,9 @@ namespace traccc::cuda::kernels {
 
 __global__ void build_tracks(
     const __grid_constant__ bool run_mbf,
+    const __grid_constant__ measurement_selector::config calib_cfg,
     const __grid_constant__ device::build_tracks_payload payload) {
 
-    device::build_tracks(details::global_index1(), run_mbf, payload);
+    device::build_tracks(details::global_index1(), run_mbf, calib_cfg, payload);
 }
 }  // namespace traccc::cuda::kernels

--- a/device/cuda/src/finding/kernels/build_tracks.cuh
+++ b/device/cuda/src/finding/kernels/build_tracks.cuh
@@ -15,5 +15,6 @@ namespace traccc::cuda::kernels {
 
 __global__ void build_tracks(
     const __grid_constant__ bool run_mbf,
+    const __grid_constant__ measurement_selector::config calib_cfg,
     const __grid_constant__ device::build_tracks_payload payload);
 }

--- a/device/sycl/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/sycl/src/finding/combinatorial_kalman_filter.hpp
@@ -750,7 +750,7 @@ combinatorial_kalman_filter(
                         ::sycl::nd_item<1> item) {
                         device::build_tracks(
                             details::global_index(item),
-                            config.run_mbf_smoother,
+                            config.run_mbf_smoother, config.meas_calibration,
                             {.seeds_view = seeds,
                              .links_view = links,
                              .tips_view = tips,


### PR DESCRIPTION
Use the predicted chi2 in CKF in order to sort measurements, which is faster to compute. Also introduces the `measurement_selector` which abstracts the retrieval of the measurements and their covariances, so that the usage of calibrations can be prepared. The configuration to retrieve the measurement calibration has been added to the track finding and fitting as placeholders.