### PR TITLE
Disable smem spilling for relocatable device code

### DIFF
--- a/device/cuda/src/utils/hints.hpp
+++ b/device/cuda/src/utils/hints.hpp
@@ -8,7 +8,8 @@
 
 #pragma once
 
-#if defined(__CUDA_ARCH__) && CUDART_VERSION >= 13000
+#if defined(__CUDA_ARCH__) && CUDART_VERSION >= 13000 && \
+    !defined(__CUDACC_RDC__) && !defined(__CUDACC_DEBUG__)
 #define TRACCC_CUDA_SPILL_TO_SHARED_MEMORY        \
     do {                                          \
         asm(".pragma \"enable_smem_spilling\";"); \


### PR DESCRIPTION
The shared memory register spilling pragma doesn't worm in relocatable CUDA device code for obvious reasons. This commit updates the compiler macro we use to invoke this PTX pragma so that it doesn't run when the CUDA compiler is set to emit relocatable code, or when it is running in debug mode (which also enabled RDC).