### PR TITLE
Add guard to avoid FPE crash

### DIFF
--- a/device/cuda/src/gbts_seeding/gbts_seeding_algorithm.cu
+++ b/device/cuda/src/gbts_seeding/gbts_seeding_algorithm.cu
@@ -709,10 +709,16 @@ gbts_seeding_algorithm::output_type gbts_seeding_algorithm::operator()(
         &path_sizes[1],
         &ctx.d_counters[traccc::device::gbts_counter::nTerminusEdges],
         sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
-    unsigned int pathsPerTerminus = 1 + (path_sizes[0] - 1) / path_sizes[1];
 
     TRACCC_DEBUG(path_sizes[0] << "size of path store | nTerminusEdges "
                                << path_sizes[1]);
+
+    if (path_sizes[1] == 0) {
+        TRACCC_DEBUG("No paths found long enough to form seeds");
+        return {0, m_mr.main};
+    }
+
+    unsigned int pathsPerTerminus = 1 + (path_sizes[0] - 1) / path_sizes[1];
 
     cudaMalloc(&ctx.d_path_store,
                (path_sizes[0] + path_sizes[1]) * sizeof(int2));


### PR DESCRIPTION
This is a patch in case the number of terminus edges ends up being zero.

Without this there is a FPE error that ends up in a crash with a message pointing towards `traccc::cuda::gbts_seeding_algorithm::operator()`

I think it can be reproduced with any EF Tracking pipeline that uses GBTS when running on single mu? In my case it was triggered before the 50th event when running on `/eos/project/a/atlas-eftracking/RDOFiles_EFTrkPerf/list_mc21_14TeV.900495.PG_single_muonpm_Pt10_etaFlatnp0_43.recon.RDO.e8557_s4422_r16128_tid41864947_00.txt` (10GeV single mu)

Since I'm not really confident with the solution given the lack of familiarity with the code, @m-brettell could you have a look?

