### PR TITLE
expected layer pattern in track finding

### DIFF
--- a/core/include/traccc/finding/actors/expected_layer_pattern_collector.hpp
+++ b/core/include/traccc/finding/actors/expected_layer_pattern_collector.hpp
@@ -1,0 +1,171 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "traccc/definitions/qualifiers.hpp"
+
+// Detray include(s).
+#include <detray/geometry/barcode.hpp>
+#include <detray/propagator/base_actor.hpp>
+
+// System include(s).
+#include <array>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace traccc {
+
+using expected_layer_pattern_type = std::array<unsigned int, 4>;
+
+struct expected_layer_mapping_entry {
+    detray::geometry::barcode::value_t barcode{0u};
+    unsigned int pattern_index{0u};
+    unsigned int layer_index{0u};
+};
+
+namespace details {
+
+inline thread_local std::vector<expected_layer_pattern_type>
+    g_last_expected_layer_patterns{};
+
+inline void clear_last_expected_layer_patterns() {
+    g_last_expected_layer_patterns.clear();
+}
+
+inline void set_last_expected_layer_patterns(
+    std::vector<expected_layer_pattern_type> patterns) {
+    g_last_expected_layer_patterns = std::move(patterns);
+}
+
+inline const std::vector<expected_layer_pattern_type>&
+last_expected_layer_patterns() {
+    return g_last_expected_layer_patterns;
+}
+
+}  // namespace details
+
+/// Default mapper that disables pattern updates.
+struct null_expected_layer_mapper {
+    struct result {
+        bool valid{false};
+        unsigned int pattern_index{0u};
+        unsigned int layer_index{0u};
+    };
+
+    TRACCC_HOST_DEVICE constexpr result
+    operator()(const detray::geometry::barcode&) const {
+        return {};
+    }
+};
+
+/// Mapper that uses a flat lookup table of barcode entries.
+struct expected_layer_table_mapper {
+    using entry_type = expected_layer_mapping_entry;
+
+    struct result {
+        bool valid{false};
+        unsigned int pattern_index{0u};
+        unsigned int layer_index{0u};
+    };
+
+    const entry_type* entries{nullptr};
+    std::size_t size{0u};
+
+    TRACCC_HOST_DEVICE result
+    operator()(const detray::geometry::barcode& barcode) const {
+        if (entries == nullptr || size == 0u) {
+            return {};
+        }
+
+        const auto value = barcode.value();
+        for (std::size_t i = 0u; i < size; ++i) {
+            const auto& entry = entries[i];
+            if (entry.barcode == value) {
+                return {true, entry.pattern_index, entry.layer_index};
+            }
+        }
+
+        return {};
+    }
+};
+
+/// Collector actor for expected-layer-pattern bitmasks.
+///
+/// The mapper must return:
+/// - valid = true if the barcode can be mapped
+/// - pattern_index in [0,3]
+/// - layer_index in [0,31]
+template <typename mapper_t = null_expected_layer_mapper>
+struct expected_layer_pattern_collector : detray::actor {
+
+    using pattern_type = std::array<unsigned int, 4>;
+    using mapper_type = mapper_t;
+    using mapping_result_type = typename mapper_type::result;
+
+    struct state {
+        /// Target bitmask to update.
+        pattern_type* pattern{nullptr};
+        /// Mapping from detray barcode to (pattern index, layer index).
+        mapper_type mapper{};
+
+        /// Optional guard against repeated updates on the same surface.
+        bool deduplicate_consecutive_surfaces{true};
+        detray::geometry::barcode last_surface{};
+        bool has_last_surface{false};
+
+        /// Lightweight counters for debugging.
+        unsigned int n_updates{0u};
+        unsigned int n_skipped{0u};
+    };
+
+    template <typename propagator_state_t>
+    TRACCC_HOST_DEVICE void operator()(state& actor_state,
+                                       propagator_state_t& propagation) const {
+
+        const auto& navigation = propagation._navigation;
+
+        // Keep behavior aligned with sensitive detector element collection.
+        if (!navigation.is_on_sensitive()) {
+            return;
+        }
+
+        const auto& sf_desc = std::as_const(navigation).current().surface();
+        const auto sf_barcode = sf_desc.barcode();
+
+        if (actor_state.deduplicate_consecutive_surfaces &&
+            actor_state.has_last_surface &&
+            sf_barcode == actor_state.last_surface) {
+            ++actor_state.n_skipped;
+            return;
+        }
+
+        actor_state.last_surface = sf_barcode;
+        actor_state.has_last_surface = true;
+
+        if (actor_state.pattern == nullptr) {
+            ++actor_state.n_skipped;
+            return;
+        }
+
+        const mapping_result_type mapping = actor_state.mapper(sf_barcode);
+        if (!mapping.valid || mapping.pattern_index >= 4u ||
+            mapping.layer_index >=
+                static_cast<unsigned int>(sizeof(unsigned int) * 8u)) {
+            ++actor_state.n_skipped;
+            return;
+        }
+
+        (*actor_state.pattern)[mapping.pattern_index] |=
+            (1u << mapping.layer_index);
+        ++actor_state.n_updates;
+    }
+};
+
+}  // namespace traccc

--- a/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -73,6 +73,10 @@ combinatorial_kalman_filter(
            "overstep tolerance");
     assert(config.min_track_candidates_per_track >= 1);
 
