### PR TITLE
Update version number to 1.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Set up the project.
 cmake_minimum_required( VERSION 3.25 )
-project( traccc VERSION 1.5.1 LANGUAGES CXX )
+project( traccc VERSION 1.6.0 LANGUAGES CXX )
 
 # Set up the used C++ standard(s).
 set( CMAKE_CXX_STANDARD 20 CACHE STRING "The (host) C++ standard to use" )


### PR DESCRIPTION
Update the version number of traccc to 1.6.0, which will (hopefully) be the last ever version of traccc as a standalone project.