### PR TITLE
Fix Alpaka-HIP InvalidDeviceFunction error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ endif()
 set( CMAKE_CUDA_ARCHITECTURES "75" CACHE STRING
    "CUDA architectures to build device code for" )
 
+# Set the HIP architecture to build code for.
+set( CMAKE_HIP_ARCHITECTURES "gfx1101;gfx90a" CACHE STRING
+   "HIP architectures to build device code for" )
+
 # Flag controlling whether warnings should make the build fail.
 option( TRACCC_FAIL_ON_WARNINGS
    "Make the build fail on compiler/linker warnings" FALSE )


### PR DESCRIPTION
Without this the Alpaka-HIP in Athena crashes with the following error:

```
RAWtoALL 13:15:25 PixelRDO_ContainerCnv                                  0     0    INFO PixelRDO_ContainerCnv::initialize()
RAWtoALL 13:15:25 GPUClusteringAlg                                       0     0   FATAL Standard std::exception is caught in sysExecute
RAWtoALL 13:15:25 GPUClusteringAlg                                       0     0   ERROR parallel_for failed: hipErrorInvalidDeviceFunction: invalid device function
RAWtoALL 13:15:25 GPUClusteringAlg                                       0     0   ERROR Maximum number of errors ( 'ErrorMax':1) reached.
RAWtoALL 13:15:25 AlgTask                                                0     0 WARNING Execution of algorithm GPUClusteringAlg failed
RAWtoALL 13:15:25 BeamSpotCondAlg                                        0     0    INFO Read from condDB status 0 pos (0,0,0) sigma (0.012,0.012,50) tilt (0,0) sigmaXY 0
RAWtoALL 13:15:25 BeamSpotCondAlg                                        0     0    INFO Recorded new InDet::BeamSpotData to BeamSpotData with range {[350200,l:0] - [410000,l:0]} into conditions store.
RAWtoALL 13:15:26 AvalancheSchedulerSvc                                  0     0   ERROR *** Stall detected, event context: s: 0  e: 0
RAWtoALL 13:15:26 AvalancheSchedulerSvc                                  0     0   ERROR Event 0 on slot 0 failed
```

Given that the `CMAKE_CUDA_ARCHITECTURES` is defined in here I followed the lead and added the HIP one as well.
`gfx1101` is needed for the CERN tbed while `gfx90a` was suggested as an extra addition by Stewart.

cc: @stephenswat @krasznaa @StewMH 