### PR TITLE
feat: Define stream operators for the EDM types

### DIFF
--- a/core/include/traccc/edm/measurement_collection.hpp
+++ b/core/include/traccc/edm/measurement_collection.hpp
@@ -212,17 +212,17 @@ class measurement : public BASE {
     /// @returns a string stream that prints the measurement details
     TRACCC_HOST
     friend std::ostream& operator<<(std::ostream& os, const measurement& m) {
-        os << "ID = " << m.identifier() << ", dim = " << m.dimension()
+        os << "ID = " << m.identifier() << ", dim = " << m.dimensions()
            << ", surface: " << m.surface_link() << std::endl;
 
         os << " -> cluster idx = " << m.cluster_index() << std::endl;
 
         os << " -> loc pos     = [" << m.local_position()[0];
-        for (unsigned int i = 1u; i < m.dimension(); ++i) {
+        for (unsigned int i = 1u; i < m.dimensions(); ++i) {
             os << ", " << m.local_position()[i];
         }
         os << "]\n -> loc var     = [" << m.local_variance()[0];
-        for (unsigned int i = 1u; i < m.dimension(); ++i) {
+        for (unsigned int i = 1u; i < m.dimensions(); ++i) {
             os << ", " << m.local_variance()[i];
         }
         os << "]" << std::endl;

--- a/core/include/traccc/edm/measurement_collection.hpp
+++ b/core/include/traccc/edm/measurement_collection.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Local include(s).
+#include "traccc/definitions/common.hpp"
 #include "traccc/definitions/qualifiers.hpp"
 
 // Detray include(s).
@@ -20,6 +21,7 @@
 #include <array>
 #include <compare>
 #include <cstdint>
+#include <ostream>
 
 namespace traccc::edm {
 
@@ -205,6 +207,33 @@ class measurement : public BASE {
         const measurement<T>& other) const;
 
     /// @}
+
+    private:
+    /// @returns a string stream that prints the measurement details
+    TRACCC_HOST
+    friend std::ostream& operator<<(std::ostream& os, const measurement& m) {
+        os << "ID = " << m.identifier() << ", dim = " << m.dimension()
+           << ", surface: " << m.surface_link() << std::endl;
+
+        os << " -> cluster idx = " << m.cluster_index() << std::endl;
+
+        os << " -> loc pos     = [" << m.local_position()[0];
+        for (unsigned int i = 1u; i < m.dimension(); ++i) {
+            os << ", " << m.local_position()[i];
+        }
+        os << "]\n -> loc var     = [" << m.local_variance()[0];
+        for (unsigned int i = 1u; i < m.dimension(); ++i) {
+            os << ", " << m.local_variance()[i];
+        }
+        os << "]" << std::endl;
+
+        os << " -> t           = " << m.time() * traccc::unit<float>::s << "s"
+           << std::endl;
+        os << " -> diameter    = " << m.diameter() * traccc::unit<float>::mm
+           << "mm" << std::endl;
+
+        return os;
+    }
 
 };  // class measurement
 

--- a/core/include/traccc/edm/seed_collection.hpp
+++ b/core/include/traccc/edm/seed_collection.hpp
@@ -14,6 +14,9 @@
 // VecMem include(s).
 #include <vecmem/edm/container.hpp>
 
+// System include(s)
+#include <ostream>
+
 namespace traccc::edm {
 
 /// Interface for the @c traccc::edm::seed_collection class.
@@ -120,6 +123,18 @@ class seed : public BASE {
         const seed<T>& other) const;
 
     /// @}
+
+    private:
+    /// @returns a string stream that prints the seed details
+    TRACCC_HOST
+    friend std::ostream& operator<<(std::ostream& os, const seed& s) {
+        os << "quality: " << s.quality() << std::endl;
+        os << "measurements: [bottom = " << s.bottom_index()
+           << ", middle = " << s.middle_index() << ", top = " << s.top_index()
+           << "]" << std::endl;
+
+        return os;
+    }
 
 };  // class seed
 

--- a/core/include/traccc/edm/track_collection.hpp
+++ b/core/include/traccc/edm/track_collection.hpp
@@ -19,6 +19,9 @@
 // VecMem include(s).
 #include <vecmem/edm/container.hpp>
 
+// System include(s)
+#include <ostream>
+
 namespace traccc::edm {
 
 /// Interface for the @c traccc::edm::track_collection type.
@@ -156,6 +159,19 @@ class track : public BASE {
     TRACCC_HOST_DEVICE bool operator==(const track<T>& other) const;
 
     /// @}
+
+    private:
+    /// @returns a string stream that prints the track details
+    TRACCC_HOST
+    friend std::ostream& operator<<(std::ostream& os, const track& t) {
+        os << "Track: [states: " << t.constituent_links().size()
+           << ", holes: " << t.nholes() << ", chi2 sum: " << t.chi2()
+           << ", ndf: " << t.ndf() << ", pval: " << t.pval() << ", fit res. "
+           << fit_outcome_debug_msg{t.fit_outcome()}() << ", seed:\n "
+           << t.params() << "\n]";
+
+        return os;
+    }
 
 };  // class track_fit
 

--- a/core/include/traccc/edm/track_constituent_link.hpp
+++ b/core/include/traccc/edm/track_constituent_link.hpp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// System include(s)
+#include <ostream>
+
 namespace traccc::edm {
 
 /// A link to a constituent of a track
@@ -30,6 +33,22 @@ struct track_constituent_link {
     /// For some reason Clang fails to generate it automatically for this type.
     ///
     bool operator==(const track_constituent_link&) const = default;
+
+    private:
+    /// @returns a string stream that prints the constituent link
+    TRACCC_HOST
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const track_constituent_link& l) {
+        if (l.type == constituent_type::measurement) {
+            os << "measurement index: " << l.index;
+        } else if (l.type == constituent_type::track_state) {
+            os << "track state index: " << l.index;
+        } else {
+            os << "ERROR: Unknown link type!";
+        }
+
+        return os;
+    }
 
 };  // struct track_constituent_link
 

--- a/core/include/traccc/edm/track_container.hpp
+++ b/core/include/traccc/edm/track_container.hpp
@@ -147,4 +147,59 @@ struct track_container {
 
 };  // struct track_container
 
+/// Convenience function to print the entire track information (const device)
+///
+/// @param track_cont the track container, holding track and states/measurements
+/// @param trk_idx the index into the track collection to fetch the track that
+/// should be printed
+template <typename algebra_t>
+TRACCC_HOST inline void print_track(
+    typename edm::track_container<algebra_t>::const_device& track_cont,
+    unsigned int trk_idx) {
+    // Print the general track information
+    const auto trk = track_cont.tracks.at(trk_idx);
+    std::cout << "TRACK IDX " << trk_idx << ":\n" << trk << std::endl;
+
+    if (trk.constituent_links().empty()) {
+        std::cout << "Track does not contain data" << std::endl;
+        return;
+    }
+
+    // Print the track states or measurements that belong to the trac
+    if (trk.constituent_links().at(0).type ==
+        edm::track_constituent_link::constituent_type::track_state) {
+        for (const auto& link : trk.constituent_links()) {
+            std::cout << "-> State " << link.index << ":\n"
+                      << track_cont.states.at(link.index) << std::endl;
+        }
+    } else {
+        edm::measurement_collection::const_device measurements{
+            track_cont.measurements};
+        for (const auto& link : trk.constituent_links()) {
+            std::cout << "-> Measurement " << link.index << ":\n"
+                      << measurements.at(link.index) << std::endl;
+        }
+    }
+}
+
+/// Convenience function to print the entire track information (host)
+///
+/// @param track_cont the track container, holding track and states/measurements
+/// @param trk_idx the index into the track collection to fetch the track that
+/// should be printed
+template <typename algebra_t>
+TRACCC_HOST inline void print_track(
+    typename edm::track_container<algebra_t>::host& track_cont,
+    unsigned int trk_idx) {
+
+    typename edm::track_container<algebra_t>::const_data const_tracks_data{
+        track_cont};
+    typename edm::track_container<algebra_t>::const_view const_tracks_view{
+        const_tracks_data};
+    typename edm::track_container<algebra_t>::const_device const_device_tracks{
+        const_tracks_view};
+
+    edm::print_track<algebra_t>(const_device_tracks, trk_idx);
+}
+
 }  // namespace traccc::edm

--- a/core/include/traccc/edm/track_fit_outcome.hpp
+++ b/core/include/traccc/edm/track_fit_outcome.hpp
@@ -26,4 +26,47 @@ enum class track_fit_outcome : std::uint16_t {
     MAX_OUTCOME
 };
 
+/// Convert a fit outcome code into a human readable string
+struct fit_outcome_debug_msg {
+
+    TRACCC_HOST std::string operator()() const {
+        switch (m_code) {
+            using enum track_fit_outcome;
+            case UNKNOWN: {
+                return "Unknown";
+            }
+            case SUCCESS: {
+                return "Success";
+            }
+            case FAILURE_NON_POSITIVE_NDF: {
+                return "Negative NDF";
+            }
+            case FAILURE_NOT_ALL_FITTED: {
+                return "Not all track states fitted";
+            }
+            case FAILURE_NOT_ALL_SMOOTHED: {
+                return "Not all track states smoothed";
+            }
+            case FAILURE_FITTER: {
+                return "Fitter failure";
+            }
+            case FAILURE_SMOOTHER: {
+                return "Smoother failure";
+            }
+            case FAILURE_FORWARD_PROPAGATION: {
+                return "Forward propagation failure";
+            }
+            case FAILURE_BACKWARD_PROPAGATION: {
+                return "Backward propagation failure";
+            }
+            default: {
+                return "Not a defined fit outcome code: " +
+                       std::to_string(static_cast<int>(m_code));
+            }
+        }
+    }
+
+    track_fit_outcome m_code{track_fit_outcome::MAX_OUTCOME};
+};
+
 }  // namespace traccc

--- a/core/include/traccc/edm/track_state_collection.hpp
+++ b/core/include/traccc/edm/track_state_collection.hpp
@@ -20,6 +20,7 @@
 // System include(s).
 #include <concepts>
 #include <cstdint>
+#include <ostream>
 
 namespace traccc::edm {
 
@@ -191,6 +192,28 @@ class track_state : public BASE {
     void set_smoothed(bool value = true);
 
     /// @}
+
+    private:
+    /// @returns a string stream that prints the track state details
+    TRACCC_HOST
+    friend std::ostream& operator<<(std::ostream& os, const track_state& s) {
+        os << "hole: " << std::boolalpha << s.is_hole() << std::noboolalpha
+           << std::endl;
+        if (!s.is_hole()) {
+            os << "measurement index: " << s.measurement_index() << std::endl;
+        }
+
+        os << "filtered: chi2 (fw) = " << s.filtered_chi2()
+           << ", chi2 (bw) = " << s.backward_chi2() << "\n"
+           << s.filtered_params() << std::endl;
+
+        if (s.is_smoothed()) {
+            os << "smoothed: chi2 = " << s.smoothed_chi2() << "\n"
+               << s.smoothed_params() << std::endl;
+        }
+
+        return os;
+    }
 
 };  // class track_state
 


### PR DESCRIPTION
Allow easy host side printing of tracking EDM result types for debugging. Additionally, adds a convenience function to the track container that prints the data of all track states or measurements for a given track