### PR TITLE
Split find tracks kernel into compute and storage

### DIFF
--- a/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/alpaka/src/finding/combinatorial_kalman_filter.hpp
@@ -20,6 +20,7 @@
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/finding/details/combinatorial_kalman_filter_types.hpp"
 #include "traccc/finding/device/build_tracks.hpp"
+#include "traccc/finding/device/condense_tracks.hpp"
 #include "traccc/finding/device/fill_finding_duplicate_removal_sort_keys.hpp"
 #include "traccc/finding/device/fill_finding_propagation_sort_keys.hpp"
 #include "traccc/finding/device/find_tracks.hpp"
@@ -47,8 +48,6 @@ struct find_tracks {
 
         auto& shared_num_out_params =
             ::alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
-        auto& shared_out_offset =
-            ::alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
         auto& shared_candidates_size =
             ::alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
         unsigned long long int* const s =
@@ -65,8 +64,24 @@ struct find_tracks {
 
         device::find_tracks<detector_t>(
             thread_id, barrier, cfg, *payload,
-            {shared_num_out_params, shared_out_offset, shared_insertion_mutex,
-             shared_candidates, shared_candidates_size});
+            {.shared_num_out_params = shared_num_out_params,
+             .shared_insertion_mutex = shared_insertion_mutex,
+             .shared_candidates = shared_candidates,
+             .shared_candidates_size = shared_candidates_size});
+    }
+};
+
+/// Alpaka kernel functor for @c traccc::device::condense_tracks
+template <typename detector_t>
+struct condense_tracks {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        const device::condense_tracks_payload<detector_t>* payload) const {
+
+        const device::global_index_t globalThreadIdx =
+            ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
+        device::condense_tracks<detector_t>(globalThreadIdx, *payload);
     }
 };
 
@@ -343,6 +358,12 @@ combinatorial_kalman_filter(
         }
 
         {
+            vecmem::data::vector_buffer<unsigned int>
+                out_params_per_in_param_buffer(n_in_params, mr.main);
+            copy.setup(out_params_per_in_param_buffer)->ignore();
+            vecmem::data::vector_buffer<unsigned int> out_params_index_buffer(
+                n_in_params, mr.main);
+            copy.setup(out_params_index_buffer)->ignore();
             vecmem::data::vector_buffer<candidate_link> tmp_links_buffer(
                 n_max_candidates, mr.main);
             copy.setup(tmp_links_buffer)->ignore();
@@ -362,20 +383,13 @@ combinatorial_kalman_filter(
                 .links_view = links_buffer,
                 .prev_links_idx =
                     (step == 0 ? 0 : step_to_link_idx_map[step - 1]),
-                .curr_links_idx = step_to_link_idx_map[step],
                 .step = step,
-                .out_params_view = updated_params_buffer,
-                .out_params_liveness_view = updated_liveness_buffer,
+                .out_params_per_in_param_view = out_params_per_in_param_buffer,
                 .tips_view = tips_buffer,
                 .tip_lengths_view = tip_length_buffer,
                 .n_tracks_per_seed_view = n_tracks_per_seed_buffer,
                 .tmp_params_view = tmp_params_buffer,
-                .tmp_links_view = tmp_links_buffer,
-                .jacobian_ptr = jacobian_ptr.get(),
-                .tmp_jacobian_ptr = tmp_jacobian_ptr.get(),
-                .link_predicted_parameter_view =
-                    link_predicted_parameter_buffer,
-                .link_filtered_parameter_view = link_filtered_parameter_buffer};
+                .tmp_links_view = tmp_links_buffer};
             // Now copy it to device memory.
             vecmem::data::vector_buffer<payload_t> device_payload(1u, mr.main);
             copy.setup(device_payload)->wait();
@@ -394,6 +408,67 @@ combinatorial_kalman_filter(
                                 kernels::find_tracks<detector_t>{}, config,
                                 device_payload.ptr());
             ::alpaka::wait(queue);
+
+            {
+                vecmem::device_vector<unsigned int>
+                    out_params_per_in_param_vector(
+                        out_params_per_in_param_buffer);
+                vecmem::device_vector<unsigned int> out_params_index_vector(
+                    out_params_index_buffer);
+                details::inclusive_scan(queue, mr,
+                                        out_params_per_in_param_vector.begin(),
+                                        out_params_per_in_param_vector.end(),
+                                        out_params_index_vector.begin());
+            }
+
+            {
+                using condense_payload_t =
+                    device::condense_tracks_payload<detector_t>;
+                const condense_payload_t condense_host_payload{
+                    .n_in_params = n_in_params,
+                    .step = step,
+                    .curr_links_idx = step_to_link_idx_map[step],
+                    .max_num_branches_per_surface =
+                        config.max_num_branches_per_surface,
+                    .min_track_candidates_per_track =
+                        config.min_track_candidates_per_track,
+                    .max_track_candidates_per_track =
+                        config.max_track_candidates_per_track,
+                    .links_view = links_buffer,
+                    .in_params_view = in_params_buffer,
+                    .in_tmp_params_view = tmp_params_buffer,
+                    .in_tmp_links_view = tmp_links_buffer,
+                    .in_params_index_view = out_params_index_buffer,
+                    .out_params_view = updated_params_buffer,
+                    .out_params_liveness_view = updated_liveness_buffer,
+                    .tips_view = tips_buffer,
+                    .tip_lengths_view = tip_length_buffer,
+                    .jacobian_ptr = jacobian_ptr.get(),
+                    .tmp_jacobian_ptr = tmp_jacobian_ptr.get(),
+                    .link_predicted_parameter_view =
+                        link_predicted_parameter_buffer,
+                    .link_filtered_parameter_view =
+                        link_filtered_parameter_buffer};
+                vecmem::data::vector_buffer<condense_payload_t>
+                    condense_device_payload(1u, mr.main);
+                copy.setup(condense_device_payload)->wait();
+                copy(vecmem::data::vector_view<const condense_payload_t>(
+                         1u, &condense_host_payload),
+                     condense_device_payload)
+                    ->wait();
+
+                const Idx condense_threadsPerBlock = 256;
+                const Idx condense_blocksPerGrid =
+                    (n_in_params + condense_threadsPerBlock - 1) /
+                    condense_threadsPerBlock;
+                const auto condense_workDiv = makeWorkDiv<Acc>(
+                    condense_blocksPerGrid, condense_threadsPerBlock);
+
+                ::alpaka::exec<Acc>(queue, condense_workDiv,
+                                    kernels::condense_tracks<detector_t>{},
+                                    condense_device_payload.ptr());
+                ::alpaka::wait(queue);
+            }
 
             std::swap(in_params_buffer, updated_params_buffer);
             std::swap(param_liveness_buffer, updated_liveness_buffer);

--- a/device/alpaka/src/utils/oneDPL.hpp
+++ b/device/alpaka/src/utils/oneDPL.hpp
@@ -15,3 +15,4 @@
 // oneDPL include(s).
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
+#include <oneapi/dpl/numeric>

--- a/device/alpaka/src/utils/parallel_algorithms.hpp
+++ b/device/alpaka/src/utils/parallel_algorithms.hpp
@@ -112,6 +112,18 @@ void upper_bound(Queue &q, const memory_resource &mr, ForwardIt1 first1,
 #endif
 }
 
+template <typename InputIterator, typename OutputIterator>
+void inclusive_scan(Queue &q, const memory_resource &mr, InputIterator first,
+                    InputIterator last, OutputIterator d_first) {
+    auto execPolicy = getExecutionPolicy(q, mr);
+
+#if defined(ALPAKA_ACC_SYCL_ENABLED)
+    oneapi::dpl::inclusive_scan(execPolicy, first, last, d_first);
+#else
+    thrust::inclusive_scan(execPolicy, first, last, d_first);
+#endif
+}
+
 template <typename InputIt, typename OutputIt, typename Compare>
 OutputIt unique_copy(Queue &q, const memory_resource &mr, InputIt first,
                      InputIt last, OutputIt d_first, Compare comp) {

--- a/device/common/include/traccc/finding/device/condense_tracks.hpp
+++ b/device/common/include/traccc/finding/device/condense_tracks.hpp
@@ -1,0 +1,181 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "traccc/device/global_index.hpp"
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+#include "traccc/edm/track_parameters.hpp"
+#include "traccc/finding/candidate_link.hpp"
+#include "traccc/utils/logging.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/data/vector_view.hpp>
+#include <vecmem/containers/device_vector.hpp>
+
+// System include(s).
+#include <cassert>
+
+namespace traccc::device {
+
+/// (Event Data) Payload for the @c traccc::device::condense_tracks function
+template <typename detector_t>
+struct condense_tracks_payload {
+    /**
+     * @brief The total number of input parameters
+     */
+    const unsigned int n_in_params;
+    const unsigned int step;
+    const unsigned int curr_links_idx;
+    const unsigned int max_num_branches_per_surface;
+    const unsigned int min_track_candidates_per_track;
+    const unsigned int max_track_candidates_per_track;
+
+    /**
+     * @brief View object to the link vector
+     */
+    vecmem::data::vector_view<candidate_link> links_view;
+
+    /**
+     * @brief View object to the vector of track parameters
+     */
+    bound_track_parameters_collection_types::const_view in_params_view;
+
+    /**
+     * @brief View object to the temporary track parameter vector
+     */
+    bound_track_parameters_collection_types::const_view in_tmp_params_view;
+
+    /**
+     * @brief View object to the temporary link vector
+     */
+    vecmem::data::vector_view<const candidate_link> in_tmp_links_view;
+
+    vecmem::data::vector_view<const unsigned int> in_params_index_view;
+
+    /**
+     * @brief View object to the output track parameter vector
+     */
+    bound_track_parameters_collection_types::view out_params_view;
+
+    /**
+     * @brief View object to the output track parameter liveness vector
+     */
+    vecmem::data::vector_view<unsigned int> out_params_liveness_view;
+
+    /**
+     * @brief View object to the vector of tips
+     */
+    vecmem::data::vector_view<unsigned int> tips_view;
+
+    /**
+     * @brief Vector to hold the number of track states per tip
+     */
+    vecmem::data::vector_view<unsigned int> tip_lengths_view;
+
+    bound_matrix<typename detector_t::algebra_type>* jacobian_ptr = nullptr;
+    bound_matrix<typename detector_t::algebra_type>* tmp_jacobian_ptr = nullptr;
+    bound_track_parameters_collection_types::view link_predicted_parameter_view;
+    bound_track_parameters_collection_types::view link_filtered_parameter_view;
+};
+
+/// Condense the per-input-parameter outputs of @c traccc::device::find_tracks
+/// into a tightly-packed array using the prefix-summed
+/// @c in_params_index_view, then write the corresponding Jacobians, the
+/// optional predicted/filtered parameters, and emit tips on the last step.
+///
+/// @param[in] thread_id The index of the current thread
+/// @param[inout] payload The function call payload
+///
+template <typename detector_t>
+TRACCC_HOST_DEVICE inline void condense_tracks(
+    global_index_t thread_id,
+    const condense_tracks_payload<detector_t>& payload) {
+
+    const unsigned int in_param_id = thread_id;
+
+    if (in_param_id >= payload.n_in_params) {
+        return;
+    }
+
+    const bool last_step =
+        payload.step == payload.max_track_candidates_per_track - 1;
+
+    vecmem::device_vector<const unsigned int> in_params_index(
+        payload.in_params_index_view);
+    vecmem::device_vector<const candidate_link> in_tmp_links(
+        payload.in_tmp_links_view);
+    vecmem::device_vector<candidate_link> links(payload.links_view);
+    bound_track_parameters_collection_types::const_device in_params(
+        payload.in_params_view);
+    bound_track_parameters_collection_types::const_device in_tmp_params(
+        payload.in_tmp_params_view);
+    bound_track_parameters_collection_types::device out_params(
+        payload.out_params_view);
+    vecmem::device_vector<unsigned int> out_params_liveness(
+        payload.out_params_liveness_view);
+    vecmem::device_vector<unsigned int> tips(payload.tips_view);
+    vecmem::device_vector<unsigned int> tip_lengths(payload.tip_lengths_view);
+    bound_track_parameters_collection_types::device link_predicted_parameters(
+        payload.link_predicted_parameter_view);
+    bound_track_parameters_collection_types::device link_filtered_parameters(
+        payload.link_filtered_parameter_view);
+
+    unsigned int num_parameters;
+    unsigned int idx;
+
+    if (in_param_id == 0) {
+        idx = 0;
+        num_parameters = in_params_index.at(in_param_id);
+    } else {
+        idx = in_params_index.at(in_param_id - 1);
+        num_parameters = in_params_index.at(in_param_id) - idx;
+    }
+
+    for (unsigned int i = 0; i < num_parameters; ++i) {
+        const unsigned int in_offset =
+            in_param_id * payload.max_num_branches_per_surface + i;
+        const unsigned int param_out_index = idx + i;
+        const unsigned int link_out_index =
+            param_out_index + payload.curr_links_idx;
+
+        out_params.at(param_out_index) = in_tmp_params.at(in_offset);
+        out_params_liveness.at(param_out_index) =
+            static_cast<unsigned int>(!last_step);
+        links.at(link_out_index) = in_tmp_links.at(in_offset);
+
+        if (payload.tmp_jacobian_ptr != nullptr) {
+            assert(payload.jacobian_ptr != nullptr);
+            payload.jacobian_ptr[link_out_index] =
+                payload.tmp_jacobian_ptr[in_param_id];
+        }
+
+        if (link_filtered_parameters.capacity() > 0) {
+            link_filtered_parameters.at(link_out_index) =
+                in_tmp_params.at(in_offset);
+        }
+
+        if (link_predicted_parameters.capacity() > 0) {
+            link_predicted_parameters.at(link_out_index) =
+                in_params.at(in_param_id);
+        }
+
+        const unsigned int n_cands =
+            payload.step + 1 - in_tmp_links.at(in_offset).n_skipped;
+
+        if (last_step && n_cands >= payload.min_track_candidates_per_track) {
+            TRACCC_ERROR_DEVICE("Create tip: Max no. candidates");
+            auto tip_pos = tips.push_back(link_out_index);
+            tip_lengths.at(tip_pos) = n_cands;
+        }
+    }
+}
+
+}  // namespace traccc::device

--- a/device/common/include/traccc/finding/device/find_tracks.hpp
+++ b/device/common/include/traccc/finding/device/find_tracks.hpp
@@ -75,24 +75,14 @@ struct find_tracks_payload {
     const unsigned int prev_links_idx;
 
     /**
-     * @brief Index in the link vector at which the current step starts
-     */
-    const unsigned int curr_links_idx;
-
-    /**
      * @brief The current step identifier
      */
     unsigned int step;
 
     /**
-     * @brief View object to the output track parameter vector
+     * @brief View object to the output parameter counting vector
      */
-    bound_track_parameters_collection_types::view out_params_view;
-
-    /**
-     * @brief View object to the output track parameter liveness vector
-     */
-    vecmem::data::vector_view<unsigned int> out_params_liveness_view;
+    vecmem::data::vector_view<unsigned int> out_params_per_in_param_view;
 
     /**
      * @brief View object to the vector of tips
@@ -119,11 +109,6 @@ struct find_tracks_payload {
      * @brief View object to the temporary link vector
      */
     vecmem::data::vector_view<candidate_link> tmp_links_view;
-
-    bound_matrix<typename detector_t::algebra_type>* jacobian_ptr = nullptr;
-    bound_matrix<typename detector_t::algebra_type>* tmp_jacobian_ptr = nullptr;
-    bound_track_parameters_collection_types::view link_predicted_parameter_view;
-    bound_track_parameters_collection_types::view link_filtered_parameter_view;
 };
 
 /// (Shared Event Data) Payload for the @c traccc::device::find_tracks function
@@ -133,12 +118,6 @@ struct find_tracks_shared_payload {
      * parameters to write to permanent storage.
      */
     unsigned int& shared_num_out_params;
-
-    /**
-     * @brief Shared-memory value indicating the offset at which the block
-     * will write its parameters.
-     */
-    unsigned int& shared_out_offset;
 
     /**
      * @brief Shared-memory array with mutexes for the insertionof parameters.

--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -65,16 +65,14 @@ TRACCC_HOST_DEVICE inline void find_tracks(
     vecmem::device_vector<candidate_link> tmp_links(payload.tmp_links_view);
     bound_track_parameters_collection_types::device tmp_params(
         payload.tmp_params_view);
+    vecmem::device_vector<unsigned int> out_params_per_in_param(
+        payload.out_params_per_in_param_view);
     vecmem::device_vector<const unsigned int> meas_ranges(
         payload.measurement_ranges_view);
     vecmem::device_vector<unsigned int> tips(payload.tips_view);
     vecmem::device_vector<unsigned int> tip_lengths(payload.tip_lengths_view);
     vecmem::device_vector<unsigned int> n_tracks_per_seed(
         payload.n_tracks_per_seed_view);
-    bound_track_parameters_collection_types::device link_predicted_parameters(
-        payload.link_predicted_parameter_view);
-    bound_track_parameters_collection_types::device link_filtered_parameters(
-        payload.link_filtered_parameter_view);
 
     /*
      * Initialize the block-shared data; in particular, set the total size of
@@ -559,9 +557,7 @@ TRACCC_HOST_DEVICE inline void find_tracks(
     unsigned int prev_ndf_sum = 0u;
     scalar prev_chi2_sum = 0.f;
 
-    unsigned int local_out_offset = 0;
     unsigned int local_num_params = 0;
-    unsigned int params_to_add = 0;
 
     bool in_param_can_create_hole = false;
 
@@ -590,154 +586,80 @@ TRACCC_HOST_DEVICE inline void find_tracks(
      * index at which this block will write.
      */
     if (in_param_is_live) {
+        assert(prev_link_idx != std::numeric_limits<unsigned int>::max());
+        assert(n_skipped != std::numeric_limits<unsigned int>::max());
+
         local_num_params = std::get<1>(decode_insertion_mutex(
             shared_payload
                 .shared_insertion_mutex[thread_id.getLocalThreadIdX()]));
+
+        /*
+         * If we found zero parameters and we can create a hole, add that hole
+         * to the temporary link and parameter lists.
+         */
+        if (local_num_params == 0 && in_param_can_create_hole) {
+            const unsigned int in_offset = thread_id.getGlobalThreadIdX() *
+                                           cfg.max_num_branches_per_surface;
+
+            tmp_links.at(in_offset) = {
+                .step = payload.step,
+                .previous_candidate_idx = prev_link_idx,
+                .meas_idx = std::numeric_limits<unsigned int>::max(),
+                .seed_idx = seed_idx,
+                .n_skipped = n_skipped + 1,
+                .n_consecutive_skipped = n_consecutive_skipped + 1,
+                .chi2 = std::numeric_limits<traccc::scalar>::max(),
+                .chi2_sum = prev_chi2_sum,
+                .ndf_sum = prev_ndf_sum};
+
+            tmp_params.at(in_offset) = in_params.at(in_param_id);
+
+            /*
+             * If we created a hole, we now have a single output parameter!
+             */
+            local_num_params = 1;
+        }
+
         /*
          * NOTE: We always create at least one state, because we also create
          * hole states for nodes which don't find any good compatible
          * measurements.
          */
-        if (local_num_params > 0 || in_param_can_create_hole) {
-            unsigned int desired_params_to_add = std::max(1u, local_num_params);
-
+        if (local_num_params > 0) {
             vecmem::device_atomic_ref<unsigned int> num_tracks_per_seed(
                 n_tracks_per_seed.at(seed_idx));
-            params_to_add = std::min(desired_params_to_add,
-                                     cfg.max_num_branches_per_seed -
-                                         std::min(cfg.max_num_branches_per_seed,
-                                                  num_tracks_per_seed.fetch_add(
-                                                      desired_params_to_add)));
+            const unsigned int params_to_add = std::min(
+                local_num_params,
+                cfg.max_num_branches_per_seed -
+                    std::min(cfg.max_num_branches_per_seed,
+                             num_tracks_per_seed.fetch_add(local_num_params)));
 
-            local_out_offset =
-                vecmem::device_atomic_ref<unsigned int,
-                                          vecmem::device_address_space::local>(
-                    shared_payload.shared_num_out_params)
-                    .fetch_add(params_to_add);
+            out_params_per_in_param.at(in_param_id) = params_to_add;
+
+            vecmem::device_atomic_ref<unsigned int,
+                                      vecmem::device_address_space::local>(
+                shared_payload.shared_num_out_params)
+                .fetch_add(params_to_add);
+        } else {
+            out_params_per_in_param.at(in_param_id) = 0;
+
+            assert(!in_param_can_create_hole);
+            const unsigned int n_cands = payload.step - n_skipped;
+
+            if (n_cands >= cfg.min_track_candidates_per_track) {
+                TRACCC_WARNING_DEVICE("Create tip: Max no. holes");
+                auto tip_pos = tips.push_back(prev_link_idx);
+                tip_lengths.at(tip_pos) = n_cands;
+            }
         }
+    } else {
+        out_params_per_in_param.at(in_param_id) = 0;
     }
 
     barrier.blockBarrier();
 
     if (thread_id.getLocalThreadIdX() == 0) {
-        shared_payload.shared_out_offset =
-            links.bulk_append_implicit(shared_payload.shared_num_out_params);
-    }
-
-    barrier.blockBarrier();
-
-    /*
-     * Finally, transfer the links and parameters from temporary storage
-     * to the permanent storage in global memory, remembering to create hole
-     * states even for threads which have zero states.
-     */
-    bound_track_parameters_collection_types::device out_params(
-        payload.out_params_view);
-    vecmem::device_vector<unsigned int> out_params_liveness(
-        payload.out_params_liveness_view);
-
-    if (in_param_is_live) {
-        assert(prev_link_idx != std::numeric_limits<unsigned int>::max());
-        assert(seed_idx != std::numeric_limits<unsigned int>::max());
-        assert(n_skipped != std::numeric_limits<unsigned int>::max());
-
-        if (local_num_params == 0) {
-            assert(params_to_add <= 1);
-
-            if (in_param_can_create_hole && params_to_add == 1) {
-                const unsigned int out_offset =
-                    shared_payload.shared_out_offset + local_out_offset;
-
-                links.at(out_offset) = {
-                    .step = payload.step,
-                    .previous_candidate_idx = prev_link_idx,
-                    .meas_idx = std::numeric_limits<unsigned int>::max(),
-                    .seed_idx = seed_idx,
-                    .n_skipped = n_skipped + 1,
-                    .n_consecutive_skipped = n_consecutive_skipped + 1,
-                    .chi2 = std::numeric_limits<traccc::scalar>::max(),
-                    .chi2_sum = prev_chi2_sum,
-                    .ndf_sum = prev_ndf_sum};
-
-                if (payload.tmp_jacobian_ptr != nullptr) {
-                    assert(payload.jacobian_ptr != nullptr);
-                    payload.jacobian_ptr[out_offset] =
-                        payload.tmp_jacobian_ptr[in_param_id];
-                }
-
-                if (link_filtered_parameters.capacity() > 0) {
-                    link_filtered_parameters.at(out_offset) =
-                        in_params.at(in_param_id);
-                }
-
-                if (link_predicted_parameters.capacity() > 0) {
-                    link_predicted_parameters.at(out_offset) =
-                        in_params.at(in_param_id);
-                }
-
-                TRACCC_VERBOSE_DEVICE("Hole state created");
-
-                unsigned int param_pos = out_offset - payload.curr_links_idx;
-
-                out_params.at(param_pos) = in_params.at(in_param_id);
-                out_params_liveness.at(param_pos) =
-                    static_cast<unsigned int>(!last_step);
-            } else {
-                const unsigned int n_cands = payload.step - n_skipped;
-
-                if (n_cands >= cfg.min_track_candidates_per_track) {
-                    if (!in_param_can_create_hole) {
-                        TRACCC_WARNING_DEVICE("Create tip: Max no. holes");
-                    } else {
-                        TRACCC_WARNING_DEVICE(
-                            "Create tip: No next sensitive found");
-                    }
-                    auto tip_pos = tips.push_back(prev_link_idx);
-                    tip_lengths.at(tip_pos) = n_cands;
-                }
-            }
-        } else {
-            for (unsigned int i = 0; i < params_to_add; ++i) {
-                const unsigned int in_offset =
-                    thread_id.getGlobalThreadIdX() *
-                        cfg.max_num_branches_per_surface +
-                    i;
-                const unsigned int out_offset =
-                    shared_payload.shared_out_offset + local_out_offset + i;
-
-                unsigned int param_pos = out_offset - payload.curr_links_idx;
-
-                out_params.at(param_pos) = tmp_params.at(in_offset);
-                out_params_liveness.at(param_pos) =
-                    static_cast<unsigned int>(!last_step);
-                links.at(out_offset) = tmp_links.at(in_offset);
-
-                if (payload.tmp_jacobian_ptr != nullptr) {
-                    assert(payload.jacobian_ptr != nullptr);
-                    payload.jacobian_ptr[out_offset] =
-                        payload.tmp_jacobian_ptr[in_param_id];
-                }
-
-                if (link_filtered_parameters.capacity() > 0) {
-                    link_filtered_parameters.at(out_offset) =
-                        tmp_params.at(in_offset);
-                }
-
-                if (link_predicted_parameters.capacity() > 0) {
-                    link_predicted_parameters.at(out_offset) =
-                        in_params.at(in_param_id);
-                }
-
-                const unsigned int n_cands = payload.step + 1 - n_skipped;
-
-                if (last_step &&
-                    n_cands >= cfg.min_track_candidates_per_track) {
-                    TRACCC_ERROR_DEVICE("Create tip: Max no. candidates");
-                    auto tip_pos = tips.push_back(out_offset);
-                    tip_lengths.at(tip_pos) = n_cands;
-                }
-            }
-        }
+        links.bulk_append_implicit(shared_payload.shared_num_out_params);
     }
 }
 

--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -65,6 +65,7 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/finding/kernels/remove_duplicates.cu"
   "src/finding/kernels/build_tracks.cu"
   "src/finding/kernels/build_tracks.cuh"
+  "src/finding/kernels/condense_tracks.cuh"
   "src/finding/kernels/find_tracks.cuh"
   "src/finding/kernels/gather_best_tips_per_measurement.cu"
   "src/finding/kernels/gather_measurement_votes.cu"
@@ -129,6 +130,25 @@ foreach(DETECTOR_NAME ${TRACCC_SUPPORTED_DETECTORS})
             --detector "${DETECTOR_NAME}"
         DEPENDS "${KERNEL_SPECIALIZATION_PY}" "${TEMPLATE_SOURCE}"
         COMMENT "Generating kernel specialization of `find_tracks` for ${DETECTOR_NAME}"
+    )
+    target_sources(traccc_cuda PRIVATE ${GENERATED_SOURCE})
+endforeach()
+
+# Generate specializations of condense_tracks
+foreach(DETECTOR_NAME ${TRACCC_SUPPORTED_DETECTORS})
+    set(GENERATED_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/src/finding/kernels/specializations/condense_tracks_${DETECTOR_NAME}.cu")
+    set(TEMPLATE_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/src/finding/kernels/specializations/condense_tracks.cu.template")
+    add_custom_command(
+        OUTPUT "${GENERATED_SOURCE}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/src/finding/kernels/specializations/"
+        COMMAND
+            Python::Interpreter
+            "${KERNEL_SPECIALIZATION_PY}"
+            "${TEMPLATE_SOURCE}"
+            -o "${GENERATED_SOURCE}"
+            --detector "${DETECTOR_NAME}"
+        DEPENDS "${KERNEL_SPECIALIZATION_PY}" "${TEMPLATE_SOURCE}"
+        COMMENT "Generating kernel specialization of `condense_tracks` for ${DETECTOR_NAME}"
     )
     target_sources(traccc_cuda PRIVATE ${GENERATED_SOURCE})
 endforeach()

--- a/device/cuda/src/finding/combinatorial_kalman_filter.cuh
+++ b/device/cuda/src/finding/combinatorial_kalman_filter.cuh
@@ -14,6 +14,7 @@
 #include "../utils/thread_id.hpp"
 #include "../utils/utils.hpp"
 #include "./kernels/build_tracks.cuh"
+#include "./kernels/condense_tracks.cuh"
 #include "./kernels/fill_finding_duplicate_removal_sort_keys.cuh"
 #include "./kernels/fill_finding_propagation_sort_keys.cuh"
 #include "./kernels/find_tracks.cuh"
@@ -312,6 +313,12 @@ combinatorial_kalman_filter(
         }
 
         {
+            vecmem::data::vector_buffer<unsigned int>
+                out_params_per_in_param_buffer(n_in_params, mr.main);
+            copy.setup(out_params_per_in_param_buffer)->ignore();
+            vecmem::data::vector_buffer<unsigned int> out_params_index_buffer(
+                n_in_params, mr.main);
+            copy.setup(out_params_index_buffer)->ignore();
             vecmem::data::vector_buffer<candidate_link> tmp_links_buffer(
                 n_max_candidates, mr.main);
             copy.setup(tmp_links_buffer)->ignore();
@@ -331,33 +338,77 @@ combinatorial_kalman_filter(
                 .links_view = links_buffer,
                 .prev_links_idx =
                     (step == 0 ? 0 : step_to_link_idx_map[step - 1]),
-                .curr_links_idx = step_to_link_idx_map[step],
                 .step = step,
-                .out_params_view = updated_params_buffer,
-                .out_params_liveness_view = updated_liveness_buffer,
+                .out_params_per_in_param_view = out_params_per_in_param_buffer,
                 .tips_view = tips_buffer,
                 .tip_lengths_view = tip_length_buffer,
                 .n_tracks_per_seed_view = n_tracks_per_seed_buffer,
                 .tmp_params_view = tmp_params_buffer,
-                .tmp_links_view = tmp_links_buffer,
-                .jacobian_ptr = jacobian_ptr.get(),
-                .tmp_jacobian_ptr = tmp_jacobian_ptr.get(),
-                .link_predicted_parameter_view =
-                    link_predicted_parameter_buffer,
-                .link_filtered_parameter_view = link_filtered_parameter_buffer};
+                .tmp_links_view = tmp_links_buffer};
 
-            // The number of threads, blocks and shared memory to use.
-            const unsigned int nThreads = warp_size * 2;
-            const unsigned int nBlocks =
-                (n_in_params + nThreads - 1) / nThreads;
-            const std::size_t shared_size =
-                nThreads * sizeof(unsigned long long int) +
-                2 * nThreads * sizeof(std::pair<unsigned int, unsigned int>);
+            {
+                // The number of threads, blocks and shared memory to use.
+                const unsigned int nThreads = warp_size * 2;
+                const unsigned int nBlocks =
+                    (n_in_params + nThreads - 1) / nThreads;
+                const std::size_t shared_size =
+                    nThreads * sizeof(unsigned long long int) +
+                    2 * nThreads *
+                        sizeof(std::pair<unsigned int, unsigned int>);
 
-            // Run the kernel.
-            find_tracks<detector_t>(nBlocks, nThreads, shared_size, stream,
-                                    config, host_payload);
-            TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+                // Run the kernel.
+                find_tracks<detector_t>(nBlocks, nThreads, shared_size, stream,
+                                        config, host_payload);
+                TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+            }
+
+            {
+                vecmem::device_vector<unsigned int>
+                    out_params_per_in_param_vector(
+                        out_params_per_in_param_buffer);
+                vecmem::device_vector<unsigned int> out_params_index_vector(
+                    out_params_index_buffer);
+                thrust::inclusive_scan(thrust_policy,
+                                       out_params_per_in_param_vector.begin(),
+                                       out_params_per_in_param_vector.end(),
+                                       out_params_index_vector.begin());
+            }
+
+            {
+                // The number of threads, blocks and shared memory to use.
+                const unsigned int nThreads = 256;
+                const unsigned int nBlocks =
+                    (n_in_params + nThreads - 1) / nThreads;
+                condense_tracks<detector_t>(
+                    nBlocks, nThreads, 0, stream,
+                    device::condense_tracks_payload<detector_t>{
+                        .n_in_params = n_in_params,
+                        .step = step,
+                        .curr_links_idx = step_to_link_idx_map[step],
+                        .max_num_branches_per_surface =
+                            config.max_num_branches_per_surface,
+                        .min_track_candidates_per_track =
+                            config.min_track_candidates_per_track,
+                        .max_track_candidates_per_track =
+                            config.max_track_candidates_per_track,
+                        .links_view = links_buffer,
+                        .in_params_view = in_params_buffer,
+                        .in_tmp_params_view = tmp_params_buffer,
+                        .in_tmp_links_view = tmp_links_buffer,
+                        .in_params_index_view = out_params_index_buffer,
+                        .out_params_view = updated_params_buffer,
+                        .out_params_liveness_view = updated_liveness_buffer,
+                        .tips_view = tips_buffer,
+                        .tip_lengths_view = tip_length_buffer,
+                        .jacobian_ptr = jacobian_ptr.get(),
+                        .tmp_jacobian_ptr = tmp_jacobian_ptr.get(),
+                        .link_predicted_parameter_view =
+                            link_predicted_parameter_buffer,
+                        .link_filtered_parameter_view =
+                            link_filtered_parameter_buffer});
+
+                TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+            }
 
             std::swap(in_params_buffer, updated_params_buffer);
             std::swap(param_liveness_buffer, updated_liveness_buffer);

--- a/device/cuda/src/finding/kernels/condense_tracks.cuh
+++ b/device/cuda/src/finding/kernels/condense_tracks.cuh
@@ -1,0 +1,23 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/finding/device/condense_tracks.hpp"
+
+// CUDA include(s).
+#include <cuda_runtime.h>
+
+namespace traccc::cuda {
+
+template <typename detector_t>
+void condense_tracks(const dim3& grid_size, const dim3& block_size,
+                     std::size_t shared_mem_size, const cudaStream_t& stream,
+                     const device::condense_tracks_payload<detector_t> payload);
+
+}  // namespace traccc::cuda

--- a/device/cuda/src/finding/kernels/specializations/condense_tracks.cu.template
+++ b/device/cuda/src/finding/kernels/specializations/condense_tracks.cu.template
@@ -1,0 +1,20 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "${SOURCE_DIR}/condense_tracks_src.cuh"
+
+// Project include(s).
+#include "traccc/geometry/detector.hpp"
+
+namespace traccc::cuda {
+template void condense_tracks<traccc::${DETECTOR_NAME}::device>(
+    const dim3& grid_size, const dim3& block_size, std::size_t shared_mem_size,
+    const cudaStream_t& stream,
+    const device::condense_tracks_payload<traccc::${DETECTOR_NAME}::device>
+        payload);
+}  // namespace traccc::cuda

--- a/device/cuda/src/finding/kernels/specializations/condense_tracks_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/condense_tracks_src.cuh
@@ -1,0 +1,39 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "../../../utils/global_index.hpp"
+#include "../condense_tracks.cuh"
+
+// Project include(s).
+#include "traccc/finding/device/condense_tracks.hpp"
+
+namespace traccc::cuda {
+namespace kernels {
+
+template <typename detector_t>
+__global__ void condense_tracks(
+    const __grid_constant__ device::condense_tracks_payload<detector_t>
+        payload) {
+
+    device::condense_tracks<detector_t>(details::global_index1(), payload);
+}
+
+}  // namespace kernels
+
+template <typename detector_t>
+void condense_tracks(
+    const dim3& grid_size, const dim3& block_size, std::size_t shared_mem_size,
+    const cudaStream_t& stream,
+    const device::condense_tracks_payload<detector_t> payload) {
+    kernels::
+        condense_tracks<<<grid_size, block_size, shared_mem_size, stream>>>(
+            payload);
+}
+}  // namespace traccc::cuda

--- a/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
@@ -25,7 +25,6 @@ __global__ void find_tracks(
     const __grid_constant__ finding_config cfg,
     const __grid_constant__ device::find_tracks_payload<detector_t> payload) {
     __shared__ unsigned int shared_num_out_params;
-    __shared__ unsigned int shared_out_offset;
     __shared__ unsigned int shared_candidates_size;
     extern __shared__ unsigned long long int s[];
     unsigned long long int* shared_insertion_mutex = s;
@@ -38,8 +37,11 @@ __global__ void find_tracks(
 
     device::find_tracks<detector_t>(
         thread_id, barrier, cfg, payload,
-        {shared_num_out_params, shared_out_offset, shared_insertion_mutex,
-         shared_candidates, shared_candidates_size});
+        device::find_tracks_shared_payload{
+            .shared_num_out_params = shared_num_out_params,
+            .shared_insertion_mutex = shared_insertion_mutex,
+            .shared_candidates = shared_candidates,
+            .shared_candidates_size = shared_candidates_size});
 }
 
 }  // namespace kernels

--- a/device/sycl/src/finding/combinatorial_kalman_filter.hpp
+++ b/device/sycl/src/finding/combinatorial_kalman_filter.hpp
@@ -26,6 +26,7 @@
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/finding/details/combinatorial_kalman_filter_types.hpp"
 #include "traccc/finding/device/build_tracks.hpp"
+#include "traccc/finding/device/condense_tracks.hpp"
 #include "traccc/finding/device/fill_finding_duplicate_removal_sort_keys.hpp"
 #include "traccc/finding/device/fill_finding_propagation_sort_keys.hpp"
 #include "traccc/finding/device/find_tracks.hpp"
@@ -66,14 +67,16 @@ template <typename T>
 struct update_tip_length_buffer {};
 template <typename T>
 struct build_tracks {};
-
 template <typename T>
 struct upper_bound {};
 template <typename T>
 struct sort_by_key_1 {};
 template <typename T>
 struct sort_by_key_2 {};
-
+template <typename T>
+struct inclusive_scan {};
+template <typename T>
+struct condense_tracks {};
 }  // namespace kernels
 
 /// Templated implementation of the track finding algorithm.
@@ -303,6 +306,12 @@ combinatorial_kalman_filter(
         }
 
         {
+            vecmem::data::vector_buffer<unsigned int>
+                out_params_per_in_param_buffer(n_in_params, mr.main);
+            copy.setup(out_params_per_in_param_buffer)->wait();
+            vecmem::data::vector_buffer<unsigned int> out_params_index_buffer(
+                n_in_params, mr.main);
+            copy.setup(out_params_index_buffer)->wait();
             vecmem::data::vector_buffer<candidate_link> tmp_links_buffer(
                 n_max_candidates, mr.main);
             copy.setup(tmp_links_buffer)->wait();
@@ -325,20 +334,13 @@ combinatorial_kalman_filter(
                 .links_view = links_buffer,
                 .prev_links_idx =
                     (step == 0 ? 0 : step_to_link_idx_map[step - 1]),
-                .curr_links_idx = step_to_link_idx_map[step],
                 .step = step,
-                .out_params_view = updated_params_buffer,
-                .out_params_liveness_view = updated_liveness_buffer,
+                .out_params_per_in_param_view = out_params_per_in_param_buffer,
                 .tips_view = tips_buffer,
                 .tip_lengths_view = tip_length_buffer,
                 .n_tracks_per_seed_view = n_tracks_per_seed_buffer,
                 .tmp_params_view = tmp_params_buffer,
-                .tmp_links_view = tmp_links_buffer,
-                .jacobian_ptr = jacobian_ptr.get(),
-                .tmp_jacobian_ptr = tmp_jacobian_ptr.get(),
-                .link_predicted_parameter_view =
-                    link_predicted_parameter_buffer,
-                .link_filtered_parameter_view = link_filtered_parameter_buffer};
+                .tmp_links_view = tmp_links_buffer};
             // Now copy it to device memory.
             vecmem::data::vector_buffer<payload_t> device_payload(1u, mr.main);
             copy.setup(device_payload)->wait();
@@ -359,15 +361,13 @@ combinatorial_kalman_filter(
                         shared_candidates_size(1, h);
                     vecmem::sycl::local_accessor<unsigned int>
                         shared_num_out_params(1, h);
-                    vecmem::sycl::local_accessor<unsigned int>
-                        shared_out_offset(1, h);
                     // Launch the kernel.
                     h.parallel_for<kernels::find_tracks<kernel_t>>(
                         calculate1DimNdRange(n_in_params, nFindTracksThreads),
                         [config, payload = device_payload.ptr(),
                          shared_insertion_mutex, shared_candidates,
-                         shared_candidates_size, shared_num_out_params,
-                         shared_out_offset](::sycl::nd_item<1> item) {
+                         shared_candidates_size,
+                         shared_num_out_params](::sycl::nd_item<1> item) {
                             // SYCL wrappers used in the algorithm.
                             const details::barrier barrier{item};
                             const details::thread_id thread_id{item};
@@ -375,13 +375,80 @@ combinatorial_kalman_filter(
                             // Call the device function to find tracks.
                             device::find_tracks<detector_t>(
                                 thread_id, barrier, config, *payload,
-                                {shared_num_out_params[0], shared_out_offset[0],
-                                 &(shared_insertion_mutex[0]),
-                                 &(shared_candidates[0]),
-                                 shared_candidates_size[0]});
+                                {.shared_num_out_params =
+                                     shared_num_out_params[0],
+                                 .shared_insertion_mutex =
+                                     &(shared_insertion_mutex[0]),
+                                 .shared_candidates = &(shared_candidates[0]),
+                                 .shared_candidates_size =
+                                     shared_candidates_size[0]});
                         });
                 })
                 .wait_and_throw();