+    // Clear buffer before starting the CKF, to avoid previous event's pattern 
+    // leaking into the current event's track finding
+    traccc::details::clear_last_expected_layer_patterns();
+
     /// The algebra type
     using algebra_type = typename detector_t::algebra_type;
     /// The scalar type
@@ -127,6 +131,10 @@ combinatorial_kalman_filter(
 
     std::vector<std::vector<std::size_t>> param_to_link;
     param_to_link.resize(config.max_track_candidates_per_track);
+
+    // Create expected layer patterns buffer for each link at each step
+    std::vector<std::vector<expected_layer_pattern_type>> expected_layer_patterns;
+    expected_layer_patterns.resize(config.max_track_candidates_per_track);
 
     std::vector<std::pair<unsigned int, unsigned int>> tips;
 
@@ -350,6 +358,9 @@ combinatorial_kalman_filter(
          * For documentation, see the device version.
          */
         const std::size_t n_links = links[step].size();
+        // Resize expected layer patterns buffer to match the number of links 
+        // for this step
+        expected_layer_patterns[step].resize(n_links);
         std::vector<unsigned int> param_liveness;
         param_liveness.resize(n_links);
 
@@ -507,8 +518,6 @@ combinatorial_kalman_filter(
 
             typename detray::pathlimit_aborter<scalar_type>::state
                 aborter_state;
-            typename detray::parameter_transporter<
-                typename detector_t::algebra_type>::state transporter_state;
             traccc::details::ckf_interactor_t::state interactor_state;
             typename interaction_register<traccc::details::ckf_interactor_t>::
                 state interaction_register_state{interactor_state};
@@ -517,6 +526,17 @@ combinatorial_kalman_filter(
                 prop_cfg};
             typename detray::momentum_aborter<scalar_type>::state
                 momentum_aborter_state{};
+            // Configure expected layer pattern collector state
+            typename expected_layer_pattern_collector<
+                expected_layer_table_mapper>::state
+                expected_layer_pattern_collector_state{};
+            expected_layer_pattern_type propagated_expected_layer_pattern{};
+            expected_layer_pattern_collector_state.pattern =
+                &propagated_expected_layer_pattern;
+            expected_layer_pattern_collector_state.mapper.entries =
+                config.expected_layer_map;
+            expected_layer_pattern_collector_state.mapper.size =
+                config.expected_layer_map_size;
             typename ckf_aborter::state ckf_aborter_state;
 
             // Update the actor config
@@ -531,11 +551,13 @@ combinatorial_kalman_filter(
 
             // Propagate to the next surface
             TRACCC_DEBUG_HOST("Propagating... ");
+            // Add expected layer pattern collector to the actor chain
             propagator.propagate(
                 propagation,
-                detray::tie(aborter_state, transporter_state,
-                            interaction_register_state, interactor_state,
+                detray::tie(aborter_state, interaction_register_state,
+                            interactor_state,
                             resetter_state, momentum_aborter_state,
+                            expected_layer_pattern_collector_state,
                             ckf_aborter_state));
             TRACCC_DEBUG_HOST("Finished propagation");
 
@@ -571,6 +593,8 @@ combinatorial_kalman_filter(
                 if (valid_track) {
                     out_params.push_back(out_param);
                     param_to_link[step].push_back(link_id);
+                    expected_layer_patterns[step][link_id] =
+                        propagated_expected_layer_pattern;
                 }
             }
             // Unless the track found a surface, it is considered a
@@ -606,10 +630,15 @@ combinatorial_kalman_filter(
     typename edm::track_container<algebra_type>::host output_candidates{
         mr, measurements_view};
     output_candidates.tracks.reserve(tips.size());
+    // Buffer for expected layer patterns of the output tracks
+    std::vector<expected_layer_pattern_type> output_expected_layer_patterns;
+    output_expected_layer_patterns.reserve(tips.size());
 
     for (const auto& tip : tips) {
         // Get the link corresponding to tip
         auto L = links.at(tip.first).at(tip.second);
+        auto current_step = tip.first;
+        auto current_link_idx = tip.second;
 
         const unsigned int n_cands = tip.first + 1 - L.n_skipped;
 
@@ -628,6 +657,7 @@ combinatorial_kalman_filter(
         // Track summary variables
         scalar ndf_sum = 0.f;
         scalar chi2_sum = 0.f;
+        expected_layer_pattern_type track_expected_pattern{};
 
         // Reversely iterate to fill the track candidates
         for (auto it = cands_per_track.rbegin(); it != cands_per_track.rend();
@@ -637,12 +667,19 @@ combinatorial_kalman_filter(
                 const auto link_pos =
                     param_to_link.at(L.step - 1u).at(L.previous_candidate_idx);
 
+                current_step = L.step - 1u;
+                current_link_idx = link_pos;
                 L = links.at(L.step - 1u).at(link_pos);
             }
 
             // Break if the measurement is still invalid
             if (L.meas_idx >= measurements.size()) {
                 break;
+            }
+            // Merge per-link patterns into track-level expected layer pattern
+            for (std::size_t i = 0; i < track_expected_pattern.size(); ++i) {
+                track_expected_pattern[i] |=
+                    expected_layer_patterns.at(current_step).at(current_link_idx)[i];
             }
 
             *it = {edm::track_constituent_link::measurement, L.meas_idx};
@@ -674,14 +711,33 @@ combinatorial_kalman_filter(
                 track.pval() = pval;
                 track.nholes() = L.n_skipped;
                 track.constituent_links() = cands_per_track;
+                output_expected_layer_patterns.push_back(track_expected_pattern);
 
             } else {
                 const auto l_pos =
                     param_to_link.at(L.step - 1u).at(L.previous_candidate_idx);
 
+                current_step = L.step - 1u;
+                current_link_idx = l_pos;
                 L = links.at(L.step - 1u).at(l_pos);
             }
         }
+    }
+    // Publish expected layer patterns for the found tracks
+    traccc::details::set_last_expected_layer_patterns(
+        std::move(output_expected_layer_patterns));
+
+    // NOTE: For debugging purposes only
+    TRACCC_DEBUG_HOST("Published expected-layer patterns for "
+                      << traccc::details::last_expected_layer_patterns().size()
+                      << " tracks");
+    for (std::size_t i = 0;
+         i < traccc::details::last_expected_layer_patterns().size(); ++i) {
+        const auto& pattern = traccc::details::last_expected_layer_patterns().at(i);
+        (void)pattern;
+        TRACCC_DEBUG_HOST("  pattern[" << i << "] = {"
+                          << pattern[0] << ", " << pattern[1] << ", "
+                          << pattern[2] << ", " << pattern[3] << "}");
     }
 
     return output_candidates;

--- a/core/include/traccc/finding/details/combinatorial_kalman_filter_types.hpp
+++ b/core/include/traccc/finding/details/combinatorial_kalman_filter_types.hpp
@@ -11,6 +11,7 @@
 #include "traccc/definitions/common.hpp"
 #include "traccc/definitions/primitives.hpp"
 #include "traccc/finding/actors/ckf_aborter.hpp"
+#include "traccc/finding/actors/expected_layer_pattern_collector.hpp"
 #include "traccc/finding/actors/interaction_register.hpp"
 
 // Detray include(s).
@@ -37,13 +38,17 @@ using ckf_interactor_t =
     detray::pointwise_material_interactor<traccc::default_algebra>;
 
 /// Actor chain used in the Combinatorial Kalman Filter (CKF)
+/// Expected layer pattern collector added to the chain
 using ckf_actor_chain_t =
     detray::actor_chain<detray::pathlimit_aborter<traccc::scalar>,
                         detray::parameter_transporter<traccc::default_algebra>,
                         interaction_register<ckf_interactor_t>,
                         ckf_interactor_t,
                         detray::parameter_resetter<traccc::default_algebra>,
-                        detray::momentum_aborter<traccc::scalar>, ckf_aborter>;
+                        detray::momentum_aborter<traccc::scalar>,
+                        expected_layer_pattern_collector<
+                            expected_layer_table_mapper>,
+                        ckf_aborter>;
 
 /// Propagator type used in the Combinatorial Kalman Filter (CKF)
 ///

--- a/core/include/traccc/finding/finding_config.hpp
+++ b/core/include/traccc/finding/finding_config.hpp
@@ -15,7 +15,12 @@
 // detray include(s).
 #include <detray/propagator/propagation_config.hpp>
 
+// System include(s).
+#include <cstddef>
+
 namespace traccc {
+
+struct expected_layer_mapping_entry;
 
 /// Configuration struct for track finding
 struct finding_config {
@@ -89,6 +94,10 @@ struct finding_config {
     /// @note This parameter affects GPU-based track finding only.
     unsigned int initial_links_per_seed = 100;
     /// @}
+
+    /// Optional mapping table for expected-layer patterns.
+    const expected_layer_mapping_entry* expected_layer_map{nullptr};
+    std::size_t expected_layer_map_size{0u};
 };
 
 }  // namespace traccc

--- a/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp
@@ -377,7 +377,7 @@ struct kalman_actor : detray::actor {
                     navigation.current_surface().has_material()) {
                     // Add this to the surface sequence for the backward fit
                     actor_state.add_to_sequence(
-                        std::as_const(navigation).current().sf_desc);
+                        std::as_const(navigation).current().surface());
                 }
                 return;
             } else if (actor_state.fit_result !=
@@ -425,7 +425,7 @@ struct kalman_actor : detray::actor {
 
                     // Add this to the surface sequence for the backward fit
                     actor_state.add_to_sequence(
-                        std::as_const(navigation).current().sf_desc);
+                        std::as_const(navigation).current().surface());
                 } else {
                     assert(false);
                 }
@@ -504,7 +504,7 @@ struct kalman_actor : detray::actor {
 
             // Add this to the surface sequence for the backward fit
             actor_state.add_to_sequence(
-                std::as_const(navigation).current().sf_desc);
+                std::as_const(navigation).current().surface());
         }
     }
 };

--- a/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_fitter.hpp
@@ -127,8 +127,8 @@ class kalman_fitter {
         TRACCC_HOST_DEVICE
         typename forward_actor_chain_type::state_ref_tuple operator()() {
             return detray::tie(m_momentum_aborter_state,
-                               m_pathlimit_aborter_state, m_transporter_state,
-                               m_interactor_state, m_fit_actor_state,
+                               m_pathlimit_aborter_state, m_interactor_state,
+                               m_fit_actor_state,
                                m_parameter_resetter, m_step_aborter_state);
         }
 
@@ -137,8 +137,8 @@ class kalman_fitter {
         typename backward_actor_chain_type::state_ref_tuple
         backward_actor_state() {
             return detray::tie(m_momentum_aborter_state,
-                               m_pathlimit_aborter_state, m_transporter_state,
-                               m_fit_actor_state, m_interactor_state,
+                               m_pathlimit_aborter_state, m_fit_actor_state,
+                               m_interactor_state,
                                m_parameter_resetter, m_step_aborter_state);
         }
 

--- a/device/common/include/traccc/finding/device/build_tracks.hpp
+++ b/device/common/include/traccc/finding/device/build_tracks.hpp
@@ -16,6 +16,7 @@
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/finding/finding_config.hpp"
+#include "traccc/finding/actors/expected_layer_pattern_collector.hpp"
 
 // VecMem include(s).
 #include <vecmem/containers/data/jagged_vector_view.hpp>
@@ -44,6 +45,18 @@ struct build_tracks_payload {
      * @brief View object to the vector of track candidates
      */
     edm::track_container<default_algebra>::view tracks_view;
+
+    /**
+     * @brief View object to the per-link expected-layer patterns
+     */
+    vecmem::data::vector_view<const expected_layer_pattern_type>
+        expected_layer_patterns_view;
+
+    /**
+     * @brief View object to the per-track expected-layer patterns
+     */
+    vecmem::data::vector_view<expected_layer_pattern_type>
+        output_expected_layer_patterns_view;
 
     /**
      * @brief Optional mapping from tip index to output index

--- a/device/common/include/traccc/finding/device/impl/build_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/build_tracks.ipp
@@ -31,6 +31,12 @@ TRACCC_HOST_DEVICE inline void build_tracks(
     const vecmem::device_vector<const candidate_link> links(payload.links_view);
 
     const vecmem::device_vector<const unsigned int> tips(payload.tips_view);
+    // Expected layer patterns
+    const vecmem::device_vector<const expected_layer_pattern_type>
+        expected_layer_patterns(payload.expected_layer_patterns_view);
+    vecmem::device_vector<expected_layer_pattern_type>
+        output_expected_layer_patterns(
+            payload.output_expected_layer_patterns_view);
 
     edm::track_collection<default_algebra>::device track_candidates(
         payload.tracks_view.tracks);
@@ -65,6 +71,9 @@ TRACCC_HOST_DEVICE inline void build_tracks(
     // Track summary variables
     scalar ndf_sum = 0.f;
     scalar chi2_sum = 0.f;
+    
+    // Initialize track-level expected layer pattern bitmask
+    expected_layer_pattern_type track_expected_pattern{};
 
     bound_matrix<default_algebra> big_lambda_tilde =
         matrix::zero<bound_matrix<default_algebra>>();
@@ -182,6 +191,15 @@ TRACCC_HOST_DEVICE inline void build_tracks(
         } else {
             *it = {edm::track_constituent_link::measurement, L.meas_idx};
         }
+        
+        // Merge per-link patterns into track-level expected layer bitmask 
+        // as done in CPU
+        if (expected_layer_patterns.size() > link_idx) {
+            const auto& link_pattern = expected_layer_patterns.at(link_idx);
+            for (std::size_t i = 0; i < track_expected_pattern.size(); ++i) {
+                track_expected_pattern[i] |= link_pattern[i];
+            }
+        }
 
         // Sanity check on chi2
         assert(L.chi2 < std::numeric_limits<traccc::scalar>::max());
@@ -205,6 +223,11 @@ TRACCC_HOST_DEVICE inline void build_tracks(
             track.chi2() = chi2_sum;
             track.pval() = prob(track.chi2(), track.ndf());
             track.nholes() = L.n_skipped;
+            // Write final expected layer pattern to output
+            if (output_expected_layer_patterns.size() > output_idx) {
+                output_expected_layer_patterns.at(output_idx) =
+                    track_expected_pattern;
+            }
         } else {
             link_idx = L.previous_candidate_idx;
             L = links.at(link_idx);

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -12,9 +12,20 @@
 #include "traccc/utils/particle.hpp"
 
 // Detray include(s).
+#include <detray/geometry/shapes/line.hpp>
+#include <detray/geometry/tracking_surface.hpp>
+#include <detray/materials/material_rod.hpp>
+#include <detray/navigation/direct_navigator.hpp>
+#include <detray/navigation/external_surface.hpp>
 #include <detray/plugins/algebra/array_definitions.hpp>
+#include <detray/propagator/actor_chain.hpp>
 #include <detray/propagator/constrained_step.hpp>
+#include <detray/propagator/propagator.hpp>
+#include <detray/utils/ranges/single.hpp>
 #include <detray/utils/tuple_helpers.hpp>
+
+// System include(s).
+#include <limits>
 
 namespace traccc::device {
 
@@ -46,6 +57,10 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     vecmem::device_vector<unsigned int> params_liveness(
         payload.params_liveness_view);
 
+    // Expected layer patterns
+    vecmem::device_vector<expected_layer_pattern_type>
+        expected_layer_patterns(payload.expected_layer_patterns_view);
+
     // tips
     vecmem::device_vector<unsigned int> tips(payload.tips_view);
     vecmem::device_vector<unsigned int> tip_lengths(payload.tip_lengths_view);
@@ -57,6 +72,13 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     bound_track_parameters_collection_types::device params(payload.params_view);
 
     if (params_liveness.at(param_id) == 0u) {
+        //NOTE: FIX FOR GARABEGE VALUES OF EXPECTED LAYER PATTERNS. Set to 0 if param is dead, otherwise 1.
+        if (expected_layer_patterns.size() > link_idx) {
+            auto& link_pattern = expected_layer_patterns.at(link_idx);
+            for (unsigned int i = 0u; i < link_pattern.size(); ++i) {
+                link_pattern[i] = 0u;
+            }
+        }
         return;
     }
 
@@ -84,8 +106,9 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     // Pathlimit aborter
     typename detray::detail::tuple_element<0, actor_tuple_type>::type::state
         s0{};
-    typename detray::detail::tuple_element<1, actor_tuple_type>::type::state
-        s1{};
+    
+    // typename detray::detail::tuple_element<1, actor_tuple_type>::type::state
+    //     s1{};
     // CKF-interactor
     typename detray::detail::tuple_element<3, actor_tuple_type>::type::state
         s3{};
@@ -97,8 +120,10 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
         prop_cfg};
     // Momentum aborter
     typename detray::detail::tuple_element<5, actor_tuple_type>::type::state s5;
-    // CKF aborter
+    // Expected layer pattern collector
     typename detray::detail::tuple_element<6, actor_tuple_type>::type::state s6;
+    // CKF aborter
+    typename detray::detail::tuple_element<7, actor_tuple_type>::type::state s7;
 
     /*
      * If we are running the MBF smoother, we need to accumulate the Jacobians
@@ -111,19 +136,149 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
 
         payload.tmp_jacobian_ptr[param_id] = matrix::identity<
             bound_matrix<typename propagator_t::detector_type::algebra_type>>();
-        s1._full_jacobian_ptr = &payload.tmp_jacobian_ptr[param_id];
+        // s1._full_jacobian_ptr = &payload.tmp_jacobian_ptr[param_id];
     }
 
     s5.min_pT(static_cast<scalar_t>(cfg.min_pT));
     s5.min_p(static_cast<scalar_t>(cfg.min_p));
-    s6.min_step_length = cfg.min_step_length_for_next_surface;
-    s6.max_count = cfg.max_step_counts_for_next_surface;
+    // NOTE: CKF aborter is now s7, instead of s6
+    s7.min_step_length = cfg.min_step_length_for_next_surface;
+    s7.max_count = cfg.max_step_counts_for_next_surface;
 
     // Propagate to the next surface
-    propagator.propagate(propagation, detray::tie(s0, s1, s2, s3, s4, s5, s6));
+    //NOTE: transporter not in device actor chain now, so not included in tie
+    // propagator.propagate(propagation, detray::tie(s0, s1, s2, s3, s4, s5, s6));
+    // Run a perigee prepass for step 0, initialize pattern, wire collector, 
+    // then propagate with new actor chain.
+    if (expected_layer_patterns.size() > link_idx) {
+        expected_layer_pattern_type perigee_pattern{};
+        bool perigee_pattern_ready = false;
+
+        if (payload.step == 0 && payload.expected_layer_map != nullptr &&
+            payload.expected_layer_map_size > 0u) {
+            using detector_t = typename propagator_t::detector_type;
+            using algebra_t = typename detector_t::algebra_type;
+            using scalar_t = typename detector_t::scalar_type;
+            using nav_link_t =
+                typename detector_t::surface_type::navigation_link;
+            using perigee_surface_t =
+                detray::external_surface<algebra_t, detray::line_circular,
+                                         detray::material_rod<scalar_t>,
+                                         nav_link_t>;
+            using perigee_navigator_t =
+                detray::direct_navigator<
+                    detector_t,
+                    detray::ranges::single_view<perigee_surface_t>>;
+            using perigee_propagator_t =
+                detray::propagator<typename propagator_t::stepper_type,
+                                   perigee_navigator_t, detray::actor_chain<>>;
+
+            static constexpr typename perigee_surface_t::material_type
+                perigee_material{detray::vacuum<scalar_t>{},
+                                 std::numeric_limits<scalar_t>::max()};
+            static constexpr typename perigee_surface_t::mask_type perigee_mask{
+                0u, std::numeric_limits<scalar_t>::max(),
+                -std::numeric_limits<scalar_t>::max()};
+            perigee_surface_t perigee_surface{
+                detray::dtransform3D<algebra_t>{}, perigee_mask,
+                perigee_material, 0u, detray::surface_id::e_passive};
+
+            const detray::tracking_surface sf{det, in_par.surface_link()};
+            const auto free_seed =
+                sf.bound_to_free_vector(typename detector_t::geometry_context{},
+                                        in_par);
+
+            perigee_propagator_t perigee_propagator(prop_cfg);
+            typename perigee_propagator_t::state perigee_state(
+                free_seed, payload.field_data, det,
+                detray::ranges::single_view<perigee_surface_t>{perigee_surface},
+                prop_cfg.context);
+            perigee_state.set_particle(detail::correct_particle_hypothesis(
+                cfg.ptc_hypothesis, free_seed));
+            perigee_state._stepping
+                .template set_constraint<detray::step::constraint::e_accuracy>(
+                    cfg.propagation.stepping.step_constraint);
+            perigee_state._navigation.set_direction(
+                detray::navigation::direction::e_backward);
+            perigee_propagator.propagate(perigee_state);
+
+            if (perigee_propagator.finished(perigee_state) &&
+                !perigee_state._stepping().is_invalid()) {
+                propagator_t perigee_to_first(prop_cfg);
+                typename propagator_t::state perigee_propagation(
+                    perigee_state._stepping(), payload.field_data, det);
+                perigee_propagation.set_particle(
+                    detail::correct_particle_hypothesis(
+                        cfg.ptc_hypothesis, perigee_state._stepping()));
+                perigee_propagation._stepping
+                    .template set_constraint<
+                        detray::step::constraint::e_accuracy>(
+                        cfg.propagation.stepping.step_constraint);
+
+                typename detray::detail::tuple_element<0, actor_tuple_type>::type::
+                    state p0{};
+                typename detray::detail::tuple_element<3, actor_tuple_type>::type::
+                    state p3{};
+                typename detray::detail::tuple_element<2, actor_tuple_type>::type::
+                    state p2{p3};
+                typename detray::detail::tuple_element<4, actor_tuple_type>::type::
+                    state p4{prop_cfg};
+                typename detray::detail::tuple_element<5, actor_tuple_type>::type::
+                    state p5;
+                typename detray::detail::tuple_element<6, actor_tuple_type>::type::
+                    state p6;
+                typename detray::detail::tuple_element<7, actor_tuple_type>::type::
+                    state p7;
+
+                p5.min_pT(static_cast<scalar_t>(cfg.min_pT));
+                p5.min_p(static_cast<scalar_t>(cfg.min_p));
+                p7.min_step_length = cfg.min_step_length_for_next_surface;
+                p7.max_count = cfg.max_step_counts_for_next_surface;
+
+                p6.pattern = &perigee_pattern;
+                p6.mapper.entries = payload.expected_layer_map;
+                p6.mapper.size = payload.expected_layer_map_size;
+
+                perigee_to_first.propagate(
+                    perigee_propagation,
+                    detray::tie(p0, p2, p3, p4, p5, p6, p7));
+
+                perigee_pattern_ready = p7.success;
+                if (globalIndex < 3u) {
+                    TRACCC_INFO_DEVICE(
+                        "Perigee prepass idx=%u success=%u updates=%u "
+                        "skipped=%u",
+                        globalIndex, static_cast<unsigned int>(p7.success),
+                        p6.n_updates, p6.n_skipped);
+                }
+            } else if (globalIndex < 3u) {
+                TRACCC_INFO_DEVICE(
+                    "Perigee prepass idx=%u failed perigee_extrapolation",
+                    globalIndex);
+            }
+        }
+
+        //NOTE: ADDED TO FIX GARBAGE VALUE ISSUE IN THE EXPECTED LAYER PATTERN
+        auto& link_pattern = expected_layer_patterns.at(link_idx);
+        for (unsigned int i = 0u; i < link_pattern.size(); ++i) {
+            link_pattern[i] = 0u;
+        }
+        if (perigee_pattern_ready) {
+            for (unsigned int i = 0u; i < link_pattern.size(); ++i) {
+                link_pattern[i] = perigee_pattern[i];
+            }
+        }
+        s6.pattern = &link_pattern;
+        s6.mapper.entries = payload.expected_layer_map;
+        s6.mapper.size = payload.expected_layer_map_size;
+    }
+
+    propagator.propagate(propagation,
+                         detray::tie(s0, s2, s3, s4, s5, s6, s7));
 
     // If a surface found, add the parameter for the next step
-    if (s6.success) {
+    // NOTE: CKF aborter is now s7, instead of s6
+    if (s7.success) {
         assert(propagation._navigation.is_on_sensitive());
         assert(!propagation._stepping.bound_params().is_invalid());
 

--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -15,6 +15,7 @@
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/finding/candidate_link.hpp"
 #include "traccc/finding/finding_config.hpp"
+#include "traccc/finding/actors/expected_layer_pattern_collector.hpp"
 
 // VecMem include(s).
 #include <vecmem/containers/data/vector_view.hpp>
@@ -79,6 +80,22 @@ struct propagate_to_next_surface_payload {
      * @brief Vector to hold the number of track states per tip
      */
     vecmem::data::vector_view<unsigned int> tip_lengths_view;
+
+    /**
+     * @brief View object to the per-link expected-layer patterns
+     */
+    vecmem::data::vector_view<expected_layer_pattern_type>
+        expected_layer_patterns_view;
+
+    /**
+     * @brief Device pointer to the expected-layer mapping table
+     */
+    const expected_layer_mapping_entry* expected_layer_map;
+
+    /**
+     * @brief Size of the expected-layer mapping table
+     */
+    unsigned int expected_layer_map_size;
 
     bound_matrix<typename propagator_t::detector_type::algebra_type>*
         tmp_jacobian_ptr;

--- a/device/cuda/src/finding/combinatorial_kalman_filter.cuh
+++ b/device/cuda/src/finding/combinatorial_kalman_filter.cuh
@@ -34,6 +34,7 @@
 #include "traccc/finding/details/combinatorial_kalman_filter_types.hpp"
 #include "traccc/finding/device/barcode_surface_comparator.hpp"
 #include "traccc/finding/finding_config.hpp"
+#include "traccc/finding/actors/expected_layer_pattern_collector.hpp"
 #include "traccc/utils/logging.hpp"
 #include "traccc/utils/memory_resource.hpp"
 #include "traccc/utils/projections.hpp"
@@ -162,6 +163,31 @@ combinatorial_kalman_filter(
     vecmem::data::vector_buffer<candidate_link> links_buffer(
         link_buffer_capacity, mr.main, vecmem::data::buffer_type::resizable);
     copy.setup(links_buffer)->ignore();
+    
+    // Create a buffer for expected layer patterns
+    vecmem::data::vector_buffer<expected_layer_pattern_type>
+        expected_layer_patterns_buffer(
+            link_buffer_capacity, mr.main,
+            vecmem::data::buffer_type::fixed_size);
+    copy.setup(expected_layer_patterns_buffer)->ignore();
+
+    // Copy mapping table for expected layer patterns to device
+    const auto expected_layer_map_size =
+        static_cast<vecmem::data::vector_buffer<
+            expected_layer_mapping_entry>::size_type>(
+            config.expected_layer_map_size);
+    vecmem::data::vector_buffer<expected_layer_mapping_entry>
+        expected_layer_map_buffer(expected_layer_map_size, mr.main);
+    const expected_layer_mapping_entry* expected_layer_map_ptr = nullptr;
+    if (config.expected_layer_map != nullptr &&
+        config.expected_layer_map_size > 0u) {
+        copy.setup(expected_layer_map_buffer)->wait();
+        copy(vecmem::data::vector_view<const expected_layer_mapping_entry>(
+             expected_layer_map_size, config.expected_layer_map),
+             expected_layer_map_buffer)
+            ->wait();
+        expected_layer_map_ptr = expected_layer_map_buffer.ptr();
+    }
 
     vecmem::unique_alloc_ptr<bound_matrix<typename detector_t::algebra_type>[]>
         jacobian_ptr = nullptr;
@@ -270,6 +296,19 @@ combinatorial_kalman_filter(
             copy(links_buffer, new_links_buffer)->wait();
 
             links_buffer = std::move(new_links_buffer);
+            
+            // Resize the expected layer patterns buffer as well, 
+            // to keep it in sync with the links buffer
+            vecmem::data::vector_buffer<expected_layer_pattern_type>
+                new_expected_layer_patterns_buffer(
+                    link_buffer_capacity, mr.main,
+                    vecmem::data::buffer_type::fixed_size);
+            copy.setup(new_expected_layer_patterns_buffer)->ignore();
+            copy(expected_layer_patterns_buffer,
+                 new_expected_layer_patterns_buffer)
+                ->wait();
+            expected_layer_patterns_buffer =
+                std::move(new_expected_layer_patterns_buffer);
 
             if (config.run_mbf_smoother) {
                 vecmem::unique_alloc_ptr<
@@ -435,6 +474,17 @@ combinatorial_kalman_filter(
         // If no more CKF step is expected, the tips and links are populated,
         // and any further time-consuming action is avoided
         if (step == config.max_track_candidates_per_track - 1) {
+        //NOTE: ADDED TO FIX GARBAGE VALUE ISSUE IN THE EXPECTED LAYER PATTERN
+            if (n_candidates > 0) {
+                vecmem::device_vector<expected_layer_pattern_type>
+                    patterns_device(expected_layer_patterns_buffer);
+                const unsigned int offset = step_to_link_idx_map[step];
+                thrust::fill(thrust_policy,
+                             patterns_device.begin() + offset,
+                             patterns_device.begin() + offset + n_candidates,
+                             expected_layer_pattern_type{});
+                str.synchronize();
+            }
             break;
         }
 
@@ -489,6 +539,8 @@ combinatorial_kalman_filter(
                 using payload_t = device::propagate_to_next_surface_payload<
                     traccc::details::ckf_propagator_t<detector_t, bfield_t>,
                     bfield_t>;
+                // Add expected layer pattern buffer and map to the payload 
+                // for collection during propagation
                 const payload_t host_payload{
                     .det_data = det,
                     .field_data = field,
@@ -501,6 +553,12 @@ combinatorial_kalman_filter(
                     .n_in_params = n_candidates,
                     .tips_view = tips_buffer,
                     .tip_lengths_view = tip_length_buffer,
+                    .expected_layer_patterns_view =
+                        expected_layer_patterns_buffer,
+                    .expected_layer_map = expected_layer_map_ptr,
+                    .expected_layer_map_size =
+                        static_cast<unsigned int>(
+                            config.expected_layer_map_size),
                     .tmp_jacobian_ptr = tmp_jacobian_ptr.get()};
 
                 const unsigned int nThreads = warp_size * 4;
@@ -513,6 +571,39 @@ combinatorial_kalman_filter(
                 TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 
                 str.synchronize();
+                
+                //NOTE: For debugging purposes only
+                TRACCC_DEBUG("Step " << step << " n_candidates="
+                                     << n_candidates << " link_offset="
+                                     << step_to_link_idx_map[step]
+                                     << " map_ptr="
+                                     << (expected_layer_map_ptr != nullptr)
+                                     << " map_size="
+                                     << static_cast<unsigned int>(
+                                            config.expected_layer_map_size));
+
+                if (n_candidates > 0 && expected_layer_map_ptr != nullptr) {
+                    const unsigned int sample =
+                        std::min(3u, n_candidates);
+                    vecmem::device_vector<expected_layer_pattern_type>
+                        patterns_device(expected_layer_patterns_buffer);
+                    std::vector<expected_layer_pattern_type> host_sample(
+                        sample);
+                    const unsigned int offset = step_to_link_idx_map[step];
+                    TRACCC_CUDA_ERROR_CHECK(cudaMemcpyAsync(
+                        host_sample.data(),
+                        patterns_device.data() + offset,
+                        sizeof(expected_layer_pattern_type) * sample,
+                        cudaMemcpyDeviceToHost, stream));
+                    str.synchronize();
+                    for (unsigned int i = 0; i < sample; ++i) {
+                        const auto& p = host_sample[i];
+                        TRACCC_DEBUG("Step " << step << " pattern[" << i
+                                            << "] = {" << p[0] << ", "
+                                            << p[1] << ", " << p[2] << ", "
+                                            << p[3] << "}");
+                    }
+                }
             }
         }
 
@@ -665,17 +756,27 @@ combinatorial_kalman_filter(
     copy.setup(track_candidates_buffer.tracks)->ignore();
     copy.setup(track_candidates_buffer.states)->ignore();
 
+    // Create output buffer for expected layer patterns
+    vecmem::data::vector_buffer<expected_layer_pattern_type>
+        output_expected_layer_patterns_buffer(n_tips_total_filtered, mr.main);
+    copy.setup(output_expected_layer_patterns_buffer)->ignore();
+
     // @Note: nBlocks can be zero in case there is no tip. This happens when
     // chi2_max config is set tightly and no tips are found
     if (n_tips_total > 0) {
         const unsigned int nThreads = warp_size * 2;
         const unsigned int nBlocks = (n_tips_total + nThreads - 1) / nThreads;
 
+        // Add expected layer pattern buffer and map to the payload 
+        // for final collection during track building
         const device::build_tracks_payload payload{
             .seeds_view = seeds,
             .links_view = links_buffer,
             .tips_view = tips_buffer,
             .tracks_view = {track_candidates_buffer},
+            .expected_layer_patterns_view = expected_layer_patterns_buffer,
+            .output_expected_layer_patterns_view =
+                output_expected_layer_patterns_buffer,
             .tip_to_output_map = tip_to_output_map.get(),
             .jacobian_ptr = jacobian_ptr.get(),
             .link_predicted_parameter_view = link_predicted_parameter_buffer,
@@ -686,6 +787,20 @@ combinatorial_kalman_filter(
         TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 
         str.synchronize();
+    }
+
+    // Publish expected layer patterns for the found tracks
+    if (n_tips_total_filtered > 0) {
+        vecmem::vector<expected_layer_pattern_type> host_patterns(mr.host);
+        host_patterns.resize(n_tips_total_filtered);
+        copy(output_expected_layer_patterns_buffer, host_patterns)->wait();
+        traccc::details::set_last_expected_layer_patterns(
+            std::vector<expected_layer_pattern_type>(
+                host_patterns.begin(), host_patterns.end()));
+        TRACCC_INFO("Published expected-layer patterns for "
+                     << host_patterns.size() << " tracks (CUDA)");
+    } else {
+        traccc::details::clear_last_expected_layer_patterns();
     }
 
     return track_candidates_buffer;


### PR DESCRIPTION
Adding expected-layer pattern collection and propagation through the traccc tracking workflow, including host and device CKF paths and the Athena conversion chain.

Main changes:

* Collect and store expected-layer patterns during track finding.
* Propagate precomputed patterns through track conversion instead of recomputing them later at `TrackToTrackParticleCnvAlg` in CPU.
* Added mapping support and pattern aggregation for track candidates.
* Some minor fixes (empty-buffer checks, pattern initialization, cell ordering updates).
* Added debugging and timing checks to help validate the implementation. This was done for comparing expected layer pattern across different implementations, so can be removed later.

Details on the results can be found in [this](https://indico.cern.ch/event/1688349/) GPU roundtable meeting. This implementation sets a collector pipeline for expected layer pattern. As of now, it uses perigee_extrapolator from detray [#1099](https://github.com/acts-project/detray/pull/1099) which is a  linear step propagator from tracks to origin (0,0,0). Because of this, although the match percentage of expected layer patterns has increased by 17.1% after using perigee extrapolator, there is still room to improve by implementing the actual perigee surface along with back propagation (this is to be done in detray and used in traccc).

Adding log of this implementation validated with single muon data at `/eos/atlas/atlaslocalgroupdisk/dq2/rucio/mc21_14TeV/a2/de/RDO.41864945._000003.pool.root.1` with 100 events (tests also done with larger nEvents). 
[log_with_expectedLayerPattern_collector.log](https://github.com/user-attachments/files/28518372/log_with_expectedLayerPattern_collector.log)

The table shows the improvement after implementation of expected layer pattern collector in traccc along with perigee (0, 0,0) collector in detray. As expected, most of the mismatch comes from the endcap and transition layers.
| expectedLayerPattern in G200 | Match % wrt G200 + computation on CPU | Barrel match % | Endcap match % | Transition layer match % |
|------------------------------|----------------------------------------|----------------|----------------|--------------------------|
| **Without perigee<br>extrapolation** | 50 | 68.3 | 40 | 33.33 |
| **With perigee<br>extrapolation** | 67.1 | 83.92 | 50 | 52.63 |