### PR TITLE
CUDA Flag Tweak, main branch (2026.06.01.)

### DIFF
--- a/cmake/traccc-compiler-options-cuda.cmake
+++ b/cmake/traccc-compiler-options-cuda.cmake
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2025 CERN for the benefit of the ACTS project
+# (c) 2021-2026 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -27,7 +27,7 @@ endif()
 
 # Allow to use functions in device code that are constexpr, even if they are
 # not marked with __device__.
-traccc_add_flag( CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr --use_fast_math" )
+traccc_add_flag( CMAKE_CUDA_FLAGS "--use_fast_math" )
 
 # Make CUDA generate debug symbols for the device code as well in a debug
 # build.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -161,3 +161,10 @@ target_include_directories(traccc_core
 install(
   DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/include/"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" )
+
+# Any client that wants to use traccc::core with nvcc, needs to use the
+# "--expt-relaxed-constexpr" flag. Otherwise nvcc has a tendency to generate
+# invalid code.
+target_compile_options(traccc_core
+  INTERFACE
+  $<$<AND:$<CUDA_COMPILER_ID:NVIDIA>,$<COMPILE_LANGUAGE:CUDA>>:--expt-relaxed-constexpr>)


### PR DESCRIPTION
While working on https://gitlab.cern.ch/atlas/athena/-/merge_requests/88385 I had to realize that `nvcc` (at least in CUDA 12.8 in this case) is not great with warning us about our use of [std::array](https://en.cppreference.com/cpp/container/array) in device code. :thinking: 

To prevent other people from wasting as much time as I have done on Friday and today, this setup should make it a bit easier to make use of the traccc EDM in CUDA code. CUDA code that may not live in this project.

While I'm a bit worried about hardcoding compiler specific flags into our installation files (as it locks us into using appropriate CUDA versions), the alternative is that clients would have to know about this flag explicitly. Which is also not great. :thinking: