### PR TITLE
Candidate Measurement Fix, main branch (2026.05.13.)

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
+++ b/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
@@ -28,11 +28,9 @@ struct candidate_measurement {
     float chi2{std::numeric_limits<float>::max()};
 
     /// Define comparisons
-    TRACCC_HOST_DEVICE
     constexpr bool operator<=>(const candidate_measurement& other) const =
         default;
 };
-/// @}
 
 /// Associate a measurement to a candidate track
 struct measurement_selector {


### PR DESCRIPTION
I noticed this one in #1259. Once again this is an issue that CUDA only complains about when paired with Clang as the host compiler. Namely that:

```
[build] /home/krasznaa/ATLAS/projects/traccc/traccc/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp(31): error #20012-D: __host__ annotation is ignored on a function("operator<=>") that is explicitly defaulted on its first declaration
[build]       __attribute__((host)) __attribute__((device))
[build]                      ^
[build] 
[build] Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
[build] 
[build] /home/krasznaa/ATLAS/projects/traccc/traccc/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp(31): error #20012-D: __device__ annotation is ignored on a function("operator<=>") that is explicitly defaulted on its first declaration
[build]       __attribute__((host)) __attribute__((device))
[build]                                            ^
```

I've run into similar things in [vecmem](https://github.com/acts-project/vecmem) a couple of times in the past. That one cannot use `__device__` and `__host__` declarations for auto-generated functions. Luckily since the function is anyway declared to be `constexpr`, `nvcc` uses it happily even without the `__device__` declaration.