### PR TITLE
SYCL Throughput Fix, main branch (2026.05.06.)

### DIFF
--- a/examples/run/sycl/src/full_chain_algorithm.cpp
+++ b/examples/run/sycl/src/full_chain_algorithm.cpp
@@ -126,7 +126,9 @@ full_chain_algorithm::full_chain_algorithm(
     TRACCC_INFO("Using SYCL device: " << m_data->m_queue.device_name());
 
     // Copy the detector (description) to the device.
+    m_copy.setup(m_device_det_descr)->wait();
     m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->wait();
+    m_copy(vecmem::get_data(m_det_cond.get()), m_device_det_cond)->wait();
     if (m_detector != nullptr) {
         m_device_detector =
             traccc::buffer_from_host_detector(*m_detector, m_device_mr, m_copy);
@@ -216,7 +218,9 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
       usingGBTS(parent.usingGBTS) {
 
     // Copy the detector (description) to the device.
+    m_copy.setup(m_device_det_descr)->wait();
     m_copy(vecmem::get_data(m_det_descr.get()), m_device_det_descr)->wait();
+    m_copy(vecmem::get_data(m_det_cond.get()), m_device_det_cond)->wait();
     if (m_detector != nullptr) {
         m_device_detector =
             traccc::buffer_from_host_detector(*m_detector, m_device_mr, m_copy);


### PR DESCRIPTION
I found an oversight from #1272. The detector description is not being copied correctly in `traccc::sycl::full_chain_algorithm`. 😦

Unfortunately this is not great news though. Because I was hoping that the crashes that I was getting very reproducibly with `traccc_throughput_mt_sycl`, would shed a light on the very rare and random crashes that I was seeing with `traccc_throughput_mt_cuda` yesterday...

```
Event processing   [==========>                                       ] 21% [00m:05s] terminate called after throwing an instance of 'vecmem::cuda::runtime_error'
terminate called recursively
  what():  /shared/measurements_2026_05_05/build_main/_deps/vecmem-src/cuda/src/utils/cuda/async_copy.cpp:76 Failed to execute: cudaEventSynchronize(m_event) (an illegal memory access was encountered)
../traccc/extras/traccc_odd_throughput_mt_profiler.sh: line 138: 102737 Aborted                 (core dumped) ${TRACCC_EXECUTABLE} --read-bfield-from-file --bfield-file=geometries/odd/odd-bfield.cvf --input-directory="${TRACCC_INPUT_DIR}/geant4_${EVTDIR}/" --input-events=500 --cpu-threads=${NTHREAD} --cold-run-events=$((5*${NTHREAD})) --processed-events=$((${TRACCC_EVT_COUNT[${EVTDIR}]}*${NTHREAD})) --track-candidates-range=5:100 --seedfinder-vertex-range=-150:150 --max-num-branches-per-seed=2 --initial-links-per-seed=10 --deterministic=1 --log-file="${TRACCC_CSV_FILE}"
```

As I told @stephenswat today, these may be a bit hard to debug unfortunately. As I had to run on a lot of events to see a couple of crashes. 🤔 

Oh, well. At least the easy problem is fixed with this PR.