### PR TITLE
Remove measurement covariance hack

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -16,6 +16,7 @@
 #include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/utils/logging.hpp"
+#include "traccc/utils/matrix_helpers.hpp"
 #include "traccc/utils/subspace.hpp"
 
 namespace traccc {
@@ -52,7 +53,7 @@ struct gain_matrix_updater {
 
         static constexpr unsigned int D = 2;
 
-        [[maybe_unused]] const unsigned int dim{measurement.dimensions()};
+        const unsigned int dim{measurement.dimensions()};
 
         TRACCC_VERBOSE_HOST_DEVICE("Perform Kalman filtering...");
         TRACCC_VERBOSE_HOST_DEVICE("-> Measurement dim: %d", dim);
@@ -91,11 +92,11 @@ struct gain_matrix_updater {
         const matrix_type<e_bound_size, D> projected_cov =
             matrix::transposed_product<false, true>(predicted_cov, H);
 
-        const matrix_type<D, D> M = H * projected_cov + V;
+        const matrix_type<D, D> M_inv =
+            masked_inverse<algebra_t>(H * projected_cov + V, dim);
 
         // Kalman gain matrix
-        assert(matrix::determinant(M) != 0.f);
-        const matrix_type<6, D> K = projected_cov * matrix::inverse(M);
+        const matrix_type<6, D> K = projected_cov * M_inv;
 
         TRACCC_DEBUG_HOST("-> H:\n" << H);
         TRACCC_DEBUG_HOST("-> K:\n" << K);

--- a/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
+++ b/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
@@ -15,6 +15,7 @@
 #include "traccc/edm/measurement_helpers.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/utils/logging.hpp"
+#include "traccc/utils/matrix_helpers.hpp"
 #include "traccc/utils/subspace.hpp"
 
 // System include(s)
@@ -131,7 +132,8 @@ struct measurement_selector {
         // @TODO: Fix properly
         if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
             // if (measurement.dimensions() == 1) {
-            getter::element(V, 1u, 1u) = 10000.f;
+            getter::element(V, 1u, 1u) =
+                std::numeric_limits<detray::dscalar<algebra_t>>::max();
         }
 
         TRACCC_DEBUG_HOST("--> Measurement covariance (uncalibrated):\n" << V);
@@ -186,9 +188,11 @@ struct measurement_selector {
                     bound_params.covariance(), H) +
             V;
 
+        const matrix_t<algebra_t, D, D> R_inv =
+            masked_inverse<algebra_t>(R, measurement.dimensions());
+
         TRACCC_DEBUG_HOST("--> R:\n" << R);
-        TRACCC_DEBUG_HOST_DEVICE("--> det(R): %.10e", matrix::determinant(R));
-        TRACCC_DEBUG_HOST("--> R_inv:\n" << matrix::inverse(R));
+        TRACCC_DEBUG_HOST("--> R_inv:\n" << R_inv);
 
         // Residual between measurement and (projected) vector (innovation)
         const matrix_t<algebra_t, D, 1> residual =
@@ -197,9 +201,7 @@ struct measurement_selector {
         TRACCC_DEBUG_HOST("--> Predicted residual:\n" << residual);
 
         const matrix_t<algebra_t, 1, 1> pred_chi2 =
-            matrix::transposed_product<true, false>(
-                residual, traccc::matrix::inverse(R)) *
-            residual;
+            matrix::transposed_product<true, false>(residual, R_inv) * residual;
 
         const scalar_t pred_chi2_val{getter::element(pred_chi2, 0, 0)};
 

--- a/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
+++ b/core/include/traccc/fitting/kalman_filter/two_filters_smoother.hpp
@@ -17,6 +17,7 @@
 #include "traccc/fitting/kalman_filter/measurement_selector.hpp"
 #include "traccc/fitting/status_codes.hpp"
 #include "traccc/utils/logging.hpp"
+#include "traccc/utils/matrix_helpers.hpp"
 
 namespace traccc {
 
@@ -47,7 +48,7 @@ struct two_filters_smoother {
 
         static constexpr unsigned int D = 2;
 
-        [[maybe_unused]] const unsigned int dim{measurement.dimensions()};
+        const unsigned int dim{measurement.dimensions()};
 
         assert(dim == 1u || dim == 2u);
 
@@ -150,20 +151,20 @@ struct two_filters_smoother {
         const matrix_type<D, D> R_smt =
             V - H * matrix::transposed_product<false, true>(smoothed_cov, H);
 
+        const matrix_type<D, D> R_smt_inv =
+            masked_inverse<algebra_t>(R_smt, dim);
+
         // Eq (3.40) of "Pattern Recognition, Tracking and Vertex
         // Reconstruction in Particle Detectors"
-        assert(matrix::determinant(R_smt) != 0.f);
         const matrix_type<1, 1> chi2_smt =
-            matrix::transposed_product<true, false>(residual_smt,
-                                                    matrix::inverse(R_smt)) *
+            matrix::transposed_product<true, false>(residual_smt, R_smt_inv) *
             residual_smt;
 
         const scalar chi2_smt_value{getter::element(chi2_smt, 0, 0)};
 
         TRACCC_VERBOSE_HOST("Smoothed residual: " << residual_smt);
         TRACCC_DEBUG_HOST("R_smt:\n" << R_smt);
-        TRACCC_DEBUG_HOST_DEVICE("det(R_smt): %f", matrix::determinant(R_smt));
-        TRACCC_DEBUG_HOST("R_smt_inv:\n" << matrix::inverse(R_smt));
+        TRACCC_DEBUG_HOST("R_smt_inv:\n" << R_smt_inv);
         TRACCC_VERBOSE_HOST_DEVICE("Smoothed chi2: %f", chi2_smt_value);
 
         if (chi2_smt_value < 0.f) {
@@ -192,12 +193,11 @@ struct two_filters_smoother {
         const matrix_type<e_bound_size, D> projected_cov =
             matrix::transposed_product<false, true>(predicted_cov, H);
 
-        const matrix_type<D, D> M = H * projected_cov + V;
+        const matrix_type<D, D> M_inv =
+            masked_inverse<algebra_t>(H * projected_cov + V, dim);
 
         // Kalman gain matrix
-        assert(matrix::determinant(M) != 0.f);
-        assert(std::isfinite(matrix::determinant(M)));
-        const matrix_type<6, D> K = projected_cov * matrix::inverse(M);
+        const matrix_type<6, D> K = projected_cov * M_inv;
 
         TRACCC_DEBUG_HOST("H:\n" << H);
         TRACCC_DEBUG_HOST("K:\n" << K);
@@ -252,18 +252,17 @@ struct two_filters_smoother {
 
         // Calculate backward chi2
         const matrix_type<D, D> R = (I_m - H * K) * V;
-        // assert(matrix::determinant(R) != 0.f); // @TODO: This fails
-        assert(std::isfinite(matrix::determinant(R)));
-        const matrix_type<1, 1> chi2 = matrix::transposed_product<true, false>(
-                                           residual, matrix::inverse(R)) *
-                                       residual;
+
+        const matrix_type<D, D> R_inv = masked_inverse<algebra_t>(R, dim);
+
+        const matrix_type<1, 1> chi2 =
+            matrix::transposed_product<true, false>(residual, R_inv) * residual;
 
         const scalar chi2_val{getter::element(chi2, 0, 0)};
 
         TRACCC_VERBOSE_HOST("Filtered residual: " << residual);
         TRACCC_DEBUG_HOST("R:\n" << R);
-        TRACCC_DEBUG_HOST_DEVICE("det(R): %f", matrix::determinant(R));
-        TRACCC_DEBUG_HOST("R_inv:\n" << matrix::inverse(R));
+        TRACCC_DEBUG_HOST("R_inv:\n" << R_inv);
         TRACCC_VERBOSE_HOST_DEVICE("Filtered chi2: %f", chi2_val);
 
         if (chi2_val < 0.f) {

--- a/core/include/traccc/utils/matrix_helpers.hpp
+++ b/core/include/traccc/utils/matrix_helpers.hpp
@@ -1,0 +1,47 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/primitives.hpp"
+#include "traccc/definitions/qualifiers.hpp"
+
+// System include(s)
+#include <cassert>
+
+namespace traccc {
+
+/// @brief Compute a masked inverse of a 2x2 matrix.
+///
+/// For 1D measurements only the [0, 0] element of the input matrix is
+/// meaningful, so we compute 1 / M[0,0] and zero out the rest. For 2D
+/// measurements a regular 2x2 inverse is computed.
+///
+/// @param M   the 2x2 matrix to invert
+/// @param dim the meaningful dimension of @c M (1 or 2)
+/// @returns the masked inverse of @c M
+template <detray::concepts::algebra algebra_t>
+TRACCC_HOST_DEVICE inline detray::dmatrix<algebra_t, 2, 2> masked_inverse(
+    const detray::dmatrix<algebra_t, 2, 2>& M, const unsigned int dim) {
+
+    assert(dim == 1u || dim == 2u);
+
+    detray::dmatrix<algebra_t, 2, 2> M_inv;
+    if (dim == 1u) {
+        assert(getter::element(M, 0u, 0u) != 0.f);
+        getter::element(M_inv, 0u, 0u) = 1.f / getter::element(M, 0u, 0u);
+        getter::element(M_inv, 0u, 1u) = 0.f;
+        getter::element(M_inv, 1u, 0u) = 0.f;
+        getter::element(M_inv, 1u, 1u) = 0.f;
+    } else {
+        M_inv = matrix::inverse(M);
+    }
+    return M_inv;
+}
+
+}  // namespace traccc

--- a/device/common/include/traccc/finding/device/impl/build_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/build_tracks.ipp
@@ -14,6 +14,7 @@
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/edm/track_state_helpers.hpp"
 #include "traccc/fitting/kalman_filter/measurement_selector.hpp"
+#include "traccc/utils/matrix_helpers.hpp"
 #include "traccc/utils/prob.hpp"
 #include "traccc/utils/subspace.hpp"
 
@@ -151,8 +152,10 @@ TRACCC_HOST_DEVICE inline void build_tracks(
                 measurement_selector::observation_model<default_algebra, 2>(
                     meas, predicted_params, false);
 
-            const auto S = H * predicted_covariance * matrix::transpose(H) + V;
-            const auto S_inv = matrix::inverse(S);
+            const auto S_inv = masked_inverse<default_algebra>(
+                H * predicted_covariance * matrix::transpose(H) + V,
+                meas.dimensions());
+
             const auto K = predicted_covariance * matrix::transpose(H) * S_inv;
             const auto C_hat =
                 matrix::identity<detray::dmatrix<default_algebra, e_bound_size,


### PR DESCRIPTION
In order to keep the measurement covariance inverible we currently put large values in element [1, 1] for 1D measurements, but this is a bit of a hack. A better solution is to perform a masked inverse of the matrices, so that the value in [1, 1] doesn't matter at all. This commit implements that and makes the code a bit less hacky.