### PR TITLE
Update ACTS to version 46.6.0

### DIFF
--- a/extern/acts/CMakeLists.txt
+++ b/extern/acts/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Acts as part of the TRACCC project" )
 
 # Declare where to get Acts from.
 set( TRACCC_ACTS_SOURCE
-   "URL;https://github.com/acts-project/acts/archive/refs/tags/v46.0.0.tar.gz;URL_MD5;1e0cc5c3db1b5605c792b66a366de6d1"
+   "URL;https://github.com/acts-project/acts/archive/refs/tags/v46.6.0.tar.gz;URL_MD5;b6ddb9a50df9ac7c23f1b792a2363454"
    CACHE STRING "Source for Acts, when built as part of this project" )
 mark_as_advanced( TRACCC_ACTS_SOURCE )
 FetchContent_Declare( Acts SYSTEM ${TRACCC_ACTS_SOURCE} )


### PR DESCRIPTION
This commit updates our ACTS dependency to version 46.6.0. It does _not_ update our detray dependency.