### PR TITLE
Remove measurement dimension hack

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
+++ b/core/include/traccc/fitting/kalman_filter/measurement_selector.hpp
@@ -73,8 +73,7 @@ struct measurement_selector {
 
         detray::dmatrix<algebra_t, D, 1> meas_local;
         edm::get_measurement_local<algebra_t>(measurement, meas_local);
-        if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
-            // if (measurement.dimensions() == 1) {
+        if (measurement.dimensions() == 1) {
             getter::element(H, 1u, 0u) = 0.f;
             getter::element(H, 1u, 1u) = 0.f;
         }
@@ -129,9 +128,7 @@ struct measurement_selector {
 
         detray::dmatrix<algebra_t, D, 1> meas_local;
         edm::get_measurement_local<algebra_t>(measurement, meas_local);
-        // @TODO: Fix properly
-        if (/*dim == 1*/ getter::element(meas_local, 1u, 0u) == 0.f) {
-            // if (measurement.dimensions() == 1) {
+        if (measurement.dimensions() == 1) {
             getter::element(V, 1u, 1u) =
                 std::numeric_limits<detray::dscalar<algebra_t>>::max();
         }


### PR DESCRIPTION
This commit removes a long-standing hack where we don't use the `dimensions()` member of the measurement to check whether it is a 1D measurement.