+
+            {
+                vecmem::device_vector<unsigned int>
+                    out_params_per_in_param_vector(
+                        out_params_per_in_param_buffer);
+                vecmem::device_vector<unsigned int> out_params_index_vector(
+                    out_params_index_buffer);
+                oneapi::dpl::inclusive_scan(
+                    oneapi::dpl::execution::device_policy<
+                        kernels::inclusive_scan<kernel_t>>{queue},
+                    out_params_per_in_param_vector.begin(),
+                    out_params_per_in_param_vector.end(),
+                    out_params_index_vector.begin());
+                queue.wait_and_throw();
+            }
+
+            {
+                using condense_payload_t =
+                    device::condense_tracks_payload<detector_t>;
+                const condense_payload_t condense_host_payload{
+                    .n_in_params = n_in_params,
+                    .step = step,
+                    .curr_links_idx = step_to_link_idx_map[step],
+                    .max_num_branches_per_surface =
+                        config.max_num_branches_per_surface,
+                    .min_track_candidates_per_track =
+                        config.min_track_candidates_per_track,
+                    .max_track_candidates_per_track =
+                        config.max_track_candidates_per_track,
+                    .links_view = links_buffer,
+                    .in_params_view = in_params_buffer,
+                    .in_tmp_params_view = tmp_params_buffer,
+                    .in_tmp_links_view = tmp_links_buffer,
+                    .in_params_index_view = out_params_index_buffer,
+                    .out_params_view = updated_params_buffer,
+                    .out_params_liveness_view = updated_liveness_buffer,
+                    .tips_view = tips_buffer,
+                    .tip_lengths_view = tip_length_buffer,
+                    .jacobian_ptr = jacobian_ptr.get(),
+                    .tmp_jacobian_ptr = tmp_jacobian_ptr.get(),
+                    .link_predicted_parameter_view =
+                        link_predicted_parameter_buffer,
+                    .link_filtered_parameter_view =
+                        link_filtered_parameter_buffer};
+                vecmem::data::vector_buffer<condense_payload_t>
+                    condense_device_payload(1u, mr.main);
+                copy.setup(condense_device_payload)->wait();
+                copy(vecmem::data::vector_view<const condense_payload_t>(
+                         1u, &condense_host_payload),
+                     condense_device_payload)
+                    ->wait();
+
+                queue
+                    .submit([&](::sycl::handler& h) {
+                        h.parallel_for<kernels::condense_tracks<kernel_t>>(
+                            calculate1DimNdRange(n_in_params, 256),
+                            [payload = condense_device_payload.ptr()](
+                                ::sycl::nd_item<1> item) {
+                                device::condense_tracks<detector_t>(
+                                    details::global_index(item), *payload);
+                            });
+                    })
+                    .wait_and_throw();
+            }
 
             std::swap(in_params_buffer, updated_params_buffer);
             std::swap(param_liveness_buffer, updated_liveness_buffer);

--- a/device/sycl/src/utils/oneDPL.hpp
+++ b/device/sycl/src/utils/oneDPL.hpp
@@ -15,3 +15,4 @@
 // oneDPL include(s).
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
+#include <oneapi/dpl/numeric>


### PR DESCRIPTION
This commit splits the `find_tracks` kernel up into two parts, a compute kernel and a storage kernel. Interleaved between these kernels is an inclusive scan. This allows us to preserve the order of track parameters, and to more precisely tune the performance of the two kernels.