### PR TITLE
Remove use of smem spilling in find tracks kernel

### DIFF
--- a/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/find_tracks_src.cuh
@@ -26,7 +26,6 @@ __global__ void find_tracks(
     const __grid_constant__ finding_config cfg,
     const __grid_constant__ typename detector_t::const_view_type det,
     const __grid_constant__ device::find_tracks_payload payload) {
-    TRACCC_CUDA_SPILL_TO_SHARED_MEMORY;
 
     __shared__ unsigned int shared_num_out_params;
     __shared__ unsigned int shared_candidates_size;


### PR DESCRIPTION
This commit removes the erroneous use of the compiler macro that enables spilling to registers to shared memory in the `find_tracks` kernel, allowing the code to be compiled with CUDA 13.