### PR TITLE
Fixes gcc16 build errors, added needed climits header

### DIFF
--- a/core/src/gbts_seeding/gbts_seeding_config.cpp
+++ b/core/src/gbts_seeding/gbts_seeding_config.cpp
@@ -8,6 +8,7 @@
 #include "traccc/gbts_seeding/gbts_seeding_config.hpp"
 
 #include <algorithm>
+#include <climits>
 #include <ranges>
 
 namespace traccc {


### PR DESCRIPTION
`climits` header is needed for `SHRT_MAX` and `UINT_MAX`