### PR TITLE
CMake Config Fix, main branch (2026.05.20.)

### DIFF
--- a/cmake/traccc-config.cmake.in
+++ b/cmake/traccc-config.cmake.in
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2022-2024 CERN for the benefit of the ACTS project
+# (c) 2022-2026 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -27,12 +27,10 @@ list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}" )
 
 # Find all packages that traccc needs to function.
 include( CMakeFindDependencyMacro )
+find_dependency( Acts COMPONENTS Core )
 find_dependency( Thrust )
 if( TRACCC_BUILD_ALPAKA )
    find_dependency( alpaka )
-endif()
-if ( TRACCC_BUILD_IO )
-   find_dependency( Acts )
 endif()
 find_dependency( vecmem )
 find_dependency( detray )


### PR DESCRIPTION
During the Athena integration exercise I discovered this gem as well. That this configuration was never updated to account for `traccc::core` publicly depending on `Acts::Core`.

Note that `traccc::io` only privately depends on `Acts::PluginJson`, so setting up that component as a dependency is not necessary. 🤔 

Tagging @paradajzblond.