### PR TITLE
fix: Use traccc internal IO includes

### DIFF
--- a/tests/common/tests/triplet_fitting_telescope_test.hpp
+++ b/tests/common/tests/triplet_fitting_telescope_test.hpp
@@ -9,10 +9,8 @@
 
 // Project include(s).
 #include "test_detectors.hpp"
+#include "traccc/io/detector.hpp"
 #include "triplet_fitting_test.hpp"
-
-// Detray include(s).
-#include <detray/io/frontend/detector_writer.hpp>
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/tests/common/tests/triplet_fitting_test.hpp
+++ b/tests/common/tests/triplet_fitting_test.hpp
@@ -20,14 +20,6 @@
 // Covfie include(s).
 #include <covfie/core/field.hpp>
 
-// detray include(s).
-// #include <detray/definitions/pdg_particle.hpp>
-// #include <detray/detectors/magnetic_field.hpp>
-// #include <detray/navigation/navigator.hpp>
-// #include <detray/propagator/propagator.hpp>
-// #include <detray/propagator/rk_stepper.hpp>
-// #include <detray/test/utils/simulation/event_generator/track_generators.hpp>
-
 // GTest include(s).
 #include <gtest/gtest.h>
 
@@ -48,15 +40,6 @@ class TripletFittingTests : public testing::Test {
     using scalar_type = device_detector_type::scalar_type;
     using b_field_t =
         covfie::field<traccc::const_bfield_backend_t<scalar_type>>;
-    /*using rk_stepper_type =
-        detray::rk_stepper<b_field_t::view_t, traccc::default_algebra,
-                           detray::constrained_step<scalar_type>>;
-    using host_navigator_type = detray::navigator<const host_detector_type>;
-    using host_fitter_type =
-        kalman_fitter<rk_stepper_type, host_navigator_type>;
-    using device_navigator_type = detray::navigator<const device_detector_type>;
-    using device_fitter_type =
-        kalman_fitter<rk_stepper_type, device_navigator_type>;*/
 
     // Use deterministic random number generator for testing
     using uniform_gen_t =

--- a/tests/cpu/test_triplet_fitter_telescope.cpp
+++ b/tests/cpu/test_triplet_fitter_telescope.cpp
@@ -8,6 +8,7 @@
 // Project include(s).
 #include "traccc/bfield/construct_const_bfield.hpp"
 #include "traccc/fitting/triplet_fitting_algorithm.hpp"
+#include "traccc/io/detector.hpp"
 #include "traccc/io/read_detector.hpp"
 #include "traccc/io/utils.hpp"
 #include "traccc/resolution/fitting_performance_writer.hpp"
@@ -18,9 +19,6 @@
 
 // Test include(s).
 #include "tests/triplet_fitting_telescope_test.hpp"
-
-// detray include(s).
-#include <detray/io/frontend/detector_reader.hpp>
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>


### PR DESCRIPTION
Use traccc IO headers, so that the detector IO log output remains turned off. Also removes some dead code.