### PR TITLE
exp: Pre-filter measurements by local radius

### DIFF
--- a/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -243,7 +243,8 @@ combinatorial_kalman_filter(
                 const edm::measurement meas = measurements.at(meas_id);
 
                 const scalar_type chi2 = measurement_selector::predicted_chi2(
-                    meas, in_param, config.meas_calibration, is_line);
+                    meas, in_param, config.meas_calibration, is_line,
+                    config.max_measurement_radius);
 
                 // If the measurement is outside the chi2 cut, skip it
                 if (chi2 > config.chi2_max || chi2 < 0.f) {

--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -57,6 +57,10 @@ struct finding_config {
     /// Maximum Chi-square that is allowed for branching
     float chi2_max = 30.f;
 
+    // Maximal local radius a measurement is allowed to be away from the
+    // predicted track position in order to be considered as a condidate
+    float max_measurement_radius{10.f * traccc::unit<float>::mm};
+
     /// Propagation configuration
     detray::propagation::config propagation{};
     /// Measurement calibration configuration

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/measurement_collection.hpp"
+#include "traccc/edm/measurement_helpers.hpp"
 #include "traccc/edm/track_collection.hpp"
 #include "traccc/edm/track_state_collection.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"

--- a/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
+++ b/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
@@ -148,6 +148,7 @@ struct measurement_selector {
     /// @param bound_params predicted bound track parameters
     /// @param cfg the calibration configuration
     /// @param is_line whether the measurement belong to a line surface
+    /// @param max_dist maximal local distance under which to calculate the chi2
     ///
     /// @returns the predicted chi2 of the calibrated measurement
     template <typename measurement_backend_t,
@@ -155,7 +156,9 @@ struct measurement_selector {
     TRACCC_HOST_DEVICE static detray::dscalar<algebra_t> predicted_chi2(
         const edm::measurement<measurement_backend_t>& measurement,
         const bound_track_parameters<algebra_t>& bound_params,
-        const config& cfg, const bool is_line) {
+        const config& cfg, const bool is_line,
+        const detray::dscalar<algebra_t> max_dist =
+            std::numeric_limits<detray::dscalar<algebra_t>>::max()) {
 
         using scalar_t = detray::dscalar<algebra_t>;
 
@@ -174,12 +177,22 @@ struct measurement_selector {
         const matrix_t<algebra_t, D, 1> meas_local =
             calibrated_measurement_position<algebra_t, D>(measurement, cfg);
 
-        const matrix_t<algebra_t, D, D> V =
-            calibrated_measurement_covariance<algebra_t, D>(measurement, cfg);
-
         // Project the predicted covariance to the observation
         const matrix_t<algebra_t, D, e_bound_size> H =
             observation_model<algebra_t, D>(measurement, bound_params, is_line);
+
+        // Residual between measurement and (projected) vector (innovation)
+        const matrix_t<algebra_t, D, 1> residual =
+            meas_local - H * bound_params.vector();
+
+        const scalar_t loc_0{getter::element(residual, 0u, 0u)};
+        const scalar_t loc_1{getter::element(residual, 1u, 0u)};
+        if (math::sqrt(loc_0 * loc_0 + loc_1 * loc_1) > max_dist) {
+            return std::numeric_limits<scalar_t>::max();
+        }
+
+        const matrix_t<algebra_t, D, D> V =
+            calibrated_measurement_covariance<algebra_t, D>(measurement, cfg);
 
         const matrix_t<algebra_t, D, D> R =
             H * matrix::transposed_product<false, true>(
@@ -189,10 +202,6 @@ struct measurement_selector {
         TRACCC_DEBUG_HOST("--> R:\n" << R);
         TRACCC_DEBUG_HOST_DEVICE("--> det(R): %.10e", matrix::determinant(R));
         TRACCC_DEBUG_HOST("--> R_inv:\n" << matrix::inverse(R));
-
-        // Residual between measurement and (projected) vector (innovation)
-        const matrix_t<algebra_t, D, 1> residual =
-            meas_local - H * bound_params.vector();
 
         TRACCC_DEBUG_HOST("--> Predicted residual:\n" << residual);
 
@@ -274,8 +283,7 @@ struct measurement_selector {
     /// @param cfg the calibration configuration
     /// @param is_line whether the measurement belong to a line surface
     ///
-    /// @returns a collection of compatible measurements, sorted by pred.
-    /// chi2
+    /// @returns a collection of compatible measurements, sorted by pred. chi2
     template <detray::concepts::algebra algebra_t>
     TRACCC_HOST_DEVICE static vecmem::vector<candidate_measurement>
     find_compatible_measurements(

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -22,6 +22,7 @@
 
 // Project include(s).
 #include "traccc/device/array_insertion_mutex.hpp"
+#include "traccc/edm/measurement_helpers.hpp"
 #include "traccc/edm/track_state_helpers.hpp"
 #include "traccc/fitting/kalman_filter/gain_matrix_updater.hpp"
 #include "traccc/fitting/kalman_filter/is_line_visitor.hpp"
@@ -211,7 +212,8 @@ TRACCC_HOST_DEVICE inline void find_tracks(
 
                 const traccc::scalar chi2 =
                     measurement_selector::predicted_chi2(
-                        meas, in_par, cfg.meas_calibration, is_line);
+                        meas, in_par, cfg.meas_calibration, is_line,
+                        cfg.max_measurement_radius);
 
                 if (chi2 <= cfg.chi2_max && chi2 >= 0.f) {
 


### PR DESCRIPTION
Don't consider measurements if they are far away from the local track position. This parameter is configuratble, so that the option can be turned off.