### PR TITLE
Disable smem spilling in propagate kernel

### DIFF
--- a/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
@@ -25,7 +25,9 @@ __global__ __launch_bounds__(128) void propagate_to_next_surface(
     typename propagator_t::detector_type::const_view_type det_data,
     const __grid_constant__ bfield_t field_data,
     const __grid_constant__ device::propagate_to_next_surface_payload payload) {
-    TRACCC_CUDA_SPILL_TO_SHARED_MEMORY;
+    // TODO: Reenable this this additional checks for compilation with the ABI
+    // enabled.
+    // TRACCC_CUDA_SPILL_TO_SHARED_MEMORY;
 
     device::propagate_to_next_surface<propagator_t>(
         details::global_index1(), cfg, det_data, field_data, payload);


### PR DESCRIPTION
This is a temporary fix until the constraints of this feature are better understood.