### PR TITLE
Fix OOB write for halo threads in `find_tracks`

### DIFF
--- a/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -653,7 +653,7 @@ TRACCC_HOST_DEVICE inline void find_tracks(
                 tip_lengths.at(tip_pos) = n_cands;
             }
         }
-    } else {
+    } else if (in_param_id < payload.n_in_params) {
         out_params_per_in_param.at(in_param_id) = 0;
     }
 


### PR DESCRIPTION
This commit fixes a bug in the `find_tracks` kernel where halo threads would attempt to write outside the bounds of the parameter counting vector. This is easily fixed by wrapping the else clause in an additional check to establish whether the thread is actually part of the functional grid.