### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This repository is archived, and development of the traccc project has moved to [the ACTS repository](https://github.com/acts-project/acts). Please open any new issues and pull requests on the main ACTS repository rather than here.
+
 # traccc
 
 Demonstrator tracking chain for accelerators.


### PR DESCRIPTION
This commit adds an archive notice to the README, indicating that any new issues and PRs should go to the ACTS repository instead.