### PR TITLE
Add accessors for strided vectors of structs

### DIFF
--- a/device/common/include/traccc/device/strided_vector.hpp
+++ b/device/common/include/traccc/device/strided_vector.hpp
@@ -1,0 +1,182 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <vecmem/containers/data/vector_buffer.hpp>
+#include <vecmem/containers/data/vector_view.hpp>
+
+#include "traccc/definitions/qualifiers.hpp"
+
+namespace traccc::device {
+/*
+ * This file contains classes that can be used to access memory in a strided
+ * way with arbitrary, standard C++ structs. The design is similar to that of
+ * vecmem vectors, where memory is owned by a buffer object which can be
+ * passed to a kernel as a view object. The kernel can then create a device
+ * vector out of it in order to load and store elements.
+ *
+ * The purpose of this class is to provide optimal coalescing even when using
+ * large structs. Operates in a similar fashion to CUDA local memory.
+ */
+
+template <typename T, std::size_t MaxStride>
+class strided_vector_view;
+
+/**
+ * @brief Buffer object for a strided vector.
+ *
+ * Simply wraps a vecmem buffer, and must be created from a vecmem buffer.
+ */
+template <typename T, std::size_t MaxStride = 4>
+class strided_vector_buffer {
+    static_assert(MaxStride == 8 || MaxStride == 4 || MaxStride == 2 ||
+                  MaxStride == 1);
+
+    public:
+    TRACCC_HOST_DEVICE strided_vector_buffer(vecmem::data::vector_buffer<T> &&b)
+        : m_buffer(std::move(b)) {}
+
+    private:
+    friend strided_vector_view<T, MaxStride>;
+    vecmem::data::vector_buffer<T> m_buffer;
+};
+
+template <typename T, std::size_t MaxStride>
+class strided_vector_device;
+
+/**
+ * @brief View object for a strided vector.
+ *
+ * Simply wraps a vecmem view. Implicitly creatable from a strided vector
+ * buffer in the same way a vecmem buffer can be turned into a vecmem view.
+ */
+template <typename T, std::size_t MaxStride = 4>
+class strided_vector_view {
+    static_assert(MaxStride == 8 || MaxStride == 4 || MaxStride == 2 ||
+                  MaxStride == 1);
+
+    public:
+    TRACCC_HOST_DEVICE strided_vector_view(
+        const strided_vector_buffer<T, MaxStride> &b)
+        : m_view(b.m_buffer) {}
+
+    private:
+    friend strided_vector_device<T, MaxStride>;
+
+    vecmem::data::vector_view<T> m_view;
+};
+
+/**
+ * @brief Device-side accessor for a strided vector.
+ *
+ * This class supports loading and storing large structs stored in memory in
+ * a strided way. When accessing data in such a vector, we always load at most
+ * `MaxStride` bytes of adjacent memory.
+ */
+template <typename T, std::size_t MaxStride = 4>
+class strided_vector_device {
+    static_assert(MaxStride == 8 || MaxStride == 4 || MaxStride == 2 ||
+                  MaxStride == 1);
+
+    using SIZE_8_TYPE = long;
+    using SIZE_4_TYPE = int;
+    using SIZE_2_TYPE = short;
+    using SIZE_1_TYPE = char;
+
+    static_assert(sizeof(SIZE_8_TYPE) == 8);
+    static_assert(sizeof(SIZE_4_TYPE) == 4);
+    static_assert(sizeof(SIZE_2_TYPE) == 2);
+    static_assert(sizeof(SIZE_1_TYPE) == 1);
+
+    public:
+    TRACCC_HOST_DEVICE strided_vector_device(
+        strided_vector_view<T, MaxStride> &v)
+        : m_ptr(v.m_view.ptr()), m_size(v.m_view.size()) {}
+
+    TRACCC_HOST_DEVICE strided_vector_device(void *ptr, unsigned int size)
+        : m_ptr(ptr), m_size(size) {}
+
+    /**
+     * @brief Store the given object at the given index.
+     */
+    TRACCC_HOST_DEVICE void store(const T &in, unsigned int i) {
+        unsigned int b0 = 0;
+        constexpr unsigned int b = sizeof(T);
+        char *const out_byte_ptr = reinterpret_cast<char *>(m_ptr);
+        const char *const in_byte_ptr = reinterpret_cast<const char *>(&in);
+
+        while (b0 < b) {
+            unsigned int delta = b - b0;
+            if (MaxStride >= 8 && delta >= 8) {
+                *reinterpret_cast<SIZE_8_TYPE *>(out_byte_ptr + b0 * m_size +
+                                                 i * 8) =
+                    *reinterpret_cast<const SIZE_8_TYPE *>(in_byte_ptr + b0);
+                b0 += 8;
+            } else if (MaxStride >= 4 && delta >= 4) {
+                *reinterpret_cast<SIZE_4_TYPE *>(out_byte_ptr + b0 * m_size +
+                                                 i * 4) =
+                    *reinterpret_cast<const SIZE_4_TYPE *>(in_byte_ptr + b0);
+                b0 += 4;
+            } else if (MaxStride >= 2 && delta >= 2) {
+                *reinterpret_cast<SIZE_2_TYPE *>(out_byte_ptr + b0 * m_size +
+                                                 i * 2) =
+                    *reinterpret_cast<const SIZE_2_TYPE *>(in_byte_ptr + b0);
+                b0 += 2;
+            } else if (MaxStride >= 1 && delta >= 1) {
+                *reinterpret_cast<SIZE_1_TYPE *>(out_byte_ptr + b0 * m_size +
+                                                 i) =
+                    *reinterpret_cast<const SIZE_1_TYPE *>(in_byte_ptr + b0);
+                b0 += 1;
+            }
+        }
+    }
+
+    /**
+     * @brief Load an object from the given index.
+     */
+    TRACCC_HOST_DEVICE T load(unsigned int i) {
+        T out;
+        unsigned int b0 = 0;
+        constexpr unsigned int b = sizeof(T);
+        char *const out_byte_ptr = reinterpret_cast<char *>(&out);
+        const char *const in_byte_ptr = reinterpret_cast<const char *>(m_ptr);
+
+        while (b0 < b) {
+            unsigned int delta = b - b0;
+            if (MaxStride >= 8 && delta >= 8) {
+                *reinterpret_cast<SIZE_8_TYPE *>(out_byte_ptr + b0) =
+                    *reinterpret_cast<const SIZE_8_TYPE *>(in_byte_ptr +
+                                                           b0 * m_size + i * 8);
+                b0 += 8;
+            } else if (MaxStride >= 4 && delta >= 4) {
+                *reinterpret_cast<SIZE_4_TYPE *>(out_byte_ptr + b0) =
+                    *reinterpret_cast<const SIZE_4_TYPE *>(in_byte_ptr +
+                                                           b0 * m_size + i * 4);
+                b0 += 4;
+            } else if (MaxStride >= 2 && delta >= 2) {
+                *reinterpret_cast<SIZE_2_TYPE *>(out_byte_ptr + b0) =
+                    *reinterpret_cast<const SIZE_2_TYPE *>(in_byte_ptr +
+                                                           b0 * m_size + i * 2);
+                b0 += 2;
+            } else if (MaxStride >= 1 && delta >= 1) {
+                *reinterpret_cast<SIZE_1_TYPE *>(out_byte_ptr + b0) =
+                    *reinterpret_cast<const SIZE_1_TYPE *>(in_byte_ptr +
+                                                           b0 * m_size + i);
+                b0 += 1;
+            }
+        }
+        return out;
+    }
+
+    private:
+    void *m_ptr;
+    unsigned int m_size;
+};
+}  // namespace traccc::device

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -53,6 +53,7 @@ traccc_add_test(
     test_sanity_contiguous_on.cu
     test_sanity_ordered_on.cu
     test_sort.cu
+    test_strided_vector.cu
 
     LINK_LIBRARIES
     CUDA::cudart

--- a/tests/cuda/test_strided_vector.cu
+++ b/tests/cuda/test_strided_vector.cu
@@ -1,0 +1,292 @@
+/**
+ * traccc library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+
+#include "traccc/device/strided_vector.hpp"
+
+struct MyStruct {
+    int a;
+    bool b;
+    float c;
+    unsigned long d;
+    float e[4];
+
+    bool operator==(const MyStruct &) const = default;
+};
+
+template <typename T>
+struct InitHelper {};
+
+template <>
+struct InitHelper<char> {
+    TRACCC_HOST_DEVICE static char init(unsigned int i) {
+        return static_cast<char>(i % 211);
+    }
+};
+
+template <>
+struct InitHelper<short> {
+    TRACCC_HOST_DEVICE static short init(unsigned int i) {
+        return static_cast<short>(
+            (((i % 2 == 0) ? static_cast<short>(-1) : static_cast<short>(1)) *
+             (991 * i)) %
+            52119);
+    }
+};
+
+template <>
+struct InitHelper<unsigned int> {
+    TRACCC_HOST_DEVICE static unsigned int init(unsigned int i) {
+        return static_cast<unsigned int>((5019291 * i) % 12452119);
+    }
+};
+
+template <>
+struct InitHelper<long> {
+    TRACCC_HOST_DEVICE static long init(unsigned int i) {
+        return static_cast<long>((((i % 2 == 0) ? -1L : 1L) * (991215 * i)) %
+                                 52119215);
+    }
+};
+
+template <>
+struct InitHelper<MyStruct> {
+    TRACCC_HOST_DEVICE static MyStruct init(unsigned int i) {
+        return {
+            static_cast<int>(i * 4),
+            i % 2 == 0,
+            static_cast<float>(i) * 2.3f,
+            i * 410,
+            {static_cast<float>(i), 6.0f, static_cast<float>(i) * 4.4f, 19.4f}};
+    }
+};
+
+template <>
+struct InitHelper<std::array<char, 7>> {
+    TRACCC_HOST_DEVICE static std::array<char, 7> init(unsigned int i) {
+        return {
+            static_cast<char>(i % 21),       static_cast<char>((2 * i) % 61),
+            static_cast<char>((3 * i) % 93), static_cast<char>((4 * i) % 151),
+            static_cast<char>((5 * i) % 51), static_cast<char>((6 * i) % 101),
+            static_cast<char>((7 * i) % 9)};
+    }
+};
+
+template <>
+struct InitHelper<std::array<short, 5>> {
+    TRACCC_HOST_DEVICE static std::array<short, 5> init(unsigned int i) {
+        return {static_cast<char>(i % 21), static_cast<char>((2 * i) % 61),
+                static_cast<char>((3 * i) % 93),
+                static_cast<char>((4 * i) % 151),
+                static_cast<char>((7 * i) % 9)};
+    }
+};
+
+template <typename T, std::size_t MaxStride>
+__global__ void store_kernel_ptr(void *out, unsigned int n) {
+    unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < n) {
+        traccc::device::strided_vector_device<T, MaxStride> acc(out, n);
+
+        acc.store(InitHelper<T>::init(tid), tid);
+    }
+}
+
+template <typename T, std::size_t MaxStride>
+__global__ void load_kernel_ptr(void *in, T *out, unsigned int n) {
+    unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < n) {
+        traccc::device::strided_vector_device<T, MaxStride> acc(in, n);
+
+        out[tid] = acc.load(tid);
+    }
+}
+
+template <typename T, std::size_t MaxStride>
+__global__ void store_kernel_view(
+    traccc::device::strided_vector_view<T, MaxStride> v, unsigned int n) {
+    unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < n) {
+        traccc::device::strided_vector_device<T, MaxStride> acc(v);
+
+        acc.store(InitHelper<T>::init(tid), tid);
+    }
+}
+
+template <typename T, std::size_t MaxStride>
+__global__ void load_kernel_view(
+    traccc::device::strided_vector_view<T, MaxStride> v, T *out,
+    unsigned int n) {
+    unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < n) {
+        traccc::device::strided_vector_device<T, MaxStride> acc(v);
+
+        out[tid] = acc.load(tid);
+    }
+}
+
+template <typename T>
+class CUDAStridedVector : public testing::Test {};
+
+template <typename T, std::size_t MaxStride>
+struct Config {
+    using type = T;
+    static constexpr std::size_t stride = MaxStride;
+};
+
+using TestTypes = ::testing::Types<
+    Config<char, 1>, Config<char, 2>, Config<char, 4>, Config<char, 8>,
+    Config<short, 1>, Config<short, 2>, Config<short, 4>, Config<short, 8>,
+    Config<unsigned int, 1>, Config<unsigned int, 2>, Config<unsigned int, 4>,
+    Config<unsigned int, 8>, Config<long, 1>, Config<long, 2>, Config<long, 4>,
+    Config<long, 8>, Config<MyStruct, 1>, Config<MyStruct, 2>,
+    Config<MyStruct, 4>, Config<MyStruct, 8>, Config<std::array<char, 7>, 1>,
+    Config<std::array<char, 7>, 2>, Config<std::array<char, 7>, 4>,
+    Config<std::array<char, 7>, 8>, Config<std::array<short, 5>, 1>,
+    Config<std::array<short, 5>, 2>, Config<std::array<short, 5>, 4>,
+    Config<std::array<short, 5>, 8>>;
+TYPED_TEST_SUITE(CUDAStridedVector, TestTypes);
+
+static_assert(sizeof(char) == 1);
+static_assert(sizeof(short) == 2);
+static_assert(sizeof(unsigned int) == 4);
+static_assert(sizeof(long) == 8);
+static_assert(sizeof(MyStruct) == 40);
+static_assert(sizeof(std::array<char, 7>) == 7);
+static_assert(sizeof(std::array<short, 5>) == 10);
+
+TYPED_TEST(CUDAStridedVector, FromPointer1024) {
+    unsigned int n = 1024;
+
+    void *tmp;
+    ASSERT_EQ(cudaMallocManaged(&tmp, n * sizeof(typename TypeParam::type)),
+              cudaSuccess);
+
+    typename TypeParam::type *out;
+    cudaMallocManaged(&out, n * sizeof(typename TypeParam::type));
+
+    unsigned int nThreads = 256;
+    unsigned int nBlocks = (n + nThreads - 1) / nThreads;
+
+    store_kernel_ptr<typename TypeParam::type, TypeParam::stride>
+        <<<nBlocks, nThreads>>>(tmp, n);
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    load_kernel_ptr<typename TypeParam::type, TypeParam::stride>
+        <<<nBlocks, nThreads>>>(tmp, out, n);
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    for (unsigned int i = 0; i < n; ++i) {
+        EXPECT_EQ(InitHelper<typename TypeParam::type>::init(i), out[i])
+            << " index " << i;
+    }
+}
+
+TYPED_TEST(CUDAStridedVector, FromPointer531) {
+    unsigned int n = 531;
+
+    void *tmp;
+    ASSERT_EQ(cudaMallocManaged(&tmp, n * sizeof(typename TypeParam::type)),
+              cudaSuccess);
+
+    typename TypeParam::type *out;
+    cudaMallocManaged(&out, n * sizeof(typename TypeParam::type));
+
+    unsigned int nThreads = 256;
+    unsigned int nBlocks = (n + nThreads - 1) / nThreads;
+
+    store_kernel_ptr<typename TypeParam::type, TypeParam::stride>
+        <<<nBlocks, nThreads>>>(tmp, n);
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    load_kernel_ptr<typename TypeParam::type, TypeParam::stride>
+        <<<nBlocks, nThreads>>>(tmp, out, n);
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    for (unsigned int i = 0; i < n; ++i) {
+        EXPECT_EQ(InitHelper<typename TypeParam::type>::init(i), out[i])
+            << " index " << i;
+    }
+}
+
+TYPED_TEST(CUDAStridedVector, FromVecmem1024) {
+    unsigned int n = 1024;
+
+    vecmem::cuda::device_memory_resource device_resource;
+
+    vecmem::data::vector_buffer<typename TypeParam::type> tmp_buff(
+        n, device_resource);
+    traccc::device::strided_vector_buffer<typename TypeParam::type,
+                                          TypeParam::stride>
+        tmp(std::move(tmp_buff));
+
+    typename TypeParam::type *out;
+    cudaMallocManaged(&out, n * sizeof(typename TypeParam::type));
+
+    unsigned int nThreads = 256;
+    unsigned int nBlocks = (n + nThreads - 1) / nThreads;
+
+    store_kernel_view<typename TypeParam::type, TypeParam::stride>
+        <<<nBlocks, nThreads>>>(tmp, n);
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    load_kernel_view<typename TypeParam::type, TypeParam::stride>
+        <<<nBlocks, nThreads>>>(tmp, out, n);
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    for (unsigned int i = 0; i < n; ++i) {
+        EXPECT_EQ(InitHelper<typename TypeParam::type>::init(i), out[i])
+            << " index " << i;
+    }
+}
+
+TYPED_TEST(CUDAStridedVector, FromVecmem531) {
+    unsigned int n = 531;
+
+    vecmem::cuda::device_memory_resource device_resource;
+
+    vecmem::data::vector_buffer<typename TypeParam::type> tmp_buff(
+        n, device_resource);
+    traccc::device::strided_vector_buffer<typename TypeParam::type,
+                                          TypeParam::stride>
+        tmp(std::move(tmp_buff));
+
+    typename TypeParam::type *out;
+    cudaMallocManaged(&out, n * sizeof(typename TypeParam::type));
+
+    unsigned int nThreads = 256;
+    unsigned int nBlocks = (n + nThreads - 1) / nThreads;
+
+    store_kernel_view<typename TypeParam::type, TypeParam::stride>
+        <<<nBlocks, nThreads>>>(tmp, n);
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    load_kernel_view<typename TypeParam::type, TypeParam::stride>
+        <<<nBlocks, nThreads>>>(tmp, out, n);
+    ASSERT_EQ(cudaPeekAtLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    for (unsigned int i = 0; i < n; ++i) {
+        EXPECT_EQ(InitHelper<typename TypeParam::type>::init(i), out[i])
+            << " index " << i;
+    }
+}


### PR DESCRIPTION
This commit adds several new types that allow us to access vectors of structs in a fully strided way, which will allow us to better exploit the coalescing properties of CUDA (and other GPU) devices.