### PR TITLE
CUDA Register Spilling Config, main branch (2026.06.17.)

### DIFF
--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -198,3 +198,18 @@ if( ( "${CMAKE_CUDA_COMPILER_ID}" STREQUAL "NVIDIA" ) AND
   set_target_properties( traccc_cuda PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON )
 endif()
+
+# Control whether to enable register spilling into shared memory. Also allowing
+# users to override our chosen default.
+set(TRACCC_CUDA_ENABLE_SPILL_TO_SHARED_MEMORY_DEFAULT OFF)
+if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 13.0)
+  set(TRACCC_CUDA_ENABLE_SPILL_TO_SHARED_MEMORY_DEFAULT ON)
+endif()
+option(TRACCC_CUDA_ENABLE_SPILL_TO_SHARED_MEMORY
+  "Enable spilling of registers to shared memory in CUDA kernels"
+  ${TRACCC_CUDA_ENABLE_SPILL_TO_SHARED_MEMORY_DEFAULT})
+mark_as_advanced(TRACCC_CUDA_ENABLE_SPILL_TO_SHARED_MEMORY)
+if(TRACCC_CUDA_ENABLE_SPILL_TO_SHARED_MEMORY)
+  target_compile_definitions(traccc_cuda
+    PRIVATE TRACCC_CUDA_ENABLE_SPILL_TO_SHARED_MEMORY)
+endif()

--- a/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
@@ -26,7 +26,6 @@ __global__ void find_tracks(
     const __grid_constant__ finding_config cfg,
     const __grid_constant__ typename detector_t::const_view_type det,
     const __grid_constant__ device::find_tracks_payload payload) {
-    TRACCC_CUDA_SPILL_TO_SHARED_MEMORY;
 
     __shared__ unsigned int shared_num_out_params;
     __shared__ unsigned int shared_candidates_size;

--- a/device/cuda/src/utils/hints.hpp
+++ b/device/cuda/src/utils/hints.hpp
@@ -1,14 +1,14 @@
 /**
  * TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-#if defined(__CUDA_ARCH__) && CUDART_VERSION >= 13000
+#if defined(__CUDA_ARCH__) && defined(TRACCC_CUDA_ENABLE_SPILL_TO_SHARED_MEMORY)
 #define TRACCC_CUDA_SPILL_TO_SHARED_MEMORY        \
     do {                                          \
         asm(".pragma \"enable_smem_spilling\";"); \


### PR DESCRIPTION
Changed the logic of enabling/disabling CUDA register spilling. Since it seems that at least in some cases with CUDA 13 it doesn't actually work. So this allows users to turn it off by hand if necessary.

With a local CUDA 13.2.1 + GCC 13.3.0 I observed the following:

```
[build] ptxas fatal   : Pragma 'enable_smem_spilling' is not allowed for dynamic SMEM
[build] gmake[2]: *** [device/cuda/CMakeFiles/traccc_cuda.dir/build.make:675: device/cuda/CMakeFiles/traccc_cuda.dir/src/finding/kernels/specializations/find_tracks.cu.in.default_detector.cu.o] Error 255
[build] gmake[2]: *** Waiting for unfinished jobs....
```

Which I couldn't track down to its root yet. And since the problem only shows up for certain detector types as it seems, I also couldn't figure out a good way for checking for this behaviour with [try_compile(...)](https://cmake.org/cmake/help/latest/command/try_compile.html). So for now I just did this dumb thing.

This is because I'm 99% sure that the Athena nightlies will need to make use of this knob. :thinking: 