### PR TITLE
Const Copy, main branch (2026.06.18.)

### DIFF
--- a/device/alpaka/include/traccc/alpaka/clusterization/clusterization_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/clusterization/clusterization_algorithm.hpp
@@ -36,8 +36,8 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     /// @param config The clustering configuration
     ///
     clusterization_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy, alpaka::queue& q,
-        const config_type& config,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
+        alpaka::queue& q, const config_type& config,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     private:

--- a/device/alpaka/include/traccc/alpaka/clusterization/measurement_sorting_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/clusterization/measurement_sorting_algorithm.hpp
@@ -46,7 +46,7 @@ class measurement_sorting_algorithm
     /// @param q The Alpaka queue to schedule the measurement sorting in
     ///
     measurement_sorting_algorithm(
-        const traccc::memory_resource& mr, ::vecmem::copy& copy, queue& q,
+        const traccc::memory_resource& mr, const ::vecmem::copy& copy, queue& q,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     /// Callable operator performing the sorting on a container
@@ -61,7 +61,7 @@ class measurement_sorting_algorithm
     // The memory resource(s) to use
     traccc::memory_resource m_mr;
     /// Copy object to use in the algorithm
-    std::reference_wrapper<::vecmem::copy> m_copy;
+    std::reference_wrapper<const ::vecmem::copy> m_copy;
     /// The Alpaka queue to use
     std::reference_wrapper<queue> m_queue;
 

--- a/device/alpaka/include/traccc/alpaka/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -24,7 +24,7 @@ class combinatorial_kalman_filter_algorithm
     /// Constructor with the algorithm's configuration
     combinatorial_kalman_filter_algorithm(
         const finding_config& config, const traccc::memory_resource& mr,
-        vecmem::copy& copy, alpaka::queue& queue,
+        const vecmem::copy& copy, alpaka::queue& queue,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     private:

--- a/device/alpaka/include/traccc/alpaka/fitting/kalman_fitting_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/fitting/kalman_fitting_algorithm.hpp
@@ -49,7 +49,7 @@ class kalman_fitting_algorithm
     ///
     kalman_fitting_algorithm(
         const config_type& config, const traccc::memory_resource& mr,
-        vecmem::copy& copy, queue& q,
+        const vecmem::copy& copy, queue& q,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     /// Execute the algorithm
@@ -71,7 +71,7 @@ class kalman_fitting_algorithm
     /// Memory resource used by the algorithm
     traccc::memory_resource m_mr;
     /// Copy object used by the algorithm
-    std::reference_wrapper<vecmem::copy> m_copy;
+    std::reference_wrapper<const vecmem::copy> m_copy;
     /// Queue wrapper
     std::reference_wrapper<queue> m_queue;
 

--- a/device/alpaka/include/traccc/alpaka/gbts_seeding/gbts_seeding_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/gbts_seeding/gbts_seeding_algorithm.hpp
@@ -35,7 +35,7 @@ class gbts_seeding_algorithm : public device::gbts_seeding_algorithm,
     ///
     gbts_seeding_algorithm(
         const gbts_seedfinder_config& cfg, const memory_resource& mr,
-        vecmem::copy& copy, alpaka::queue& q,
+        const vecmem::copy& copy, alpaka::queue& q,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     private:

--- a/device/alpaka/include/traccc/alpaka/seeding/seed_parameter_estimation_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/seeding/seed_parameter_estimation_algorithm.hpp
@@ -32,7 +32,7 @@ struct seed_parameter_estimation_algorithm
     ///
     seed_parameter_estimation_algorithm(
         const track_params_estimation_config& config,
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         alpaka::queue& queue,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 

--- a/device/alpaka/include/traccc/alpaka/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp
@@ -34,7 +34,8 @@ class silicon_pixel_spacepoint_formation_algorithm
     /// @param logger The logger instance to use
     ///
     silicon_pixel_spacepoint_formation_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy, alpaka::queue& q,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
+        alpaka::queue& q,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     private:

--- a/device/alpaka/include/traccc/alpaka/seeding/triplet_seeding_algorithm.hpp
+++ b/device/alpaka/include/traccc/alpaka/seeding/triplet_seeding_algorithm.hpp
@@ -32,7 +32,8 @@ class triplet_seeding_algorithm : public device::triplet_seeding_algorithm,
         const seedfinder_config& finder_config,
         const spacepoint_grid_config& grid_config,
         const seedfilter_config& filter_config,
-        const traccc::memory_resource& mr, vecmem::copy& copy, alpaka::queue& q,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
+        alpaka::queue& q,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     private:

--- a/device/alpaka/src/clusterization/clusterization_algorithm.cpp
+++ b/device/alpaka/src/clusterization/clusterization_algorithm.cpp
@@ -91,8 +91,9 @@ struct reify_cluster_data {
 }  // namespace kernels
 
 clusterization_algorithm::clusterization_algorithm(
-    const traccc::memory_resource& mr, vecmem::copy& copy, alpaka::queue& q,
-    const config_type& config, std::unique_ptr<const Logger> logger)
+    const traccc::memory_resource& mr, const vecmem::copy& copy,
+    alpaka::queue& q, const config_type& config,
+    std::unique_ptr<const Logger> logger)
     : device::clusterization_algorithm(mr, copy, config, std::move(logger)),
       alpaka::algorithm_base(q) {}
 

--- a/device/alpaka/src/clusterization/measurement_sorting_algorithm.cpp
+++ b/device/alpaka/src/clusterization/measurement_sorting_algorithm.cpp
@@ -57,7 +57,7 @@ struct fill_sorted_measurements {
 }  // namespace kernels
 
 measurement_sorting_algorithm::measurement_sorting_algorithm(
-    const traccc::memory_resource& mr, vecmem::copy& copy, queue& q,
+    const traccc::memory_resource& mr, const vecmem::copy& copy, queue& q,
     std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)), m_mr{mr}, m_copy{copy}, m_queue{q} {}
 

--- a/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp
+++ b/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp
@@ -197,7 +197,8 @@ struct build_tracks {
 
 combinatorial_kalman_filter_algorithm::combinatorial_kalman_filter_algorithm(
     const config_type& config, const traccc::memory_resource& mr,
-    vecmem::copy& copy, alpaka::queue& q, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, alpaka::queue& q,
+    std::unique_ptr<const Logger> logger)
     : device::combinatorial_kalman_filter_algorithm(config, mr, copy,
                                                     std::move(logger)),
       alpaka::algorithm_base(q) {}

--- a/device/alpaka/src/fitting/kalman_fitting.hpp
+++ b/device/alpaka/src/fitting/kalman_fitting.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -116,8 +116,8 @@ kalman_fitting(
     const bfield_t& field_view,
     const typename edm::track_container<
         typename detector_t::algebra_type>::const_view& track_candidates_view,
-    const fitting_config& config, const memory_resource& mr, vecmem::copy& copy,
-    Queue& queue) {
+    const fitting_config& config, const memory_resource& mr,
+    const vecmem::copy& copy, Queue& queue) {
 
     // Number of threads per block to use.
     const Idx threadsPerBlock = getWarpSize<Acc>() * 2;

--- a/device/alpaka/src/fitting/kalman_fitting_algorithm.cpp
+++ b/device/alpaka/src/fitting/kalman_fitting_algorithm.cpp
@@ -19,7 +19,7 @@ namespace traccc::alpaka {
 
 kalman_fitting_algorithm::kalman_fitting_algorithm(
     const config_type& config, const traccc::memory_resource& mr,
-    vecmem::copy& copy, queue& q, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, queue& q, std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)),
       m_config{config},
       m_mr{mr},

--- a/device/alpaka/src/gbts_seeding/gbts_seeding_algorithm.cpp
+++ b/device/alpaka/src/gbts_seeding/gbts_seeding_algorithm.cpp
@@ -313,7 +313,8 @@ struct gbts_convert_seeds {
 
 gbts_seeding_algorithm::gbts_seeding_algorithm(
     const gbts_seedfinder_config& cfg, const memory_resource& mr,
-    vecmem::copy& copy, alpaka::queue& q, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, alpaka::queue& q,
+    std::unique_ptr<const Logger> logger)
     : device::gbts_seeding_algorithm(cfg, mr, copy, std::move(logger)),
       alpaka::algorithm_base{q} {}
 

--- a/device/alpaka/src/seeding/seed_parameter_estimation_algorithm.cpp
+++ b/device/alpaka/src/seeding/seed_parameter_estimation_algorithm.cpp
@@ -40,8 +40,8 @@ struct estimate_track_params {
 
 seed_parameter_estimation_algorithm::seed_parameter_estimation_algorithm(
     const track_params_estimation_config& config,
-    const traccc::memory_resource& mr, vecmem::copy& copy, alpaka::queue& q,
-    std::unique_ptr<const Logger> logger)
+    const traccc::memory_resource& mr, const vecmem::copy& copy,
+    alpaka::queue& q, std::unique_ptr<const Logger> logger)
     : device::seed_parameter_estimation_algorithm(config, mr, copy,
                                                   std::move(logger)),
       alpaka::algorithm_base(q) {}

--- a/device/alpaka/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cpp
+++ b/device/alpaka/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cpp
@@ -40,8 +40,8 @@ struct form_spacepoints {
 
 silicon_pixel_spacepoint_formation_algorithm::
     silicon_pixel_spacepoint_formation_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy, alpaka::queue& q,
-        std::unique_ptr<const Logger> logger)
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
+        alpaka::queue& q, std::unique_ptr<const Logger> logger)
     : device::silicon_pixel_spacepoint_formation_algorithm(mr, copy,
                                                            std::move(logger)),
       alpaka::algorithm_base(q) {}

--- a/device/alpaka/src/seeding/triplet_seeding_algorithm.cpp
+++ b/device/alpaka/src/seeding/triplet_seeding_algorithm.cpp
@@ -224,7 +224,8 @@ triplet_seeding_algorithm::triplet_seeding_algorithm(
     const seedfinder_config& finder_config,
     const spacepoint_grid_config& grid_config,
     const seedfilter_config& filter_config, const traccc::memory_resource& mr,
-    vecmem::copy& copy, alpaka::queue& q, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, alpaka::queue& q,
+    std::unique_ptr<const Logger> logger)
     : device::triplet_seeding_algorithm(finder_config, grid_config,
                                         filter_config, mr, copy,
                                         std::move(logger)),

--- a/device/common/include/traccc/clusterization/device/clusterization_algorithm.hpp
+++ b/device/common/include/traccc/clusterization/device/clusterization_algorithm.hpp
@@ -73,7 +73,7 @@ class clusterization_algorithm
     /// partition
     ///
     clusterization_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         const config_type& config,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 

--- a/device/common/include/traccc/device/algorithm_base.hpp
+++ b/device/common/include/traccc/device/algorithm_base.hpp
@@ -30,15 +30,11 @@ class algorithm_base {
     /// @param mr     The memory resource(s) to use
     /// @param copy   The copy object to use
     ///
-    algorithm_base(const memory_resource& mr, vecmem::copy& copy);
+    algorithm_base(const memory_resource& mr, const vecmem::copy& copy);
 
-    /// The memory resource(s) to use in the algorithm (non-const)
-    memory_resource& mr();
     /// The memory resource(s) to use in the algorithm (const)
     const memory_resource& mr() const;
 
-    /// The copy object to use in the algorithm (non-const)
-    vecmem::copy& copy();
     /// The copy object to use in the algorithm (const)
     const vecmem::copy& copy() const;
 
@@ -46,7 +42,7 @@ class algorithm_base {
     /// Memory resource(s) to use in the algorithm
     memory_resource m_mr;
     /// Copy object to use in the algorithm
-    std::reference_wrapper<vecmem::copy> m_copy;
+    std::reference_wrapper<const vecmem::copy> m_copy;
 
 };  // class algorithm_base
 

--- a/device/common/include/traccc/finding/device/combinatorial_kalman_filter_algorithm.hpp
+++ b/device/common/include/traccc/finding/device/combinatorial_kalman_filter_algorithm.hpp
@@ -65,7 +65,7 @@ class combinatorial_kalman_filter_algorithm
     ///
     combinatorial_kalman_filter_algorithm(
         const finding_config& config, const traccc::memory_resource& mr,
-        vecmem::copy& copy,
+        const vecmem::copy& copy,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
     /// Destructor
     virtual ~combinatorial_kalman_filter_algorithm();

--- a/device/common/include/traccc/gbts_seeding/device/gbts_seeding_algorithm.hpp
+++ b/device/common/include/traccc/gbts_seeding/device/gbts_seeding_algorithm.hpp
@@ -79,7 +79,7 @@ class gbts_seeding_algorithm
     ///
     gbts_seeding_algorithm(
         const gbts_seedfinder_config& cfg, const memory_resource& mr,
-        vecmem::copy& copy,
+        const vecmem::copy& copy,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     /// Destructor

--- a/device/common/include/traccc/seeding/device/seed_parameter_estimation_algorithm.hpp
+++ b/device/common/include/traccc/seeding/device/seed_parameter_estimation_algorithm.hpp
@@ -47,7 +47,7 @@ struct seed_parameter_estimation_algorithm
     ///
     seed_parameter_estimation_algorithm(
         const track_params_estimation_config& config,
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
     /// Destructor
     ~seed_parameter_estimation_algorithm();

--- a/device/common/include/traccc/seeding/device/silicon_pixel_spacepoint_formation_algorithm.hpp
+++ b/device/common/include/traccc/seeding/device/silicon_pixel_spacepoint_formation_algorithm.hpp
@@ -41,7 +41,7 @@ class silicon_pixel_spacepoint_formation_algorithm
     /// @param logger The logger instance to use
     ///
     silicon_pixel_spacepoint_formation_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     /// Construct spacepoints from 2D silicon pixel measurements

--- a/device/common/include/traccc/seeding/device/triplet_seeding_algorithm.hpp
+++ b/device/common/include/traccc/seeding/device/triplet_seeding_algorithm.hpp
@@ -55,7 +55,7 @@ class triplet_seeding_algorithm
         const seedfinder_config& finder_config,
         const spacepoint_grid_config& grid_config,
         const seedfilter_config& filter_config, const memory_resource& mr,
-        vecmem::copy& copy,
+        const vecmem::copy& copy,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
     /// Destructor
     virtual ~triplet_seeding_algorithm();

--- a/device/common/src/clusterization/clusterization_algorithm.cpp
+++ b/device/common/src/clusterization/clusterization_algorithm.cpp
@@ -13,7 +13,7 @@
 namespace traccc::device {
 
 clusterization_algorithm::clusterization_algorithm(
-    const traccc::memory_resource& mr, vecmem::copy& cp,
+    const traccc::memory_resource& mr, const vecmem::copy& cp,
     const config_type& config, std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)),
       algorithm_base{mr, cp},

--- a/device/common/src/device/algorithm_base.cpp
+++ b/device/common/src/device/algorithm_base.cpp
@@ -10,22 +10,13 @@
 
 namespace traccc::device {
 
-algorithm_base::algorithm_base(const memory_resource& mr, vecmem::copy& copy)
+algorithm_base::algorithm_base(const memory_resource& mr,
+                               const vecmem::copy& copy)
     : m_mr{mr}, m_copy{copy} {}
-
-memory_resource& algorithm_base::mr() {
-
-    return m_mr;
-}
 
 const memory_resource& algorithm_base::mr() const {
 
     return m_mr;
-}
-
-vecmem::copy& algorithm_base::copy() {
-
-    return m_copy.get();
 }
 
 const vecmem::copy& algorithm_base::copy() const {

--- a/device/common/src/finding/combinatorial_kalman_filter_algorithm.cpp
+++ b/device/common/src/finding/combinatorial_kalman_filter_algorithm.cpp
@@ -23,7 +23,7 @@ struct combinatorial_kalman_filter_algorithm::data {
 
 combinatorial_kalman_filter_algorithm::combinatorial_kalman_filter_algorithm(
     const finding_config& config, const traccc::memory_resource& mr,
-    vecmem::copy& copy, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)),
       algorithm_base{mr, copy},
       m_data{std::make_unique<data>(config)} {

--- a/device/common/src/gbts_seeding/gbts_seeding_algorithm.cpp
+++ b/device/common/src/gbts_seeding/gbts_seeding_algorithm.cpp
@@ -541,7 +541,7 @@ auto gbts_seeding_algorithm::extract_seeds(
 
 gbts_seeding_algorithm::gbts_seeding_algorithm(
     const gbts_seedfinder_config& cfg, const memory_resource& mr,
-    vecmem::copy& copy, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)), algorithm_base{mr, copy}, m_config{cfg} {}
 
 auto gbts_seeding_algorithm::operator()(

--- a/device/common/src/seeding/seed_parameter_estimation_algorithm.cpp
+++ b/device/common/src/seeding/seed_parameter_estimation_algorithm.cpp
@@ -19,7 +19,7 @@ struct seed_parameter_estimation_algorithm::data {
 
 seed_parameter_estimation_algorithm::seed_parameter_estimation_algorithm(
     const track_params_estimation_config& config,
-    const traccc::memory_resource& mr, vecmem::copy& copy,
+    const traccc::memory_resource& mr, const vecmem::copy& copy,
     std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)),
       algorithm_base{mr, copy},

--- a/device/common/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cpp
+++ b/device/common/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cpp
@@ -12,7 +12,7 @@ namespace traccc::device {
 
 silicon_pixel_spacepoint_formation_algorithm::
     silicon_pixel_spacepoint_formation_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)), algorithm_base(mr, copy) {}
 

--- a/device/common/src/seeding/triplet_seeding_algorithm.cpp
+++ b/device/common/src/seeding/triplet_seeding_algorithm.cpp
@@ -44,7 +44,7 @@ triplet_seeding_algorithm::triplet_seeding_algorithm(
     const seedfinder_config& finder_config,
     const spacepoint_grid_config& grid_config,
     const seedfilter_config& filter_config, const memory_resource& mr,
-    vecmem::copy& copy, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)),
       algorithm_base{mr, copy},
       m_data{std::make_unique<data>(

--- a/device/cuda/include/traccc/cuda/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.hpp
@@ -1,6 +1,6 @@
 /** TRACCC library, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -43,7 +43,7 @@ class greedy_ambiguity_resolution_algorithm
     ///
     greedy_ambiguity_resolution_algorithm(
         const config_type& cfg, const traccc::memory_resource& mr,
-        vecmem::copy& copy, stream& str,
+        const vecmem::copy& copy, stream& str,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     /// Run the algorithm
@@ -63,7 +63,7 @@ class greedy_ambiguity_resolution_algorithm
     /// The memory resource to use
     traccc::memory_resource m_mr;
     /// The copy object to use
-    std::reference_wrapper<vecmem::copy> m_copy;
+    std::reference_wrapper<const vecmem::copy> m_copy;
     /// The CUDA stream to use
     std::reference_wrapper<stream> m_stream;
     /// Warp size of the GPU being used

--- a/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp
@@ -37,7 +37,7 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     /// @param logger The logger instance to use for messaging
     ///
     clusterization_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         cuda::stream& str, const config_type& config,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 

--- a/device/cuda/include/traccc/cuda/clusterization/measurement_sorting_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/clusterization/measurement_sorting_algorithm.hpp
@@ -44,7 +44,8 @@ class measurement_sorting_algorithm
     /// @param str The CUDA stream to schedule the measurement sorting in
     ///
     measurement_sorting_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy, stream& str,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
+        stream& str,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     /// Callable operator performing the sorting on a container
@@ -59,7 +60,7 @@ class measurement_sorting_algorithm
     /// The memory resource(s) to use
     traccc::memory_resource m_mr;
     /// Copy object to use in the algorithm
-    std::reference_wrapper<vecmem::copy> m_copy;
+    std::reference_wrapper<const vecmem::copy> m_copy;
     /// CUDA stream used by the algorithm
     std::reference_wrapper<stream> m_stream;
 };  // class measurement_sorting_algorithm

--- a/device/cuda/include/traccc/cuda/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -24,7 +24,7 @@ class combinatorial_kalman_filter_algorithm
     /// Constructor with the algorithm's configuration
     combinatorial_kalman_filter_algorithm(
         const finding_config& config, const traccc::memory_resource& mr,
-        vecmem::copy& copy, cuda::stream& str,
+        const vecmem::copy& copy, cuda::stream& str,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     private:

--- a/device/cuda/include/traccc/cuda/fitting/kalman_fitting_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/fitting/kalman_fitting_algorithm.hpp
@@ -49,7 +49,7 @@ class kalman_fitting_algorithm
     ///
     kalman_fitting_algorithm(
         const config_type& config, const traccc::memory_resource& mr,
-        vecmem::copy& copy, stream& str,
+        const vecmem::copy& copy, stream& str,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     /// Execute the algorithm
@@ -71,7 +71,7 @@ class kalman_fitting_algorithm
     /// Memory resource used by the algorithm
     traccc::memory_resource m_mr;
     /// Copy object used by the algorithm
-    std::reference_wrapper<vecmem::copy> m_copy;
+    std::reference_wrapper<const vecmem::copy> m_copy;
     /// The CUDA stream to use
     std::reference_wrapper<stream> m_stream;
     /// Warp size of the GPU being used

--- a/device/cuda/include/traccc/cuda/gbts_seeding/gbts_seeding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/gbts_seeding/gbts_seeding_algorithm.hpp
@@ -35,7 +35,7 @@ class gbts_seeding_algorithm : public device::gbts_seeding_algorithm,
     ///
     gbts_seeding_algorithm(
         const gbts_seedfinder_config& cfg, const memory_resource& mr,
-        vecmem::copy& copy, cuda::stream& str,
+        const vecmem::copy& copy, cuda::stream& str,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     private:

--- a/device/cuda/include/traccc/cuda/seeding/seed_parameter_estimation_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/seed_parameter_estimation_algorithm.hpp
@@ -32,7 +32,7 @@ struct seed_parameter_estimation_algorithm
     ///
     seed_parameter_estimation_algorithm(
         const track_params_estimation_config& config,
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         cuda::stream& str,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 

--- a/device/cuda/include/traccc/cuda/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp
@@ -34,7 +34,7 @@ class silicon_pixel_spacepoint_formation_algorithm
     /// @param logger The logger instance to use
     ///
     silicon_pixel_spacepoint_formation_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         cuda::stream& str,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 

--- a/device/cuda/include/traccc/cuda/seeding/triplet_seeding_algorithm.hpp
+++ b/device/cuda/include/traccc/cuda/seeding/triplet_seeding_algorithm.hpp
@@ -36,7 +36,7 @@ class triplet_seeding_algorithm : public device::triplet_seeding_algorithm,
         const seedfinder_config& finder_config,
         const spacepoint_grid_config& grid_config,
         const seedfilter_config& filter_config, const memory_resource& mr,
-        vecmem::copy& copy, cuda::stream& str,
+        const vecmem::copy& copy, cuda::stream& str,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     private:

--- a/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
+++ b/device/cuda/src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cu
@@ -72,7 +72,7 @@ struct track_comparator {
 
 greedy_ambiguity_resolution_algorithm::greedy_ambiguity_resolution_algorithm(
     const config_type& cfg, const traccc::memory_resource& mr,
-    vecmem::copy& copy, stream& str, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, stream& str, std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)),
       m_config(cfg),
       m_mr(mr),

--- a/device/cuda/src/clusterization/clusterization_algorithm.cu
+++ b/device/cuda/src/clusterization/clusterization_algorithm.cu
@@ -23,8 +23,9 @@
 namespace traccc::cuda {
 
 clusterization_algorithm::clusterization_algorithm(
-    const traccc::memory_resource& mr, vecmem::copy& copy, cuda::stream& str,
-    const config_type& config, std::unique_ptr<const Logger> logger)
+    const traccc::memory_resource& mr, const vecmem::copy& copy,
+    cuda::stream& str, const config_type& config,
+    std::unique_ptr<const Logger> logger)
     : device::clusterization_algorithm(mr, copy, config, std::move(logger)),
       cuda::algorithm_base(str) {}
 

--- a/device/cuda/src/clusterization/measurement_sorting_algorithm.cu
+++ b/device/cuda/src/clusterization/measurement_sorting_algorithm.cu
@@ -58,7 +58,7 @@ __global__ void fill_sorted_measurements(
 }  // namespace kernels
 
 measurement_sorting_algorithm::measurement_sorting_algorithm(
-    const traccc::memory_resource& mr, vecmem::copy& copy, stream& str,
+    const traccc::memory_resource& mr, const vecmem::copy& copy, stream& str,
     std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)), m_mr{mr}, m_copy{copy}, m_stream{str} {}
 

--- a/device/cuda/src/finding/combinatorial_kalman_filter_algorithm.cpp
+++ b/device/cuda/src/finding/combinatorial_kalman_filter_algorithm.cpp
@@ -12,7 +12,8 @@ namespace traccc::cuda {
 
 combinatorial_kalman_filter_algorithm::combinatorial_kalman_filter_algorithm(
     const finding_config& config, const traccc::memory_resource& mr,
-    vecmem::copy& copy, cuda::stream& str, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, cuda::stream& str,
+    std::unique_ptr<const Logger> logger)
     : device::combinatorial_kalman_filter_algorithm(config, mr, copy,
                                                     std::move(logger)),
       cuda::algorithm_base(str) {}

--- a/device/cuda/src/fitting/kalman_fitting.cuh
+++ b/device/cuda/src/fitting/kalman_fitting.cuh
@@ -58,8 +58,8 @@ kalman_fitting(
     const bfield_t& field_view,
     const typename edm::track_container<
         typename detector_t::algebra_type>::const_view& track_candidates_view,
-    const fitting_config& config, const memory_resource& mr, vecmem::copy& copy,
-    stream& str, unsigned int warp_size) {
+    const fitting_config& config, const memory_resource& mr,
+    const vecmem::copy& copy, stream& str, unsigned int warp_size) {
 
     // Get a convenience variable for the stream that we'll be using.
     cudaStream_t stream = details::get_stream(str);

--- a/device/cuda/src/fitting/kalman_fitting_algorithm.cpp
+++ b/device/cuda/src/fitting/kalman_fitting_algorithm.cpp
@@ -14,7 +14,7 @@ namespace traccc::cuda {
 
 kalman_fitting_algorithm::kalman_fitting_algorithm(
     const config_type& config, const traccc::memory_resource& mr,
-    vecmem::copy& copy, stream& str, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, stream& str, std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)),
       m_config{config},
       m_mr{mr},

--- a/device/cuda/src/gbts_seeding/gbts_seeding_algorithm.cu
+++ b/device/cuda/src/gbts_seeding/gbts_seeding_algorithm.cu
@@ -232,7 +232,8 @@ __global__ void gbts_convert_seeds(
 
 gbts_seeding_algorithm::gbts_seeding_algorithm(
     const gbts_seedfinder_config& cfg, const memory_resource& mr,
-    vecmem::copy& copy, cuda::stream& str, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, cuda::stream& str,
+    std::unique_ptr<const Logger> logger)
     : device::gbts_seeding_algorithm(cfg, mr, copy, std::move(logger)),
       cuda::algorithm_base{str} {}
 

--- a/device/cuda/src/seeding/seed_parameter_estimation_algorithm.cu
+++ b/device/cuda/src/seeding/seed_parameter_estimation_algorithm.cu
@@ -36,8 +36,8 @@ __global__ void estimate_track_params(
 
 seed_parameter_estimation_algorithm::seed_parameter_estimation_algorithm(
     const track_params_estimation_config& config,
-    const traccc::memory_resource& mr, vecmem::copy& copy, cuda::stream& str,
-    std::unique_ptr<const Logger> logger)
+    const traccc::memory_resource& mr, const vecmem::copy& copy,
+    cuda::stream& str, std::unique_ptr<const Logger> logger)
     : device::seed_parameter_estimation_algorithm(config, mr, copy,
                                                   std::move(logger)),
       cuda::algorithm_base(str) {}

--- a/device/cuda/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cu
+++ b/device/cuda/src/seeding/silicon_pixel_spacepoint_formation_algorithm.cu
@@ -34,7 +34,7 @@ __global__ void __launch_bounds__(1024, 1)
 
 silicon_pixel_spacepoint_formation_algorithm::
     silicon_pixel_spacepoint_formation_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         cuda::stream& str, std::unique_ptr<const Logger> logger)
     : device::silicon_pixel_spacepoint_formation_algorithm(mr, copy,
                                                            std::move(logger)),

--- a/device/cuda/src/seeding/triplet_seeding_algorithm.cu
+++ b/device/cuda/src/seeding/triplet_seeding_algorithm.cu
@@ -165,7 +165,8 @@ triplet_seeding_algorithm::triplet_seeding_algorithm(
     const seedfinder_config& finder_config,
     const spacepoint_grid_config& grid_config,
     const seedfilter_config& filter_config, const traccc::memory_resource& mr,
-    vecmem::copy& copy, cuda::stream& str, std::unique_ptr<const Logger> logger)
+    const vecmem::copy& copy, cuda::stream& str,
+    std::unique_ptr<const Logger> logger)
     : device::triplet_seeding_algorithm(finder_config, grid_config,
                                         filter_config, mr, copy,
                                         std::move(logger)),

--- a/device/hip/include/traccc/hip/clusterization/clusterization_algorithm.hpp
+++ b/device/hip/include/traccc/hip/clusterization/clusterization_algorithm.hpp
@@ -37,8 +37,8 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     /// @param logger The logger instance to use for messaging
     ///
     clusterization_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy, hip::stream& str,
-        const config_type& config,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
+        hip::stream& str, const config_type& config,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     private:

--- a/device/hip/src/clusterization/clusterization_algorithm.hip
+++ b/device/hip/src/clusterization/clusterization_algorithm.hip
@@ -18,8 +18,9 @@
 namespace traccc::hip {
 
 clusterization_algorithm::clusterization_algorithm(
-    const traccc::memory_resource& mr, vecmem::copy& copy, hip::stream& str,
-    const config_type& config, std::unique_ptr<const Logger> logger)
+    const traccc::memory_resource& mr, const vecmem::copy& copy,
+    hip::stream& str, const config_type& config,
+    std::unique_ptr<const Logger> logger)
     : device::clusterization_algorithm(mr, copy, config, std::move(logger)),
       hip::algorithm_base(str) {}
 

--- a/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/clusterization_algorithm.hpp
@@ -36,7 +36,7 @@ class clusterization_algorithm : public device::clusterization_algorithm,
     ///              invocation
     /// @param config the clustering configuration
     clusterization_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         queue_wrapper& queue, const config_type& config,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 

--- a/device/sycl/include/traccc/sycl/clusterization/measurement_sorting_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/clusterization/measurement_sorting_algorithm.hpp
@@ -45,7 +45,7 @@ class measurement_sorting_algorithm
     /// @param queue Wrapper for the for the SYCL queue for kernel invocation
     ///
     measurement_sorting_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         queue_wrapper& queue,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
@@ -61,7 +61,7 @@ class measurement_sorting_algorithm
     /// Memory resource(s) to use
     traccc::memory_resource m_mr;
     /// Copy object to use in the algorithm
-    std::reference_wrapper<vecmem::copy> m_copy;
+    std::reference_wrapper<const vecmem::copy> m_copy;
     /// The SYCL queue to use
     std::reference_wrapper<queue_wrapper> m_queue;
 };  // class measurement_sorting_algorithm

--- a/device/sycl/include/traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -27,7 +27,7 @@ class combinatorial_kalman_filter_algorithm
     /// Constructor with the algorithm's configuration
     combinatorial_kalman_filter_algorithm(
         const finding_config& config, const traccc::memory_resource& mr,
-        vecmem::copy& copy, queue_wrapper& queue,
+        const vecmem::copy& copy, queue_wrapper& queue,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     private:

--- a/device/sycl/include/traccc/sycl/fitting/kalman_fitting_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/fitting/kalman_fitting_algorithm.hpp
@@ -45,7 +45,7 @@ class kalman_fitting_algorithm
     ///
     kalman_fitting_algorithm(
         const config_type& config, const traccc::memory_resource& mr,
-        vecmem::copy& copy, queue_wrapper queue,
+        const vecmem::copy& copy, queue_wrapper queue,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 
     /// Execute the algorithm
@@ -67,7 +67,7 @@ class kalman_fitting_algorithm
     /// Memory resource used by the algorithm
     traccc::memory_resource m_mr;
     /// Copy object used by the algorithm
-    std::reference_wrapper<vecmem::copy> m_copy;
+    std::reference_wrapper<const vecmem::copy> m_copy;
     /// Queue wrapper
     mutable queue_wrapper m_queue;
 

--- a/device/sycl/include/traccc/sycl/seeding/seed_parameter_estimation_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/seed_parameter_estimation_algorithm.hpp
@@ -32,7 +32,7 @@ struct seed_parameter_estimation_algorithm
     ///
     seed_parameter_estimation_algorithm(
         const track_params_estimation_config& config,
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         queue_wrapper& queue,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 

--- a/device/sycl/include/traccc/sycl/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp
@@ -34,7 +34,7 @@ class silicon_pixel_spacepoint_formation_algorithm
     /// @param logger The logger instance to use
     ///
     silicon_pixel_spacepoint_formation_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         queue_wrapper& queue,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 

--- a/device/sycl/include/traccc/sycl/seeding/triplet_seeding_algorithm.hpp
+++ b/device/sycl/include/traccc/sycl/seeding/triplet_seeding_algorithm.hpp
@@ -31,7 +31,7 @@ class triplet_seeding_algorithm : public device::triplet_seeding_algorithm,
         const seedfinder_config& finder_config,
         const spacepoint_grid_config& grid_config,
         const seedfilter_config& filter_config,
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         queue_wrapper& queue,
         std::unique_ptr<const Logger> logger = getDummyLogger().clone());
 

--- a/device/sycl/src/clusterization/clusterization_algorithm.sycl
+++ b/device/sycl/src/clusterization/clusterization_algorithm.sycl
@@ -37,8 +37,9 @@ class reify_cluster_data;
 }  // namespace kernels
 
 clusterization_algorithm::clusterization_algorithm(
-    const traccc::memory_resource& mr, vecmem::copy& copy, queue_wrapper& queue,
-    const config_type& config, std::unique_ptr<const Logger> logger)
+    const traccc::memory_resource& mr, const vecmem::copy& copy,
+    queue_wrapper& queue, const config_type& config,
+    std::unique_ptr<const Logger> logger)
     : device::clusterization_algorithm(mr, copy, config, std::move(logger)),
       sycl::algorithm_base(queue) {}
 

--- a/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
+++ b/device/sycl/src/clusterization/measurement_sorting_algorithm.sycl
@@ -27,8 +27,8 @@ class fill_sorted_measurements;
 }  // namespace kernels
 
 measurement_sorting_algorithm::measurement_sorting_algorithm(
-    const traccc::memory_resource& mr, vecmem::copy& copy, queue_wrapper& queue,
-    std::unique_ptr<const Logger> logger)
+    const traccc::memory_resource& mr, const vecmem::copy& copy,
+    queue_wrapper& queue, std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)), m_mr{mr}, m_copy{copy}, m_queue{queue} {}
 
 measurement_sorting_algorithm::output_type

--- a/device/sycl/src/finding/combinatorial_kalman_filter_algorithm.cpp
+++ b/device/sycl/src/finding/combinatorial_kalman_filter_algorithm.cpp
@@ -12,7 +12,7 @@ namespace traccc::sycl {
 
 combinatorial_kalman_filter_algorithm::combinatorial_kalman_filter_algorithm(
     const config_type& config, const traccc::memory_resource& mr,
-    vecmem::copy& copy, queue_wrapper& queue,
+    const vecmem::copy& copy, queue_wrapper& queue,
     std::unique_ptr<const Logger> logger)
     : device::combinatorial_kalman_filter_algorithm(config, mr, copy,
                                                     std::move(logger)),

--- a/device/sycl/src/fitting/kalman_fitting.hpp
+++ b/device/sycl/src/fitting/kalman_fitting.hpp
@@ -72,8 +72,8 @@ kalman_fitting(
     const bfield_t& field_view,
     const typename edm::track_container<
         typename detector_t::algebra_type>::const_view& track_candidates_view,
-    const fitting_config& config, const memory_resource& mr, vecmem::copy& copy,
-    ::sycl::queue& queue) {
+    const fitting_config& config, const memory_resource& mr,
+    const vecmem::copy& copy, ::sycl::queue& queue) {
 
     // Get the number of tracks.
     const unsigned int n_tracks = copy.get_size(track_candidates_view.tracks);

--- a/device/sycl/src/fitting/kalman_fitting_algorithm.cpp
+++ b/device/sycl/src/fitting/kalman_fitting_algorithm.cpp
@@ -12,7 +12,7 @@ namespace traccc::sycl {
 
 kalman_fitting_algorithm::kalman_fitting_algorithm(
     const config_type& config, const traccc::memory_resource& mr,
-    vecmem::copy& copy, queue_wrapper queue,
+    const vecmem::copy& copy, queue_wrapper queue,
     std::unique_ptr<const Logger> logger)
     : messaging(std::move(logger)),
       m_config{config},

--- a/device/sycl/src/seeding/seed_parameter_estimation_algorithm.sycl
+++ b/device/sycl/src/seeding/seed_parameter_estimation_algorithm.sycl
@@ -22,8 +22,8 @@ namespace traccc::sycl {
 
 seed_parameter_estimation_algorithm::seed_parameter_estimation_algorithm(
     const track_params_estimation_config& config,
-    const traccc::memory_resource& mr, vecmem::copy& copy, queue_wrapper& queue,
-    std::unique_ptr<const Logger> logger)
+    const traccc::memory_resource& mr, const vecmem::copy& copy,
+    queue_wrapper& queue, std::unique_ptr<const Logger> logger)
     : device::seed_parameter_estimation_algorithm(config, mr, copy,
                                                   std::move(logger)),
       sycl::algorithm_base(queue) {}

--- a/device/sycl/src/seeding/silicon_pixel_spacepoint_formation_algorithm.sycl
+++ b/device/sycl/src/seeding/silicon_pixel_spacepoint_formation_algorithm.sycl
@@ -22,7 +22,7 @@ namespace traccc::sycl {
 
 silicon_pixel_spacepoint_formation_algorithm::
     silicon_pixel_spacepoint_formation_algorithm(
-        const traccc::memory_resource& mr, vecmem::copy& copy,
+        const traccc::memory_resource& mr, const vecmem::copy& copy,
         queue_wrapper& queue, std::unique_ptr<const Logger> logger)
     : device::silicon_pixel_spacepoint_formation_algorithm(mr, copy,
                                                            std::move(logger)),

--- a/device/sycl/src/seeding/triplet_seeding_algorithm.sycl
+++ b/device/sycl/src/seeding/triplet_seeding_algorithm.sycl
@@ -67,7 +67,7 @@ triplet_seeding_algorithm::triplet_seeding_algorithm(
     const seedfinder_config& finder_config,
     const spacepoint_grid_config& grid_config,
     const seedfilter_config& filter_config, const traccc::memory_resource& mr,
-    vecmem::copy& copy, queue_wrapper& queue,
+    const vecmem::copy& copy, queue_wrapper& queue,
     std::unique_ptr<const Logger> logger)
     : device::triplet_seeding_algorithm(finder_config, grid_config,
                                         filter_config, mr, copy,


### PR DESCRIPTION
As yet another thing that @paradajzblond noticed while integrating the algorithms/tools into Athena, we've been needlessly requiring non-const references to `vecmem::copy` objects in our device algorithms.

The idea here was that this would prevent people constructing a device algorithm with a temporary copy object. 🤔 But people will always be able to shoot themselves in the foot if they want to. And using a non-const reference for this purpose was not such a good idea anyway.

The changes are all super trivial luckily, as [vecmem::copy](https://acts-project.github.io/vecmem/classvecmem_1_1copy.html) already defines all of its functions/operators as `const` anyway.